### PR TITLE
CM-371 - Update assembly to only generate zip distribution with execute file permission on .sh files

### DIFF
--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -465,9 +465,6 @@
       </move>
       <zip destfile="bi-server-ce-${project.revision}-all-sources.zip"
            basedir="${dist.dir}/bi-server-ce-${project.revision}-all-sources" />
-      <tar destfile="bi-server-ce-${project.revision}-all-sources.tar.gz"
-           basedir="${dist.dir}/bi-server-ce-${project.revision}-all-sources"
-           compression="gzip" />
       <delete dir="${dist.dir}/bi-server-ce-${project.revision}-all-sources" />
     </sequential>
   </target>

--- a/assembly/build-res/subfloor-pkg.xml
+++ b/assembly/build-res/subfloor-pkg.xml
@@ -113,19 +113,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   <target name="package-zip">
     <zip destfile="${dist.dir}/${package.basename}.zip">
-      <zipfileset dir="${stage.dir}" />
+      <zipfileset dir="${stage.dir}" filemode="755" >
+        <include name="**/*.sh"/>
+       </zipfileset>
+      <zipfileset dir="${stage.dir}">
+         <exclude name="**/*.sh"/>
+      </zipfileset>
     </zip>
   </target>
 
   <target name="package-targz">
-    <tar destfile="${dist.dir}/${package.basename}.tar.gz" longfile="gnu" compression="gzip">
-      <tarfileset dir="${stage.dir}" mode="755">
-        <include name="**/*.sh" />
-      </tarfileset>
-      <tarfileset dir="${stage.dir}">
-        <exclude name="**/*.sh" />
-      </tarfileset>
-    </tar>
   </target>
 
   <!-- ============================================linuxPackage===================================================== -->


### PR DESCRIPTION
CM-371 - Updated the assembly process to (a) no longer generate a .tar.gz artifact and (b) to include file permissions in the .zip artifact
