### PR TITLE
Fix NPE on import junit testing

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/importer/PentahoPlatformImporter.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/PentahoPlatformImporter.java
@@ -84,7 +84,7 @@ public class PentahoPlatformImporter implements IPlatformImporter {
     } catch (Exception e) {
       //If we are doing a logged import then we do not want to fail on a single file
       //so log the error and keep going.
-      if (repositoryImportLogger.hasLogger()){
+      if (repositoryImportLogger != null && repositoryImportLogger.hasLogger()){
         repositoryImportLogger.error(e);
       } else {
         if (e instanceof PlatformImportException) {


### PR DESCRIPTION
Non-standard setup of Importer in junit testing leaves logger PentahoPlatformImporter without a RepositoryLogger (manager).  
