### PR TITLE
BISERVER-7280 Get Jobs List checking if logged user is Admin 

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -554,14 +554,6 @@ public class FileResource extends AbstractJaxRSResource {
   }
 
   @GET
-  @Path("/canSchedule")
-  @Produces(TEXT_PLAIN)
-  public String doGetCanSchedule() {
-    Boolean isAllowed =  policy.isAllowed(IAuthorizationPolicy.MANAGE_SCHEDULING);
-    return isAllowed ? "true" : "false"; //$NON-NLS-1$//$NON-NLS-2$
-  }
-
-  @GET
   @Path("{pathId : .+}/acl")
   @Produces({APPLICATION_XML, APPLICATION_JSON})
   public RepositoryFileAclDto doGetFileAcl(@PathParam("pathId") String pathId) {

--- a/user-console/source/org/pentaho/mantle/client/MantleApplication.java
+++ b/user-console/source/org/pentaho/mantle/client/MantleApplication.java
@@ -219,7 +219,7 @@ public class MantleApplication implements IUserSettingsListener, IMantleSettings
           SolutionBrowserPanel.getInstance().setAdministrator(isAdministrator);
 
           try {
-            String restUrl2 = GWT.getHostPageBaseURL() + "api/repo/files/canSchedule"; //$NON-NLS-1$
+            String restUrl2 = GWT.getHostPageBaseURL() + "api/scheduler/canSchedule"; //$NON-NLS-1$
             RequestBuilder requestBuilder2 = new RequestBuilder(RequestBuilder.GET, restUrl2);
             requestBuilder2.sendRequest(null, new RequestCallback() {
               @Override

--- a/user-console/source/org/pentaho/mantle/client/workspace/WorkspacePanel.java
+++ b/user-console/source/org/pentaho/mantle/client/workspace/WorkspacePanel.java
@@ -187,7 +187,7 @@ public class WorkspacePanel extends SimplePanel {
           WorkspacePanel.this.isAdmin = "true".equalsIgnoreCase(response.getText());
 
           try {
-            final String url2 = GWT.getHostPageBaseURL() + "api/repo/files/canSchedule"; //$NON-NLS-1$
+            final String url2 = GWT.getHostPageBaseURL() + "api/scheduler/canSchedule"; //$NON-NLS-1$
             RequestBuilder requestBuilder2 = new RequestBuilder(RequestBuilder.GET, url2);
             requestBuilder2.setHeader("accept", "text/plain");
             requestBuilder2.sendRequest(null, new RequestCallback() {


### PR DESCRIPTION
- Updated jobs call to include a check like canAdminister on FireResource;
- Updated user name used to filter jobs. Currently is only checking via Pentaho session because previously it wasn't matching using SecurityHelper.getInstance().getAuthentication().getName();
- Moved canSchedule call from FileResource (bad location) to SchedulerResource. Consequently, calls on user-console project were updated to this new url. 
