### PR TITLE
PDI-9368 Changing JcrUserRoleDao.getUsers() and getRoles() to use JcrTen...

### DIFF
--- a/repository/src/org/pentaho/platform/security/userroledao/jackrabbit/JcrUserRoleDao.java
+++ b/repository/src/org/pentaho/platform/security/userroledao/jackrabbit/JcrUserRoleDao.java
@@ -160,12 +160,12 @@ public class JcrUserRoleDao extends AbstractJcrBackedUserRoleDao {
 
   @Override
   public List<IPentahoRole> getRoles() throws UncategorizedUserRoleDaoException {
-    return getRoles(JcrTenantUtils.getCurrentTenant());
+    return getRoles(JcrTenantUtils.getTenant());
   }
 
   @Override
   public List<IPentahoUser> getUsers() throws UncategorizedUserRoleDaoException {
-    return getUsers(JcrTenantUtils.getCurrentTenant());
+    return getUsers(JcrTenantUtils.getTenant());
   }
 
   @Override


### PR DESCRIPTION
...antUtils.getTenant() instead of JcrTenantUtils.getCurrentTenant()

JcrTenantUtils.getTenant() first tries getCurrentTenant() and then falls back to the default tenant if null.
