### PR TITLE
BISERVER-8444 - moved metadata to general tab on file properties dialog

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/FilePropertiesDialog.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/FilePropertiesDialog.java
@@ -12,22 +12,33 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2008 Pentaho Corporation.  All rights reserved.
+ * Copyright 2013 Pentaho Corporation.  All rights reserved.
  *
  * Created Mar 25, 2008
  * @author Michael D'Amour
  */
 package org.pentaho.mantle.client.solutionbrowser.fileproperties;
 
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.http.client.*;
+import com.google.gwt.user.client.ui.Widget;
 import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
+import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
 import org.pentaho.gwt.widgets.client.dialogs.PromptDialogBox;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFile;
 import org.pentaho.gwt.widgets.client.tabs.PentahoTab;
 import org.pentaho.gwt.widgets.client.tabs.PentahoTabPanel;
 import org.pentaho.mantle.client.messages.Messages;
 import org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel;
-import com.google.gwt.user.client.ui.Widget;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * File properties parent panel displayed when right clicking
+ * a file in PUC repo browser. Subpanels include: General,
+ * Share, History
+ */
 public class FilePropertiesDialog extends PromptDialogBox {
   public enum Tabs {
     GENERAL, PERMISSION, HISTORY
@@ -38,12 +49,26 @@ public class FilePropertiesDialog extends PromptDialogBox {
   private PermissionsPanel permissionsTab;
   private GeneratedContentPanel generatedContentTab;
 
+  private String moduleBaseURL = GWT.getModuleBaseURL();
+  private String moduleName = GWT.getModuleName();
+  private String contextURL = moduleBaseURL.substring(0, moduleBaseURL.lastIndexOf(moduleName));
+
+  boolean dirty = false;
+
+  /**
+   *
+   * @param fileSummary
+   * @param propertyTabs
+   * @param callback
+   * @param defaultTab
+   */
   public FilePropertiesDialog(RepositoryFile fileSummary, final PentahoTabPanel propertyTabs, final IDialogCallback callback, Tabs defaultTab) {
     super(fileSummary.getName() + " " + Messages.getString("properties"), Messages.getString("ok"), Messages.getString("cancel"), false, true); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     boolean isInTrash = fileSummary.getPath().contains("/.trash/pho:");
     setContent(propertyTabs);
 
     generalTab = new GeneralPanel(this, fileSummary);
+
     if (!fileSummary.isFolder()) {
       generatedContentTab = new GeneratedContentPanel(SolutionBrowserPanel.pathToId(fileSummary.getPath()), null, null);
     }
@@ -55,6 +80,11 @@ public class FilePropertiesDialog extends PromptDialogBox {
     if (!isInTrash) {
       permissionsTab.getElement().setId("filePropertiesPermissionsTab");
     }
+
+    // get metadata via REST
+    getMetadata(fileSummary);
+    getAcls(fileSummary);
+
     okButton.getElement().setId("filePropertiesOKButton");
     cancelButton.getElement().setId("filePropertiesCancelButton");
 
@@ -87,15 +117,65 @@ public class FilePropertiesDialog extends PromptDialogBox {
     showTab(defaultTab);
   }
 
+  /**
+   *
+   */
   private void applyPanel() {
+    List<RequestBuilder> requestBuilders = new ArrayList();
     for (int i=0;i<propertyTabs.getTabCount();i++) {
       Widget w = propertyTabs.getTab(i).getContent();
       if (w instanceof IFileModifier) {
-        ((IFileModifier) w).apply();
+        // get requests from sub panels
+        if(((IFileModifier) w).prepareRequests() != null){
+          requestBuilders.addAll(((IFileModifier) w).prepareRequests());
+        }
       }
+    }
+
+    RequestCallback requestCallback;
+
+    // chain requests from subpanels using callbacks to try and avoid any StaleItemStateExceptions
+    for(int i = 0; i <= requestBuilders.size() - 1; i++ ){
+      RequestBuilder requestBuilder = requestBuilders.get(i);
+      if(i < requestBuilders.size() - 1){
+        final RequestBuilder nextRequest = requestBuilders.get(i + 1);
+        requestCallback = new ChainedRequestCallback(nextRequest);
+      }
+      else{
+        requestCallback = new RequestCallback() {
+          @Override
+          public void onError(Request arg0, Throwable arg1) {
+            MessageDialogBox dialogBox = new MessageDialogBox(Messages.getString("error"), arg1.toString(), false, false, true); //$NON-NLS-1$
+            dialogBox.center();
+          }
+
+          @Override
+          public void onResponseReceived(Request arg0, Response arg1) {
+            if (arg1.getStatusCode() == Response.SC_OK) {
+              dirty = false;
+            } else {
+              MessageDialogBox dialogBox = new MessageDialogBox(Messages.getString("error"), arg1.toString(), false, false, true); //$NON-NLS-1$
+              dialogBox.center();
+            }
+          }
+        };
+      }
+      requestBuilder.setCallback(requestCallback);
+    }
+
+    // start the chain
+    try{
+      requestBuilders.get(0).send();
+    }
+    catch (RequestException e){
+
     }
   }
 
+  /**
+   *
+   * @param tab
+   */
   public void showTab(Tabs tab) {
     for (int i=0; i<propertyTabs.getTabCount(); i++) {
       PentahoTab pTab = propertyTabs.getTab(i);
@@ -118,6 +198,134 @@ public class FilePropertiesDialog extends PromptDialogBox {
         default:
           break;
       }
+    }
+  }
+
+  /**
+   *
+   * @param fileSummary
+   */
+  protected void getAcls(RepositoryFile fileSummary) {
+    String url = contextURL + "api/repo/files/" + SolutionBrowserPanel.pathToId(fileSummary.getPath()) + "/acl"; //$NON-NLS-1$ //$NON-NLS-2$
+    RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, url);
+    try {
+      builder.sendRequest(null, new RequestCallback() {
+
+        public void onError(Request request, Throwable exception) {
+          MessageDialogBox dialogBox = new MessageDialogBox(Messages.getString("error"), exception.getLocalizedMessage(), false, false, true); //$NON-NLS-1$
+          dialogBox.center();
+        }
+
+        public void onResponseReceived(Request request, Response response) {
+          if (response.getStatusCode() == Response.SC_OK) {
+            generalTab.setAclResponse(response);
+            permissionsTab.setAclResponse(response);
+          } else {
+            MessageDialogBox dialogBox = new MessageDialogBox(
+                Messages.getString("error"), Messages.getString("serverErrorColon") + " " + response.getStatusCode(), false, false, true); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+            dialogBox.center();
+          }
+        }
+      });
+    } catch (RequestException e) {
+      MessageDialogBox dialogBox = new MessageDialogBox(Messages.getString("error"), e.getLocalizedMessage(), false, false, true); //$NON-NLS-1$
+      dialogBox.center();
+    }
+  }
+
+  /**
+   *
+   * @param fileSummary
+   */
+  protected void getMetadata(RepositoryFile fileSummary){
+    String metadataUrl = contextURL + "api/repo/files/" + SolutionBrowserPanel.pathToId(fileSummary.getPath()) + "/metadata"; //$NON-NLS-1$ //$NON-NLS-2$
+    RequestBuilder metadataBuilder = new RequestBuilder(RequestBuilder.GET, metadataUrl);
+    metadataBuilder.setHeader("accept", "application/json");
+    try {
+      metadataBuilder.sendRequest(null, new RequestCallback() {
+
+        public void onError(Request request, Throwable exception) {
+          MessageDialogBox dialogBox = new MessageDialogBox(Messages.getString("error"), exception.getLocalizedMessage(), false, false, true); //$NON-NLS-1$
+          dialogBox.center();
+        }
+
+        public void onResponseReceived(Request request, Response response) {
+          if (response.getStatusCode() == Response.SC_OK) {
+            if (response.getText() != null && !"".equals(response.getText()) && !response.getText().equals("null")) {
+              generalTab.setMetadataResponse(response);
+            }
+          } else {
+            MessageDialogBox dialogBox = new MessageDialogBox(
+                Messages.getString("error"), Messages.getString("serverErrorColon") + " " + response.getStatusCode(), false, false, true); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+            dialogBox.center();
+          }
+        }
+      });
+    } catch (RequestException e) {
+      MessageDialogBox dialogBox = new MessageDialogBox(Messages.getString("error"), e.getLocalizedMessage(), false, false, true); //$NON-NLS-1$
+      dialogBox.center();
+    }
+  }
+
+  /**
+   *
+   */
+  protected class ChainedRequestCallback implements RequestCallback{
+    RequestBuilder nextRequest;
+
+    /**
+     *
+     * @param arg0
+     * @param arg1
+     */
+    @Override
+    public void onError(Request arg0, Throwable arg1) {
+      MessageDialogBox dialogBox = new MessageDialogBox(Messages.getString("error"), arg1.toString(), false, false, true); //$NON-NLS-1$
+      dialogBox.center();
+    }
+
+    /**
+     *
+     * @param arg0
+     * @param arg1
+     */
+    @Override
+    public void onResponseReceived(Request arg0, Response arg1) {
+      if (arg1.getStatusCode() == Response.SC_OK) {
+        try{
+          nextRequest.send();
+        }
+        catch (RequestException e){
+
+        }
+        dirty = false;
+      } else {
+        MessageDialogBox dialogBox = new MessageDialogBox(Messages.getString("error"), arg1.toString(), false, false, true); //$NON-NLS-1$
+        dialogBox.center();
+      }
+    }
+
+    /**
+     *
+     * @param nextRequest
+     */
+    public void setNextRequest(RequestBuilder nextRequest){
+      this.nextRequest = nextRequest;
+    }
+
+    /**
+     *
+     * @param nextRequest
+     */
+    public ChainedRequestCallback(RequestBuilder nextRequest){
+      this.nextRequest = nextRequest;
+    }
+
+    /**
+     *
+     */
+    public ChainedRequestCallback(){
+
     }
   }
 }

--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/GeneratedContentPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/GeneratedContentPanel.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
-import org.pentaho.gwt.widgets.client.filechooser.JsonToRepositoryFileTreeConverter;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFile;
+import org.pentaho.gwt.widgets.client.filechooser.JsonToRepositoryFileTreeConverter;
 import org.pentaho.gwt.widgets.client.toolbar.Toolbar;
 import org.pentaho.gwt.widgets.client.toolbar.ToolbarButton;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
@@ -33,7 +33,6 @@ import org.pentaho.mantle.client.images.MantleImages;
 import org.pentaho.mantle.client.messages.Messages;
 import org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel;
 import org.pentaho.mantle.client.solutionbrowser.filelist.FileCommand.COMMAND;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.gen2.table.client.FixedWidthFlexTable;
 import com.google.gwt.gen2.table.client.FixedWidthGrid;
@@ -68,12 +67,12 @@ public class GeneratedContentPanel extends VerticalPanel implements IFileModifie
   protected HistoryToolbar toolbar;
   protected String user;
   private String lineageId;
-  
+
   public GeneratedContentPanel(final String repositoryFilePath, final String lineageId, final String user) {
     this.repositoryFilePath = repositoryFilePath;
     this.user = user;
     this.lineageId = lineageId;
-    
+
     toolbar = new HistoryToolbar();
     toolbar.getRunButton().setEnabled(false);
     this.add(toolbar);
@@ -104,6 +103,15 @@ public class GeneratedContentPanel extends VerticalPanel implements IFileModifie
     // TODO Auto-generated method stub
   }
 
+  /**
+   *
+   * @return
+   */
+  @Override
+  public List<RequestBuilder> prepareRequests() {
+    return null;  //To change body of implemented methods use File | Settings | File Templates.
+  }
+
   /* (non-Javadoc)
    * @see org.pentaho.mantle.client.solutionbrowser.fileproperties.IFileModifier#init(org.pentaho.gwt.widgets.client.filechooser.RepositoryFile, com.google.gwt.xml.client.Document)
    */
@@ -112,6 +120,11 @@ public class GeneratedContentPanel extends VerticalPanel implements IFileModifie
     init(SolutionBrowserPanel.pathToId(fileSummary.getPath()), fileInfo);
   }
 
+  /**
+   *
+   * @param fileSummaryPath
+   * @param fileInfo
+   */
   private void init(final String fileSummaryPath, Document fileInfo) {
     String moduleBaseURL = GWT.getModuleBaseURL();
     String moduleName = GWT.getModuleName();
@@ -160,6 +173,10 @@ public class GeneratedContentPanel extends VerticalPanel implements IFileModifie
     }    
   }
   
+  /**
+   *
+   * @param event
+   */
   public void onBrowserEvent(Event event) {
     if (event.getTypeInt() == Event.ONDBLCLICK) {
       new RunContentCommand().execute();
@@ -173,6 +190,9 @@ public class GeneratedContentPanel extends VerticalPanel implements IFileModifie
   public class HistoryToolbar extends Toolbar {
     ToolbarButton refreshBtn, runBtn;
 
+    /**
+     *
+     */
     public HistoryToolbar() {
       super();
 
@@ -185,6 +205,9 @@ public class GeneratedContentPanel extends VerticalPanel implements IFileModifie
       createMenus();
     }
 
+    /**
+     *
+     */
     private void createMenus() {
       addSpacer(5);
       Label label = new Label(Messages.getString("history"));
@@ -209,6 +232,10 @@ public class GeneratedContentPanel extends VerticalPanel implements IFileModifie
       add(refreshBtn);
     }
     
+    /**
+     *
+     * @return
+     */
     public ToolbarButton getRunButton() {
       return runBtn;
     }
@@ -256,6 +283,9 @@ public class GeneratedContentPanel extends VerticalPanel implements IFileModifie
     } 
   }
 
+  /**
+   *
+   */
   private class FileAwareLabel extends Label {
     private RepositoryFile file;
     
@@ -280,6 +310,9 @@ public class GeneratedContentPanel extends VerticalPanel implements IFileModifie
     }
   }
   
+  /**
+   *
+   */
   public class ContentSorter extends ColumnSorter {
 
     /* (non-Javadoc)

--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/IFileModifier.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/IFileModifier.java
@@ -12,17 +12,34 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2008 Pentaho Corporation.  All rights reserved.
+ * Copyright 2013 Pentaho Corporation.  All rights reserved.
  *
  * Created Mar 25, 2008
  * @author Michael D'Amour
  */
 package org.pentaho.mantle.client.solutionbrowser.fileproperties;
 
+import com.google.gwt.http.client.RequestBuilder;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFile;
 import com.google.gwt.xml.client.Document;
 
+import java.util.List;
+
+/**
+ * Interface for sub panels of the FilePropertiesDialog which provides methods
+ * for passing
+ */
 public interface IFileModifier {
   public void init(RepositoryFile fileSummary, Document fileInfo);
   public void apply();
+
+  /**
+   * Use this method to create RequestBuilder objects and use RequestBuilder.setRequestData
+   * Add RequestBuilder objects to the List which is then used by FilePropertiesDialog
+   * to iterate through and call each request sequentially by chaining them in the callbacks.
+   * It is not necessary to set a callback since FilePropertiesDialog will add its own
+   * @see FilePropertiesDialog#applyPanel()
+   * @return
+   */
+  public List<RequestBuilder> prepareRequests();
 }

--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/SubscriptionsPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/SubscriptionsPanel.java
@@ -12,13 +12,14 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2008 Pentaho Corporation.  All rights reserved.
+ * Copyright 2013 Pentaho Corporation.  All rights reserved.
  *
  * @created Jun 30, 2008 
  * @author wseyler
  */
 package org.pentaho.mantle.client.solutionbrowser.fileproperties;
 
+import com.google.gwt.http.client.RequestBuilder;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFile;
 import org.pentaho.mantle.client.messages.Messages;
 import org.pentaho.mantle.client.objects.SolutionFileInfo;
@@ -36,6 +37,8 @@ import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.xml.client.Document;
 
+import java.util.List;
+
 /**
  * @author wseyler
  * 
@@ -51,6 +54,9 @@ public class SubscriptionsPanel extends VerticalPanel implements IFileModifier {
   private Button moveAllRightBtn = new Button();
   private Button moveAllLeftBtn = new Button();
 
+  /**
+   *
+   */
   public SubscriptionsPanel() {
     layout();
 
@@ -69,6 +75,9 @@ public class SubscriptionsPanel extends VerticalPanel implements IFileModifier {
 
   }
 
+  /**
+   *
+   */
   public void layout() {
     this.setSize("100%", "100%"); //$NON-NLS-1$//$NON-NLS-2$
     enableSubscriptions.addClickHandler(new ClickHandler() {
@@ -157,22 +166,40 @@ public class SubscriptionsPanel extends VerticalPanel implements IFileModifier {
 
   }
 
+  /**
+   *
+   */
   protected void moveSelectedToRight() {
     moveItems(availableLB, appliedLB, false);
   }
 
+  /**
+   *
+   */
   protected void moveAllToRight() {
     moveItems(availableLB, appliedLB, true);
   }
 
+  /**
+   *
+   */
   protected void moveSelectedToLeft() {
     moveItems(appliedLB, availableLB, false);
   }
 
+  /**
+   *
+   */
   protected void moveAllToLeft() {
     moveItems(appliedLB, availableLB, true);
   }
 
+  /**
+   *
+   * @param srcLB
+   * @param destLB
+   * @param moveAll
+   */
   protected void moveItems(ListBox srcLB, ListBox destLB, boolean moveAll) {
     int itemCount = srcLB.getItemCount();
     int srcSelectionIndex = srcLB.getSelectedIndex();
@@ -196,6 +223,11 @@ public class SubscriptionsPanel extends VerticalPanel implements IFileModifier {
     }
   }
 
+  /**
+   *
+   * @param targetListBox
+   * @param removeAll
+   */
   private void removeItems(ListBox targetListBox, boolean removeAll) {
     int itemCount = targetListBox.getItemCount();
     for (int i = itemCount - 1; i >= 0; i--) {
@@ -206,7 +238,7 @@ public class SubscriptionsPanel extends VerticalPanel implements IFileModifier {
   }
 
   /**
-   * @param destLB
+   * @param targetListBox
    */
   private void deselectAll(ListBox targetListBox) {
     for (int i = 0; i < targetListBox.getItemCount(); i++) {
@@ -222,6 +254,16 @@ public class SubscriptionsPanel extends VerticalPanel implements IFileModifier {
   public void apply() {
   }
 
+  @Override
+  public List<RequestBuilder> prepareRequests() {
+    return null;  //To change body of implemented methods use File | Settings | File Templates.
+  }
+
+  /**
+   *
+   * @param fileSummary
+   * @param fileInfo
+   */
   public void init(RepositoryFile fileSummary, Document fileInfo) {
     
   }
@@ -235,6 +277,9 @@ public class SubscriptionsPanel extends VerticalPanel implements IFileModifier {
     updateState();
   }
 
+  /**
+   *
+   */
   protected void updateControls() {
     availableLB.setEnabled(enableSubscriptions.getValue());
     appliedLB.setEnabled(enableSubscriptions.getValue());

--- a/user-console/source/org/pentaho/mantle/public/messages/mantleMessages.properties
+++ b/user-console/source/org/pentaho/mantle/public/messages/mantleMessages.properties
@@ -438,4 +438,6 @@ none=None
 short=Short
 verbose=Verbose
 schedulable=Allow Scheduling
+hidden=Hidden
+owner=Owner
 fromName=From Name


### PR DESCRIPTION
...; added owner label; applied some formatting

BISERVER-8512 - Moved REST GET calls to FilePropertiesDialog and passing result to sub panels to consolidate since General and Sharing tabs both need results of get ACL and Metadata. Also added owner field to General tab

BISERVER-8512 - Modified PermissionsPanel to receive get ACL response from FilePropertiesDialog

BISERVER-8418 StaleItemStateException occurs when saving sharing properties - Instead of firing off REST calls from each panel, pass request objects to FilePropertiesDialog parent which will chain the requests via callbacks to execute sequentially

BISERVER-8418 - Added some comments to interface
