### PR TITLE
Changes for BISERVER-8335  Update the Import Service to consume .property files using the repository API

### DIFF
--- a/assembly/package-res-common/biserver/pentaho-solutions/system/importExport.xml
+++ b/assembly/package-res-common/biserver/pentaho-solutions/system/importExport.xml
@@ -77,6 +77,7 @@
                 <entry key="ktr" value="text/xml"/>
                 <entry key="png" value="image/png"/>
                 <entry key="properties" value="text/plain"/>
+                <entry key="locale" value="text/locale"/>
                 <entry key="report" value="text/xml"/>
                 <entry key="rptdesign" value="text/xml"/>
                 <entry key="svg" value="image/svg+xml"/>
@@ -164,6 +165,16 @@
                     <bean class="org.pentaho.platform.plugin.services.importer.MondrianImportHandler">
                         <constructor-arg ref="IMondrianCatalogService"/>
                     </bean>
+                </entry>
+				<entry key="text/locale">
+                    <bean class="org.pentaho.platform.plugin.services.importer.LocaleImportHandler">
+						<constructor-arg>
+		            		<list>
+                				<value>xaction</value>
+                				<value>url</value>
+		            		</list>
+	        			</constructor-arg>
+		    		</bean>	
                 </entry>
             </map>
         </constructor-arg>

--- a/assembly/package-res/biserver/pentaho-solutions/system/importExport.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/importExport.xml
@@ -78,6 +78,7 @@
                 <entry key="ktr" value="text/xml"/>
                 <entry key="png" value="image/png"/>
                 <entry key="properties" value="text/plain"/>
+                <entry key="locale" value="text/locale"/>
                 <entry key="report" value="text/xml"/>
                 <entry key="rptdesign" value="text/xml"/>
                 <entry key="svg" value="image/svg+xml"/>
@@ -165,6 +166,16 @@
                     <bean class="org.pentaho.platform.plugin.services.importer.MondrianImportHandler">
                         <constructor-arg ref="IMondrianCatalogService"/>
                     </bean>
+                </entry>
+				<entry key="text/locale">
+                    <bean class="org.pentaho.platform.plugin.services.importer.LocaleImportHandler">
+						<constructor-arg>
+		            		<list>
+                				<value>xaction</value>
+                				<value>url</value>
+		            		</list>
+	        			</constructor-arg>
+		    		</bean>	
                 </entry>
             </map>
         </constructor-arg>

--- a/extensions/src/org/pentaho/platform/plugin/services/importer/LocaleFileDescriptor.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/LocaleFileDescriptor.java
@@ -1,0 +1,81 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the 
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software 
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this 
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html 
+ * or from the Free Software Foundation, Inc., 
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2013 Pentaho Corporation.  All rights reserved.
+ *
+ * @author Ezequiel Cuellar
+ */
+
+package org.pentaho.platform.plugin.services.importer;
+
+import java.io.InputStream;
+
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+
+public class LocaleFileDescriptor {
+
+	private String name;
+	private String path;
+	private String description;
+	private RepositoryFile file;
+	private InputStream inputStream;
+
+	public LocaleFileDescriptor(String name, String description, String path, RepositoryFile file, InputStream inputStream) {
+		this.name = name;
+		this.description = description;
+		this.path = path;
+		this.inputStream = inputStream;
+		this.file = file;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public InputStream getInputStream() {
+		return inputStream;
+	}
+
+	public void setInputStream(InputStream inputStream) {
+		this.inputStream = inputStream;
+	}
+
+	public RepositoryFile getFile() {
+		return file;
+	}
+
+	public void setFile(RepositoryFile file) {
+		this.file = file;
+	}
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/importer/LocaleFilesProcessor.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/LocaleFilesProcessor.java
@@ -1,0 +1,80 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the 
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software 
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this 
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html 
+ * or from the Free Software Foundation, Inc., 
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2013 Pentaho Corporation.  All rights reserved.
+ *
+ * @author Ezequiel Cuellar
+ */
+
+package org.pentaho.platform.plugin.services.importer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.importexport.ImportSource.IRepositoryFileBundle;
+import org.pentaho.platform.repository.RepositoryFilenameUtils;
+
+public class LocaleFilesProcessor {
+
+	private List<LocaleFileDescriptor> localeFiles;
+
+	public LocaleFilesProcessor() {
+		localeFiles = new ArrayList<LocaleFileDescriptor>();
+	}
+
+	public boolean isLocaleFile(IRepositoryFileBundle file, String parentPath, InputStream inputStream) throws IOException {
+		
+		boolean isLocale = false;
+		String fileName = file.getFile().getName();
+		if(fileName.endsWith(".properties")) {
+			
+			Properties properties = new Properties();
+			properties.load(inputStream);
+			
+			String name = properties.getProperty("name");
+			String description = properties.getProperty("description");
+			if (name != null && description != null) {
+
+				String filePath = (file.getPath().equals("/") || file.getPath().equals("\\")) ? "" : file.getPath();
+				filePath = RepositoryFilenameUtils.concat(parentPath, filePath);
+				
+				LocaleFileDescriptor localeFile = new LocaleFileDescriptor(name, description, filePath, file.getFile(), inputStream);
+				localeFiles.add(localeFile);
+				isLocale = true;
+			}
+		}
+		return isLocale;		
+	}
+
+	public void processLocaleFiles(IPlatformImporter importer) throws PlatformImportException {
+		RepositoryFileImportBundle.Builder bundleBuilder = new RepositoryFileImportBundle.Builder();
+		NameBaseMimeResolver mimeResolver = PentahoSystem.get(NameBaseMimeResolver.class);
+		String mimeType = mimeResolver.resolveMimeForFileName("file.locale");
+		
+		for (LocaleFileDescriptor localeFile : localeFiles) {
+			bundleBuilder.name(localeFile.getName());
+			bundleBuilder.comment(localeFile.getDescription());
+			bundleBuilder.path(localeFile.getPath());
+			bundleBuilder.file(localeFile.getFile());
+			bundleBuilder.input(localeFile.getInputStream());
+			bundleBuilder.mime(mimeType);
+			IPlatformImportBundle platformImportBundle = bundleBuilder.build();
+			importer.importFile(platformImportBundle);
+		}
+	}
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/importer/LocaleImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/LocaleImportHandler.java
@@ -1,0 +1,94 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the 
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software 
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this 
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html 
+ * or from the Free Software Foundation, Inc., 
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2013 Pentaho Corporation.  All rights reserved.
+ *
+ * @author Ezequiel Cuellar
+ */
+
+package org.pentaho.platform.plugin.services.importer;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+import org.pentaho.metadata.repository.DomainAlreadyExistsException;
+import org.pentaho.metadata.repository.DomainIdNullException;
+import org.pentaho.metadata.repository.DomainStorageException;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+
+public class LocaleImportHandler implements IPlatformImportHandler {
+
+	private List<String> artifacts;
+	private IUnifiedRepository unifiedRepository;
+
+	public LocaleImportHandler(List<String> artifacts) {
+		this.unifiedRepository = PentahoSystem.get(IUnifiedRepository.class);
+		this.artifacts = artifacts;
+	}
+
+	public void importFile(IPlatformImportBundle bundle) throws PlatformImportException, DomainIdNullException, DomainAlreadyExistsException, DomainStorageException, IOException {
+		RepositoryFileImportBundle locale = (RepositoryFileImportBundle) bundle;
+		RepositoryFile localeParent = getLocaleParent(locale);
+
+		Properties localeProperties = new Properties();
+		localeProperties.setProperty("name", locale.getName());
+		localeProperties.setProperty("description", locale.getComment());
+
+		if(localeParent != null) {
+			unifiedRepository.setLocalePropertiesForFile(localeParent, "en", localeProperties);
+		}
+	}
+
+	private RepositoryFile getLocaleParent(RepositoryFileImportBundle locale) {
+		RepositoryFile localeParent = null;
+		String localeFileName = locale.getFile().getName();
+		RepositoryFile localeFolder = unifiedRepository.getFile(locale.getPath());
+
+		if (localeFileName.startsWith("index") && localeFileName.endsWith(".properties")) {
+			localeParent = localeFolder;
+		} else {
+			List<RepositoryFile> localeFolderChildren = unifiedRepository.getChildren(localeFolder.getId());
+			for (RepositoryFile localeChild : localeFolderChildren) {
+
+				String localeChildName = extractFileName(localeChild.getName());
+				String localeChildExtension = extractExtension(localeChild.getName());
+
+				if (localeFileName.startsWith(localeChildName) && artifacts.contains(localeChildExtension)) {
+					localeParent = localeChild;
+					break;
+				}
+			}
+		}
+		return localeParent;
+	}
+
+	private String extractExtension(String name) {
+		int idx = name.lastIndexOf(".");
+		if (idx == -1 || idx == name.length()) {
+			return name;
+		}
+		return name.substring(idx + 1);
+	}
+
+	private String extractFileName(String name) {
+		int idx = name.lastIndexOf(".");
+		if (idx == -1 || idx == name.length()) {
+			return name;
+		}
+		return name.substring(0, idx);
+	}
+}


### PR DESCRIPTION
Changes for BISERVER-8335  Update the Import Service to consume .property files using the repository API
