### PR TITLE
[BISERVER-8565] Removing usage of RepositoryFile.titleMap and RepositoryFile.descriptionMap.

### DIFF
--- a/repository/src/org/pentaho/platform/repository/JcrBackedDatasourceMgmtService.java
+++ b/repository/src/org/pentaho/platform/repository/JcrBackedDatasourceMgmtService.java
@@ -58,7 +58,7 @@ public class JcrBackedDatasourceMgmtService implements IDatasourceMgmtService{
       //databaseMeta.setPassword(passwordService.encrypt(databaseMeta.getPassword()));
 
       RepositoryFile file = new RepositoryFile.Builder(RepositoryFilenameUtils.escape(databaseConnection.getName() 
-          + RepositoryObjectType.DATABASE.getExtension(), cachedReservedChars)).title(RepositoryFile.ROOT_LOCALE, databaseConnection.getName()).versioned(true).build();
+          + RepositoryObjectType.DATABASE.getExtension(), cachedReservedChars)).title(RepositoryFile.DEFAULT_LOCALE, databaseConnection.getName()).versioned(true).build();
       file = repository.createFile(getDatabaseParentFolderId(), file, new NodeRepositoryFileData(databaseHelper.databaseConnectionToDataNode(databaseConnection)), null);
       if(file != null && file.getId() != null) {
         return file.getId().toString();
@@ -239,7 +239,7 @@ public class JcrBackedDatasourceMgmtService implements IDatasourceMgmtService{
       //databaseMeta.setPassword(passwordService.encrypt(databaseMeta.getPassword()));
 
       if(file != null) {
-        file = new RepositoryFile.Builder(file).title(RepositoryFile.ROOT_LOCALE, databaseConnection.getName()).build();
+        file = new RepositoryFile.Builder(file).title(RepositoryFile.DEFAULT_LOCALE, databaseConnection.getName()).build();
         file = repository.updateFile(file, new NodeRepositoryFileData(databaseHelper.databaseConnectionToDataNode(databaseConnection)),null);
         renameIfNecessary(databaseConnection, file);
         return file.getId().toString();

--- a/repository/src/org/pentaho/platform/repository2/unified/exportManifest/ExportManifestEntity.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/exportManifest/ExportManifestEntity.java
@@ -133,8 +133,8 @@ public class ExportManifestEntity {
 		return new RepositoryFile(null, emd.getName(), emd.getIsFolder(),
 				emd.getIsHidden(), false, null, emd.getPath(),
 				XmlGregorianCalendarConverter.asDate(emd.getCreatedDate()), null,
-				false, null, null, null, "en-US", emd.getTitle(), null,
-				emd.getDescription(), null, null, null, 0, emd.getOwner(), null);
+				false, null, null, null, "en-US", emd.getTitle(),
+				emd.getDescription(), null, null, 0, emd.getOwner(), null);
 	}
 
 	/**

--- a/repository/src/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDao.java
@@ -177,7 +177,7 @@ public class FileSystemRepositoryFileDao implements IRepositoryFileDao {
       file = new RepositoryFile.Builder(f.getAbsolutePath(), f.getName()).createdDate(new Date(f.lastModified()))
           .lastModificationDate(new Date(f.lastModified())).folder(f.isDirectory()).versioned(false).path(jcrPath)
           .versionId(f.getName()).locked(false).lockDate(null).lockMessage(null).lockOwner(null).title(f.getName())
-          .description(f.getName()).titleMap(null).descriptionMap(null).locale(null).fileSize(f.length()).build();
+          .description(f.getName()).locale(null).fileSize(f.length()).build();
     }
     return file;
 

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
@@ -912,7 +912,7 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
   @Override
   public Properties getLocalePropertiesForFile(RepositoryFile repositoryFile, String locale) {
     if(org.apache.commons.lang.StringUtils.isBlank(locale)){
-      locale = PentahoJcrConstants.DEFAULT_LOCALE;
+      locale = RepositoryFile.DEFAULT_LOCALE;
     }
     if(repositoryFile != null && repositoryFile.getLocalePropertiesMap() != null){
       Properties properties = repositoryFile.getLocalePropertiesMap().get(locale);

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -181,28 +181,19 @@ public class JcrRepositoryFileUtils {
     }
 
     if (isPentahoHierarchyNode(session, pentahoJcrConstants, node)) {
-      if (node.hasNode(pentahoJcrConstants.getPHO_TITLE())) {
-        title = getLocalizedString(session, pentahoJcrConstants, node.getNode(pentahoJcrConstants.getPHO_TITLE()),
-            pentahoLocale);
-      }
-      if (node.hasNode(pentahoJcrConstants.getPHO_DESCRIPTION())) {
-        description = getLocalizedString(session, pentahoJcrConstants,
-            node.getNode(pentahoJcrConstants.getPHO_DESCRIPTION()), pentahoLocale);
-      }
+      if (node.hasNode(pentahoJcrConstants.getPHO_LOCALES())) {
+        localePropertiesMap = getLocalePropertiesMap(session, pentahoJcrConstants,
+           node.getNode(pentahoJcrConstants.getPHO_LOCALES()));
 
-      if (loadMaps) {
-        if (node.hasNode(pentahoJcrConstants.getPHO_TITLE())) {
-          titleMap = getLocalizedStringMap(session, pentahoJcrConstants,
-              node.getNode(pentahoJcrConstants.getPHO_TITLE()));
-        }
-        if (node.hasNode(pentahoJcrConstants.getPHO_DESCRIPTION())) {
-          descriptionMap = getLocalizedStringMap(session, pentahoJcrConstants,
-              node.getNode(pentahoJcrConstants.getPHO_DESCRIPTION()));
-        }
-
-        if (node.hasNode(pentahoJcrConstants.getPHO_LOCALES())) {
-          localePropertiesMap = getLocalePropertiesMap(session, pentahoJcrConstants,
-             node.getNode(pentahoJcrConstants.getPHO_LOCALES()));
+        if(localePropertiesMap != null && pentahoLocale != null){
+          Properties properties = localePropertiesMap.get(pentahoLocale.getLocale().toString());
+          if(properties == null){
+            properties = localePropertiesMap.get(pentahoLocale.getLocale().getLanguage()); // try just the language
+          }
+          if(properties != null){
+            title = properties.getProperty(RepositoryFile.FILE_TITLE);
+            description = properties.getProperty(RepositoryFile.FILE_DESCRIPTION);
+          }
         }
       }
     }
@@ -228,7 +219,7 @@ public class JcrRepositoryFileUtils {
     RepositoryFile file = new RepositoryFile.Builder(id, name).createdDate(created).creatorId(creatorId)
         .lastModificationDate(lastModified).folder(folder).versioned(versioned).path(path).versionId(versionId)
         .fileSize(fileSize).locked(locked).lockDate(lockDate).hidden(hidden).lockMessage(lockMessage)
-        .lockOwner(lockOwner).title(title).description(description).titleMap(titleMap).descriptionMap(descriptionMap)
+        .lockOwner(lockOwner).title(title).description(description)
         .locale(pentahoLocale.toString()).localePropertiesMap(localePropertiesMap).build();
 
     return file;
@@ -448,16 +439,6 @@ public class JcrRepositoryFileUtils {
     fileNode.setProperty(pentahoJcrConstants.getPHO_LASTMODIFIED(), Calendar.getInstance());
     fileNode.setProperty(pentahoJcrConstants.getPHO_HIDDEN(), file.isHidden());
     fileNode.setProperty(pentahoJcrConstants.getPHO_FILESIZE(), content.getDataSize());
-    if (file.getTitleMap() != null && !file.getTitleMap().isEmpty()) {
-      Node titleNode = fileNode.addNode(pentahoJcrConstants.getPHO_TITLE(),
-          pentahoJcrConstants.getPHO_NT_LOCALIZEDSTRING());
-      setLocalizedStringMap(session, pentahoJcrConstants, titleNode, file.getTitleMap());
-    }
-    if (file.getDescriptionMap() != null && !file.getDescriptionMap().isEmpty()) {
-      Node descriptionNode = fileNode.addNode(pentahoJcrConstants.getPHO_DESCRIPTION(),
-          pentahoJcrConstants.getPHO_NT_LOCALIZEDSTRING());
-      setLocalizedStringMap(session, pentahoJcrConstants, descriptionNode, file.getDescriptionMap());
-    }
     if (file.getLocalePropertiesMap() != null && !file.getLocalePropertiesMap().isEmpty()) {
       Node localeNodes = fileNode.addNode(pentahoJcrConstants.getPHO_LOCALES(), pentahoJcrConstants.getPHO_NT_LOCALE());
       setLocalePropertiesMap(session, pentahoJcrConstants, localeNodes, file.getLocalePropertiesMap());
@@ -503,26 +484,6 @@ public class JcrRepositoryFileUtils {
     fileNode.setProperty(pentahoJcrConstants.getPHO_LASTMODIFIED(), Calendar.getInstance());
     fileNode.setProperty(pentahoJcrConstants.getPHO_HIDDEN(), file.isHidden());
     fileNode.setProperty(pentahoJcrConstants.getPHO_FILESIZE(), content.getDataSize());
-    if (file.getTitleMap() != null && !file.getTitleMap().isEmpty()) {
-      Node titleNode = null;
-      if (!fileNode.hasNode(pentahoJcrConstants.getPHO_TITLE())) {
-        titleNode = fileNode.addNode(pentahoJcrConstants.getPHO_TITLE(),
-            pentahoJcrConstants.getPHO_NT_LOCALIZEDSTRING());
-      } else {
-        titleNode = fileNode.getNode(pentahoJcrConstants.getPHO_TITLE());
-      }
-      setLocalizedStringMap(session, pentahoJcrConstants, titleNode, file.getTitleMap());
-    }
-    if (file.getDescriptionMap() != null && !file.getDescriptionMap().isEmpty()) {
-      Node descriptionNode = null;
-      if (!fileNode.hasNode(pentahoJcrConstants.getPHO_DESCRIPTION())) {
-        descriptionNode = fileNode.addNode(pentahoJcrConstants.getPHO_DESCRIPTION(),
-            pentahoJcrConstants.getPHO_NT_LOCALIZEDSTRING());
-      } else {
-        descriptionNode = fileNode.getNode(pentahoJcrConstants.getPHO_DESCRIPTION());
-      }
-      setLocalizedStringMap(session, pentahoJcrConstants, descriptionNode, file.getDescriptionMap());
-    }
     if (file.getLocalePropertiesMap() != null && !file.getLocalePropertiesMap().isEmpty()) {
       Node localePropertiesMapNode = null;
       if (!fileNode.hasNode(pentahoJcrConstants.getPHO_LOCALES())) {

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/PentahoJcrConstants.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/PentahoJcrConstants.java
@@ -63,8 +63,6 @@ public class PentahoJcrConstants extends JcrConstants {
   public static String PHO_CONTENTCREATOR = "contentCreator";  //$NON-NLS-1$
 
   public static String PHO_SCHEDULENAME = "scheduleName";  //$NON-NLS-1$
-
-  public static final String DEFAULT_LOCALE = "default"; //$NON-NLS-1$
   
   private static final String PHO_LOCKEDNODEREF = "lockedNodeRef"; //$NON-NLS-1$
 

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAdapter.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAdapter.java
@@ -66,20 +66,6 @@ public class RepositoryFileAdapter extends XmlAdapter<RepositoryFileDto, Reposit
     if (v.getVersionId() != null) {
       f.versionId = v.getVersionId().toString();
     }
-    if (v.getTitleMap() != null) {
-      f.titleMapEntries = new ArrayList<StringKeyStringValueDto>();
-      for (Map.Entry<String, String> entry : v.getTitleMap().entrySet()) {
-        StringKeyStringValueDto entryDto = new StringKeyStringValueDto(entry.getKey(), entry.getValue());
-        f.titleMapEntries.add(entryDto);
-      }
-    }
-    if (v.getDescriptionMap() != null) {
-      f.descriptionMapEntries = new ArrayList<StringKeyStringValueDto>();
-      for (Map.Entry<String, String> entry : v.getDescriptionMap().entrySet()) {
-        StringKeyStringValueDto entryDto = new StringKeyStringValueDto(entry.getKey(), entry.getValue());
-        f.descriptionMapEntries.add(entryDto);
-      }
-    }
     if (v.getLocalePropertiesMap() != null) {
       f.localePropertiesMapEntries = new ArrayList<LocaleMapDto>();
       for (Map.Entry<String, Properties> entry : v.getLocalePropertiesMap().entrySet()) {
@@ -141,17 +127,6 @@ public class RepositoryFileAdapter extends XmlAdapter<RepositoryFileDto, Reposit
       owner = new RepositoryFileSid(v.owner, RepositoryFileSid.Type.values()[v.ownerType]);
     } else {
       owner = null;
-    }
-    if (v.titleMapEntries != null) {
-      for (StringKeyStringValueDto entryDto : v.titleMapEntries) {
-        builder.title(entryDto.getKey(), entryDto.getValue());
-      }
-    }
-
-    if (v.descriptionMapEntries != null) {
-      for (StringKeyStringValueDto entryDto : v.descriptionMapEntries) {
-        builder.description(entryDto.getKey(), entryDto.getValue());
-      }
     }
     if (v.localePropertiesMapEntries != null) {
       for (LocaleMapDto localeMapDto : v.localePropertiesMapEntries) {

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileDto.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileDto.java
@@ -80,10 +80,6 @@ public class RepositoryFileDto implements Serializable {
 
   Date deletedDate;
 
-  List<StringKeyStringValueDto> titleMapEntries;
-
-  List<StringKeyStringValueDto> descriptionMapEntries;
-
   List<LocaleMapDto> localePropertiesMapEntries;
 
   public RepositoryFileDto() {
@@ -279,22 +275,6 @@ public class RepositoryFileDto implements Serializable {
     this.deletedDate = deletedDate;
   }
 
-  public List<StringKeyStringValueDto> getTitleMapEntries() {
-    return titleMapEntries;
-  }
-
-  public void setTitleMapEntries(List<StringKeyStringValueDto> titleMapEntries) {
-    this.titleMapEntries = titleMapEntries;
-  }
-
-  public List<StringKeyStringValueDto> getDescriptionMapEntries() {
-    return descriptionMapEntries;
-  }
-
-  public void setDescriptionMapEntries(List<StringKeyStringValueDto> descriptionMapEntries) {
-    this.descriptionMapEntries = descriptionMapEntries;
-  }
-
   public List<LocaleMapDto> getLocalePropertiesMapEntries() {
     return localePropertiesMapEntries;
   }
@@ -308,11 +288,11 @@ public class RepositoryFileDto implements Serializable {
   public String toString() {
     return "RepositoryFileDto [id=" + id + ", name=" + name + ", path=" + path + ", folder=" + folder + ", size=" + fileSize
         + ", createdDate=" + createdDate + ", creatorId=" + creatorId + ", deletedDate=" + deletedDate + ", description=" + description
-        + ", descriptionMapEntries=" + descriptionMapEntries + ", hidden=" + hidden + ", lastModifiedDate="
+        + ", hidden=" + hidden + ", lastModifiedDate="
         + lastModifiedDate + ", locale=" + locale + ", lockDate=" + lockDate + ", lockMessage=" + lockMessage
         + ", lockOwner=" + lockOwner + ", locked=" + locked 
         + ", originalParentFolderPath=" + originalParentFolderPath + ", owner=" + owner + ", ownerType=" + ownerType
-        + ", title=" + title + ", titleMapEntries=" + titleMapEntries + ", localePropertiesMapEntries=" + localePropertiesMapEntries
+        + ", title=" + title + ", localePropertiesMapEntries=" + localePropertiesMapEntries
         + ", versionId=" + versionId + ", versioned=" + versioned + "]";
   }
 

--- a/repository/test-src/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryTest.java
@@ -286,7 +286,7 @@ public class DefaultUnifiedRepositoryTest implements ApplicationContextAware {
     ITenant tenantAcme = tenantManager.createTenant(systemTenant, TENANT_ID_ACME, tenantAdminRoleName, tenantAuthenticatedRoleName, "Anonymous");
     userRoleDao.createUser(tenantAcme, USERNAME_SUZY, "password", "", new String[]{tenantAdminRoleName});
     logout();
-    
+
     login(USERNAME_SUZY, tenantAcme, new String[]{tenantAdminRoleName, tenantAuthenticatedRoleName});
     final String fileName = "helloworld.sample";
     RepositoryFile newFile = createSampleFile(ClientRepositoryPaths.getUserHomeFolderPath(USERNAME_SUZY), fileName,
@@ -296,14 +296,16 @@ public class DefaultUnifiedRepositoryTest implements ApplicationContextAware {
     final String EN_US_VALUE = "Hello World Sample";
     builder.title(Locale.getDefault().toString(), EN_US_VALUE);
     final String ROOT_LOCALE_VALUE = "Hello World";
-    builder.title(RepositoryFile.ROOT_LOCALE, ROOT_LOCALE_VALUE);
+    builder.title(RepositoryFile.DEFAULT_LOCALE, ROOT_LOCALE_VALUE);
     final SampleRepositoryFileData modContent = new SampleRepositoryFileData("blah", false, 123);
     repo.updateFile(builder.build(), modContent, null);
     RepositoryFile updatedFileWithMaps = repo.getFile(ClientRepositoryPaths.getUserHomeFolderPath(USERNAME_SUZY)
         + RepositoryFile.SEPARATOR + "helloworld.sample", true);
 
-    assertEquals(EN_US_VALUE, updatedFileWithMaps.getTitleMap().get(Locale.getDefault().toString()));
-    assertEquals(ROOT_LOCALE_VALUE, updatedFileWithMaps.getTitleMap().get(RepositoryFile.ROOT_LOCALE));
+    assertEquals(EN_US_VALUE, updatedFileWithMaps.getLocalePropertiesMap()
+       .get(Locale.getDefault().toString()).getProperty(RepositoryFile.FILE_TITLE));
+    assertEquals(ROOT_LOCALE_VALUE, updatedFileWithMaps.getLocalePropertiesMap()
+       .get(RepositoryFile.DEFAULT_LOCALE).getProperty(RepositoryFile.FILE_TITLE));
     logout();
   }
 
@@ -325,7 +327,7 @@ public class DefaultUnifiedRepositoryTest implements ApplicationContextAware {
     // Test filename title matches created file name
     assertEquals(fileName, file.getTitle());
 
-    final IPentahoLocale SPANISH = new PentahoLocale(new Locale("sp"));
+    final IPentahoLocale SPANISH = new PentahoLocale(new Locale("es"));
     final IPentahoLocale US = new PentahoLocale(Locale.US);
     final String EN_US_TITLE = "Locale Sample";
     final String EN_US_DESCRIPTION = "This is a test for retrieving localized words";
@@ -349,13 +351,6 @@ public class DefaultUnifiedRepositoryTest implements ApplicationContextAware {
     // Retrieve file - gets full map
     RepositoryFile updatedFile = repo.getFile(file.getPath(), true);
 
-    // Assert messages are the same
-    assertEquals(EN_US_TITLE, updatedFile.getTitleMap().get(US.toString()));
-    assertEquals(EN_US_DESCRIPTION, updatedFile.getDescriptionMap().get(US.toString()));
-
-    assertEquals(SP_TITLE, updatedFile.getTitleMap().get(SPANISH.toString()));
-    assertEquals(SP_DESCRIPTION, updatedFile.getDescriptionMap().get(SPANISH.toString()));
-
     /*
      * Retrieve single result with locale
      */
@@ -376,7 +371,7 @@ public class DefaultUnifiedRepositoryTest implements ApplicationContextAware {
     updatedFile = repo.getFile(file.getPath(), null);
 
     assertEquals(fileName, updatedFile.getTitle());
-    assertEquals("", updatedFile.getDescription());
+    assertEquals(null, updatedFile.getDescription());
 
     logout();
   }
@@ -2098,7 +2093,7 @@ public class DefaultUnifiedRepositoryTest implements ApplicationContextAware {
 
     RepositoryFile.Builder builder = new RepositoryFile.Builder(newFile);
     final String desc = "Hello World description";
-    builder.description(RepositoryFile.ROOT_LOCALE, desc);
+    builder.description(RepositoryFile.DEFAULT_LOCALE, desc);
     repo.updateFile(builder.build(), modData, null);
 
     List<VersionSummary> versionSummaries = repo.getVersionSummaries(newFile.getId());

--- a/repository/test-src/org/pentaho/test/platform/repository2/unified/MockUnifiedRepository.java
+++ b/repository/test-src/org/pentaho/test/platform/repository2/unified/MockUnifiedRepository.java
@@ -335,23 +335,33 @@ public class MockUnifiedRepository implements IUnifiedRepository {
 
   private static String findTitle(final RepositoryFile file) {
     String title = null;
-    if (file.getTitleMap() != null) {
-      title = file.getTitleMap().get(Locale.getDefault().toString());
-      if (title == null) {
-        title = file.getTitleMap().get(RepositoryFile.ROOT_LOCALE);
+    Properties properties = file.getLocalePropertiesMap().get(Locale.getDefault().toString());
+    if(properties == null){
+      properties = file.getLocalePropertiesMap().get(RepositoryFile.DEFAULT_LOCALE);
+      if(properties != null){
+        title = properties.getProperty(RepositoryFile.FILE_TITLE);
+        if(StringUtils.isBlank(title)){
+          title = properties.getProperty(RepositoryFile.TITLE);
+        }
       }
     }
+
     return title;
   }
 
   private static String findDesc(final RepositoryFile file) {
     String desc = null;
-    if (file.getDescriptionMap() != null) {
-      desc = file.getDescriptionMap().get(Locale.getDefault().toString());
-      if (desc == null) {
-        desc = file.getDescriptionMap().get(RepositoryFile.ROOT_LOCALE);
+    Properties properties = file.getLocalePropertiesMap().get(Locale.getDefault().toString());
+    if(properties == null){
+      properties = file.getLocalePropertiesMap().get(RepositoryFile.DEFAULT_LOCALE);
+      if(properties != null){
+        desc = properties.getProperty(RepositoryFile.FILE_DESCRIPTION);
+        if(StringUtils.isBlank(desc)){
+          desc = properties.getProperty(RepositoryFile.DESCRIPTION);
+        }
       }
     }
+
     return desc;
   }
 

--- a/repository/test-src/org/pentaho/test/platform/repository2/unified/exportManifest/ExportManifestTest.java
+++ b/repository/test-src/org/pentaho/test/platform/repository2/unified/exportManifest/ExportManifestTest.java
@@ -151,8 +151,8 @@ public class ExportManifestTest extends TestCase {
 		String baseName = path.substring(path.lastIndexOf("/") + 1);
 		RepositoryFile mockRepositoryFile = new RepositoryFile("12345", baseName,
 				isFolder, false, false, "versionId", path, createdDate, lastModeDate,
-				false, "lockOwner", "lockMessage", lockDate, "en_US", "title", null,
-				"description", null, "/original/parent/folder/path", deletedDate, 4096,
+				false, "lockOwner", "lockMessage", lockDate, "en_US", "title",
+				"description", "/original/parent/folder/path", deletedDate, 4096,
 				"creatorId", null);
 		return mockRepositoryFile;
 	}


### PR DESCRIPTION
The more generic RepositoryFile.localePropertiesMap should be used.
