### PR TITLE
Check if the local node already exists before saving locale properties.

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -312,7 +312,13 @@ public class JcrRepositoryFileUtils {
         Properties properties = localePropertiesMap.get(locale);
         if(properties != null){
           // create node and set properties for each locale
-          Node localeNode = localeRootNode.addNode(locale, pentahoJcrConstants.getNT_UNSTRUCTURED());
+          Node localeNode;
+          if (!localeRootNode.hasNode(locale)) {
+            localeNode = localeRootNode.addNode(locale, pentahoJcrConstants.getNT_UNSTRUCTURED());
+          }
+          else {
+            localeNode = localeRootNode.getNode(locale);
+          }
           for(String propertyName : properties.stringPropertyNames()){
             localeNode.setProperty(propertyName, properties.getProperty(propertyName));
           }


### PR DESCRIPTION
...locale properties were saved without checking if the locale node already exists.
