### PR TITLE
BISERVER-8436 - LDAP group and user mapping - Prepopulate admin group and user with defaults

### DIFF
--- a/assembly/package-res-common/biserver/pentaho-solutions/system/applicationContext-security-ldap.properties
+++ b/assembly/package-res-common/biserver/pentaho-solutions/system/applicationContext-security-ldap.properties
@@ -19,3 +19,6 @@ allAuthoritiesSearch.searchFilter=(objectClass\=organizationalRole)
 allUsernamesSearch.usernameAttribute=uid
 allUsernamesSearch.searchBase=ou\=users
 allUsernamesSearch.searchFilter=objectClass\=Person
+
+adminRole=cn\=Administrator,ou\=roles
+adminUser=uid\=Admin,ou\=users

--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-security-ldap.properties
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-security-ldap.properties
@@ -19,3 +19,6 @@ allAuthoritiesSearch.searchFilter=(objectClass\=organizationalRole)
 allUsernamesSearch.usernameAttribute=uid
 allUsernamesSearch.searchBase=ou\=users
 allUsernamesSearch.searchFilter=objectClass\=Person
+
+adminRole=cn\=Administrator,ou\=roles
+adminUser=uid\=Admin,ou\=users


### PR DESCRIPTION
BISERVER-8436 - LDAP group and user mapping - Prepopulate admin group and user with defaults
