### PR TITLE
Avoid attempts to read a single value from a multi-value JCR property.

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -295,7 +295,9 @@ public class JcrRepositoryFileUtils {
       PropertyIterator propertyIterator = node.getProperties();
       while(propertyIterator.hasNext()){
         Property property = propertyIterator.nextProperty();
-        properties.put(property.getName(), property.getValue().getString());
+        if (!property.isMultiple()) {
+           properties.put(property.getName(), property.getValue().getString());
+        }
       }
       localePropertiesMap.put(locale, properties);
     }


### PR DESCRIPTION
...up having a multi-value property.  This was causing errors.
