### PR TITLE
[FIX] Avoid frequent and unnecessary JavaScript NRE errors.

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/usersettings/JsSetting.java
+++ b/user-console/source/org/pentaho/mantle/client/usersettings/JsSetting.java
@@ -30,8 +30,9 @@ public class JsSetting extends JavaScriptObject {
 
   public final static native JsArray<JsSetting> parseSettingsJson(String json)
   /*-{
+    if(json == null || json === '') { return null; }
     var obj = eval('(' + json + ')');
-    return obj.setting;
+    return obj != null ? obj.setting : obj;
   }-*/;
   
 }


### PR DESCRIPTION
[FIX] Avoid frequent and unnecessary JavaScript NRE errors, reported in the browser console, when evaluating "null" JSON results of "user-settings/list" service.
