### PR TITLE
BISERVER-8598 Clicking Back Button causes error in Schedule Dialog

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/bi-developers/reporting/parameter_template.html
+++ b/assembly/package-res/biserver/pentaho-solutions/bi-developers/reporting/parameter_template.html
@@ -4,9 +4,12 @@
       <link rel="stylesheet" type="text/css" href="/pentaho-style/pentaho.css"></link>
       <title>Parameter Page Customization Example</title>
             			
-						<script src="../../../js/parameters.js" type="text/javascript"></script>
+				<script src="../../../js/parameters.js" type="text/javascript"></script>
 						
       			<script><![CDATA[
+      			  var pentaho_notOptionalMessage = 'Please select something for {0}';
+				  var pentaho_backgroundWarning = 'Info:  Reports that prompt for parameters are not supported with this feature.  Run in Background may report errors. Click OK to continue.';
+				  var USEPOSTFORFORMS = false;
                   var url=window.location.pathname;
       			  var target=unescape('');
       			  function doForm() {

--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/js/parameters.js
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/js/parameters.js
@@ -30,7 +30,7 @@ window.initSchedulingParams = function(filepath, callback) {
 /*
  * this method is called by gwt to retrieve the schedule/background param vals
  */
-window.getParams = function() {
+window.getParams = function(suppressAlerts) {
 	try {
 		var id = null;
 		
@@ -56,9 +56,13 @@ window.getParams = function() {
 	
 			if( elements[i].name != lastName ) {
 				if( lastName != null && lastName.length > 0) {
-					var ckRtn = checkParams( form, element.type, lastName, gotOne );
+					var ckRtn = checkParams( form, element.type, lastName, gotOne, suppressAlerts );
 					if( ckRtn == 0 ) {
-						throw 'Parameter Check Failed.';
+						if (suppressAlerts) {
+							continue;
+						} else {
+							throw 'Parameter Check Failed.';
+						}
 					}
 				}
 				gotOne = 0;
@@ -118,7 +122,8 @@ window.getParams = function() {
 				}
 			}
 		}
-		var ckRtn2 = checkParams( form, element.type, lastName, gotOne );
+
+		var ckRtn2 = checkParams( form, element.type, lastName, gotOne, suppressAlerts );
 		if( ckRtn2 == 0 ) {
 			return 'Parameter Check Failed.';
 		} else if (ckRtn2 == 2) {
@@ -362,7 +367,7 @@ function convertHtmlEntitiesToCharacters(theStr) {
     return newDiv.innerHTML;
 }
 
-function checkParams(form, type, lastName, gotOne ) {
+function checkParams(form, type, lastName, gotOne, suppressAlerts ) {
     // pentaho_optionalParams is defined in the XSL file
 	if( gotOne == 0 && type != 'hidden' ) {
 		try {
@@ -377,9 +382,12 @@ function checkParams(form, type, lastName, gotOne ) {
 				return 2;
 			}
 		} catch (e) {
-		}		
-		var msg = convertHtmlEntitiesToCharacters(pentaho_notOptionalMessage.replace("{0}", pentaho_paramName[form.name + '.' + lastName] ));
-		alert( msg );
+		}
+		if (!suppressAlerts) {
+		    var msg = pentaho_notOptionalMessage;
+			var msg = convertHtmlEntitiesToCharacters(msg.replace("{0}", lastName));
+			alert( msg );
+		}
 		return 0;
 	}
 	return 1;
@@ -399,7 +407,7 @@ function getParameters( id ) {
 
 		if( elements[i].name != lastName ) {
 			if( lastName != null && lastName.length > 0) {
-				var ckRtn = checkParams( form, element.type, lastName, gotOne );
+				var ckRtn = checkParams( form, element.type, lastName, gotOne, false );
 				if( ckRtn == 0 ) {
 					return null;
 				}
@@ -461,7 +469,7 @@ function getParameters( id ) {
 			}
 		}
 	}
-	var ckRtn2 = checkParams( form, element.type, lastName, gotOne );
+	var ckRtn2 = checkParams( form, element.type, lastName, gotOne, false );
 	if( ckRtn2 == 0 ) {
 		return null;
 	} else if (ckRtn2 == 2) {

--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/scheduling/ScheduleParamsDialog.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/scheduling/ScheduleParamsDialog.java
@@ -158,8 +158,8 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
     scheduleParamsWizardPanel.setScheduleDescription(description);
   }
 
-  JSONArray getScheduleParams() {
-    JsArray<JsSchedulingParameter> schedulingParams = scheduleParamsWizardPanel.getParams();
+  JSONArray getScheduleParams(boolean suppressAlerts) {
+    JsArray<JsSchedulingParameter> schedulingParams = scheduleParamsWizardPanel.getParams(suppressAlerts);
     JSONArray params = new JSONArray();
     for (int i = 0; i < schedulingParams.length(); i++) {
       params.set(i, new JSONObject(schedulingParams.get(i)));
@@ -174,7 +174,7 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
    */
   @Override
   protected boolean onFinish() {
-    scheduleParams = getScheduleParams();
+    scheduleParams = getScheduleParams(false);
     if (editJob != null) {
       String lineageId = editJob.getJobParam("lineage-id");
       JsArrayString lineageIdValue = (JsArrayString) JavaScriptObject.createArray().cast();
@@ -300,7 +300,12 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
    */
   @Override
   protected void backClicked() {
-    scheduleParams = getScheduleParams();
+    try {
+      scheduleParams = getScheduleParams(true);
+    } catch (Exception e) {
+      //If error generate on trying to assign params while backing out,
+      //obviously you want to ignore it.
+    }
     parentDialog.center();
     hide();
   }


### PR DESCRIPTION
Fix the following:
1) No error trapping in ScheduleParameterDialog on back-click
2) No message settings in parameter_template.html
3) Substitute field name instead of field value when the error is the field is not entered. (parameters.js)
4) Add supressAlerts parameter to ScheduleParamsWizard.getParameters function in  GwtWidgets) and  propogate value down to parameters.js to supress alerts.  This allow clicking on the 'back'   button while holding any values, but not generating errors on values that do not validate. 
