### PR TITLE
BISERVER-4248 DBCP BasicDataSource configuration doesn't have pool options set - MySQL timeouts will result

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-jdbc.properties
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-jdbc.properties
@@ -1,0 +1,38 @@
+# For full set of properties see http://commons.apache.org/proper/commons-dbcp/configuration.html
+
+# Please notice: this is only for Hypersonic. Update this for any other database you are using
+
+# The fully qualified Java class name of the JDBC driver to be used
+datasource.driver.classname=org.hsqldb.jdbcDriver
+
+# The connection URL to be passed to our JDBC driver to establish a connection
+datasource.url=jdbc:hsqldb:hsql://localhost:9002/userdb
+
+# The connection username to be passed to our JDBC driver to establish a connection
+datasource.username=sa
+
+# The connection password to be passed to our JDBC driver to establish a connection
+datasource.password=
+
+# The SQL query that will be used to validate connections from this pool before returning them to the caller. 
+# This query must be an SELECT statement that returns at least one row.
+# HSQLDB: SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS
+# MySQL, H2, MS-SQL, POSTGRESQL, SQLite: SELECT 1
+# ORACLE: SELECT 1 FROM DUAL
+datasource.validation.query=SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS
+
+# the maximum number of milliseconds that the pool will wait (when there are no available connections) 
+# for a connection to be returned before throwing an exception, or <= 0 to wait indefinitely. Default value is -1
+datasource.pool.max.wait=-1
+
+# The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit. Default value is 8
+datasource.pool.max.active=8
+ 
+# The maximum number of connections that can remain idle in the pool, without extra ones being destroyed, or negative for no limit. Default value is 8
+datasource.max.idle=4
+
+# The minimum number of active connections that can remain idle in the pool, without extra ones being created when the evictor runs, or 0 to create none. Default value is 0
+datasource.min.idle=0
+
+
+

--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-jdbc.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-jdbc.xml
@@ -51,14 +51,21 @@
 	    </pen:publish>
 	</bean>
   
-	<!--  This is only for Hypersonic. Please update this section for any other database you are using -->
-	<bean id="dataSource"
-		class="org.apache.commons.dbcp.BasicDataSource">
-		<property name="driverClassName" value="org.hsqldb.jdbcDriver" />
-		<property name="url"
-			value="jdbc:hsqldb:hsql://localhost:9002/userdb" />
-		<property name="username" value="sa" />
-		<property name="password" value="" />
+	<bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource">
+		<property name="driverClassName" value="${datasource.driver.classname}" />
+		<property name="url" value="${datasource.url}" />
+		<property name="username" value="${datasource.username}" />
+		<property name="password" value="${datasource.password}" />
+		<!-- the following are optional -->
+		<property name="validationQuery" value="${datasource.validation.query}" />
+		<property name="maxWait" value="${datasource.pool.max.wait}" />
+		<property name="maxActive" value="${datasource.pool.max.active}" />
+		<property name="maxIdle" value="${datasource.max.idle}" />
+		<property name="minIdle" value="${datasource.min.idle}" />
+	</bean>
+	
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="location" value="applicationContext-spring-security-jdbc.properties" />
 	</bean>
 
   <bean id="passwordEncoder"


### PR DESCRIPTION
In trunk, changes to the applicationContext-_hibernate_ and _jdbc_ will result in mysql timeouts after the connection gets stale.

1- Settings need to be added that include the connection check query - for mysql, this should be set to "/\* ping */select 1". For others, see the connection check queries in the hibernate files.

2- The settings also should include minimum/maximum idle, maximum connections, etc. For this login stuff, I'm going to suggest a minimum idle of 0, and a max idle of 4. Other pool settings should be in there too.
