### PR TITLE
fixing scheduler build.

### DIFF
--- a/scheduler/test-src/org/pentaho/platform/scheduler2/quartz/BlockingQuartzJobTest.java
+++ b/scheduler/test-src/org/pentaho/platform/scheduler2/quartz/BlockingQuartzJobTest.java
@@ -58,7 +58,7 @@ public class BlockingQuartzJobTest {
         one(blockoutManager).shouldFireNow();
         will(returnValue(false));
         one(logger).warn("Job 'myjob' attempted to run during a blockout period.  This job was not executed");
-        one(context).getJobDetail();
+        allowing(context).getJobDetail();
         will(returnValue(new JobDetail("myjob", BlockingQuartzJob.class)));
       }
     });


### PR DESCRIPTION
correcting mock expectations in BlockingQuartzJobTest.testJobIsBlockedDuringABlockout so that it will pass.
