### PR TITLE
Fix for BISERVER-8889

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/themes/onyx/mantleOnyx.css
+++ b/user-console/source/org/pentaho/mantle/public/themes/onyx/mantleOnyx.css
@@ -6,6 +6,10 @@
 	padding-left: 40px;
 }
 
+#adminContentPanel.vbox > tbody > tr > td {  
+  height: 100%;
+}
+
 .admin-perspective {
 	padding-top: 40px;
 	padding-left: 40px;

--- a/user-console/source/org/pentaho/mantle/public/themes/slate/mantleSlate.css
+++ b/user-console/source/org/pentaho/mantle/public/themes/slate/mantleSlate.css
@@ -737,3 +737,11 @@ a:active, a:hover {
    text-align: left;
    text-shadow: 0 1px 1px #FFF;
 }
+
+#adminContentPanel {
+	padding-left: 40px;
+}
+
+#adminContentPanel.vbox > tbody > tr > td {  
+  height: 100%;
+}


### PR DESCRIPTION
FF only: The Licenses module does not display correct in FF but looks ok
in IE. Go to the Administration tab an click the Licenses menu.
