### PR TITLE
BISERVER-8922 - Chrome: PUC tool bar now taller - looks like extra padding below icons.

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/themes/onyx/mantleOnyx.css
+++ b/user-console/source/org/pentaho/mantle/public/themes/onyx/mantleOnyx.css
@@ -245,7 +245,7 @@
 }
 
 #mainToolbar {
-  padding: 0px 0px 4px 0px;
+  padding: 0px 0px 0px 0px;
 }
 
 .puc-horizontal-split-panel {


### PR DESCRIPTION
BISERVER-8922 - Chrome: PUC tool bar now taller - looks like extra padding below icons.
