### PR TITLE
[BISERVER-8883] Fix the IE8 Bug introduced by the BISERVER-8759 fix

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
@@ -693,9 +693,21 @@ public class SolutionBrowserPanel extends HorizontalPanel {
 
 
   public static native String setElementHeightOffset(Element ele, int offset)/*-{
-      var height= ($wnd.top.innerHeight)+offset;
-      var offSetHeight=height+ 'px';
-      ele.style.height = offSetHeight;
+
+    var h = 0;
+    if ($wnd.innerHeight){
+      h = $wnd.innerHeight;
+    }
+    else if ($wnd.document.documentElement && $wnd.document.documentElement.clientHeight != 0){
+      h = $wnd.document.documentElement.clientHeight;
+    }
+    else if ($wnd.document.body){
+      h = $wnd.document.body.clientHeight;
+    }
+
+    var height= h+offset;
+    var offSetHeight=height+ 'px';
+    ele.style.height = offSetHeight;
   }-*/;
 
   private void adjustWidth() {


### PR DESCRIPTION
IE8 does not handle window.top.innerHeight properly. As a result, analyzer/dashboards/pir reports do not open in PUC. This fix uses window.documentElement.clientHeight for IE.
