### PR TITLE
BISERVER-8921 chrome: no padding above tabs in open perspective so they overlap the main toolbar.

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
@@ -705,7 +705,7 @@ public class SolutionBrowserPanel extends HorizontalPanel {
       h = $wnd.document.body.clientHeight;
     }
 
-    var height= h+offset;
+    var height= h+offset-5;
     var offSetHeight=height+ 'px';
     ele.style.height = offSetHeight;
   }-*/;

--- a/user-console/source/org/pentaho/mantle/public/MantleStyle.css
+++ b/user-console/source/org/pentaho/mantle/public/MantleStyle.css
@@ -204,7 +204,6 @@ body{
 }
 
 .IE .puc-horizontal-split-panel {
-    top: 42px;
     overflow: hidden;
 }
 
@@ -670,4 +669,14 @@ code {
 /* BISERVER-8429 */
 .leaf-widget table td {
   padding: 0px;
+}
+
+/* add some padding between the perspective and the top toolbar/filemenu */
+.applicationShell .panelWithTitledToolbar {
+  padding-top: 2px;
+}
+
+/* don't let IE take up all the space of its parent, it will be off screen */
+.IE .mantle-default-tab-background {
+  height: 95% !important;
 }


### PR DESCRIPTION
BISERVER-8921
chrome: no padding above tabs in open perspective so they overlap the main toolbar.
