### PR TITLE
BISERVER-8696 

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/tree/SolutionTreeWrapper.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/tree/SolutionTreeWrapper.java
@@ -16,13 +16,7 @@
  */
 package org.pentaho.mantle.client.solutionbrowser.tree;
 
-import org.pentaho.mantle.client.solutionbrowser.MantlePopupPanel;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.MenuBar;
-import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.gwt.user.client.ui.SimplePanel;
 
 public class SolutionTreeWrapper extends SimplePanel {
@@ -37,23 +31,7 @@ public class SolutionTreeWrapper extends SimplePanel {
   }
 
   public void onBrowserEvent(Event event) {
-    if (((DOM.eventGetButton(event) & NativeEvent.BUTTON_RIGHT) == NativeEvent.BUTTON_RIGHT && (DOM.eventGetType(event) & Event.ONMOUSEUP) == Event.ONMOUSEUP)) {
-      // bring up a popup with 'create new folder' option
-      final int left = Window.getScrollLeft() + DOM.eventGetClientX(event);
-      final int top = Window.getScrollTop() + DOM.eventGetClientY(event);
-      handleRightClick(left, top);
-    } else {
-      super.onBrowserEvent(event);
-    }
-  }
-
-  private void handleRightClick(int left, int top) {
-    final PopupPanel popupMenu = MantlePopupPanel.getInstance(true);
-    popupMenu.setPopupPosition(left, top);
-    MenuBar menuBar = new MenuBar(true);
-    menuBar.setAutoOpen(true);
-    popupMenu.setWidget(menuBar);
-    popupMenu.show();
+    return; 
   }
 
 }


### PR DESCRIPTION
Removed right click handlers creating empty popups when a right click event gets triggered on a folder icon or outside the tree
