### PR TITLE
[BISERVER-9097] Use encodePathSegment instead of encodeQueryString when ...

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/commands/NewFolderCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/NewFolderCommand.java
@@ -104,7 +104,7 @@ public class NewFolderCommand extends AbstractCommand {
 
       public void okPressed() {
         String createDirUrl = contextURL
-            + "api/repo/dirs/" + SolutionBrowserPanel.pathToId(parentFolder.getPath() + "/" + URL.encodeQueryString(folderNameTextBox.getText())); //$NON-NLS-1$
+            + "api/repo/dirs/" + SolutionBrowserPanel.pathToId(parentFolder.getPath() + "/" + URL.encodePathSegment(folderNameTextBox.getText())); //$NON-NLS-1$
         RequestBuilder createDirRequestBuilder = new RequestBuilder(RequestBuilder.PUT, createDirUrl);
 
         try {

--- a/user-console/source/org/pentaho/mantle/public/browser/index.jsp
+++ b/user-console/source/org/pentaho/mantle/public/browser/index.jsp
@@ -66,7 +66,16 @@
           }
         });
 
-        // refresh folder list on create new folder / delete folder/ paste / import
+      window.top.mantle_addHandler("SolutionFileActionEvent", function(event){
+        if((event.action.indexOf('ScheduleHelper') >= 0)    ||
+           (event.action.indexOf('ShareFileCommand') >= 0)){
+          if(event.message == 'Open' || event.message == 'Success'){
+            window.top.mantle_setPerspective('browser.perspective'); // change to browse perspective
+          }
+        }
+      });
+
+      // refresh folder list on create new folder / delete folder / import
         window.top.mantle_addHandler("SolutionFolderActionEvent", function(event){
           if((event.action.indexOf('NewFolderCommand') >= 0)    ||
              (event.action.indexOf('DeleteFolderCommand') >= 0) ||
@@ -76,15 +85,6 @@
             }
             else{
               window.top.mantle_showMessage('Error', event.message);
-            }
-          }
-        });
-
-        window.top.mantle_addHandler("SolutionFileActionEvent", function(event){
-          if((event.action.indexOf('ScheduleHelper') >= 0)    ||
-             (event.action.indexOf('ShareFileCommand') >= 0)){
-            if(event.message == 'Open' || event.message == 'Success'){
-              parent.mantle_setPerspective('browser.perspective');
             }
           }
         });


### PR DESCRIPTION
...handling filenames with spaces
