### PR TITLE
BISERVER-9113 - Remove inline styling from folder/file table in the open dialog

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/themes/crystal/mantleCrystal.css
+++ b/user-console/source/org/pentaho/mantle/public/themes/crystal/mantleCrystal.css
@@ -883,7 +883,7 @@ a:active, a:hover {
 }
 
 #pucHeader {
-/* moved to global clean */
+/* moved to global crystal */
   min-width: 820px;
 }
 
@@ -1004,7 +1004,7 @@ a:active, a:hover {
 
 /* == == == */
 #mainToolbar #openButton .toolbar-button IMG {
-  background: url('../../../content/common-ui/resources/themes/clean/images/open_32.png');
+  background: url('../../../content/common-ui/resources/themes/crystal/images/open_32.png');
   height: 32px;
   width: 32px;
 }


### PR DESCRIPTION
fixed a pathing issue to the themed Open icon used in the puc toolbar that resulted from renaming "clean" to "crystal"
