### PR TITLE
[BISERVER-9166] Running xaction in background results in exception stack

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/pentahoObjects.spring.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentahoObjects.spring.xml
@@ -22,10 +22,10 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 
   <bean id="ISolutionEngine" class="org.pentaho.platform.engine.services.solution.SolutionEngine" scope="prototype"/>
   <!-- Uncomment the following line to use a filesystem-based repository. Note: does not support ACLs.  -->
-  <!--  <bean id="ISolutionRepository" class="org.pentaho.platform.repository.solution.filebased.FileBasedSolutionRepository" scope="session" />-->
+  <!--  <bean id="ISolutionRepository" class="org.pentaho.platform.repository.solution.filebased.FileBasedSolutionRepository" scope="singleton" />-->
   <!-- Uncomment the following line to use a filesystem/db-based repository with meta information stored in a db  -->
   <bean id="ISolutionRepository" class="org.pentaho.platform.repository.solution.filebased.FileBasedSolutionRepository"
-        scope="session"/>
+        scope="singleton"/>
   <!-- runtime repositories are not used in the current implmentation of the BI platform -->
   <!-- <bean id="IRuntimeRepository" class="org.pentaho.platform.repository.runtime.RuntimeRepository" scope="session" /> -->
   <bean id="IAuditEntry" class="org.pentaho.platform.engine.services.audit.AuditFileEntry" scope="singleton"/>


### PR DESCRIPTION
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'ISolutionRepository': Scope 'session' is not active for the current thread; consider defining a scoped proxy for this bean if you intend to refer to it from a singleton; nested exception is java.lang.IllegalStateException: No thread-bound request found: Are you referring to request attributes outside of an actual web request, or processing a request outside of the originally receiving thread? If you are actually operating within a web request and still receive this message, your code is probably running outside of DispatcherServlet/DispatcherPortlet: In this case, use RequestContextListener or RequestContextFilter to expose the current request.
