### PR TITLE
PDI-9556: Added Big Data samples, MongoDB, and Cassandra plugins to CE

### DIFF
--- a/assembly/assembly.properties
+++ b/assembly/assembly.properties
@@ -17,6 +17,9 @@ dependency.pentaho-database-model=TRUNK-SNAPSHOT
 dependency.pentaho-pdi-plugin.revision=TRUNK-SNAPSHOT
 
 dependency.pentaho-big-data-plugin.revision=TRUNK-SNAPSHOT
+dependency.pentaho-big-data-plugin-samples.revision=TRUNK-SNAPSHOT
+dependency.pentaho-cassandra-plugin.revision=TRUNK-SNAPSHOT
+dependency.pentaho-mongodb-plugin.revision=TRUNK-SNAPSHOT
 
 # path to script relative to /opt/pentaho/${linuxPackage.name}
 linuxPackage.initd.startCommandDelegatee=start-pentaho.sh

--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -110,6 +110,15 @@
     <dependency org="pentaho" name="pentaho-big-data-plugin" rev="${dependency.pentaho-big-data-plugin.revision}" conf="kettle-plugin->default" changing="true" transitive="false">
       <artifact name="pentaho-big-data-plugin" type="zip" />
     </dependency>
+    <dependency org="pentaho" name="pentaho-big-data-plugin-samples" rev="${dependency.pentaho-big-data-plugin-samples.revision}" conf="kettle-plugin->default" changing="true" transitive="false">
+      <artifact name="pentaho-big-data-plugin-samples" type="zip"/>
+    </dependency>
+    <dependency org="pentaho" name="pentaho-mongodb-plugin" rev="${dependency.pentaho-mongodb-plugin.revision}" conf="kettle-plugin->default" changing="true" transitive="false">
+      <artifact name="pentaho-mongodb-plugin" type="zip"/>
+    </dependency>
+    <dependency org="pentaho" name="pentaho-cassandra-plugin" rev="${dependency.pentaho-cassandra-plugin.revision}" conf="kettle-plugin->default" changing="true" transitive="false">
+      <artifact name="pentaho-cassandra-plugin" type="zip"/>
+    </dependency>
 
 
     <!--


### PR DESCRIPTION
The Big Data samples and MongoDB plugins have been in the EE assembly, but as the Big Data plugin and samples, and the MongoDB and Cassandra plugins are open-source CE artifacts, they should be packaged with the BI Server CE assembly.
