### PR TITLE
BISERVER-8414 Provide the ability to specify the output location when creating a schedule or running a file in the background - FRONT END WORK

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/user-console/source/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -858,22 +858,12 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
    */
   @Override
   protected boolean onFinish() {
-    String name = scheduleName;
-    String alphaNumeric = "^[a-zA-Z0-9_\\.\\- ]+$"; //$NON-NLS-1$
-    // make sure it matches regex
-    if (name.matches(alphaNumeric)) {
-      //    DO NOT DELETE - verifyBlockoutConflict(schedule, trigger);
-      JsJobTrigger trigger = getJsJobTrigger();
-      JSONObject schedule = getSchedule();
+    //    DO NOT DELETE - verifyBlockoutConflict(schedule, trigger);
+    JsJobTrigger trigger = getJsJobTrigger();
+    JSONObject schedule = getSchedule();
 
-      handleWizardPanels(schedule, trigger);
-      return true;
-    }
-
-    MessageDialogBox dialogBox = new MessageDialogBox(
-        Messages.getString("error"), Messages.getString("enterAlphaNumeric", name), false, false, true); //$NON-NLS-1$ //$NON-NLS-2$
-    dialogBox.center();
-    return false;
+    handleWizardPanels(schedule, trigger);
+    return true;
   }
 
   private void showScheduleEmailDialog(final JSONObject schedule) {

--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/tree/SolutionTree.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/tree/SolutionTree.java
@@ -255,9 +255,9 @@ public class SolutionTree extends Tree implements IRepositoryFileTreeListener, U
 
   protected void onLoad() {
     super.onLoad();
+    fixLeafNodes();
     if (trashItem != null) {
       try {
-        fixLeafNodes();
         DOM.setStyleAttribute(trashItem.getElement(), "paddingLeft", "0px"); //$NON-NLS-1$//$NON-NLS-2$
       } catch (NullPointerException e) {
         // This is sometimes thrown because the dom does not yet contain the trash items or the leaf nodes.

--- a/user-console/source/org/pentaho/mantle/client/ui/PerspectiveManager.java
+++ b/user-console/source/org/pentaho/mantle/client/ui/PerspectiveManager.java
@@ -70,6 +70,9 @@ public class PerspectiveManager extends SimplePanel {
   public static final String ADMIN_PERSPECTIVE = "admin.perspective";
   public static final String SCHEDULES_PERSPECTIVE = "schedules.perspective";
   public static final String OPENED_PERSPECTIVE = "opened.perspective";
+  public static final String HOME_PERSPECTIVE = "home.perspective";
+  public static final String BROWSER_PERSPECTIVE = "browser.perspective";
+  
   public static final String PROPERTIES_EXTENSION = ".properties"; //$NON-NLS-1$
   public static final String SEPARATOR = "/"; //$NON-NLS-1$
 

--- a/user-console/source/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -32,8 +32,11 @@ import org.pentaho.gwt.widgets.client.toolbar.ToolbarButton;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
 import org.pentaho.mantle.client.commands.RefreshSchedulesCommand;
 import org.pentaho.mantle.client.dialogs.scheduling.NewScheduleDialog;
+import org.pentaho.mantle.client.events.EventBusUtil;
+import org.pentaho.mantle.client.events.GenericEvent;
 import org.pentaho.mantle.client.images.ImageUtil;
 import org.pentaho.mantle.client.messages.Messages;
+import org.pentaho.mantle.client.ui.PerspectiveManager;
 import org.pentaho.mantle.client.workspace.SchedulesPerspectivePanel.CellTableResources;
 
 import com.google.gwt.cell.client.SafeHtmlCell;
@@ -60,7 +63,6 @@ import com.google.gwt.user.cellview.client.SimplePager;
 import com.google.gwt.user.cellview.client.SimplePager.TextLocation;
 import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
@@ -292,7 +294,11 @@ public class SchedulesPanel extends SimplePanel {
       public void onCellPreview(CellPreviewEvent<JsJob> event) {
         if (event.getNativeEvent().getType().contains("click") && event.getColumn() == 3) {
           // switch to browse perspective, open at the given path
-          Window.alert(event.getValue().getOutputPath());
+          PerspectiveManager.getInstance().setPerspective(PerspectiveManager.BROWSER_PERSPECTIVE);
+          GenericEvent gevent = new GenericEvent();
+          gevent.setEventSubType("OpenFolderEvent");
+          gevent.setStringParam(event.getValue().getOutputPath());
+          EventBusUtil.EVENT_BUS.fireEvent(gevent);
         }
       }
     });
@@ -437,12 +443,12 @@ public class SchedulesPanel extends SimplePanel {
 
     table.setColumnWidth(nameColumn, 160, Unit.PX);
     table.setColumnWidth(resourceColumn, 200, Unit.PX);
-    table.setColumnWidth(outputPathColumn, 200, Unit.PX);
-    table.setColumnWidth(scheduleColumn, 150, Unit.PX);
+    table.setColumnWidth(outputPathColumn, 180, Unit.PX);
+    table.setColumnWidth(scheduleColumn, 170, Unit.PX);
     table.setColumnWidth(lastFireColumn, 130, Unit.PX);
     table.setColumnWidth(nextFireColumn, 130, Unit.PX);
-    table.setColumnWidth(userNameColumn, 120, Unit.PX);
-    table.setColumnWidth(stateColumn, 60, Unit.PX);
+    table.setColumnWidth(userNameColumn, 100, Unit.PX);
+    table.setColumnWidth(stateColumn, 70, Unit.PX);
 
     dataProvider.addDataDisplay(table);
     List<JsJob> list = dataProvider.getList();

--- a/user-console/source/org/pentaho/mantle/public/themes/crystal/mantleCrystal.css
+++ b/user-console/source/org/pentaho/mantle/public/themes/crystal/mantleCrystal.css
@@ -87,6 +87,8 @@
   height: 160px;
   overflow: auto;
   width: 300px;
+  border: 1px solid #cbdde8;
+  background-color: white;
 }
 
 .mantle-perspective-toggle {
@@ -976,7 +978,15 @@ a:active, a:hover {
   background-image: url('images/dropdown_arrow_blue.png');
 }
 
+#generated-content-location {
+  width: 360px;
+  height: 25px;
+}
 
+#schedule-name-input {
+  width: 360px;
+  height: 25px;
+}
 
 .gwt-MenuBar-horizontal .gwt-MenuItem-selected{
   background-color: #8ab3c6;

--- a/user-console/source/org/pentaho/mantle/public/themes/onyx/mantleOnyx.css
+++ b/user-console/source/org/pentaho/mantle/public/themes/onyx/mantleOnyx.css
@@ -73,6 +73,14 @@
   border-bottom: 1px solid #dfdfdf;	
 }
 
+.select-folder-tree {
+  height: 160px;
+  overflow: auto;
+  width: 300px;
+  border: 1px solid #cbdde8;
+  background-color: white;
+}
+
 .mantle-perspective-toggle {
   background: black;
   color: white;
@@ -951,6 +959,16 @@ a:active, a:hover {
 
 .custom-dropdown-pressed .custom-dropdown-arrow {
   background-image: url('images/dropdown_arrow_blue.png');
+}
+
+#generated-content-location {
+  width: 360px;
+  height: 25px;
+}
+
+#schedule-name-input {
+  width: 360px;
+  height: 25px;
 }
 
 /* == == == */


### PR DESCRIPTION
Lots of bug & UX fixes:
Folder tree is no longer indented wrong in select folder dialog
Next becomes enabled/disabled as appropriate for the first step
Moved regex schedule name parsing out of recurrence dialog and into first step
CSS updates for background, heights, widths, etc
Adjusted column widths in SchedulerPerspective
SchedulerPerspective now links to Browse Files and will auto-open to the output folder of a schedule
