### PR TITLE
Fix for BISERVER-9198

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/commands/SaveCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/SaveCommand.java
@@ -171,6 +171,9 @@ public class SaveCommand extends AbstractCommand {
    var frame = $doc.getElementById(elementId);
    frame = frame.contentWindow;
    frame.focus();
+   if (frame.getPossibleFileExtensions) {
+     return frame.getPossibleFileExtensions();
+   }
    if (frame.gCtrlr.repositoryBrowserController.getPossibleFileExtensions) {
      return frame.gCtrlr.repositoryBrowserController.getPossibleFileExtensions();
    }


### PR DESCRIPTION
Save Report - Overwrite warning doesn't show when you save report with
same name
