### PR TITLE
[PDI-9603] enabling low level support for secure database connections. T...

### DIFF
--- a/api/src/org/pentaho/platform/api/repository2/unified/data/node/DataNodeRef.java
+++ b/api/src/org/pentaho/platform/api/repository2/unified/data/node/DataNodeRef.java
@@ -18,6 +18,8 @@ import java.io.Serializable;
 
 public class DataNodeRef {
   
+  public static final String REF_MISSING = "REF_MISSING"; //$NON-NLS-1$
+  
   private Serializable id;
   
   public DataNodeRef(final Serializable id) {

--- a/repository/src/org/apache/jackrabbit/core/security/authorization/acl/MagicAceDefinition.java
+++ b/repository/src/org/apache/jackrabbit/core/security/authorization/acl/MagicAceDefinition.java
@@ -24,7 +24,9 @@ public class MagicAceDefinition {
   
   public boolean applyToTarget;
   
-  public MagicAceDefinition(final String path, final String logicalRole, final Privilege[] privileges, final boolean applyToTarget, final boolean applyToChildren, final boolean applyToAncestors) {
+  public String[] exceptChildren;
+  
+  public MagicAceDefinition(final String path, final String logicalRole, final Privilege[] privileges, final boolean applyToTarget, final boolean applyToChildren, final boolean applyToAncestors, final String[] exceptChildren) {
     super();
     this.path = path;
     this.logicalRole = logicalRole;
@@ -32,6 +34,7 @@ public class MagicAceDefinition {
     this.applyToChildren = applyToChildren;
     this.applyToAncestors = applyToAncestors;
     this.applyToTarget = applyToTarget;
+    this.exceptChildren = exceptChildren;
   }
 
   @Override
@@ -44,6 +47,7 @@ public class MagicAceDefinition {
     result = prime * result + (applyToChildren ? 1231 : 1237);
     result = prime * result + (applyToAncestors ? 8 : 9);
     result = prime * result + (applyToTarget ? 6 : 7);
+    result = prime * result + Arrays.hashCode(exceptChildren);
     return result;
   }
 
@@ -73,6 +77,8 @@ public class MagicAceDefinition {
     if (applyToAncestors != other.applyToAncestors)
       return false;
     if (applyToTarget != other.applyToTarget)
+      return false;
+    if (!Arrays.equals(exceptChildren,  other.exceptChildren))
       return false;
     return true;
   }

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
@@ -131,9 +131,12 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
     PentahoJcrConstants pentahoJcrConstants = new PentahoJcrConstants(session);
     JcrRepositoryFileUtils.checkoutNearestVersionableFileIfNecessary(session, pentahoJcrConstants, parentFolderId);
     Node folderNode = JcrRepositoryFileUtils.createFolderNode(session, pentahoJcrConstants, parentFolderId, folder);
+    // create a temporary folder object with correct path for default acl purposes.
+    String path = JcrRepositoryFileUtils.getAbsolutePath(session, pentahoJcrConstants, folderNode);
+    RepositoryFile tmpFolder = new RepositoryFile.Builder(folder).path(path).build();
     // we must create the acl during checkout
     JcrRepositoryFileAclUtils.createAcl(session, pentahoJcrConstants, folderNode.getIdentifier(),
-        acl == null ? defaultAclHandler.createDefaultAcl(folder) : acl);
+        acl == null ? defaultAclHandler.createDefaultAcl(tmpFolder) : acl);
     session.save();
     if (folder.isVersioned()) {
       JcrRepositoryFileUtils.checkinNearestVersionableNodeIfNecessary(session, pentahoJcrConstants, folderNode,
@@ -187,8 +190,11 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
         Node fileNode = JcrRepositoryFileUtils.createFileNode(session, pentahoJcrConstants, parentFolderId, file,
             content == null ? emptyContent : content,
             findTransformerForWrite(content == null ? emptyContent.getClass() : content.getClass()));
+        // create a tmp file with correct path for default acl creation purposes.
+        String path = JcrRepositoryFileUtils.getAbsolutePath(session, pentahoJcrConstants, fileNode);
+        RepositoryFile tmpFile = new RepositoryFile.Builder(file).path(path).build();
         // we must create the acl during checkout
-        aclDao.createAcl(fileNode.getIdentifier(), acl == null ? defaultAclHandler.createDefaultAcl(file) : acl);
+        aclDao.createAcl(fileNode.getIdentifier(), acl == null ? defaultAclHandler.createDefaultAcl(tmpFile) : acl);
         session.save();
         if (file.isVersioned()) {
           JcrRepositoryFileUtils.checkinNearestVersionableNodeIfNecessary(session, pentahoJcrConstants, fileNode,

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -371,7 +371,7 @@ public class JcrRepositoryFileUtils {
     }
   }
 
-  private static String getAbsolutePath(final Session session, final PentahoJcrConstants pentahoJcrConstants,
+  public static String getAbsolutePath(final Session session, final PentahoJcrConstants pentahoJcrConstants,
       final Node node) throws RepositoryException {
     if (node.isNodeType(pentahoJcrConstants.getNT_FROZENNODE())) {
       return session.getNodeByIdentifier(node.getProperty(pentahoJcrConstants.getJCR_FROZENUUID()).getString())

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/SharedObjectsDefaultAclHandler.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/SharedObjectsDefaultAclHandler.java
@@ -1,0 +1,96 @@
+package org.pentaho.platform.repository2.unified.jcr;
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2013 Pentaho Corporation.  All rights reserved.
+ *
+ * User: pminutillo
+ * Date: 2/12/13
+ * Time: 4:10 PM
+ */
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid.Type;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+
+/**
+ * This default acl handler sets the default security to Authenticated ALL for specific shared paths specified
+ * by a list in the configuration, defaulting to just databases at this time.
+ * 
+ * @author Will Gorman (wgorman@pentaho.com)
+ */
+public class SharedObjectsDefaultAclHandler extends InheritDefaultAclHandler {
+  
+  String authenticatedRoleName = "Authenticated";
+  List<String> sharedObjectPaths; // "{0}/etc/pdi/databases"
+  
+  public SharedObjectsDefaultAclHandler() {
+    sharedObjectPaths = new ArrayList<String>();
+    sharedObjectPaths.add("{0}/etc/pdi/databases");
+  }
+  
+  public SharedObjectsDefaultAclHandler(String authenticatedRoleName, List<String> sharedObjectPaths) {
+    this.authenticatedRoleName = authenticatedRoleName;
+    this.sharedObjectPaths = sharedObjectPaths;
+  }
+  
+  /**
+   * Logic to determine if we should use default Authenticated permission vs. Inheriting permission.
+   * This is the approach we take with Shared Objects in the DI Server.
+   * 
+   * @param file repository file to examine
+   * @return whether this file is in a shared object path
+   * 
+   */
+  protected boolean applyAuthRule(RepositoryFile file) {
+    ITenant tenant = JcrTenantUtils.getTenant();
+    for (String path : sharedObjectPaths) {
+      String substitutedPath = MessageFormat.format(path, tenant.getRootFolderAbsolutePath());
+      if (file.getPath() != null && file.getPath().startsWith(substitutedPath)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  
+  /**
+   * Determine the correct default acls and return it.
+   * 
+   * @return default acls
+   */
+  @Override
+  public RepositoryFileAcl createDefaultAcl(RepositoryFile repositoryFile) {
+    if (applyAuthRule(repositoryFile)) { 
+      // if the auth name is not specified in the config, create an acl without an ace
+      if (authenticatedRoleName == null || authenticatedRoleName.trim().length() == 0) {
+        return new RepositoryFileAcl.Builder(PentahoSessionHolder.getSession().getName()).entriesInheriting(false).build();
+      } else {
+        // if an auth is defined, create an acl with the ace
+        RepositoryFileSid tenantAuthenticatedRoleSid = new RepositoryFileSid(authenticatedRoleName, Type.ROLE);
+        return new RepositoryFileAcl.Builder(PentahoSessionHolder.getSession().getName()).entriesInheriting(false).ace(tenantAuthenticatedRoleSid, EnumSet.of(RepositoryFilePermission.ALL)).build();
+      }
+    } else {
+      return super.createDefaultAcl(repositoryFile);
+    }
+  }
+}

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/transform/NodeRepositoryFileDataTransformer.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/transform/NodeRepositoryFileDataTransformer.java
@@ -15,6 +15,8 @@
 package org.pentaho.platform.repository2.unified.jcr.transform;
 
 import java.util.Calendar;
+
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Property;
@@ -182,7 +184,13 @@ public class NodeRepositoryFileDataTransformer implements ITransformer<NodeRepos
           break;
         }
         case PropertyType.REFERENCE: {
-          dataNode.setProperty(propName, new DataNodeRef(prop.getNode().getIdentifier()));
+          try {
+            dataNode.setProperty(propName, new DataNodeRef(prop.getNode().getIdentifier()));
+          } catch (ItemNotFoundException e) {
+            // reference is missing, replace with missing data ref
+            // this situation can occur if the user does not have permission to access the reference.
+            dataNode.setProperty(propName,  new DataNodeRef(DataNodeRef.REF_MISSING));
+          }
           break;
         }
         default: {

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/InheritDefaultAclHandlerTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/InheritDefaultAclHandlerTest.java
@@ -1,4 +1,5 @@
-package org.pentaho.platform.repository2.unified.jcr;/*
+package org.pentaho.platform.repository2.unified.jcr;
+/*
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -19,15 +20,21 @@ package org.pentaho.platform.repository2.unified.jcr;/*
  * Time: 12:58 PM
  */
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class InheritDefaultAclHandlerTest {
 
@@ -47,5 +54,36 @@ public class InheritDefaultAclHandlerTest {
   public void testCreateDefaultAcl(){
     RepositoryFileAcl repositoryFileAcl = inheritDefaultAclHandler.createDefaultAcl(repositoryFile);
     assertTrue(repositoryFileAcl.isEntriesInheriting());
+  }
+  
+  @Test
+  public void testSharedObjectsCreateDefaultAcl() {
+    // default behavior is to inherit everything but database connections
+    SharedObjectsDefaultAclHandler aclHandler = new SharedObjectsDefaultAclHandler();
+    RepositoryFile f = mock(RepositoryFile.class);
+    when(f.getPath()).thenReturn("/pentaho/tenant0/etc/pdi/databases/Test.kdb");
+    RepositoryFileAcl acl = aclHandler.createDefaultAcl(f);
+    assertTrue(!acl.isEntriesInheriting());
+    assertTrue(acl.getAces().size() == 1);
+    assertTrue("Authenticated".equals(acl.getAces().get(0).getSid().getName().toString()));
+    assertTrue(RepositoryFileSid.Type.ROLE.equals(acl.getAces().get(0).getSid().getType()));
+    assertTrue(acl.getAces().get(0).getPermissions().size() == 1);
+    assertTrue(acl.getAces().get(0).getPermissions().contains(RepositoryFilePermission.ALL));
+
+    acl = aclHandler.createDefaultAcl(repositoryFile);
+    assertTrue(acl.isEntriesInheriting());
+
+    // null role tells the acl handler to default to no aces
+    List<String> paths = new ArrayList<String>();
+    paths.add("{0}/etc/pdi/databases");
+    aclHandler = new SharedObjectsDefaultAclHandler(null, paths);
+    
+    acl = aclHandler.createDefaultAcl(f);
+    assertTrue(!acl.isEntriesInheriting());
+    System.out.println(acl.getAces());
+    assertTrue(acl.getAces().size() == 0);
+    
+    acl = aclHandler.createDefaultAcl(repositoryFile);
+    assertTrue(acl.isEntriesInheriting());
   }
 }


### PR DESCRIPTION
...he

three main changes are to allow missing references instead of throwing an
exception, an enhancement of magic aces to allow the exclusion of children
from rules, and finally a shared objects default acl handler which gives
the correct permissions to connections.  Note that a bug was fixed to
allow visibility into the path for the default acl handler.  None of these
capabilities are enabled by default, only in the context of the DI Server
for now.
