### PR TITLE
Fix for BISERVER-9294 Unable to create a new block out time 

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/dialogs/scheduling/NewBlockoutScheduleDialog.java
+++ b/user-console/source/org/pentaho/mantle/client/dialogs/scheduling/NewBlockoutScheduleDialog.java
@@ -30,7 +30,7 @@ public class NewBlockoutScheduleDialog extends ScheduleRecurrenceDialog {
 
   public NewBlockoutScheduleDialog(final String filePath, final IDialogCallback callback, final boolean hasParams,
       final boolean isEmailConfValid) {
-    super(null, ScheduleDialogType.BLOCKOUT, Messages.getString("newBlockoutSchedule"), filePath, null, null, callback, hasParams, //$NON-NLS-1$
+    super(null, ScheduleDialogType.BLOCKOUT, Messages.getString("newBlockoutSchedule"), filePath, "", "", callback, hasParams, //$NON-NLS-1$
         isEmailConfValid);
   }
 


### PR DESCRIPTION
Fix for BISERVER-9294 Unable to create a new block out time 
