### PR TITLE
BISERVER-9315 - IE8 - IE9 -IE10- Schedules table cut off. Taking up 2/3 of page only.

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/themes/crystal/mantleCrystal.css
+++ b/user-console/source/org/pentaho/mantle/public/themes/crystal/mantleCrystal.css
@@ -30,7 +30,6 @@
 .schedule-dialog-content {
 }
 .schedulerPerspective-wrapper{
-	width: 1230px;
   margin: 0 auto;
 }
 .admin-perspective {


### PR DESCRIPTION
- The problem was actually happening in all browsers now, for the crystal them only
