### PR TITLE
Fix for BISERVER-9437

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -202,6 +202,13 @@ public class SchedulesPanel extends SimplePanel {
   }
 
   private void filterAndShowData() {
+
+	filters.add(new IJobFilter() {
+        public boolean accept(JsJob job) {
+          return !job.getFullResourceName().equals("GeneratedContentCleaner");
+        }
+    });
+	  
     ArrayList<JsJob> filteredList = new ArrayList<JsJob>();
     for (int i = 0; i < allJobs.length(); i++) {
       filteredList.add(allJobs.get(i));


### PR DESCRIPTION
Schedules - Generated Content Cleaner Schedule should not be visible in
Manage Schedules list
