### PR TITLE
[BISERVER-9545] tweaks necessary to support JPivot as a plugin.

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/MondrianModelComponent.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/MondrianModelComponent.java
@@ -208,7 +208,7 @@ public class MondrianModelComponent extends ComponentBase {
       if (modelPath.indexOf("http") == 0) { //$NON-NLS-1$
         properties.put(RolapConnectionProperties.Catalog.name(), modelPath); //$NON-NLS-1$
       } else {
-        if (!modelPath.startsWith("solution:")) { //$NON-NLS-1$
+        if (!modelPath.startsWith("solution:") && !modelPath.startsWith("mondrian:")) { //$NON-NLS-1$
           modelPath = "solution:" + modelPath; //$NON-NLS-1$
         }
         properties.put(RolapConnectionProperties.Catalog.name(), modelPath); //$NON-NLS-1$
@@ -256,7 +256,7 @@ public class MondrianModelComponent extends ComponentBase {
     if (modelPath.indexOf("http") == 0) { //$NON-NLS-1$
       properties.put(RolapConnectionProperties.Catalog.name(), modelPath); //$NON-NLS-1$
     } else {
-      if (!modelPath.startsWith("solution:")) { //$NON-NLS-1$
+      if (!modelPath.startsWith("solution:") && !modelPath.startsWith("mondrian:")) { //$NON-NLS-1$
         modelPath = "solution:" + modelPath; //$NON-NLS-1$
       }
       properties.put(RolapConnectionProperties.Catalog.name(), modelPath); //$NON-NLS-1$

--- a/extensions/src/org/pentaho/platform/web/servlet/PluginDispatchServlet.java
+++ b/extensions/src/org/pentaho/platform/web/servlet/PluginDispatchServlet.java
@@ -177,7 +177,11 @@ public class PluginDispatchServlet implements Servlet {
         if (logger.isDebugEnabled()) {
           logger.debug("calling init on servlet " + pluginServlet.getClass().getName() + " serving context " + context);  //$NON-NLS-1$//$NON-NLS-2$
         }
-        pluginServlet.init(servletConfig);
+        try {
+          pluginServlet.init(servletConfig);
+        } catch (Throwable t) {
+          logger.error("Could not load servlet '" + context + "'", t);//$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
       }
     }
 


### PR DESCRIPTION
MondrianModelComponent now supports the vfs notation "mondrian:", and
PluginDispatchServlet logs exception vs. exploding when a plugin servlet
fails to init.
