### PR TITLE
BISERVER-9701 - Button width on home perspective sometime is narrow

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/home/index.jsp
+++ b/user-console/source/org/pentaho/mantle/public/home/index.jsp
@@ -72,7 +72,7 @@
   <div class="row-fluid">
     <div class="span3" id="buttonWrapper">
       <script type="text/x-handlebars-template">
-        <div class="well sidebar" data-spy="affix">
+        <div class="well sidebar">
           <button class="btn btn-large btn-block" onclick="window.top.mantle_setPerspective('browser.perspective')">
             {{i18n.browse}}
           </button>


### PR DESCRIPTION
the data-spy setting to affix was adding a css property named affix that sets the position to "fixed" this was causing inconsistent rendering of the width of the div. the affix setting wasn't doing anything for us anyway, so it is removed here to solve the problem.
