### PR TITLE
[PDI-9265] Changed the logic that determines if we are connecting to a DI

### DIFF
--- a/api/src/org/pentaho/platform/api/repository2/unified/IUnifiedRepository.java
+++ b/api/src/org/pentaho/platform/api/repository2/unified/IUnifiedRepository.java
@@ -515,11 +515,6 @@ public interface IUnifiedRepository {
    */
   List<Character> getReservedChars();
 
-  /**
-   * Returns the product ID that was set in the pentaho-platform jar manifests.
-   */
-  String getProductID();
-
   List<Locale> getAvailableLocalesForFileById(final Serializable fileId);
 
   List<Locale> getAvailableLocalesForFileByPath(final String relPath);

--- a/assembly/package-res/biserver/pentaho-solutions/system/pentahoServices.spring.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentahoServices.spring.xml
@@ -16,8 +16,7 @@
   <!-- JAX-WS bindings -->
   <wss:binding url="/webservices/unifiedRepository">
     <wss:service>
-      <ws:service
-          impl="org.pentaho.platform.repository2.unified.webservices.jaxws.DefaultUnifiedRepositoryJaxwsWebService"/>
+      <ws:service impl="org.pentaho.platform.repository2.unified.webservices.jaxws.DefaultUnifiedRepositoryJaxwsWebService" />
     </wss:service>
   </wss:binding>
   <wss:binding url="/webservices/datasourceMgmtService">
@@ -46,8 +45,7 @@
 
   <wss:binding url="/webservices/roleBindingDao">
     <wss:service>
-      <ws:service
-          impl="org.pentaho.platform.security.policy.rolebased.ws.DefaultRoleAuthorizationPolicyRoleBindingDaoWebService"/>
+      <ws:service impl="org.pentaho.platform.security.policy.rolebased.ws.DefaultRoleAuthorizationPolicyRoleBindingDaoWebService" />
     </wss:service>
   </wss:binding>
 
@@ -60,8 +58,7 @@
   <!--  GWT services are defined as Spring beans.  The id maps to the request URL like so: 
       requests to "/ws/gwt/myService" will be dispatched to a bean with id "ws-gwt-myService"
   -->
-  <bean id="ws-gwt-unifiedRepository"
-        class="org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService"/>
+  <bean id="ws-gwt-unifiedRepository" class="org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService"/>
 
   <!-- Jersey JAXB Context Resolver (fixes 1-element array) -->
   <bean class="org.pentaho.platform.web.http.api.resources.JAXBContextResolver"/>

--- a/repository/src/org/pentaho/platform/repository2/unified/DefaultUnifiedRepository.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/DefaultUnifiedRepository.java
@@ -500,11 +500,6 @@ public class DefaultUnifiedRepository implements IUnifiedRepository {
   }
 
   @Override
-  public String getProductID() {
-    return repositoryFileDao.getProductID();
-  }
-
-  @Override
   public List<Locale> getAvailableLocalesForFileById(Serializable fileId) {
     Assert.notNull(fileId);
     return repositoryFileDao.getAvailableLocalesForFileById(fileId);

--- a/repository/src/org/pentaho/platform/repository2/unified/ExceptionLoggingDecorator.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/ExceptionLoggingDecorator.java
@@ -531,11 +531,6 @@ public class ExceptionLoggingDecorator implements IUnifiedRepository {
   }
 
   @Override
-  public String getProductID() {
-    return VersionHelper.getVersionInfo(this.getClass()).getProductID();
-  }
-
-  @Override
   public List<Locale> getAvailableLocalesForFileById(final Serializable fileId) {
     return callLogThrow(new Callable<List<Locale>>() {
       public List<Locale> call() throws Exception {

--- a/repository/src/org/pentaho/platform/repository2/unified/IRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/IRepositoryFileDao.java
@@ -37,8 +37,6 @@ import org.pentaho.platform.api.repository2.unified.VersionSummary;
  */
 public interface IRepositoryFileDao {
 
-  String getProductID();
-
   RepositoryFile getFileByAbsolutePath(final String absPath);
 
   RepositoryFile getFile(final String relPath);

--- a/repository/src/org/pentaho/platform/repository2/unified/fs/FileSystemBackedUnifiedRepository.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/fs/FileSystemBackedUnifiedRepository.java
@@ -254,11 +254,6 @@ public class FileSystemBackedUnifiedRepository implements IUnifiedRepository {
   }
 
   @Override
-  public String getProductID() {
-    return VersionHelper.getVersionInfo(this.getClass()).getProductID();
-  }
-
-  @Override
   public List<Locale> getAvailableLocalesForFileById(Serializable fileId) {
    throw new UnsupportedOperationException();
   }

--- a/repository/src/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDao.java
@@ -424,11 +424,6 @@ public class FileSystemRepositoryFileDao implements IRepositoryFileDao {
   }
 
   @Override
-  public String getProductID() {
-    return VersionHelper.getVersionInfo(this.getClass()).getProductID();
-  }
-
-  @Override
   public RepositoryFile updateFolder(RepositoryFile file, String versionMessage) {
     throw new UnsupportedOperationException("This operation is not support by this repository");
   }

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
@@ -1006,11 +1006,6 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
   }
 
   @Override
-  public String getProductID() {
-    return VersionHelper.getVersionInfo(this.getClass()).getProductID();
-  }
-
-  @Override
   public List<Locale> getAvailableLocalesForFileById(Serializable fileId) {
     RepositoryFile repositoryFile = getFileById(fileId, true);
     return getAvailableLocalesForFile(repositoryFile);

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/DefaultUnifiedRepositoryWebService.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/DefaultUnifiedRepositoryWebService.java
@@ -345,10 +345,6 @@ public class DefaultUnifiedRepositoryWebService implements IUnifiedRepositoryWeb
     }
   }
 
-  public String getProductID() {
-    return VersionHelper.getVersionInfo(this.getClass()).getProductID();
-  }
-
   @Override
   public List<PentahoLocale> getAvailableLocalesForFileById(String fileId) {
     List<PentahoLocale> pentahoLocales = new ArrayList<PentahoLocale>();

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/IUnifiedRepositoryWebService.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/IUnifiedRepositoryWebService.java
@@ -40,8 +40,6 @@ import com.google.gwt.user.client.rpc.RemoteService;
 @WebService
 public interface IUnifiedRepositoryWebService extends RemoteService {
 
-  String getProductID();
-
   RepositoryFileDto getFile(final String path, final boolean loadLocaleMaps, final PentahoLocale locale);
 
   RepositoryFileDto getFileById(final String fileId, final boolean loadLocaleMaps, final PentahoLocale locale);

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/IUnifiedRepositoryWebServiceAsync.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/IUnifiedRepositoryWebServiceAsync.java
@@ -19,8 +19,6 @@ import java.util.List;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public interface IUnifiedRepositoryWebServiceAsync {
-
-  void getProductID(AsyncCallback<String> productId);
   
   void canUnlockFile(String fileId, AsyncCallback<Boolean> arg2);
 

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/jaxws/UnifiedRepositoryToWebServiceAdapter.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/jaxws/UnifiedRepositoryToWebServiceAdapter.java
@@ -456,10 +456,6 @@ public class UnifiedRepositoryToWebServiceAdapter implements IUnifiedRepository 
     return cachedReservedChars;
   }
 
-  public String getProductID() {
-    return repoWebService.getProductID();
-  }
-
   @Override
   public List<Locale> getAvailableLocalesForFileById(Serializable fileId) {
     throw new UnsupportedOperationException();

--- a/repository/test-src/org/pentaho/test/platform/repository2/unified/EmptyUnifiedRepository.java
+++ b/repository/test-src/org/pentaho/test/platform/repository2/unified/EmptyUnifiedRepository.java
@@ -259,11 +259,6 @@ public class EmptyUnifiedRepository implements IUnifiedRepository {
   }
 
   @Override
-  public String getProductID() {
-    return null;
-  }
-
-  @Override
   public RepositoryFile getFile(String path, IPentahoLocale locale) {
     return null;
   }

--- a/repository/test-src/org/pentaho/test/platform/repository2/unified/MockUnifiedRepository.java
+++ b/repository/test-src/org/pentaho/test/platform/repository2/unified/MockUnifiedRepository.java
@@ -1310,11 +1310,6 @@ public class MockUnifiedRepository implements IUnifiedRepository {
   }
 
   @Override
-  public String getProductID() {
-    return VersionHelper.getVersionInfo(this.getClass()).getProductID();
-  }
-
-  @Override
   public List<Locale> getAvailableLocalesForFileById(Serializable fileId) {
     return Collections.emptyList();
   }

--- a/repository/test-src/org/pentaho/test/platform/repository2/unified/UnmodifiableRepository.java
+++ b/repository/test-src/org/pentaho/test/platform/repository2/unified/UnmodifiableRepository.java
@@ -630,11 +630,6 @@ public class UnmodifiableRepository implements IUnifiedRepository {
   }
 
   @Override
-  public String getProductID() {
-    return repository.getProductID();
-  }
-
-  @Override
   public List<Locale> getAvailableLocalesForFileById(Serializable fileId) {
     Assert.notNull(fileId);
     return repository.getAvailableLocalesForFileById(fileId);


### PR DESCRIPTION
Server or BA Server.  We no longer need the ProductID wired through the
repository API.  Cleaned up the pentahoServices spring file to more
closely match downstream versions.
