### PR TITLE
BISERVER-9316

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/browser/index.jsp
+++ b/user-console/source/org/pentaho/mantle/public/browser/index.jsp
@@ -28,10 +28,9 @@
             // show the opened perspective
             var extension = path.split(".").pop();
 
-            if(!($.browser.msie && extension == "pdf")){
+            if(!($("body").hasClass("IE") && extension == "pdf")){
                 parent.mantle_setPerspective('opened.perspective');
             }
-            parent.mantle_setPerspective('opened.perspective');
             window.parent.mantle_openRepositoryFile(path, mode);
         }
 

--- a/user-console/source/org/pentaho/mantle/public/home/js/home.js
+++ b/user-console/source/org/pentaho/mantle/public/home/js/home.js
@@ -87,7 +87,7 @@ pen.define([
     // show the opened perspective
     var extension = path.split(".").pop();
 
-    if(!($.browser.msie && extension == "pdf")){
+    if(!($("body").hasClass("IE") && extension == "pdf")){
     	parent.mantle_setPerspective('opened.perspective');
     }
     window.parent.mantle_openRepositoryFile(path, mode);


### PR DESCRIPTION
Changed IE check. $.browser removed in jquery 1.9
Replated to use $("body").hasClass("IE")

http://jquery.com/upgrade-guide/1.9/
jQuery.browser() removed
The jQuery.browser() method has been deprecated since jQuery 1.3 and is removed in 1.9. If needed, it is available as part of the jQuery Migrate plugin. We recommend using feature detection with a library such as Modernizr.
