### PR TITLE
BISERVER-9589 - When deleting a file in the Browse Files perspective, the confirmation dialog shows the file extension (i.e. .xanalyzer)

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/commands/DeleteFileCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/DeleteFileCommand.java
@@ -91,9 +91,16 @@ public class DeleteFileCommand extends AbstractCommand {
 
     String temp = "";
     String names="";
+    RepositoryFile rf = null;
     for (FileItem fileItem : repositoryFiles) {
-      temp += fileItem.getRepositoryFile().getId() + ","; //$NON-NLS-1$
-      names += fileItem.getRepositoryFile().getName() + ","; //$NON-NLS-1$
+      rf = fileItem.getRepositoryFile();
+      temp += rf.getId() + ","; //$NON-NLS-1$
+      if(rf.getTitle() != null) {
+        names += rf.getTitle() + ","; //$NON-NLS-1$
+      } else {
+        names += rf.getName() + ","; //$NON-NLS-1$
+      }
+
     }
     // remove trailing ","
     temp = temp.substring(0, temp.length() - 1);

--- a/user-console/source/org/pentaho/mantle/client/commands/DeleteFolderCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/DeleteFolderCommand.java
@@ -84,7 +84,7 @@ public class DeleteFolderCommand extends AbstractCommand {
     event.setAction(this.getClass().getName());
 
     final String filesList = repositoryFile.getId();
-    final String folderName = repositoryFile.getName();
+    final String folderName = repositoryFile.getTitle() == null ? repositoryFile.getName() : repositoryFile.getTitle();
     final HTML messageTextBox = new HTML(Messages.getString("moveToTrashQuestionFolder",folderName));
     final PromptDialogBox folderDeleteWarningDialogBox = new PromptDialogBox(Messages.getString("moveToTrash"), Messages.getString("yesMoveToTrash"), Messages.getString("no"), true, true);
     folderDeleteWarningDialogBox.setContent(messageTextBox);


### PR DESCRIPTION
BISERVER-9589 - When deleting a file in the Browse Files perspective, the confirmation dialog shows the file extension (i.e. .xanalyzer)
