### PR TITLE
ANALYZER-2108 - Visualizations jump/flash on initial load and tab change

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
@@ -274,8 +274,8 @@ public class SolutionBrowserPanel extends HorizontalPanel {
     Element pucHeader = DOM.getElementById("pucHeader");
     if (pucHeader != null) {
       final int offset = pucHeader.getOffsetHeight();
-      setElementHeightOffset(navigatorAndContentSplit.getElement(), 0);
-      setElementHeightOffset(contentTabPanel.getElement(), 0);
+      setElementHeightOffset(navigatorAndContentSplit.getElement(), -1 * offset);
+      setElementHeightOffset(contentTabPanel.getElement(), -1 * offset);
       Timer t = new Timer() {
         public void run() {
           setElementHeightOffset(navigatorAndContentSplit.getElement(), -1 * offset);


### PR DESCRIPTION
It was calculating the height required to set that div twice. once immediately, without accounting for the height PUC header (file menu, perspective switcher, and such). So, it would first set it's height to the same height of the browser window. Then, on a timer, it was recalculating the height and setting it 100 ms later, this time accounting for the PUC header height as an offset. This resulted in the "bouncing" effect.

@mdamour1976 can you review this since you originally wrote this code. Not sure why it was first calculating the height without accounting for the header. let me now if there was a specific reason, then i can test it and/or work around it.
