### PR TITLE
[BISERVER-9753] Files with a period in the name are mishandled when dete...

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
@@ -383,7 +383,7 @@ public class RepositoryResource extends AbstractJaxRSResource {
     RepositoryFile file;
 
     public RepositoryFileCGFactory(String contentGeneratorPath, RepositoryFile file) {
-      super(contentGeneratorPath, file.getName().substring(file.getName().indexOf('.') + 1));
+      super(contentGeneratorPath, file.getName().substring(file.getName().lastIndexOf('.') + 1));
       this.file = file;
     }
 


### PR DESCRIPTION
...rmining the extension.  This was causing migrated jpivot content to be to not open, since it ends with ".analysisview.xaction".
