### PR TITLE
BISERVER-9819 - Dialog.js (old legacy code) uses snippets without adhering to their terms of use

### DIFF
--- a/extensions/test-src/web-servlet-solution/system/custom/template.html
+++ b/extensions/test-src/web-servlet-solution/system/custom/template.html
@@ -56,7 +56,6 @@ before returning to client. Do not modify the line below.
   <script src="/pentaho/adhoc/js/common/ui/Logger.js" type="text/javascript"></script>
 	<script src="/pentaho/adhoc/js/common/ui/TabCtrl.js" type="text/javascript"></script>
   <script src="/pentaho/adhoc/js/common/ui/ListCtrl.js" type="text/javascript"></script>
-  <script src="/pentaho/adhoc/js/common/ui/Dialog.js" type="text/javascript"></script>
   <script src="/pentaho/adhoc/js/common/ui/SimpleDialog.js" type="text/javascript"></script>
   <script src="/pentaho/adhoc/js/common/ui/AclEditorDialog.js" type="text/javascript"></script>
   <script src="/pentaho/adhoc/js/common/ui/AclEditorCtrl.js" type="text/javascript"></script>
@@ -181,8 +180,7 @@ before returning to client. Do not modify the line below.
 				<table border="0" cellspacing="0" cellpadding="0" class="aclDialogTable">
 					<tr>
 						<td class="aclDialogHeader">
-							<div id="dialog.titleBarId" class="aclDialogTitleBar" onmouseover="this.onmousedown=Dialog.dragIsDown;"
-								ondragstart="return false;" onselectstart="return false;">
+							<div id="dialog.titleBarId" class="aclDialogTitleBar" ondragstart="return false;" onselectstart="return false;">
 							</div>
 						</td>
 					</tr>


### PR DESCRIPTION
BISERVER-9819 - Dialog.js (old legacy code) uses snippets without adhering to their terms of use
