### PR TITLE
BISERVER-9799: Fixed several memory leaks resulting in resources not bei...

### DIFF
--- a/assembly/package-res/biserver/import-export.bat
+++ b/assembly/package-res/biserver/import-export.bat
@@ -3,4 +3,4 @@ setlocal
 cd /D %~dp0
 call "%~dp0set-pentaho-env.bat"
 
-"%_PENTAHO_JAVA%" -classpath "%~dp0tomcat\webapps\pentaho\WEB-INF\lib\*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor %*
+"%_PENTAHO_JAVA%" -Xmx2048m -XX:MaxPermSize=256m -classpath "%~dp0tomcat\webapps\pentaho\WEB-INF\lib\*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor %*

--- a/assembly/package-res/biserver/import-export.sh
+++ b/assembly/package-res/biserver/import-export.sh
@@ -9,4 +9,4 @@ setPentahoEnv
 
 # uses Java 6 classpath wildcards
 # quotes required around classpath to prevent shell expansion
-"$_PENTAHO_JAVA" -classpath "$DIR/tomcat/webapps/pentaho/WEB-INF/lib/*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor $@
+"$_PENTAHO_JAVA" -Xmx2048m -XX:MaxPermSize=256m -classpath "$DIR/tomcat/webapps/pentaho/WEB-INF/lib/*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor $@


### PR DESCRIPTION
...ng closed.  Updated import-export scripts to pass in JVM memory parameters to increase heap space.  In performMetadataDatasourceImport(), a locale list and associated stream list was created and populated but never used.
