### PR TITLE
ENGOPS-92 - Updated the extensions ivy.xml to remove the transitive dependency on junit, ant, and ant-launcher

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -356,6 +356,8 @@
     <!-- dependencies for generating doc -->
     <dependency org="org.codehaus.enunciate" name="enunciate-top" rev="1.27" conf="enunciate->default"/>
 
+    <exclude org="junit" conf="default,runtime,source"/>
+    <exclude org="org.apache.ant" conf="default,runtime,source"/>
     <exclude org="org.glassfish" module="javax.servlet"/>
     <!-- CM-241 -->
     <exclude org="cglib" module="cglib"/>


### PR DESCRIPTION
ENGOPS-92 - Updated the extensions ivy.xml to remove the transitive dependency on junit, ant, and ant-launcher
