### PR TITLE
[BISERVER-10010]  Adding sugar configuration indicators to drillthrough-...

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/drilldown-profile.xml
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/drilldown-profile.xml
@@ -48,4 +48,32 @@
       <attribute name="formula"><![CDATA[IF(ISCONTENTLINK(["::entries"]); CONTENTLINK(["::entries"]); URLPARAMETERSEPARATOR(ENV("selfURL") & ["::parameter"]; ["::TabName"]; ["::TabActive"]))]]></attribute>
     </drilldown-profile>
   </group>
+  <group name="pentaho-sugar">
+      <drilldown-profile name="remote-sugar" class="org.pentaho.reporting.engine.classic.extensions.drilldown.SugarFormulaLinkCustomizer"
+                         bundle-name="org.pentaho.reporting.engine.classic.extensions.drilldown.drilldown-profile"
+                         expert="false" hidden="false" deprecated="false" preferred="false">
+          <attribute name="formula"><![CDATA[IF(ISCONTENTLINK(["::entries"]); CONTENTLINK(["::entries"]);OPENINMANTLETAB( ["::path"] & "api/repos/" & ["::pentaho-path"] & "/viewer?" &["::parameter"]; ["::TabName"]; ["::TabActive"]))]]></attribute>
+          <attribute name="extension">prpt</attribute>
+      </drilldown-profile>
+      <drilldown-profile name="remote-sugar-no-parameter" class="org.pentaho.reporting.engine.classic.extensions.drilldown.SugarFormulaLinkCustomizer"
+                         bundle-name="org.pentaho.reporting.engine.classic.extensions.drilldown.drilldown-profile"
+                         expert="false" hidden="false" deprecated="false" preferred="false">
+          <attribute name="formula"><![CDATA[IF(ISCONTENTLINK(["::entries"]); CONTENTLINK(["::entries"]);OPENINMANTLETAB(["::path"] & "api/repos/" & ["::pentaho-path"] & "/content?" &["::parameter"]; ["::TabName"]; ["::TabActive"]))]]></attribute>
+          <attribute name="extension">prpt</attribute>
+      </drilldown-profile>
+      <drilldown-profile name="local-sugar"
+                         class="org.pentaho.reporting.engine.classic.extensions.drilldown.SugarFormulaLinkCustomizer"
+                         bundle-name="org.pentaho.reporting.engine.classic.extensions.drilldown.drilldown-profile"
+                         expert="false" hidden="false" deprecated="false" preferred="false">
+          <attribute name="formula"><![CDATA[IF(ISCONTENTLINK(["::entries"]); CONTENTLINK(["::entries"]);OPENINMANTLETAB( ENV("pentahoBaseURL") & "api/repos/" & ["::pentaho-path"] & "/viewer?" & ["::parameter"]; ["::TabName"]; ["::TabActive"]))]]></attribute>
+          <attribute name="extension">prpt</attribute>
+      </drilldown-profile>
+      <drilldown-profile name="local-sugar-no-parameter"
+                         class="org.pentaho.reporting.engine.classic.extensions.drilldown.SugarFormulaLinkCustomizer"
+                         bundle-name="org.pentaho.reporting.engine.classic.extensions.drilldown.drilldown-profile"
+                         expert="false" hidden="false" deprecated="false" preferred="false">
+          <attribute name="formula"><![CDATA[IF(ISCONTENTLINK(["::entries"]); CONTENTLINK(["::entries"]);OPENINMANTLETAB(ENV("pentahoBaseURL") & "api/repos/" & ["::pentaho-path"] & "/content?" & ["::parameter"]; ["::TabName"]; ["::TabActive"]))]]></attribute>
+          <attribute name="extension">prpt</attribute>
+      </drilldown-profile>
+  </group>
 </drilldown-profiles>


### PR DESCRIPTION
...profile.xml for report linking.  Formerly the definitions from PRD were being used, which don't account for mantle tabs or dashboard linking via CONTENTLINK.
