### PR TITLE
PDI-10526 - Changing FileSystemRepositoryFileDao.idToPath to accept Wind...

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDao.java
@@ -11,7 +11,14 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -28,7 +35,6 @@ import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFile
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
 import org.pentaho.platform.repository.RepositoryFilenameUtils;
 import org.pentaho.platform.repository2.unified.IRepositoryFileDao;
-import org.pentaho.platform.util.VersionHelper;
 
 @SuppressWarnings("nls")
 public class FileSystemRepositoryFileDao implements IRepositoryFileDao {
@@ -192,7 +198,7 @@ public class FileSystemRepositoryFileDao implements IRepositoryFileDao {
 
   static String idToPath(String relPath) {
     relPath = relPath.replace(':', '/');
-    return relPath.replaceFirst("^/?([A-z])//(.*)","$1:/$2");
+    return relPath.replaceFirst("^/?([A-z])/[/\\\\](.*)","$1:/$2");
   }
 
   public RepositoryFile getFile(Serializable fileId, Serializable versionId) {

--- a/repository/test-src/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDaoTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDaoTest.java
@@ -1,8 +1,8 @@
 package org.pentaho.platform.repository2.unified.fs;
 
-import org.junit.Test;
+import static org.junit.Assert.*;
 
-import static junit.framework.Assert.assertEquals;
+import org.junit.Test;
 
 /**
  * User: kwalker
@@ -14,6 +14,10 @@ public class FileSystemRepositoryFileDaoTest {
   public void testIdToPath() throws Exception {
     assertEquals("C:/Program Files/pentaho/design-tools/data-integration/Unsaved Report.xanalyzer",
       FileSystemRepositoryFileDao.idToPath("C::Program Files:pentaho:design-tools:data-integration/Unsaved Report.xanalyzer"));
+    assertEquals("C:/Program Files\\pentaho\\design-tools\\data-integration\\Unsaved Report.xanalyzer",
+        FileSystemRepositoryFileDao.idToPath("C:/Program Files\\pentaho\\design-tools\\data-integration\\Unsaved Report.xanalyzer"));
+    assertEquals("C:/Program Files\\pentaho\\design-tools\\data-integration\\Unsaved Report.xanalyzer",
+        FileSystemRepositoryFileDao.idToPath("C:\\Program Files\\pentaho\\design-tools\\data-integration\\Unsaved Report.xanalyzer"));
     assertEquals("/home/pentaho/design-tools/data-integration/Unsaved Report.xanalyzer",
       FileSystemRepositoryFileDao.idToPath(":home:pentaho:design-tools:data-integration/Unsaved Report.xanalyzer"));
   }


### PR DESCRIPTION
...ows paths that start with either a / or a \ (e.g. C:/ or C:)
