### PR TITLE
Fixes for BISERVER-10240 Saving changes to a Report created from Save As, will push changes to original report

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/commands/SaveCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/SaveCommand.java
@@ -270,7 +270,7 @@ public class SaveCommand extends AbstractCommand {
     } else {
     	$wnd.mantle_showMessage("Error","The plugin has not defined a handle_puc_save function to handle the save of the content");    
     }
-    $wnd.mantle_setIsDirty(true);
+    $wnd.mantle_setIsRepoDirty(true);
   }-*/;
 
   // used via JSNI


### PR DESCRIPTION
Fixes for BISERVER-10240 Saving changes to a Report created from Save As, will push changes to original reportAs, will push changes to original report
