### PR TITLE
[PRD-4835] moved mondrian connection provider declaration line from pent...

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/classic-engine.properties
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/classic-engine.properties
@@ -40,3 +40,6 @@ org.pentaho.reporting.engine.classic.core.modules.output.table.csv.AssumeOverflo
 
 # Defines the module which contains the PentahoTableDataFactory
 org.pentaho.reporting.engine.classic.extensions.modules.PentahoTableDataFactory.Module=org.pentaho.platform.plugin.action.jfreereport.helper.PentahoTableDataFactoryModule
+
+# Defines the connection provider for mondrian datasources
+org.pentaho.reporting.engine.classic.extensions.datasources.mondrian.MondrianConnectionProvider=org.pentaho.reporting.platform.plugin.connection.PentahoMondrianConnectionProvider


### PR DESCRIPTION
...aho-platform-plugin-reporting#src/org/pentaho/reporting/platform/plugin/configuration.properties to here so that the declaration of a customMondrianConnectionProvider can be made without any changes to pentaho-platform-plugin-reporting jar
