### PR TITLE
added pentaho-bi-platform-data-access-v2 dependency to ivy’s assembly; a...

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -23,6 +23,7 @@
     <dependency org="pentaho-reporting-engine" name="pentaho-reporting-engine-classic-core-platform-plugin" rev="${dependency.pentaho-reporting-plugin.revision}" changing="true"/>
     <dependency org="pentaho-reporting-engine" name="pentaho-reporting-engine-classic-core" rev="${dependency.pentaho-reporting.revision}" changing="true" />
     <dependency org="pentaho-library" name="libserializer" rev="${dependency.libserializer.revision}" changing="true" transitive="false" conf="default->default" />
+    <dependency org="pentaho" name="pentaho-bi-platform-data-access-v2" rev="${dependency.data-access-v2-plugin.revision}" changing="true" transitive="false" conf="default->default" />
 
     <!-- Misc -->
     <dependency org="org.owasp.esapi" name="esapi" rev="2.0.1" transitive="false" />


### PR DESCRIPTION
...ssembly will then pick up /lib content and place it in tomcat’s WEB-INF/lib
