### PR TITLE
BISERVER-10600 - Include wcdf and cdfde files as file types that can be imported/exported (5.0)

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/importExport.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/importExport.xml
@@ -47,7 +47,9 @@
         <entry key="kdb" value-ref="streamConverter"/>
         <entry key="kps" value-ref="streamConverter"/>
 		<entry key="ksl" value-ref="streamConverter"/>        
-		<entry key="xjpivot" value-ref="streamConverter"/>        
+		<entry key="xjpivot" value-ref="streamConverter"/>
+        <entry key="wcdf" value-ref="streamConverter"/>        
+        <entry key="cdfde" value-ref="streamConverter"/>        
     </util:map>
 
     <bean id="DefaultExportHandler" class="org.pentaho.platform.plugin.services.importexport.DefaultExportHandler">
@@ -115,7 +117,9 @@
                 <entry key="kps" value="text/xml"/>
 				<entry key="ksl" value="text/xml"/>
 				<entry key="ktr" value="text/xml"/>                
-				<entry key="xjpivot" value="text/xml"/>                
+				<entry key="xjpivot" value="text/xml"/>
+                <entry key="cdfde" value="text/xml"/>                
+                <entry key="wcdf" value="text/xml"/>                 
             </map>
         </constructor-arg>
     </bean>
@@ -155,7 +159,9 @@
 		<value>.kbs</value>
 		<value>.kdb</value>
 		<value>.ksl</value>       
-		<value>.xjpivot</value>       
+		<value>.xjpivot</value>
+		<value>.wcdf</value>      
+    	<value>.cdfde</value>       
 	</util:list>
 
 	<util:list id="hiddenExtensionList">


### PR DESCRIPTION
Added rules to import/export cde files (cdfde and wcdf)
