### PR TITLE
BISERVER-10296 JDBC Drivers shipped with 5.0.0.1-GA are located in the w...

### DIFF
--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -192,6 +192,7 @@
       <copy todir="${stage.dir.server}/tomcat/lib">
         <fileset dir="${lib.dir}">
           <include name="jsp-api.jar" />
+          <include name="postgres*.jar" />
         </fileset>
       </copy>
 
@@ -309,6 +310,7 @@
         <exclude name="servlet-api-*.jar" />
         <exclude name="gwt-user-*.jar" />
         <exclude name="mysql-connector-*.jar" />
+        <exclude name="postgres*.jar" />
         <exclude name="*-sources.jar" />
         <!-- TODO: Remove the line below when we fix the circular dependency between kettle-engine and metadata -->
         <exclude name="hibernate-3.2.6.ga.jar" />


### PR DESCRIPTION
...rong directory. Moving postgres jar from webapps/pentaho/WEB-INF/lib to tomcat/lib
