### PR TITLE
BISERVER-10699 Lost functionality from 4.8 -> 5.0: Need alternative way of customizing startup behavior and settings to PUC

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/commands/AboutCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/AboutCommand.java
@@ -44,7 +44,7 @@ public class AboutCommand extends AbstractCommand {
   }
 
   protected void performOperation( boolean feedback ) {
-    if ( StringUtils.isEmpty( MantleApplication.mantleRevisionOverride ) ) {
+    if ( StringUtils.isEmpty( MantleApplication.mantleRevisionOverride ) == false) {
       showAboutDialog( MantleApplication.mantleRevisionOverride );
     } else {
       final String url = GWT.getHostPageBaseURL() + "api/version/show"; //$NON-NLS-1$


### PR DESCRIPTION
The startup behavior can now optionally be altered by User Settings instead of just pentaho.xml system settings.  This means that we can change startup behavior/settings globally, by tenant and by user, in that order of precedent.

This commit also fixes an issue with the AboutCommand's null check for the user-console-revision.
