### PR TITLE
BISERVER-10729 - Loading of some common-ui resources is causing 500 server errors on first server startup.

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security.xml
@@ -197,6 +197,7 @@
         -->
         <![CDATA[
 CONVERT_URL_TO_LOWERCASE_BEFORE_COMPARISON
+\A/content/common-ui/resources/web/(.+/)*.+\.js\Z=Anonymous,Authenticated
 \A/.*require-js-cfg.js\Z=Anonymous,Authenticated
 \A/content/common-ui/resources/web/require.js\Z=Anonymous,Authenticated
 \A/content/common-ui/resources/web/require-cfg.js\Z=Anonymous,Authenticated


### PR DESCRIPTION
BISERVER-10729 - Loading of some common-ui resources is causing 500 server errors on first server startup.

This problem manifested as a failure of plugins to register themselves with the PucPlugin API due to a failure to load certain resources. Some common-ui js libs are being requested prior to authentication being complete (underscore and others). The user would notice that they couldn't click on anything on the home screen. a refresh would fix the problem, but a fresh server restart "might" show this problem a gain.

This change allows any .js file from common ui to be able to be loaded without requiring authentication.
