### PR TITLE
MONDRIAN-1846 - removing the skip of fragment bundles during OSGI load. ...

### DIFF
--- a/extensions/src/org/pentaho/platform/osgi/OSGIBoot.java
+++ b/extensions/src/org/pentaho/platform/osgi/OSGIBoot.java
@@ -129,10 +129,6 @@ public class OSGIBoot implements IPentahoSystemListener {
       logger.debug( "Starting bundles" );
       for ( Bundle bundle : bundleList ) {
         try {
-          // detect if a fragment bundle and skip. They cannot be started..
-          if(bundle.getHeaders().get("Fragment-Host") != null){
-            continue;
-          }
           bundle.start();
         } catch ( Exception e ) {
           logger.error( "Error installing Bundle", e );


### PR DESCRIPTION
... This was causing a ClassNotFoundException for Mongo classes and and schema load error only on first boot.  This will cause an error to be printed during startup, but analyzer will work front to back with mongolap.
