### PR TITLE
[BISERVER-10928] Figure out why the platform is not truly 'ready' when p...

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/pentaho-spring-beans.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentaho-spring-beans.xml
@@ -2,13 +2,13 @@
 <!--+
   | This should be the only file specified in web.xml's contextConfigLocation. It should only contain imports.
   +-->
-
+  
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
+
+xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd" default-lazy-init="true">
-
-<bean class="org.pentaho.platform.engine.core.system.objfac.spring.ApplicationContextPentahoSystemRegisterer" scope="singleton"/>
+  <bean class="org.pentaho.platform.engine.core.system.objfac.spring.ApplicationContextPentahoSystemRegisterer" scope="singleton"/>
 
   <bean id="SystemConfig" class="org.pentaho.platform.config.SystemConfig">
     <constructor-arg>
@@ -23,31 +23,35 @@ http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/penta
     <pen:publish as-type="INTERFACES"/>
   </bean>
 
-  <bean class="org.pentaho.platform.config.PentahoPropertyPlaceholderConfigurer" >
-    <constructor-arg>
-      <pen:bean class="org.pentaho.platform.api.engine.ISystemConfig"/>
-    </constructor-arg>
-  </bean>
-
   <bean class="org.pentaho.platform.config.SolutionPropertiesFileConfiguration">
     <constructor-arg value="system"/>
     <constructor-arg value="system.properties"/>
     <pen:publish as-type="INTERFACES"/>
   </bean>
 
+  <bean class="org.pentaho.platform.config.PentahoPropertyPlaceholderConfigurer" >
+    <constructor-arg>
+      <pen:bean class="org.pentaho.platform.api.engine.ISystemConfig"/>
+    </constructor-arg>
+  </bean>
+
+
   <import resource="pentahoSystemConfig.xml" />
   <import resource="adminPlugins.xml" />
+
   <import resource="systemListeners.xml" />
+  
   <import resource="repository.spring.xml" />
+  <import resource="importExport.xml" />
   <import resource="applicationContext-spring-security.xml" />
-    <import resource="applicationContext-spring-security-superuser.xml" />
+  <import resource="applicationContext-spring-security-superuser.xml" />
   <import resource="applicationContext-pentaho-security-superuser.xml" />
   
   <import resource="applicationContext-common-authorization.xml" />
     <import resource="applicationContext-spring-security-memory.xml" />
+  <import resource="applicationContext-pentaho-security-memory.xml" />
 
-<import resource="applicationContext-pentaho-security-memory.xml" />
-    <import resource="applicationContext-spring-security-ldap.xml" />
+  <import resource="applicationContext-spring-security-ldap.xml" />
   <import resource="applicationContext-pentaho-security-ldap.xml" />
 
   <import resource="applicationContext-pentaho-security-jackrabbit.xml" />
@@ -55,11 +59,11 @@ http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/penta
     <import resource="applicationContext-pentaho-security-jdbc.xml" />
   <import resource="applicationContext-spring-security-jdbc.xml" />
 
-  
   <import resource="pentahoObjects.spring.xml" />
-  <import resource="GettingStartedDB-spring.xml" /> <!-- Remove this line to unhook the Getting Started DB -->
-  <import resource="importExport.xml" />
-  <import resource="defaultUser.spring.xml"/>
+  <!-- <import resource="GettingStartedDB-spring.xml" />  -->
+  <import resource="AuditDB-spring.xml" /> 
+  <import resource="defaultUser.spring.xml"/>  
   <import resource="sessionStartupActions.xml" />
   <import resource="olap4j.spring.xml"/>
 </beans>
+


### PR DESCRIPTION
...lugin lifecycle > listeners are invoked.

importHandler is a Spring dependency and needed to be re-ordered in Pentaho-Platform to be ready before the call is made.
Resolving this issue no longer requires the listener to fire in a retry thread.
