### PR TITLE
BISERVER-9847 - Browse Perspective - Rename should prevent you from renaming an active user's home folder.

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/browser/js/dialogs/browser.dialog.rename.js
+++ b/user-console/source/org/pentaho/mantle/public/browser/js/dialogs/browser.dialog.rename.js
@@ -131,6 +131,8 @@ pen.define([
     RenameDialog: null,
 
     CannotRenameDialog: null,
+    
+    RenameHomeDialog: null,
 
     overrideType: "file",
 
@@ -157,6 +159,28 @@ pen.define([
       this.initFileOverrideDialog(this.makeOverrideDialogCfg("dialogOverrideFile", RenameTemplates.dialogFileOverride), onOverrideOk, onOverrideShow);
       this.initRenameDialog();
       this.initCannotRenameDialog();
+      this.initRenameHomeDialog();
+    },
+
+		initRenameHomeDialog: function () {
+      var i18n = this.options.i18n;
+      var me = this;
+
+      var header = i18n.prop("cannotRenameHomeDialogTitle");
+
+      var body = i18n.prop("cannotRenameHomeDialogDescription");
+
+      var footer = DialogTemplates.centered_button({
+        ok: i18n.prop("close")
+      });
+
+      var cfg = Dialog.buildCfg("rename-home-dialog", header, body, footer, false);
+
+      this.RenameHomeDialog = new Dialog(cfg);
+      this.RenameHomeDialog.$dialog.find(".ok").bind("click", function () {
+        me.RenameHomeDialog.hide();
+      });
+
     },
 
     initCannotRenameDialog: function () {
@@ -296,7 +320,10 @@ pen.define([
     view: null,
 
     init: function (path, overrideType) {
-
+			if(path == window.top.HOME_FOLDER){
+				this.view.RenameHomeDialog.show();
+				return;
+			}
       var repoPath = path;
       while (repoPath.search("/") > -1) {
         repoPath = repoPath.replace("/", ":");

--- a/user-console/source/org/pentaho/mantle/public/browser/messages.properties
+++ b/user-console/source/org/pentaho/mantle/public/browser/messages.properties
@@ -70,3 +70,5 @@ renameTitle=Rename
 renameName=Name:
 cannotRenameDialogTitle = Cannot Rename
 cannotRenameDialogDescription = That name cannot be used in this location. Please try a different name.
+cannotRenameHomeDialogTitle = Cannot Rename
+cannotRenameHomeDialogDescription = The user for this folder currently exists and cannot be renamed. .

--- a/user-console/source/org/pentaho/mantle/public/browser/messages_en-US.properties
+++ b/user-console/source/org/pentaho/mantle/public/browser/messages_en-US.properties
@@ -68,4 +68,5 @@ renameTitle=Rename
 renameName=Name:
 cannotRenameDialogTitle = Cannot Rename
 cannotRenameDialogDescription = That name cannot be used in this location. Please try a different name.
-
+cannotRenameHomeDialogTitle = Cannot Rename
+cannotRenameHomeDialogDescription = The user for this folder currently exists and cannot be renamed.

--- a/user-console/source/org/pentaho/mantle/public/browser/messages_en.properties
+++ b/user-console/source/org/pentaho/mantle/public/browser/messages_en.properties
@@ -69,3 +69,5 @@ renameTitle=Rename
 renameName=Name:
 cannotRenameDialogTitle = Cannot Rename
 cannotRenameDialogDescription = That name cannot be used in this location. Please try a different name.
+cannotRenameHomeDialogTitle = Cannot Rename
+cannotRenameHomeDialogDescription = The user for this folder currently exists and cannot be renamed.


### PR DESCRIPTION
What was done:
1) added UI dialog
2) added localization
3) added check which folder is being renamed
