### PR TITLE
BISERVER-3498 - Platform shell scripts use Bourne Again Shell commands w...

### DIFF
--- a/assembly/package-res/biserver/import-export.sh
+++ b/assembly/package-res/biserver/import-export.sh
@@ -2,7 +2,7 @@
 DIR_REL=`dirname $0`
 cd $DIR_REL
 DIR=`pwd`
-cd -
+#cd -
 
 . "$DIR/set-pentaho-env.sh"
 setPentahoEnv

--- a/assembly/package-res/biserver/set-pentaho-env.sh
+++ b/assembly/package-res/biserver/set-pentaho-env.sh
@@ -39,7 +39,7 @@ setPentahoEnv() {
   DIR_REL=`dirname $0`
   cd $DIR_REL
   DIR=`pwd`
-  cd -
+  #cd -
 	
   if [ -n "$PENTAHO_JAVA" ]; then
     __LAUNCHER="$PENTAHO_JAVA"

--- a/assembly/package-res/biserver/start-pentaho-debug.sh
+++ b/assembly/package-res/biserver/start-pentaho-debug.sh
@@ -8,19 +8,20 @@
 DIR_REL=`dirname $0`
 cd $DIR_REL
 DIR=`pwd`
-cd -
+#cd -
 
 . "$DIR/set-pentaho-env.sh"
 
 setPentahoEnv "$DIR/jre"
 
-if [ -e "$DIR/promptuser.sh" ]; then
+if [ -f "$DIR/promptuser.sh" ]; then
   sh "$DIR/promptuser.sh"
   rm "$DIR/promptuser.sh"
 fi
 if [ "$?" = 0 ]; then
   cd "$DIR/tomcat/bin"
-  export CATALINA_OPTS="-Xmx2048m -Xmx2048m -XX:MaxPermSize=256m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8044 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000"
+  CATALINA_OPTS="-Xmx2048m -Xmx2048m -XX:MaxPermSize=256m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8044 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000"
+  export CATALINA_OPTS
   JAVA_HOME=$_PENTAHO_JAVA_HOME
   sh startup.sh
 fi

--- a/assembly/package-res/biserver/start-pentaho.sh
+++ b/assembly/package-res/biserver/start-pentaho.sh
@@ -8,19 +8,20 @@
 DIR_REL=`dirname $0`
 cd $DIR_REL
 DIR=`pwd`
-cd -
+#cd -
 
 . "$DIR/set-pentaho-env.sh"
 
 setPentahoEnv "$DIR/jre"
 
-if [ -e "$DIR/promptuser.sh" ]; then
+if [ -f "$DIR/promptuser.sh" ]; then
   sh "$DIR/promptuser.sh"
   rm "$DIR/promptuser.sh"
 fi
 if [ "$?" = 0 ]; then
   cd "$DIR/tomcat/bin"
-  export CATALINA_OPTS="-Xmx2048m -Xmx2048m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000"
+  CATALINA_OPTS="-Xmx2048m -Xmx2048m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000"
+  export CATALINA_OPTS
   JAVA_HOME=$_PENTAHO_JAVA_HOME
   sh startup.sh
 fi

--- a/assembly/package-res/biserver/stop-pentaho.sh
+++ b/assembly/package-res/biserver/stop-pentaho.sh
@@ -8,7 +8,7 @@
 DIR_REL=`dirname $0`
 cd $DIR_REL
 DIR=`pwd`
-cd -
+#cd -
 
 . "$DIR/set-pentaho-env.sh"
 


### PR DESCRIPTION
...hile using the Bourne Shell interpreter

What was done:
1) changed export of variable
2) changed file test condition to be suported by sh
3) commented out cd call which is unsupported by sh and seems to be
unnecessary
