### PR TITLE
BISERVER-10923 - Fix platform unit tests

### DIFF
--- a/core/src/org/pentaho/platform/engine/security/SecurityHelper.java
+++ b/core/src/org/pentaho/platform/engine/security/SecurityHelper.java
@@ -64,17 +64,31 @@ public class SecurityHelper implements ISecurityHelper {
   /**
    * The default instance of this singleton
    */
-  private static final ISecurityHelper instance = new SecurityHelper();
+  private static ISecurityHelper instance = new SecurityHelper();
+  private static ISecurityHelper mockInstance;
+
   private ITenantedPrincipleNameResolver tenantedUserNameUtils;
   private IAclVoter aclVoter;
   private UserDetailsService userDetailsService;
   private IUserRoleListService userRoleListService;
 
   /**
-   * Returns the one-and-only default instance
+   * Returns the default instance, if the test instance is not null return the test instance
    */
   public static ISecurityHelper getInstance() {
+    if (mockInstance != null) {
+      return mockInstance;
+    }
+
     return instance;
+  }
+
+  /**
+   * Set the mockInstance, this should only be used for testing
+   * @param mockInstanceValue the test implementation of SecurityHelper
+   */
+  public static void setMockInstance (ISecurityHelper mockInstanceValue) {
+      mockInstance = mockInstanceValue;
   }
 
   /**

--- a/core/test-src/org/pentaho/test/platform/engine/core/BaseTest.java
+++ b/core/test-src/org/pentaho/test/platform/engine/core/BaseTest.java
@@ -36,7 +36,9 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.StandaloneApplicationContext;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.platform.engine.core.system.objfac.StandaloneSpringPentahoObjectFactory;
+import org.pentaho.platform.engine.security.SecurityHelper;
 import org.pentaho.platform.util.web.SimpleUrlFactory;
+import org.pentaho.test.platform.engine.security.MockSecurityHelper;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
@@ -120,6 +122,9 @@ public class BaseTest extends GenericPentahoTest implements IActionCompleteListe
       // initting spring's app context
       springApplicationContext.getBean( "pentahoSystemProxy" ); //$NON-NLS-1$
 
+      //Initialize SecurityHelper with a mock for testing
+      SecurityHelper.setMockInstance(new MockSecurityHelper());
+
       initOk = PentahoSystem.init( applicationContext );
     } else {
       initOk = true;
@@ -129,7 +134,7 @@ public class BaseTest extends GenericPentahoTest implements IActionCompleteListe
   }
 
   private ApplicationContext getSpringApplicationContext() {
-
+    //todo
     String[] fns =
     {
       "pentahoObjects.spring.xml", "adminPlugins.xml", "sessionStartupActions.xml", "systemListeners.xml", "pentahoSystemConfig.xml" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$


### PR DESCRIPTION
Update to SecurityHelpr allows mocks to be used for testing.
BaseTest requires mockSecurityHelper so that tests extending this class wont fail during setup.
