### PR TITLE
BISERVER-10209 - import-export.sh Provides No Feedback when export path ...

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -357,6 +357,7 @@
                 conf="test->default"/>
     <dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-grizzly" rev="1.5"
                 conf="test->default"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.5" conf="test->default"/>
 
     <dependency org="org.springframework" name="spring-test" rev="2.5.6" conf="test->default"/>
 

--- a/extensions/src/org/pentaho/platform/plugin/services/importexport/CommandLineProcessor.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importexport/CommandLineProcessor.java
@@ -792,6 +792,10 @@ public class CommandLineProcessor {
         getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_KEY" ),
             Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_NAME" ), false, true );
     String effPath = path.replaceAll( "/", ":" );
+    if ( effPath.lastIndexOf( ":" ) == effPath.length() - 1 // remove trailing slash
+        && effPath.length() > 1  ) { // allow user to enter "--path=/"
+      effPath = effPath.substring( 0, effPath.length() - 1 );
+    }
     String logFile =
         getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_KEY" ), Messages
             .getInstance().getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_NAME" ), false, true );
@@ -805,7 +809,8 @@ public class CommandLineProcessor {
             .getInstance().getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_NAME" ), true, false );
 
     if ( !isValidExportPath( filepath, logFile ) ) {
-      return;
+      throw new ParseException( Messages.getInstance().getString( "CommandLineProcessor.ERROR_0005_INVALID_FILE_PATH"
+          , filepath ) );
     }
 
     initRestService();
@@ -829,6 +834,12 @@ public class CommandLineProcessor {
         System.out.println( message );
         writeFile( message, logFile );
       }
+    } else {
+      System.out.println( Messages.getInstance().getErrorString( "CommandLineProcessor.ERROR_0002_INVALID_RESPONSE" ) );
+      if ( response != null && response.getStatus() == 404 ) {
+        throw new ParseException( Messages.getInstance().getErrorString(
+            "CommandLineProcessor.ERROR_0004_UNKNOWN_SOURCE", path ) );
+      }
     }
   }
 
@@ -838,7 +849,7 @@ public class CommandLineProcessor {
 
     if ( filePath != null && filePath.toLowerCase().endsWith( ".zip" ) ) {
 
-      int fileNameIdx = filePath.lastIndexOf( "/" );
+      int fileNameIdx = filePath.replace( "\\", "/" ).lastIndexOf( "/" );
       if ( fileNameIdx >= 0 ) {
         String directoryPath = filePath.substring( 0, fileNameIdx );
 

--- a/extensions/src/org/pentaho/platform/plugin/services/messages/messages.properties
+++ b/extensions/src/org/pentaho/platform/plugin/services/messages/messages.properties
@@ -200,6 +200,7 @@ CommandLineProcessor.ERROR_0001_MISSING_ARG=Missing Arguments: {0}
 CommandLineProcessor.ERROR_0002_INVALID_RESPONSE=Invalid ClientResponse received in performREST()
 CommandLineProcessor.ERROR_0003_PARSE_EXCEPTION=exactly one of --import or --export is required
 CommandLineProcessor.ERROR_0004_UNKNOWN_SOURCE=Unknown source: {0}
+CommandLineProcessor.ERROR_0005_INVALID_FILE_PATH=Invalid file-path: {0}
 
 CommandLineProcessor.INFO_OPTION_HELP_KEY=h
 CommandLineProcessor.INFO_OPTION_HELP_NAME=help
@@ -237,7 +238,7 @@ CommandLineProcessor.INFO_OPTION_TYPE_DESCRIPTION=The type of content being impo
 
 CommandLineProcessor.INFO_OPTION_FILEPATH_KEY=fp
 CommandLineProcessor.INFO_OPTION_FILEPATH_NAME=file-path
-CommandLineProcessor.INFO_OPTION_FILEPATH_DESCRIPTION=Path to directory of files
+CommandLineProcessor.INFO_OPTION_FILEPATH_DESCRIPTION=Path to directory of files for import, or path to .zip file for export
 
 CommandLineProcessor.INFO_OPTION_CHARSET_KEY=c
 CommandLineProcessor.INFO_OPTION_CHARSET_NAME=charset

--- a/extensions/test-src/org/pentaho/platform/plugin/services/importexport/TestAuthorizationPolicy.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/importexport/TestAuthorizationPolicy.java
@@ -1,0 +1,19 @@
+package org.pentaho.platform.plugin.services.importexport;
+
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+
+import java.util.List;
+
+public class TestAuthorizationPolicy implements IAuthorizationPolicy {
+  @Override
+  public boolean isAllowed( String actionName ) {
+    // TODO Auto-generated method stub
+    return true;
+  }
+
+  @Override
+  public List<String> getAllowedActions( String actionNamespace ) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+}


### PR DESCRIPTION
...does not exist
and BISERVER-8362 - Trailing slash in path causes CommandLineProcessor export to fail

Parameters path and file-path are processing correctly now.
