### PR TITLE
BISERVER-10211 - import-export.sh Help indicates --path is not required ...

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/messages/messages.properties
+++ b/extensions/src/org/pentaho/platform/plugin/services/messages/messages.properties
@@ -253,7 +253,7 @@ CommandLineProcessor.INFO_OPTION_COMMENT_DESCRIPTION=version comment (import onl
 
 CommandLineProcessor.INFO_OPTION_PATH_KEY=f
 CommandLineProcessor.INFO_OPTION_PATH_NAME=path
-CommandLineProcessor.INFO_OPTION_PATH_DESCRIPTION=repository path to which to add imported files (e.g. /public) (import only)
+CommandLineProcessor.INFO_OPTION_PATH_DESCRIPTION=repository path to which to add imported files, or to export from (e.g. /public)
 
 CommandLineProcessor.INFO_OPTION_OVERWRITE_KEY=o
 CommandLineProcessor.INFO_OPTION_OVERWRITE_NAME=overwrite


### PR DESCRIPTION
...for exports even though it is

corrected the message
