### PR TITLE
[SP-1090] Version dates do not change

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
@@ -249,7 +249,7 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
         findTransformerForWrite(content.getClass()));
     session.save();
     JcrRepositoryFileUtils.checkinNearestVersionableFileIfNecessary(session, pentahoJcrConstants, file.getId(),
-        versionMessage, file.getCreatedDate(), true);
+        versionMessage, new java.util.Date(), true);
     lockHelper.removeLockTokenFromSessionIfNecessary(session, pentahoJcrConstants, file.getId());
     return JcrRepositoryFileUtils.nodeIdToFile(session, pentahoJcrConstants, pathConversionHelper, lockHelper,
         file.getId());


### PR DESCRIPTION
Backport of Regression [PDI-11359]
Timestamp for jobs in DI repository continuously displays the same value for different versions.
Fixed by creating new timestamp at check-in of JCR File.

http://jira.pentaho.com/browse/SP-1090
