### PR TITLE
BISERVER-4188 - UTF-8 bug in Mantle.jsp, localization is not working on ...

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/Mantle.jsp
+++ b/user-console/source/org/pentaho/mantle/public/Mantle.jsp
@@ -16,6 +16,7 @@
 --%>
 
 <!DOCTYPE html>
+<%@page pageEncoding="UTF-8" %>
 <%@page import="org.apache.commons.lang.StringUtils" %>
 <%@page import="org.owasp.esapi.ESAPI" %>
 <%@page import="org.pentaho.platform.util.messages.LocaleHelper" %>


### PR DESCRIPTION
...home page

What was done:
1) changed page encoding in Mantle.jsp to reflect content encoding
2) verified that properly encoded properties files (\uxxxx instead of
symbol) now allow to display unicode symbols
