### PR TITLE
[MONDRIAN-1914] MongOLAP not logging Agg Pipeline queries sent to MongoDB

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/osgi/log4j.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/osgi/log4j.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<!-- ===================================================================== -->
+<!--                                                                       -->
+<!--  Log4j Configuration                                                  -->
+<!--                                                                       -->
+<!-- ===================================================================== -->
+
+<!-- $Id: log4j.xml,v 1.1.1.1 2005/11/12 20:08:29 gmoran Exp $ -->
+
+<!--
+   | For more configuration information and examples see the Jakarta Log4j
+   | owebsite: http://jakarta.apache.org/log4j
+ -->
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+
+   <!-- ================================= -->
+   <!-- Preserve messages in a local file -->
+   <!-- ================================= -->
+
+   <!-- A time/date based rolling appender -->
+   <appender name="PENTAHOFILE" class="org.apache.log4j.DailyRollingFileAppender">
+
+      <param name="File" value="../logs/osgi_pentaho.log"/>
+      <param name="Append" value="false"/>
+
+      <!-- Rollover at midnight each day -->
+      <param name="DatePattern" value="'.'yyyy-MM-dd"/>
+
+      <!-- Rollover at the top of each hour
+      <param name="DatePattern" value="'.'yyyy-MM-dd-HH"/>
+      -->
+
+      <layout class="org.apache.log4j.PatternLayout">
+         <!-- The default pattern: Date Priority [Category] Message\n -->
+         <param name="ConversionPattern" value="%d %-5p [%c] %m%n"/>
+
+         <!-- The full pattern: Date MS Priority [Category] (Thread:NDC) Message\n
+         <param name="ConversionPattern" value="%d %-5r %-5p [%c] (%t:%x) %m%n"/>
+          -->
+      </layout>
+   </appender>
+
+   <!-- ============================== -->
+   <!-- Append messages to the console -->
+   <!-- ============================== -->
+
+   <appender name="PENTAHOCONSOLE" class="org.apache.log4j.ConsoleAppender">
+      <param name="Target" value="System.out"/>
+      <param name="Threshold" value="ERROR"/>
+
+      <layout class="org.apache.log4j.PatternLayout">
+         <!-- The default pattern: Date Priority [Category] Message\n -->
+         <param name="ConversionPattern" value="%d{ABSOLUTE} %-5p [%c{1}] %m%n"/>
+      </layout>
+   </appender>
+
+   <!-- ================ -->
+   <!-- Limit categories -->
+   <!-- ================ -->
+
+   <category name="org.hibernate">
+     <priority value="ERROR" />
+   </category>
+
+   <category name="net.sf.ehcache">
+     <priority value="ERROR" />
+   </category>
+
+   <category name="org.quartz">
+     <priority value="ERROR" />
+   </category>
+
+   <category name="org.springframework">
+     <priority value="ERROR"/>
+   </category>
+
+   <category name="org.springframework.security">
+     <priority value="ERROR"/>
+   </category>
+
+   <category name="org.pentaho">
+     <priority value="ERROR"/>
+   </category>
+
+   <category name="com.pentaho">
+     <priority value="ERROR"/>
+   </category>
+   
+   <category name="org.jfree.JCommon">
+      <priority value="ERROR"/>
+   </category>
+
+	<category
+		name="org.apache.jackrabbit.core.security.authentication.AbstractLoginModule">
+		<priority value="ERROR" />
+	</category>
+   
+   <!-- =========================== -->
+   <!-- Repository Import Log Level -->
+   <!-- =========================== -->
+   
+   <category name="RepositoryImportLog">
+      <priority value="INFO"/>
+   </category> 
+
+   <!-- ======================= -->
+   <!-- Setup the Root category -->
+   <!-- ======================= -->
+
+   <root>
+      <priority value="ERROR" />
+      <appender-ref ref="PENTAHOCONSOLE"/>
+      <appender-ref ref="PENTAHOFILE"/>
+   </root>
+   
+   
+   <!--  optional logging info for the Mondrian OLAP Engine       -->
+   
+   
+   <!-- ========================================================= -->
+   <!-- Special Log File specifically for Mondrian                -->
+   <!-- ========================================================= -->
+
+   <!-- 
+   <appender name="MONDRIAN" class="org.apache.log4j.RollingFileAppender">
+     <param name="File" value="../logs/osgi_mondrian.log"/>
+     <param name="Append" value="false"/>
+     <param name="MaxFileSize" value="500KB"/>
+     <param name="MaxBackupIndex" value="1"/>
+
+     <layout class="org.apache.log4j.PatternLayout">
+       <param name="ConversionPattern" value="%d %-5p [%c] %m%n"/>
+     </layout>
+   </appender>
+   
+   <category name="mondrian">
+      <priority value="DEBUG"/>
+      <appender-ref ref="MONDRIAN"/>
+   </category> 
+   
+   -->
+
+   <!-- ========================================================= -->
+   <!-- Special Log File specifically for Mondrian MDX Statements -->
+   <!-- ========================================================= -->
+
+   <!--
+   <appender name="MDXLOG" class="org.apache.log4j.RollingFileAppender">
+     <param name="File" value="../logs/osgi_mondrian_mdx.log"/>
+     <param name="Append" value="false"/>
+     <param name="MaxFileSize" value="500KB"/>
+     <param name="MaxBackupIndex" value="1"/>
+     <layout class="org.apache.log4j.PatternLayout">
+       <param name="ConversionPattern" value="%d %-5p [%c] %m%n"/>
+     </layout>
+   </appender>
+
+   <category name="mondrian.mdx">
+      <priority value="DEBUG"/>
+      <appender-ref ref="MDXLOG"/>
+   </category>
+   -->
+
+   <!-- ========================================================= -->
+   <!-- Special Log File specifically for Mondrian SQL Statements -->
+   <!-- ========================================================= -->
+
+   <!--
+   <appender name="SQLLOG" class="org.apache.log4j.RollingFileAppender">
+     <param name="File" value="../logs/osgi_mondrian_sql.log"/>
+     <param name="Append" value="false"/>
+     <param name="MaxFileSize" value="500KB"/>
+     <param name="MaxBackupIndex" value="1"/>
+     <layout class="org.apache.log4j.PatternLayout">
+       <param name="ConversionPattern" value="%d %-5p [%c] %m%n"/>
+     </layout>
+   </appender>
+
+   <category name="mondrian.sql">
+      <priority value="DEBUG"/>
+      <appender-ref ref="SQLLOG"/>
+   </category>
+   -->
+   
+</log4j:configuration>

--- a/extensions/src/org/pentaho/platform/osgi/OSGIBoot.java
+++ b/extensions/src/org/pentaho/platform/osgi/OSGIBoot.java
@@ -53,6 +53,13 @@ public class OSGIBoot implements IPentahoSystemListener {
     String solutionRootPath = PentahoSystem.getApplicationContext().getSolutionRootPath();
 
     final String sep = File.separator;
+
+    // set the location of the log4j config file, since OSGI won't pick up the one in webapp
+    System.setProperty( "log4j.configuration", "file:" + solutionRootPath + "/system/osgi/log4j.xml" );
+    // Setting ignoreTCL to true such that the OSGI classloader used to initialize log4j will be the
+    // same one used when instatiating appenders.
+    System.setProperty( "log4j.ignoreTCL", "true" );
+
     Properties osgiProps = new Properties();
     File propsFile = new File( solutionRootPath + sep + "system" + sep + "osgi" + sep + "config.properties" );
     if ( propsFile.exists() ) {
@@ -115,8 +122,8 @@ public class OSGIBoot implements IPentahoSystemListener {
 
       logger.debug( "Installing bundles" );
       for ( File bundleDirectory : bundleDirectories ) {
-        if(bundleDirectory.exists() == false){
-          logger.warn("Bundle directory: "+bundleDirectory.getName()+" does not exist");
+        if ( bundleDirectory.exists() == false ) {
+          logger.warn( "Bundle directory: " + bundleDirectory.getName() + " does not exist" );
           continue;
         }
         for ( File f : bundleDirectory.listFiles() ) {


### PR DESCRIPTION
This change sets the location of log4j.xml in a system property in OSGIBoot.  Also set is the log4j.ignoreTCL=true property, which governs whether it starts with the
classloader associated with the thread when loading classes.  TCL could cause CCEs, since the OSGI classloader should be used.
