### PR TITLE
SP-872 - Backport of BISERVER-10614 - Admin role doesn't map when upper ...

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
@@ -91,6 +91,7 @@
         <constructor-arg>
             <ref local="ldapRoleMap"/>
         </constructor-arg>
+        <constructor-arg value="${ldap.allAuthoritiesSearch.roleAttribute}"/>
     </bean>
 
   <!--


### PR DESCRIPTION
...case CN is used - Modified way we parse ldap string, added parameter to defaultLdapRoleMapper method to determine which key to parse on which is provided by the spring config
