### PR TITLE
BISERVER-10832 Invalid setting in ESAPI.properties - Logger.LogServerIP is neither true nor false 

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/ESAPI.properties
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/ESAPI.properties
@@ -7,4 +7,4 @@ Encryptor.CipherTransformation=AES/CBC/PKCS5Padding
 ESAPI.Logger=org.owasp.esapi.reference.JavaLogFactory
 Logger.LogApplicationName=true
 Logger.ApplicationName=Kettle
-Logger.LogServerIP=false 
+Logger.LogServerIP=false

--- a/extensions/test-src/ESAPI.properties
+++ b/extensions/test-src/ESAPI.properties
@@ -7,4 +7,4 @@ Encryptor.CipherTransformation=AES/CBC/PKCS5Padding
 ESAPI.Logger=org.owasp.esapi.reference.JavaLogFactory
 Logger.LogApplicationName=true
 Logger.ApplicationName=Kettle
-Logger.LogServerIP=false 
+Logger.LogServerIP=false


### PR DESCRIPTION
whitespace was delete
