### PR TITLE
BISERVER-4282 - web.xml needs a security-role tag so that Tomcat and oth...

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/web.xml
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/web.xml
@@ -576,7 +576,11 @@
       <transport-guarantee>NONE</transport-guarantee>
     </user-data-constraint>
   </security-constraint>
-
+  
+  <security-role>
+		<description>Non-Existent Role - this prevents direct access to JSPs</description>
+		<role-name>PENTAHO_ADMIN</role-name>
+	</security-role>
 
 	<error-page>
 		<error-code>404</error-code>

--- a/user-console/build-resources/WEB-INF/web.xml
+++ b/user-console/build-resources/WEB-INF/web.xml
@@ -346,4 +346,9 @@
     </user-data-constraint>
   </security-constraint>
 
+  <security-role>
+		<description>Non-Existent Role - this prevents direct access to JSPs</description>
+		<role-name>PENTAHO_ADMIN</role-name>
+	</security-role> 
+
 </web-app>


### PR DESCRIPTION
...er servers stop complaining.

What was done:
1) added missed entry to web.xml files
