### PR TITLE
BISERVER-9706 - Issues with exported file names when exporting a data so...

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
@@ -276,7 +276,8 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
       } catch ( Exception e ) {
         return null; // This pretty much ensures an exception will be thrown later and passed to the client
       }
-      String fileName = repoFile.getName().endsWith( ".properties" ) ? repoFile.getName() : domainId + ".xmi";
+      String fileName = repoFile.getName().endsWith( ".properties" ) ? repoFile.getName()
+          : domainId + ( domainId.endsWith( ".xmi" ) ? "" : ".xmi" );
       values.put( fileName, is );
     }
     return values;


### PR DESCRIPTION
...urce created by the data source wizard

fix double .xmi.xmi at the end of metadata file
