### PR TITLE
BISERVER-10156 - Read Only users can Copy/Paste in UI, but no error when...

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -264,6 +264,9 @@ public class FileResource extends AbstractJaxRSResource {
     if ( mode == null ) {
       mode = MODE_RENAME;
     }
+    if ( !getPolicy().isAllowed( RepositoryCreateAction.NAME ) ) {
+      return Response.status( FORBIDDEN ).build();
+    }
     try {
       String path = idToPath( pathId );
       RepositoryFile destDir = getRepository().getFile( path );
@@ -349,8 +352,8 @@ public class FileResource extends AbstractJaxRSResource {
         }
       }
     } catch ( Throwable t ) {
-      t.printStackTrace();
-      return Response.serverError().build();
+      logger.error( t );
+      return Response.serverError().entity( t.getLocalizedMessage() ).build();
     }
     return Response.ok().build();
   }

--- a/user-console/source/org/pentaho/mantle/public/messages/mantleMessages.properties
+++ b/user-console/source/org/pentaho/mantle/public/messages/mantleMessages.properties
@@ -591,3 +591,5 @@ schedule.invalidRecurrenceString=Invalid recurrence string: {0}
 schedule.noRadioBtnsSelected=There seems to not be any radio button selected, which is theoretically impossible.
 schedule.startDate=Start Date
 schedule.scheduleEdit=Schedule Edit
+
+pasteFilesCommand.accessDenied=Access denied. Please contact your Administrator.


### PR DESCRIPTION
... it fails.
1. added check for RepositoryCreateAction permission at copy/cut method
2. if other error happens - user will see it
