### PR TITLE
[PDI-11091] Errors when running the PDI Migrator tool with MSAD authenti...

### DIFF
--- a/core/src/org/pentaho/platform/engine/security/DefaultLdapRoleMapper.java
+++ b/core/src/org/pentaho/platform/engine/security/DefaultLdapRoleMapper.java
@@ -137,7 +137,7 @@ public class DefaultLdapRoleMapper implements IAuthenticationRoleMapper, Seriali
     Properties ldapProperties = new Properties();
 
     try {
-      File propertiesFile = new File(System.getProperty("PentahoSystemPath") + System.lineSeparator() + LDAP_PROPERTIES_FILENAME);
+      File propertiesFile = new File(System.getProperty("PentahoSystemPath") + System.getProperty("line.separator") + LDAP_PROPERTIES_FILENAME);
       InputStream propertiesInputFile = new FileInputStream(propertiesFile);
       ldapProperties.load(propertiesInputFile);
 


### PR DESCRIPTION
...cation implemented
- System.lineSeparator() this is a JAVA 1.7 feature. System.getProperty("line.separator") is the correct way to do it pre 1.7
