### PR TITLE
BISERVER-10812 - Javascript variable not correctly initialized causing B...

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/home/js/favorites.js
+++ b/user-console/source/org/pentaho/mantle/public/home/js/favorites.js
@@ -110,7 +110,7 @@ define(["common-ui/util/PentahoSpinner", "common-ui/util/spin.min"], function (s
     },
 
     _beforeLoad: function () {
-      this.currentItems = undefined;
+      this.currentItems = [];
     },
 
     getUrlBase: function () {


### PR DESCRIPTION
...rowse perspective to not load.

set currentItems to empty array initially
