### PR TITLE
[BISERVER-11104] - Remove HTML files from the biserver -ee manual deploy...

### DIFF
--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -585,11 +585,11 @@
 			</zipfileset>
 		</zip>
 		<!--copy install doc to the dist folder -->
-		<copy todir="${dist.dir}">
+		<!--<copy todir="${dist.dir}">
 			<fileset dir="${install-doc.dir}">
 				<include name="*.*" />
 			</fileset>
-		</copy>
+		</copy>-->
 	</target>
 
 	<!-- ===================================================================


### PR DESCRIPTION
...ment folder

HTML files were still being wrapped up in the dist installation.
