### PR TITLE
Backport of BISERVER-11242 - Connections are pooled even when pooling is...

### DIFF
--- a/api/src/org/pentaho/platform/api/data/IDBDatasourceService.java
+++ b/api/src/org/pentaho/platform/api/data/IDBDatasourceService.java
@@ -32,9 +32,10 @@ public interface IDBDatasourceService {
    public static final String JDBC_POOL = "JDBC_POOL" ; //$NON-NLS-1$
    public static final String JDBC_DATASOURCE = "DataSource" ; //$NON-NLS-1$
    public static final String IDBDATASOURCE_SERVICE = "IDBDatasourceService" ; //$NON-NLS-1$
-   public static final String MAX_ACTIVE_KEY = "POOLING_maxActive";
-   public static final String MAX_IDLE_KEY = "POOLING_maxIdle";
-   public static final String MAX_WAIT_KEY = "POOLING_maxWait";
+   public static final String MAX_ACTIVE_KEY = "maxActive";
+   public static final String MAX_IDLE_KEY = "maxIdle";
+   public static final String MIN_IDLE_KEY = "minIdle";
+   public static final String MAX_WAIT_KEY = "maxWait";
    public static final String QUERY_KEY = "query";
 
   /**

--- a/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelper.java
+++ b/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelper.java
@@ -27,6 +27,7 @@ import org.apache.commons.dbcp.ConnectionFactory;
 import org.apache.commons.dbcp.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp.PoolableConnectionFactory;
 import org.apache.commons.dbcp.PoolingDataSource;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.pool.impl.GenericObjectPool;
 import org.pentaho.database.DatabaseDialectException;
 import org.pentaho.database.IDatabaseDialect;
@@ -81,7 +82,7 @@ public class PooledDatasourceHelper {
       int minIdleConnection =  !StringUtil.isEmpty(minIdleConn) ? Integer.parseInt(minIdleConn) : -1;
       int maxIdleConnection =  !StringUtil.isEmpty(maxdleConn) ? Integer.parseInt(maxdleConn) : -1;
 
-      Map<String, String> attributes = databaseConnection.getAttributes();
+      Map<String, String> attributes = databaseConnection.getConnectionPoolingProperties();
       
       if(attributes.containsKey(IDBDatasourceService.MAX_ACTIVE_KEY)) {
         maxActiveConnection = Integer.parseInt(attributes.get(IDBDatasourceService.MAX_ACTIVE_KEY));
@@ -96,6 +97,14 @@ public class PooledDatasourceHelper {
         if(!StringUtil.isEmpty(wait)) {
           waitTime = Long.parseLong(wait);
         }
+      }
+      if(attributes.containsKey( IDBDatasourceService.MIN_IDLE_KEY )  
+    	  && NumberUtils.isDigits( attributes.get( IDBDatasourceService.MIN_IDLE_KEY ) ) ) {
+    	  minIdleConnection = Integer.parseInt( attributes.get( IDBDatasourceService.MIN_IDLE_KEY ) );
+      }
+      if(attributes.containsKey( IDBDatasourceService.MAX_IDLE_KEY )  
+          && NumberUtils.isDigits( attributes.get( IDBDatasourceService.MAX_IDLE_KEY ) ) ) {
+        	  maxIdleConnection = Integer.parseInt( attributes.get( IDBDatasourceService.MAX_IDLE_KEY ) );
       }
       if(attributes.containsKey(IDBDatasourceService.QUERY_KEY)) {
         validQuery = attributes.get(IDBDatasourceService.QUERY_KEY);


### PR DESCRIPTION
... turned off (5.0)

```
- pooling attributes were being checked in the wrong map
- added map checking for 2 missing polling connection attributes (maxIdle / minIdle )
```
