### PR TITLE
SP-1158 - Backport of BISERVER-11010 - Administrator role does not show ...

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAclAceDto.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAclAceDto.java
@@ -20,6 +20,7 @@ import java.util.List;
 public class RepositoryFileAclAceDto implements Serializable{
   String recipient;
   String tenantPath;
+  boolean modifiable = true;
 
   /**
    * RepositoryFileSid.Type enum.
@@ -67,11 +68,19 @@ public class RepositoryFileAclAceDto implements Serializable{
   public void setPermissions(List<Integer> permissions) {
     this.permissions = permissions;
   }
+  
+  public boolean isModifiable() {
+    return modifiable;
+  }
+
+  public void setModifiable( boolean modifiable ) {
+    this.modifiable = modifiable;
+  }
 
   @SuppressWarnings("nls")
   @Override
   public String toString() {
     return "RepositoryFileAclAceDto [recipient=" + recipient + ", recipientType=" + recipientType + ", permissions="
-        + permissions + "]";
+        + permissions + ", modifiable=" + modifiable + "]";
   }
 }

--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
@@ -63,6 +63,8 @@ public class PermissionsPanel extends FlexTable implements IFileModifier {
   private static final String PERMISSIONS_ELEMENT_NAME = "permissions"; //$NON-NLS-1$
 
   private static final String RECIPIENT_ELEMENT_NAME = "recipient"; //$NON-NLS-1$
+  
+  private static final String MODIFIABLE_ELEMENT_NAME = "modifiable"; //$NON-NLS-1$
 
   private static final String ACES_ELEMENT_NAME = "aces"; //$NON-NLS-1$
 
@@ -390,12 +392,15 @@ public class PermissionsPanel extends FlexTable implements IFileModifier {
     managePermissionCheckBox.setValue(perms.contains(PERM_GRANT_PERM) || perms.contains(PERM_ALL));
     inheritsCheckBox.setValue(isInheritsAcls(fileInfo));
 
-
     refreshPermission();
+    
+    if ( !isModifiableUserOrRole(fileInfo, userOrRoleString) ) {
+      managePermissionCheckBox.setEnabled( false );
+    }
 
     addButton.setEnabled(!inheritsCheckBox.getValue());
     removeButton.setEnabled(!(isOwner(userOrRoleString, USER_TYPE, fileInfo) || isOwner(userOrRoleString, ROLE_TYPE,
-        fileInfo)) && !inheritsCheckBox.getValue());
+        fileInfo) || !isModifiableUserOrRole( fileInfo, userOrRoleString )) && !inheritsCheckBox.getValue());
   }
 
   /**
@@ -628,6 +633,20 @@ public class PermissionsPanel extends FlexTable implements IFileModifier {
       }
     }
     return values;
+  }
+  
+  private Boolean isModifiableUserOrRole( Document fileInfo, String recipient ) {
+    Boolean ret = false;
+    NodeList aces = fileInfo.getElementsByTagName( ACES_ELEMENT_NAME );
+    for ( int i = 0; i < aces.getLength(); i++ ) {
+      Element ace = (Element) aces.item( i );
+      if ( ace.getElementsByTagName( RECIPIENT_ELEMENT_NAME ).item( 0 ).getFirstChild().getNodeValue().equals(
+          recipient ) ) {
+        ret = ace.getElementsByTagName( MODIFIABLE_ELEMENT_NAME ).item( 0 ).getFirstChild().getNodeValue().equals(true);        
+        return ret;
+      }
+    }
+    return ret;
   }
 
   /**


### PR DESCRIPTION
...on Share tab for existing and new folders

What was done:
1) added field is modifiable to AceAcl DTO
2) changed ui to take care of the field
3) changed WS to ignore non-modifiable role and to add admin role for
display only

Conflicts:
    extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
    user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
