### PR TITLE
BISERVER-11225 - in PUC browser if user doesn't have ACL permissions for...

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/FilePropertiesDialog.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/FilePropertiesDialog.java
@@ -230,7 +230,9 @@ public class FilePropertiesDialog extends PromptDialogBox {
         public void onResponseReceived( Request request, Response response ) {
           if ( response.getStatusCode() == Response.SC_OK ) {
             generalTab.setAclResponse( response );
-            permissionsTab.setAclResponse( response );
+            if ( permissionsTab != null ) {
+              permissionsTab.setAclResponse( response );
+            }
           } else {
             MessageDialogBox dialogBox =
                 new MessageDialogBox(

--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/GeneralPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/GeneralPanel.java
@@ -196,8 +196,10 @@ public class GeneralPanel extends FlexTable implements IFileModifier {
       }
     }
     // setMetadataBuilder.sendRequest(metadata.toString(), setMetadataCallback);
-    setMetadataBuilder.setRequestData( metadata.toString() );
-    requestBuilders.add( setMetadataBuilder );
+    if ( arr.size() > 0 ) {
+      setMetadataBuilder.setRequestData( metadata.toString() );
+      requestBuilders.add( setMetadataBuilder );
+    }
 
     return requestBuilders;
   }


### PR DESCRIPTION
... folder/file and clicks on properties, javascript error occurs.

check if permissionsTab is not null;
don't send request if there is nothing to send
