### PR TITLE
BISERVER-11354 - DefaultLdapRoleMapper#getRoleAttributeFromProperties us...

### DIFF
--- a/core/test-src/org/pentaho/commons/system/LoadDriversListenerTest.java
+++ b/core/test-src/org/pentaho/commons/system/LoadDriversListenerTest.java
@@ -79,7 +79,8 @@ public class LoadDriversListenerTest {
       return false;
     }
 
-    @Override public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    //don't add @Override annotation for Java 6 compatibility (class Driver doesn't have getParentLogger method in Java 6)
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
       return null;
     }
   }

--- a/extensions/src/org/pentaho/platform/plugin/services/connections/PentahoSystemDriver.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/connections/PentahoSystemDriver.java
@@ -119,7 +119,7 @@ public class PentahoSystemDriver implements Driver {
     return true;
   }
 
-  @Override
+  //don't add @Override annotation for Java 6 compatibility (class Driver doesn't have getParentLogger method in Java 6)
   public Logger getParentLogger() throws SQLFeatureNotSupportedException {
     throw new SQLFeatureNotSupportedException( "Impossible to know which Driver to fetch the logger from" );
   }


### PR DESCRIPTION
...es JDK7 features

That was fixed with PDI-11091, but more Java7-specific code was found
