### PR TITLE
[BISERVER-11442] Fix for can't save dashboard after attempting to schedule one of its xanalyzer reports

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
@@ -464,6 +464,7 @@ public class SolutionBrowserPanel extends HorizontalPanel {
       editFile( repositoryFile );
     } else if ( mode == FileCommand.COMMAND.SCHEDULE_NEW ) {
       ScheduleHelper.createSchedule( repositoryFile );
+      return;
     } else if ( mode == FileCommand.COMMAND.SHARE ) {
       ShareFileCommand sfc = new ShareFileCommand();
       sfc.setSolutionPath( fileNameWithPath );


### PR DESCRIPTION
Fix for can't save dashboard after attempting to schedule one of its xanalyzer reports
