### PR TITLE
[BISERVER-11268] Allow Invalid JCR Characters in file/folder names

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/filters/PentahoWebContextFilter.java
+++ b/extensions/src/org/pentaho/platform/web/http/filters/PentahoWebContextFilter.java
@@ -158,16 +158,20 @@ public class PentahoWebContextFilter implements Filter {
         printReservedChars( out );
         printReservedRegexPattern( out );
 
-        // print global resources defined in plugins
-        printResourcesForContext( GLOBAL, out, httpRequest, false );
+        boolean requireJsOnly = "true".equals( request.getParameter( "requireJsOnly" ) );
 
-        // print out external-resources defined in plugins if a context has been passed in
-        String contextName = request.getParameter( CONTEXT );
-        boolean cssOnly = "true".equals( request.getParameter( "cssOnly" ) );
-        if ( StringUtils.isNotEmpty( contextName ) ) {
-          printResourcesForContext( contextName, out, httpRequest, cssOnly );
+        if ( !requireJsOnly ) {
+          // print global resources defined in plugins
+          printResourcesForContext( GLOBAL, out, httpRequest, false );
+
+          // print out external-resources defined in plugins if a context has been passed in
+          String contextName = request.getParameter( CONTEXT );
+          boolean cssOnly = "true".equals( request.getParameter( "cssOnly" ) );
+          if ( StringUtils.isNotEmpty( contextName ) ) {
+            printResourcesForContext( contextName, out, httpRequest, cssOnly );
+          }
         }
-
+          
         // Any subclass can add more information to webcontext.js
         addCustomInfo( out );
 


### PR DESCRIPTION
[BISERVER-11435] pentaho mobile updates for encoding/decoding/reserved chars

For mobile we cannot just ask for all of what webcontext.js gives us, we need to have ONLY the require.js settings.  The default if you do not specify requireJsOnly is 'false' meaning we fall back to the old behavior to provide all resources.

I have added a requireJsOnly parameter for mobile.  There will be an additional pull request for mobile for this.
