### PR TITLE
SP-1265 - Backport of BISERVER-11381 - Publishing a Mondrian Schema with...

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/connections/mondrian/MDXOlap4jConnection.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/connections/mondrian/MDXOlap4jConnection.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Properties;
 
 import mondrian.olap.Util;
+import mondrian.parser.TokenMgrError;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -82,6 +83,10 @@ public class MDXOlap4jConnection implements IPentahoConnection {
 		} catch (Exception e) {
 			log.error(Messages.getInstance().getErrorString(
 		            "MDXConnection.ERROR_0002_INVALID_CONNECTION", "driver=" + driver + ";url=" + url), e);
+			return false;
+		} catch (TokenMgrError e) {
+			log.error( Messages.getInstance().getErrorString( "MDXConnection.ERROR_0002_INVALID_CONNECTION",
+				"driver=" + driver + ";url=" + url ), e );
 			return false;
 		}
 


### PR DESCRIPTION
... a syntax error in a Calculated Member breaks PUC UI (5.0)

What was done:
1) added catch for mondrian.parser.TokenMgrError which was not handled and
aused system fail
