### PR TITLE
[BISERVER-11268] Centralize and Standardize the encoding/decoding of WebService calls from clients of the Pentaho Servers

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -1069,9 +1069,6 @@ public class FileResource extends AbstractJaxRSResource {
     StringBuffer buffer = new StringBuffer();
     for ( int i = 0; i < reservedCharacters.size(); i++ ) {
       buffer.append( reservedCharacters.get( i ) );
-      if ( i + 1 < reservedCharacters.size() ) {
-        buffer.append( ',' );
-      }
     }
     return Response.ok( buffer.toString(), MediaType.TEXT_PLAIN ).build();
   }


### PR DESCRIPTION
Users of the API are all expecting a list of characters without any separators.  Adding the separator was causing the REGEX pattern to include , (comma) as a reserved character.
