### PR TITLE
[PDI-10744] - Uncomment EXECUTE for repository file permission

### DIFF
--- a/api/src/org/pentaho/platform/api/repository2/unified/RepositoryFilePermission.java
+++ b/api/src/org/pentaho/platform/api/repository2/unified/RepositoryFilePermission.java
@@ -57,5 +57,5 @@ package org.pentaho.platform.api.repository2.unified;
  * @author mlowery
  */
 public enum RepositoryFilePermission {
-  READ, WRITE, /* EXECUTE, */DELETE, /* APPEND, *//* DELETE_CHILD, */ACL_MANAGEMENT, /* READ_ACL, WRITE_ACL, */ALL;
+  READ, WRITE, EXECUTE, DELETE, /* APPEND, *//* DELETE_CHILD, */ACL_MANAGEMENT, /* READ_ACL, WRITE_ACL, */ALL;
 }


### PR DESCRIPTION
We are tying in EXECUTE permissions in Kettle.
