### PR TITLE
[BISERVER-11614] - Manage Roles Operation Permissions are not saving

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/transform/NodeRepositoryFileDataTransformer.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/transform/NodeRepositoryFileDataTransformer.java
@@ -95,7 +95,7 @@ public class NodeRepositoryFileDataTransformer implements ITransformer<NodeRepos
     if ( NodeHelper.hasNode( jcrParentNode, prefix, nodeName ) ) {
       jcrNode = NodeHelper.getNode( jcrParentNode, prefix, nodeName );
     } else {
-      jcrNode = jcrParentNode.addNode( nodeName, pentahoJcrConstants.getPHO_NT_INTERNALFOLDER() );
+      jcrNode = jcrParentNode.addNode( prefix + nodeName, pentahoJcrConstants.getPHO_NT_INTERNALFOLDER() );
     }
     // set any properties represented by dataNode
     for ( DataProperty dataProp : dataNode.getProperties() ) {


### PR DESCRIPTION
Node Prefix should not be encoded. Changes decouples node name from prefix. Was missing one prefix call
