### PR TITLE
[PDI-10744] Set SlaveServerConfig with absolute path

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/action/kettle/KettleSystemListener.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/kettle/KettleSystemListener.java
@@ -82,7 +82,7 @@ public class KettleSystemListener implements IPentahoSystemListener {
         Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse( is );
         Node configNode = XMLHandler.getSubNode( document, SlaveServerConfig.XML_TAG );
         SlaveServerConfig config = new SlaveServerConfig( new LogChannel( "Slave server config" ), configNode );
-        config.setFilename( slaveServerConfigFilename );
+        config.setFilename( slaveServerConfigFile.getAbsolutePath() );
         SlaveServer slaveServer = new SlaveServer();
         config.setSlaveServer( slaveServer );
         CarteSingleton.setSlaveServerConfig( config );


### PR DESCRIPTION
Slave server config should be set with absolute path to facilitate retrieval of additional properties
