### PR TITLE
[BISERVER-11606] File and Folder names do not work correctly when they start or end with a colon

### DIFF
--- a/repository/src/org/pentaho/platform/repository/RepositoryFilenameUtils.java
+++ b/repository/src/org/pentaho/platform/repository/RepositoryFilenameUtils.java
@@ -231,7 +231,7 @@ public class RepositoryFilenameUtils {
    * @return the concatenated path, or null if invalid
    */
   public static String concat( final String basePath, final String fullFilenameToAdd ) {
-    int prefix = getPrefixLength( fullFilenameToAdd );
+    int prefix = getPrefixLength( fullFilenameToAdd.replace( ":", "_" ) );
     if ( prefix < 0 ) {
       return null;
     }


### PR DESCRIPTION
This is a workaround for a bug in commons io not handling colons in filenames.  The effect has no change in the ask "getPrefixLength" nor is the replaced string ever used outside of the ask for the prefix length.
