### PR TITLE
[BISERVER-11536][regression]Unable to add new roles

### DIFF
--- a/repository/src/org/pentaho/platform/security/userroledao/ws/UserRoleWebService.java
+++ b/repository/src/org/pentaho/platform/security/userroledao/ws/UserRoleWebService.java
@@ -212,7 +212,7 @@ public class UserRoleWebService implements IUserRoleWebService {
 
   @Override
   public boolean createRole( ProxyPentahoRole proxyRole ) throws UserRoleException {
-    getDao().createRole( proxyRole.getTenant(), proxyRole.getName(), proxyRole.getDescription(), null );
+    getDao().createRole( proxyRole.getTenant(), proxyRole.getName(), proxyRole.getDescription(), new String[0] );
     return false;
   }
 


### PR DESCRIPTION
Null pointer exception was thrown when adding a new role via UserRoleWebService.
Fixed by creating role with empty user list instead of null.

http://jira.pentaho.com/browse/BISERVER-11536

Regression caused by https://github.com/pentaho/pentaho-platform/pull/1598
