### PR TITLE
[BISERVER-11758] - adding users to roles was using incorrect util for ge...

### DIFF
--- a/repository/src/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDao.java
+++ b/repository/src/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDao.java
@@ -184,7 +184,8 @@ public abstract class AbstractJcrBackedUserRoleDao implements IUserRoleDao {
       for ( String user : memberUserNames ) {
         User jackrabbitUser = getJackrabbitUser( tenant, user, session );
         if ( jackrabbitUser != null ) {
-          finalCollectionOfAssignedUsers.put( tenantedRoleNameUtils.getPrincipleId( tenant, user ), jackrabbitUser );
+          finalCollectionOfAssignedUsers.put(
+            getTenantedUserNameUtils().getPrincipleId( tenant, user ), jackrabbitUser );
         }
       }
     }
@@ -197,6 +198,7 @@ public abstract class AbstractJcrBackedUserRoleDao implements IUserRoleDao {
 
     for ( String userId : usersToRemove ) {
       jackrabbitGroup.removeMember( currentlyAssignedUsers.get( userId ) );
+      purgeUserFromCache( userId );
     }
 
     for ( String userId : usersToAdd ) {


### PR DESCRIPTION
...nerating the tenant id, causing the cache to keep the old user credentials.  Also, removing users from roles were not getting purged from the cache.
