### PR TITLE
SP-1317 - Backport of BISERVER-10547 - Folder is created in user console...

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapAuthenticationProvider.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapAuthenticationProvider.java
@@ -18,6 +18,7 @@
 package org.pentaho.platform.plugin.services.security.userrole.ldap;
 
 import org.pentaho.platform.api.engine.security.IAuthenticationRoleMapper;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.Authentication;
 import org.springframework.security.AuthenticationException;
@@ -36,13 +37,21 @@ public class DefaultLdapAuthenticationProvider extends LdapAuthenticationProvide
   public DefaultLdapAuthenticationProvider( LdapAuthenticator authenticator, IAuthenticationRoleMapper roleMapper ) {
     super( authenticator );
     this.roleMapper = roleMapper;
+    setAuthenticatedRole( null );
+  }
+
+  public DefaultLdapAuthenticationProvider( LdapAuthenticator authenticator,
+      LdapAuthoritiesPopulator authoritiesPopulator, IAuthenticationRoleMapper roleMapper ) {
+    super( authenticator, authoritiesPopulator );
+    this.roleMapper = roleMapper;
+    setAuthenticatedRole( null );
   }
 
   public DefaultLdapAuthenticationProvider( LdapAuthenticator authenticator,
       LdapAuthoritiesPopulator authoritiesPopulator, IAuthenticationRoleMapper roleMapper, String authenticatedRole ) {
     super( authenticator, authoritiesPopulator );
     this.roleMapper = roleMapper;
-    this.authenticatedRole = authenticatedRole;
+    setAuthenticatedRole( authenticatedRole );
   }
 
   /**
@@ -70,5 +79,10 @@ public class DefaultLdapAuthenticationProvider extends LdapAuthenticationProvide
       }
     }
     throw new AuthenticationServiceException( "The user doesn't have '" + authenticatedRole + "' role." );
+  }
+
+  private void setAuthenticatedRole( String authenticatedRole ) {
+    this.authenticatedRole = authenticatedRole == null
+        ? PentahoSystem.get( String.class, "singleTenantAuthenticatedAuthorityName", null ) : authenticatedRole;
   }
 }


### PR DESCRIPTION
... for non-pentaho LDAP/MSAD users who attempt to login even though authentication fails (5.1)

check if user has Authenticated role; map ldap.authenticatedRole to Authenticated

fix for https://github.com/pentaho/pentaho-platform/pull/1674
