### PR TITLE
[PDI-10610]: Changed analyze() return to IMetaverseNode for processing hierarchies

### DIFF
--- a/api/src/org/pentaho/platform/api/metaverse/IAnalyzer.java
+++ b/api/src/org/pentaho/platform/api/metaverse/IAnalyzer.java
@@ -28,8 +28,10 @@ public interface IAnalyzer<T> {
    * Analyze the given object
    *
    * @param object the object
+   * 
+   * @return the root node resulting from the analysis of the specified object
    */
-  void analyze(T object);
+  IMetaverseNode analyze(T object);
   
   /**
    * Sets the metaverse builder, used by the analyzer to create nodes and links in the metaverse generated


### PR DESCRIPTION
This allows an analyzer to reference the root node from "sub-entities", such as a Step Analyzer knowing about a DatabaseConnection root node.
