### PR TITLE
[BACKLOG-218] Add event bus to the platform and make sure it is available on the DI Server

### DIFF
--- a/api/src/org/pentaho/platform/api/monitoring/IMonitoringEvent.java
+++ b/api/src/org/pentaho/platform/api/monitoring/IMonitoringEvent.java
@@ -1,0 +1,28 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.platform.api.monitoring;
+
+import java.io.Serializable;
+
+/**
+ * top-most signature for any event being published to monitoring's event bus
+ */
+public interface IMonitoringEvent extends Serializable {
+
+  Serializable getId();
+
+}

--- a/api/src/org/pentaho/platform/api/monitoring/IMonitoringService.java
+++ b/api/src/org/pentaho/platform/api/monitoring/IMonitoringService.java
@@ -1,0 +1,45 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.platform.api.monitoring;
+
+
+public interface IMonitoringService {
+
+  /**
+   * register a subscriber ( a.k.a. event handler ) in event bus
+   *
+   * @param subscriber IMonitoringSubscriber event handler
+   */
+  <T extends IMonitoringSubscriber> void register( T subscriber );
+
+
+  /**
+   * unregister a subscriber ( a.k.a. event handler ) from event bus
+   *
+   * @param subscriber IMonitoringSubscriber event handler
+   */
+  <T extends IMonitoringSubscriber> void unregister( T subscriber );
+
+
+  /**
+   * all subscribers of this event type will be triggered
+   *
+   * @param event IMonitoringEvent event object
+   */
+  <T extends IMonitoringEvent> void post( T event );
+
+}

--- a/api/src/org/pentaho/platform/api/monitoring/IMonitoringSubscriber.java
+++ b/api/src/org/pentaho/platform/api/monitoring/IMonitoringSubscriber.java
@@ -1,0 +1,26 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.platform.api.monitoring;
+
+/**
+ * top-most signature for any event handler being subscribed onto monitoring's event bus
+ */
+public interface IMonitoringSubscriber {
+
+  String getSubscriberId();
+
+}

--- a/assembly/package-res/biserver/pentaho-solutions/system/monitoring-eventbus-plugin/plugin.spring.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/monitoring-eventbus-plugin/plugin.spring.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ws="http://jax-ws.dev.java.net/spring/core" xmlns:wss="http://jax-ws.dev.java.net/spring/servlet"
+  xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd
+                           http://jax-ws.dev.java.net/spring/core http://jax-ws.dev.java.net/spring/core.xsd
+                           http://jax-ws.dev.java.net/spring/servlet http://jax-ws.dev.java.net/spring/servlet.xsd
+                           http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd">
+
+  <context:annotation-config />
+
+  <bean id="IMonitoringService" class="org.pentaho.platform.monitoring.MonitoringService" scope="singleton" />
+
+</beans>

--- a/assembly/package-res/biserver/pentaho-solutions/system/monitoring-eventbus-plugin/plugin.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/monitoring-eventbus-plugin/plugin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin title="Pentaho Monitoring Event Bus Plugin" name="monitoring-eventbus-plugin">
+
+  <content-generator/>
+
+</plugin>

--- a/extensions/src/org/pentaho/platform/monitoring/MonitoringService.java
+++ b/extensions/src/org/pentaho/platform/monitoring/MonitoringService.java
@@ -1,0 +1,102 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.platform.monitoring;
+
+import com.google.common.eventbus.AsyncEventBus;
+import org.pentaho.platform.api.monitoring.IMonitoringEvent;
+import org.pentaho.platform.api.monitoring.IMonitoringService;
+import org.pentaho.platform.api.monitoring.IMonitoringSubscriber;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.monitoring.subscribers.MonitoringDeadEventSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+
+/**
+ * Wrapper for the AsyncEventBus class.
+ * <p/>
+ * The methods of AsyncEventBus use internal synchronization, so this singleton is thread-safe
+ */
+public class MonitoringService implements IMonitoringService {
+
+  private Logger logger = LoggerFactory.getLogger( MonitoringService.class );
+
+  private AsyncEventBus asyncEventBus; // asynchronous dispatching of events
+
+
+  public MonitoringService() {
+
+    asyncEventBus = new AsyncEventBus( Executors.newCachedThreadPool() );
+
+    // guava's elegant Catch-All-That-Fell-Thru-Cracks ( a.k.a 'DeadEvents' )
+    MonitoringDeadEventSubscriber deadEventSubscriber = new MonitoringDeadEventSubscriber();
+    getAsyncEventBus().register( deadEventSubscriber );
+
+    //register this service in PentahoSystem
+    registerMyself();
+  }
+
+  /**
+   * register a subscriber ( a.k.a. event handler ) in event bus
+   *
+   * @param subscriber IMonitoringSubscriber event handler
+   */
+  @Override
+  public synchronized <T extends IMonitoringSubscriber> void register( T subscriber ) {
+    logger.debug( "registering subscriber " + ( subscriber != null ? subscriber.getSubscriberId()  : "null" ) );
+    getAsyncEventBus().register( subscriber );
+  }
+
+  /**
+   * unregister a subscriber ( a.k.a. event handler ) from event bus
+   *
+   * @param subscriber IMonitoringSubscriber event handler
+   */
+  @Override
+  public synchronized <T extends IMonitoringSubscriber> void unregister( T subscriber ) {
+    logger.debug( "unregistering subscriber " + ( subscriber != null ? subscriber.getSubscriberId()  : "null" ) );
+    getAsyncEventBus().unregister( subscriber );
+  }
+
+  /**
+   * all subscribers of this event type will be triggered
+   *
+   * @param event IMonitoringEvent event object
+   */
+  @Override
+  public synchronized <T extends IMonitoringEvent> void post( T event ) {
+    logger.debug( "posting event " + ( event != null ? event.getId() : "null" ) );
+    getAsyncEventBus().post( event );
+  }
+
+  private AsyncEventBus getAsyncEventBus() {
+    return asyncEventBus;
+  }
+
+  private void registerMyself() {
+
+    if ( PentahoSystem.getInitializedOK() ) {
+      PentahoSystem.registerObject( this );
+    }
+
+    if ( !PentahoSystem.getInitializedOK() || PentahoSystem.get( IMonitoringService.class ) == null ) {
+      logger.error( "Unable to register Monitoring Event Bus Service in PentahoSystem" );
+    }
+  }
+
+}

--- a/extensions/src/org/pentaho/platform/monitoring/subscribers/MonitoringDeadEventSubscriber.java
+++ b/extensions/src/org/pentaho/platform/monitoring/subscribers/MonitoringDeadEventSubscriber.java
@@ -1,0 +1,45 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package org.pentaho.platform.monitoring.subscribers;
+
+import com.google.common.eventbus.DeadEvent;
+import com.google.common.eventbus.Subscribe;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.pentaho.platform.api.monitoring.IMonitoringSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * guava's elegant Catch-All-That-Fell-Thru-Cracks
+ * <p/>
+ * 'dead-letter' queue in the conventional message queuing systems for intercepting messages that failed to be delivered
+ * to any known subscriber
+ */
+public class MonitoringDeadEventSubscriber implements IMonitoringSubscriber {
+
+  private Logger logger = LoggerFactory.getLogger( MonitoringDeadEventSubscriber.class );
+
+  @Override
+  public String getSubscriberId() {
+    return this.getClass().getName();
+  }
+
+  @Subscribe
+  public void handleDeadEvent( DeadEvent e ) {
+    logger.error( e != null ? ToStringBuilder.reflectionToString( e.getEvent() ) : "null object" );
+  }
+}


### PR DESCRIPTION
- leverages on guava's async event bus
- interfaces in pentaho-platform-api and implementation of MonitorService in pentaho-platform-extensions
- shell-plugin 'monitoring-eventbus-plugin' that simply starts up MonitoringService
