### PR TITLE
PPP-3308 - Migration Tool does not migrate double byte files and folders

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -668,10 +668,12 @@ public class JcrRepositoryFileUtils {
     return transformer.fromContentNode( session, pentahoJcrConstants, fileNode );
   }
 
+
   public static List<RepositoryFile> getChildren( final Session session, final PentahoJcrConstants pentahoJcrConstants,
       final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper,
       final RepositoryRequest repositoryRequest ) throws RepositoryException {
-    Node folderNode = session.getNodeByIdentifier( JcrStringHelper.pathEncode( repositoryRequest.getPath() ) );
+    Node folderNode = session.getNodeByIdentifier( JcrStringHelper.idEncode( repositoryRequest.getPath() ) );
+
     Assert.isTrue( isPentahoFolder( pentahoJcrConstants, folderNode ) );
 
     List<RepositoryFile> children = new ArrayList<RepositoryFile>();

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelper.java
@@ -18,6 +18,7 @@
 
 package org.pentaho.platform.repository2.unified.jcr;
 
+import org.apache.jackrabbit.util.ISO9075;
 import org.apache.jackrabbit.util.Text;
 
 /**
@@ -33,7 +34,11 @@ public class JcrStringHelper {
    * @return
    */
   public static String fileNameEncode(String fileName) {
-    return Text.escapeIllegalJcrChars( fileName );
+    return ISO9075.encode( Text.escapeIllegalJcrChars( fileName ) );
+  }
+
+  public static String idEncode(String id) {
+    return Text.escapeIllegalJcrChars( id );
   }
 
   /**
@@ -42,7 +47,7 @@ public class JcrStringHelper {
    * @return
    */
   public static String fileNameDecode(String encodedFileName) {
-    return Text.unescapeIllegalJcrChars( encodedFileName );
+    return ISO9075.decode( Text.unescapeIllegalJcrChars( encodedFileName ) );
   }
 
   /**

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelperTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelperTest.java
@@ -1,0 +1,72 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.repository2.unified.jcr;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+
+public class JcrStringHelperTest {
+
+  @Test
+  public void testLetterDigitIDEncode(){
+    String id = "a243423d-adasdasdasd-asdasd";
+    String encodedId = JcrStringHelper.idEncode( id );
+    TestCase.assertEquals( id, encodedId );
+  }
+  
+  @Test
+  public void testDigitLetterIDEncode(){
+    String id = "5a243423d-adasdasdasd-asdasd";
+    String encodedId = JcrStringHelper.idEncode( id );
+    TestCase.assertEquals( id, encodedId );
+  }
+ 
+  @Test
+  public void testFilePathpecEncode(){
+    String path="/asdf/3err";
+    String encodedPath = JcrStringHelper.pathEncode( path );
+    TestCase.assertTrue( ! path.equals( encodedPath ) );
+    TestCase.assertEquals( "/asdf/_x0033_err", encodedPath );
+  }
+  
+  @Test
+  public void testFilePathSpecEncodeDecode(){
+    String path="/asdf/3err";
+    String encodedPath = JcrStringHelper.pathEncode( path );
+    TestCase.assertTrue( ! path.equals( encodedPath ) );
+    String decodedPath = JcrStringHelper.fileNameDecode( encodedPath );
+    TestCase.assertEquals( path, decodedPath );
+  }
+  
+  @Test
+  public void testFilePathEncode(){
+    String path="/asdf/err";
+    String encodedPath = JcrStringHelper.pathEncode( path );
+    TestCase.assertEquals( path, encodedPath );
+  }
+  
+  @Test
+  public void testFilePathEncodeDecode(){
+    String path="/asdf/err";
+    String encodedPath = JcrStringHelper.pathEncode( path );
+    TestCase.assertEquals( path, encodedPath );
+    String decodedPath = JcrStringHelper.fileNameDecode( encodedPath );
+    TestCase.assertEquals( path, decodedPath );
+  }
+}


### PR DESCRIPTION
What was done:
1) changed path encode and decode routines to encode invalid symbols
2) added id encode routine as it was called once but id may start with
digit which is not valid for path anymore
3) added unit tests  to validate different usage of routines
