### PR TITLE
PDI-10767 - Inconsistent repository initialization scripts cause complex...

### DIFF
--- a/assembly/package-res/appserver/jboss/res/datasources/oracle10g/PentahoHibernate-ds.xml
+++ b/assembly/package-res/appserver/jboss/res/datasources/oracle10g/PentahoHibernate-ds.xml
@@ -2,7 +2,7 @@
 <datasources>
   <local-tx-datasource>
     <jndi-name>Hibernate</jndi-name>
-    <connection-url>jdbc:oracle:thin:@localhost:1521:pentaho</connection-url>
+    <connection-url>jdbc:oracle:thin:@localhost:1521:XE</connection-url>
     <driver-class>oracle.jdbc.driver.OracleDriver</driver-class>
     <user-name>hibuser</user-name>
     <password>password</password>

--- a/assembly/package-res/appserver/jboss/res/datasources/oracle10g/quartz-ds.xml
+++ b/assembly/package-res/appserver/jboss/res/datasources/oracle10g/quartz-ds.xml
@@ -2,9 +2,9 @@
 <datasources>
   <local-tx-datasource>
     <jndi-name>Quartz</jndi-name>
-    <connection-url>jdbc:oracle:thin:@localhost:1521:pentaho</connection-url>
+    <connection-url>jdbc:oracle:thin:@localhost:1521:XE</connection-url>
     <driver-class>oracle.jdbc.driver.OracleDriver</driver-class>
-    <user-name>quartz</user-name>
+    <user-name>pentaho_user</user-name>
     <password>password</password>
     <check-valid-connection-sql>select 1 from dual</check-valid-connection-sql>
   </local-tx-datasource>

--- a/assembly/package-res/appserver/tomcat/res/datasources/oracle10g/context.xml
+++ b/assembly/package-res/appserver/tomcat/res/datasources/oracle10g/context.xml
@@ -4,14 +4,14 @@
 		factory="org.apache.commons.dbcp.BasicDataSourceFactory" maxActive="20" maxIdle="5"
 		maxWait="10000" username="hibuser" password="password"
 		driverClassName="oracle.jdbc.driver.OracleDriver"
-		url="jdbc:oracle:thin:@localhost:1521:pentaho"
+		url="jdbc:oracle:thin:@localhost:1521:XE"
 		validationQuery="select 1 from dual"/>
 		
 	<Resource name="jdbc/Quartz" auth="Container" type="javax.sql.DataSource"
 		factory="org.apache.commons.dbcp.BasicDataSourceFactory" maxActive="20" maxIdle="5"
-		maxWait="10000" username="quartz" password="password"
+		maxWait="10000" username="pentaho_user" password="password"
 		driverClassName="oracle.jdbc.driver.OracleDriver"
-		url="jdbc:oracle:thin:@localhost:1521:pentaho"
+		url="jdbc:oracle:thin:@localhost:1521:XE"
 		validationQuery="select 1 from dual"/>
 
 </Context>

--- a/assembly/package-res/biserver/data/mysql5/create_jcr_mysql.sql
+++ b/assembly/package-res/biserver/data/mysql5/create_jcr_mysql.sql
@@ -1,3 +1,5 @@
+DROP DATABASE IF EXISTS `jackrabbit`;
+DROP USER 'jcr_user'@'localhost';
 
 CREATE DATABASE IF NOT EXISTS `jackrabbit` DEFAULT CHARACTER SET latin1;
 

--- a/assembly/package-res/biserver/data/mysql5/create_quartz_mysql.sql
+++ b/assembly/package-res/biserver/data/mysql5/create_quartz_mysql.sql
@@ -1,9 +1,11 @@
-#
-# Quartz seems to work best with the driver mm.mysql-2.0.7-bin.jar
-#
-# In your Quartz properties file, you'll need to set 
-# org.quartz.jobStore.driverDelegateClass = org.quartz.impl.jdbcjobstore.StdJDBCDelegate
-#
+--
+--Quartz seems to work best with the driver mm.mysql-2.0.7-bin.jar
+--
+-- In your Quartz properties file, you'll need to set 
+-- org.quartz.jobStore.driverDelegateClass = org.quartz.impl.jdbcjobstore.StdJDBCDelegate
+--
+DROP DATABASE IF EXISTS `quartz`;
+DROP USER 'pentaho_user'@'localhost';
 
 CREATE DATABASE IF NOT EXISTS `quartz` DEFAULT CHARACTER SET latin1;
 

--- a/assembly/package-res/biserver/data/mysql5/create_repository_mysql.sql
+++ b/assembly/package-res/biserver/data/mysql5/create_repository_mysql.sql
@@ -1,6 +1,7 @@
-CREATE DATABASE IF NOT EXISTS `hibernate` DEFAULT CHARACTER SET latin1;
+DROP DATABASE IF EXISTS `hibernate`;
+DROP USER 'hibuser'@'localhost';
 
-USE hibernate;
+CREATE DATABASE IF NOT EXISTS `hibernate` DEFAULT CHARACTER SET latin1;
 
 GRANT ALL ON hibernate.* TO 'hibuser'@'localhost' identified by 'password'; 
 

--- a/assembly/package-res/biserver/data/oracle10g/create_jcr_ora.sql
+++ b/assembly/package-res/biserver/data/oracle10g/create_jcr_ora.sql
@@ -20,7 +20,4 @@ create user jcr_user identified by "password" default tablespace pentaho_tablesp
 
 grant create session, create procedure, create table, create trigger, create sequence to jcr_user;
 
---CREATE ADDITIONAL REPOSITORY TABLES
-
-conn jcr_user/password;
 commit;

--- a/assembly/package-res/biserver/data/oracle10g/create_quartz_ora.sql
+++ b/assembly/package-res/biserver/data/oracle10g/create_quartz_ora.sql
@@ -7,9 +7,9 @@
 
 -- conn admin/password@pentaho
 
-drop user quartz cascade;
+DROP USER pentaho_user CASCADE;
 
-create tablespace pentaho_tablespace
+CREATE TABLESPACE pentaho_tablespace
   logging
   datafile 'ptho_ts.dbf' 
   size 32m 
@@ -17,13 +17,13 @@ create tablespace pentaho_tablespace
   next 32m maxsize 2048m
   extent management local;
 
-create user quartz identified by "password" default tablespace pentaho_tablespace quota unlimited on pentaho_tablespace temporary tablespace temp quota 5M on system;
+CREATE USER pentaho_user IDENTIFIED BY "password" DEFAULT TABLESPACE pentaho_tablespace QUOTA unlimited ON pentaho_tablespace temporary tablespace temp quota 5M on system;
 
-grant create session, create procedure, create table to quartz;
+GRANT create session, create procedure, create table TO pentaho_user;
 
 --CREATE QUARTZ TABLES
 
-CONN quartz/password
+CONN pentaho_user/password
 
 CREATE TABLE QRTZ5_JOB_DETAILS 
   (

--- a/assembly/package-res/biserver/data/postgresql/create_jcr_postgresql.sql
+++ b/assembly/package-res/biserver/data/postgresql/create_jcr_postgresql.sql
@@ -4,11 +4,11 @@
 
 -- \connect postgres postgres
 
-drop database if exists jackrabbit;
-drop user if exists jcr_user;
+DROP DATABASE IF EXISTS jackrabbit;
+DROP USER IF EXISTS jcr_user;
 
 CREATE USER jcr_user PASSWORD 'password';
 
 CREATE DATABASE jackrabbit WITH OWNER = jcr_user ENCODING = 'UTF8' TABLESPACE = pg_default;
 
-GRANT ALL PRIVILEGES ON DATABASE jackrabbit to jcr_user;
+GRANT ALL PRIVILEGES ON DATABASE jackrabbit TO jcr_user;

--- a/assembly/package-res/biserver/data/postgresql/create_quartz_postgresql.sql
+++ b/assembly/package-res/biserver/data/postgresql/create_quartz_postgresql.sql
@@ -4,14 +4,14 @@
 
 -- \connect postgres postgres
 
-drop database if exists quartz;
-drop user if exists pentaho_user;
+DROP DATABASE IF EXISTS quartz;
+DROP USER IF EXISTS pentaho_user;
 
 CREATE USER pentaho_user PASSWORD 'password';
 
 CREATE DATABASE quartz  WITH OWNER = pentaho_user  ENCODING = 'UTF8' TABLESPACE = pg_default;
 
-GRANT ALL ON DATABASE quartz to pentaho_user;
+GRANT ALL ON DATABASE quartz TO pentaho_user;
 
 --End--
 --Begin Connect--
@@ -19,18 +19,18 @@ GRANT ALL ON DATABASE quartz to pentaho_user;
 
 begin;
 
-drop table if exists qrtz5_job_listeners;
-drop table if exists qrtz5_trigger_listeners;
-drop table if exists qrtz5_fired_triggers;
-drop table if exists qrtz5_paused_trigger_grps;
-drop table if exists qrtz5_scheduler_state;
-drop table if exists qrtz5_locks;
-drop table if exists qrtz5_simple_triggers;
-drop table if exists qrtz5_cron_triggers;
-drop table if exists qrtz5_blob_triggers;
-drop table if exists qrtz5_triggers;
-drop table if exists qrtz5_job_details;
-drop table if exists qrtz5_calendars;
+DROP TABLE IF EXISTS qrtz5_job_listeners;
+DROP TABLE IF EXISTS qrtz5_trigger_listeners;
+DROP TABLE IF EXISTS qrtz5_fired_triggers;
+DROP TABLE IF EXISTS qrtz5_paused_trigger_grps;
+DROP TABLE IF EXISTS qrtz5_scheduler_state;
+DROP TABLE IF EXISTS qrtz5_locks;
+DROP TABLE IF EXISTS qrtz5_simple_triggers;
+DROP TABLE IF EXISTS qrtz5_cron_triggers;
+DROP TABLE IF EXISTS qrtz5_blob_triggers;
+DROP TABLE IF EXISTS qrtz5_triggers;
+DROP TABLE IF EXISTS qrtz5_job_details;
+DROP TABLE IF EXISTS qrtz5_calendars;
 
 CREATE TABLE qrtz5_job_details
   (

--- a/assembly/package-res/biserver/data/postgresql/create_repository_postgresql.sql
+++ b/assembly/package-res/biserver/data/postgresql/create_repository_postgresql.sql
@@ -4,11 +4,11 @@
 
 -- \connect postgres postgres
 
-drop database if exists hibernate;
-drop user if exists hibuser;
+DROP DATABASE IF EXISTS hibernate;
+DROP USER IF EXISTS hibuser;
 
 CREATE USER hibuser PASSWORD 'password';
 
 CREATE DATABASE hibernate WITH OWNER = hibuser ENCODING = 'UTF8' TABLESPACE = pg_default;
 
-GRANT ALL PRIVILEGES ON DATABASE hibernate to hibuser;
+GRANT ALL PRIVILEGES ON DATABASE hibernate TO hibuser;

--- a/assembly/package-res/biserver/pentaho-solutions/system/dialects/oracle10g/applicationContext-spring-security-hibernate.properties
+++ b/assembly/package-res/biserver/pentaho-solutions/system/dialects/oracle10g/applicationContext-spring-security-hibernate.properties
@@ -1,5 +1,5 @@
 jdbc.driver=oracle.jdbc.driver.OracleDriver
-jdbc.url=jdbc:oracle:thin:@localhost:1521:pentaho
+jdbc.url=jdbc:oracle:thin:@localhost:1521:XE
 jdbc.username=hibuser
 jdbc.password=password
 hibernate.dialect=org.hibernate.dialect.Oracle10gDialect

--- a/assembly/package-res/biserver/pentaho-solutions/system/hibernate/oracle10g.hibernate.cfg.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/hibernate/oracle10g.hibernate.cfg.xml
@@ -12,7 +12,7 @@
 
     <!--  Oracle 10g Configuration -->
     <property name="connection.driver_class">oracle.jdbc.driver.OracleDriver</property>
-    <property name="connection.url">jdbc:oracle:thin:@localhost:1521:pentaho</property>
+    <property name="connection.url">jdbc:oracle:thin:@localhost:1521:XE</property>
     <property name="dialect">org.hibernate.dialect.Oracle10gDialect</property>
     <property name="connection.username">hibuser</property>
     <property name="connection.password">password</property>

--- a/assembly/package-res/biserver/pentaho-solutions/system/jackrabbit/repository.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/jackrabbit/repository.xml
@@ -55,7 +55,7 @@
     <param name="user" value="jcr_user"/>
     <param name="password" value="password"/>
     <param name="schemaObjectPrefix" value="fs_repos_"/>
-    <param name="tablespace" value="jackrabbit"/>
+    <param name="tablespace" value="pentaho_tablespace"/>
   </FileSystem>
 
   <FileSystem class="org.apache.jackrabbit.core.fs.db.DbFileSystem">
@@ -208,7 +208,7 @@
       <param name="user" value="jcr_user"/>
       <param name="password" value="password"/>
       <param name="schemaObjectPrefix" value="fs_ws_"/>
-      <param name="tablespace" value="jcr_user"/>
+      <param name="tablespace" value="pentaho_tablespace"/>
     </FileSystem>
 
     <FileSystem class="org.apache.jackrabbit.core.fs.db.DbFileSystem">
@@ -256,7 +256,7 @@
       <param name="password" value="password"/>
       <param name="schema" value="oracle"/>
       <param name="schemaObjectPrefix" value="${wsp.name}_pm_ws_"/>
-      <param name="tablespace" value="jackrabbit"/>
+      <param name="tablespace" value="pentaho_tablespace"/>
     </PersistenceManager>
 
     <PersistenceManager class="org.apache.jackrabbit.core.persistence.bundle.PostgreSQLPersistenceManager">
@@ -338,7 +338,7 @@ value="{0}/etc;org.pentaho.security.publish;jcr:read,jcr:readAccessControl,jcr:w
       <param name="user" value="jcr_user"/>
       <param name="password" value="password"/>
       <param name="schemaObjectPrefix" value="fs_ver_"/>
-      <param name="tablespace" value="jackrabbit"/>
+      <param name="tablespace" value="pentaho_tablespace"/>
     </FileSystem>
 
     <FileSystem class="org.apache.jackrabbit.core.fs.db.DbFileSystem">
@@ -386,7 +386,7 @@ value="{0}/etc;org.pentaho.security.publish;jcr:read,jcr:readAccessControl,jcr:w
       <param name="password" value="password"/>
       <param name="schema" value="oracle"/>
       <param name="schemaObjectPrefix" value="pm_ver_"/>
-      <param name="tablespace" value="jackrabbit"/>
+      <param name="tablespace" value="pentaho_tablespace"/>
     </PersistenceManager>
 
     <PersistenceManager class="org.apache.jackrabbit.core.persistence.bundle.PostgreSQLPersistenceManager">


### PR DESCRIPTION
...ity/frustration.

PDI-10915 - DI Server's repository.xml in system/jackrabbit oracle repository configuration comments need to match the create script for the JCR repository.
BISERVER-10526 - BA server's repository.xml in system/jackrabbit oracle repository configuration comments need to match the create script for the JCR repository.

Chenged user's names in SQL and datasources, tablespaces consistently.

Fixed bug in 3 repositories:
pentaho-platform
pentaho-platform-ee
pdi-operations-mart
