### PR TITLE
BACKLOG-399 - Added endpoint that removed an unused parameter from getJo...

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/SchedulerResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/SchedulerResource.java
@@ -264,9 +264,10 @@ public class SchedulerResource extends AbstractJaxRSResource {
   }
 
   /**
-   * Retrieve the all the job(s) visible to the current users
+   * Retrieve the all the job(s) visible to the current users.  This method is PRIVATE and subject to change/removal in the future.
+   * Callers should instead use the "/getJobs" signature instead.
    *
-   * @param asCronString (Cron string)
+   * @param asCronString (Cron string) - UNUSED
    * @return list of <code> Job </code>
    */
   @GET
@@ -274,20 +275,7 @@ public class SchedulerResource extends AbstractJaxRSResource {
   @Produces( { APPLICATION_JSON, APPLICATION_XML } )
   public List<Job> getJobs( @DefaultValue( "false" ) @QueryParam( "asCronString" ) Boolean asCronString ) {
     try {
-      IPentahoSession session = PentahoSessionHolder.getSession();
-      final String principalName = session.getName(); // this authentication wasn't matching with the job user name,
-                                                      // changed to get name via the current session
-      final Boolean canAdminister = canAdminister( session );
-
-      List<Job> jobs = scheduler.getJobs( new IJobFilter() {
-        public boolean accept( Job job ) {
-          if ( canAdminister ) {
-            return !IBlockoutManager.BLOCK_OUT_JOB_NAME.equals( job.getJobName() );
-          }
-          return principalName.equals( job.getUserName() );
-        }
-      } );
-      return jobs;
+      return schedulerService.getJobs();
     } catch ( SchedulerException e ) {
       throw new RuntimeException( e );
     }
@@ -296,7 +284,6 @@ public class SchedulerResource extends AbstractJaxRSResource {
   /**
    * Retrieve the all the job(s) visible to the current users
    *
-   * @param asCronString (Cron string)
    * @return list of <code> Job </code>
    */
   @GET
@@ -304,20 +291,7 @@ public class SchedulerResource extends AbstractJaxRSResource {
   @Produces( { APPLICATION_JSON, APPLICATION_XML } )
   public List<Job> getNonCRONJobs() {
     try {
-      IPentahoSession session = PentahoSessionHolder.getSession();
-      final String principalName = session.getName(); // this authentication wasn't matching with the job user name,
-                                                      // changed to get name via the current session
-      final Boolean canAdminister = canAdminister( session );
-
-      List<Job> jobs = scheduler.getJobs( new IJobFilter() {
-        public boolean accept( Job job ) {
-          if ( canAdminister ) {
-            return !IBlockoutManager.BLOCK_OUT_JOB_NAME.equals( job.getJobName() );
-          }
-          return principalName.equals( job.getUserName() );
-        }
-      } );
-      return jobs;
+      return schedulerService.getJobs();
     } catch ( SchedulerException e ) {
       throw new RuntimeException( e );
     }

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
@@ -20,11 +20,15 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.scheduler2.IJobFilter;
 import org.pentaho.platform.api.scheduler2.IScheduler;
 import org.pentaho.platform.api.scheduler2.Job;
 import org.pentaho.platform.api.scheduler2.SchedulerException;
@@ -80,4 +84,26 @@ public class SchedulerServiceTest {
     verify( schedulerService.policy, times( 2 ) ).isAllowed( anyString() );
   }
 
+  @Test 
+  public void testGetJobs() throws SchedulerException {
+    Job job = mock( Job.class );
+    List<Job> mockJobs = new ArrayList<Job>();
+    mockJobs.add( job );
+    
+    IPentahoSession mockPentahoSession = mock ( IPentahoSession.class );
+    
+    
+    doReturn( mockPentahoSession ).when( schedulerService ).getSession();
+    doReturn( "admin" ).when( mockPentahoSession ).getName();
+    doReturn( true ).when( schedulerService ).canAdminister( mockPentahoSession );
+    doReturn( mockJobs ).when( schedulerService.scheduler ).getJobs( (IJobFilter) anyObject() );
+    
+    List<Job> jobs = schedulerService.getJobs();
+    
+    assertEquals(mockJobs, jobs);
+    
+    verify( schedulerService, times( 1 ) ).getSession();
+    verify( mockPentahoSession, times( 1 ) ).getName();
+    verify( schedulerService, times( 1 ) ).canAdminister( mockPentahoSession );
+  }
 }


### PR DESCRIPTION
...bs().  New endpoint is called getNonCRONJobs() and is called via rest ../scheduler/getJobs.  Old method should be deprecated (private) and is called via ../scheduler/jobs.
