### PR TITLE
BACKLOG-399 - Added endpoint that removed an unused parameter from getJo...

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/SchedulerResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/SchedulerResource.java
@@ -42,8 +42,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import org.codehaus.enunciate.jaxrs.ResponseCode;
-import org.codehaus.enunciate.jaxrs.StatusCodes;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
@@ -152,33 +150,38 @@ public class SchedulerResource extends AbstractJaxRSResource {
   /**
    * Retrieve the all the job(s) visible to the current users
    *
-   * @param asCronString (Cron string)
+   * @param asCronString (Cron string) - UNUSED
    * @return list of <code> Job </code>
    */
+  @Deprecated
   @GET
   @Path( "/jobs" )
   @Produces( { APPLICATION_JSON, APPLICATION_XML } )
   public List<Job> getJobs( @DefaultValue( "false" ) @QueryParam( "asCronString" ) Boolean asCronString ) {
     try {
-      IPentahoSession session = PentahoSessionHolder.getSession();
-      final String principalName = session.getName(); // this authentication wasn't matching with the job user name,
-                                                      // changed to get name via the current session
-      final Boolean canAdminister = canAdminister( session );
-
-      List<Job> jobs = scheduler.getJobs( new IJobFilter() {
-        public boolean accept( Job job ) {
-          if ( canAdminister ) {
-            return !IBlockoutManager.BLOCK_OUT_JOB_NAME.equals( job.getJobName() );
-          }
-          return principalName.equals( job.getUserName() );
-        }
-      } );
-      return jobs;
+      return schedulerService.getJobs();
     } catch ( SchedulerException e ) {
       throw new RuntimeException( e );
     }
   }
 
+  /**
+   * Retrieve the all the job(s) visible to the current users
+   *
+   * @param asCronString (Cron string) - UNUSED
+   * @return list of <code> Job </code>
+   */
+  @GET
+  @Path( "/getJobs" )
+  @Produces( { APPLICATION_JSON, APPLICATION_XML } )
+  public List<Job> getAllJobs() {
+    try {
+      return schedulerService.getJobs();
+    } catch ( SchedulerException e ) {
+      throw new RuntimeException( e );
+    }
+  }
+ 
   private Boolean canAdminister( IPentahoSession session ) {
     if ( policy.isAllowed( AdministerSecurityAction.NAME ) ) {
       return true;

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
@@ -532,4 +532,23 @@ public class SchedulerServiceTest {
     verify( schedulerService.scheduler ).shutdown();
   }
 
+  public void testGetJobs() throws Exception {
+    IPentahoSession mockPentahoSession = mock( IPentahoSession.class );
+    
+    doReturn( mockPentahoSession ).when( schedulerService ).getSession();
+    doReturn( "admin" ).when( mockPentahoSession ).getName();
+    doReturn( true ).when( schedulerService ).canAdminister( mockPentahoSession );
+    List<Job> mockJobs = new ArrayList<Job>();
+    mockJobs.add( mock( Job.class ) );
+    doReturn( mockJobs ).when( schedulerService.scheduler ).getJobs( ( IJobFilter ) anyObject() );
+    
+    List<Job> jobs = schedulerService.getJobs();
+    
+    assertEquals( mockJobs, jobs );
+    
+    verify( schedulerService, times( 1 ) ).getSession();
+    verify( mockPentahoSession, times( 1 ) ).getName();
+    verify( schedulerService, times( 1 ) ).canAdminister( mockPentahoSession );
+    verify( schedulerService.scheduler, times( 1 ) ).getJobs( ( IJobFilter ) anyObject() );
+  }
 }


### PR DESCRIPTION
...bs().  New endpoint is called getNonCRONJobs() and is called via rest ../scheduler/getJobs.  Old method should be deprecated (private) and is called via ../scheduler/jobs.
