### PR TITLE
[BACKLOG-195] Document Rest Endpoints for Scheduling

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtil.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtil.java
@@ -28,6 +28,7 @@ import org.pentaho.platform.api.scheduler2.IJobTrigger;
 import org.pentaho.platform.api.scheduler2.IScheduler;
 import org.pentaho.platform.api.scheduler2.SchedulerException;
 import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.scheduler2.quartz.QuartzScheduler;
 import org.pentaho.platform.scheduler2.recur.QualifiedDayOfWeek;
 import org.pentaho.platform.scheduler2.recur.QualifiedDayOfWeek.DayOfWeek;
@@ -47,7 +48,7 @@ public class SchedulerResourceUtil {
   private static final Log logger = LogFactory.getLog( SchedulerResourceUtil.class );
   
   public static IJobTrigger
-  convertScheduleRequestToJobTrigger( JobScheduleRequest scheduleRequest, IScheduler scheduler )
+  convertScheduleRequestToJobTrigger( JobScheduleRequest scheduleRequest )
     throws SchedulerException, UnifiedRepositoryException {
 
     // Used to determine if created by a RunInBackgroundCommand
@@ -119,6 +120,8 @@ public class SchedulerResourceUtil {
       jobTrigger = complexJobTrigger;
 
     } else if ( scheduleRequest.getCronJobTrigger() != null ) {
+
+      IScheduler scheduler = PentahoSystem.get( IScheduler.class, "IScheduler2", null ); //$NON-NLS-1$
 
       if ( scheduler instanceof QuartzScheduler ) {
         String cronString = scheduleRequest.getCronJobTrigger().getCronString();

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
@@ -270,7 +270,7 @@ public class SchedulerServiceTest {
     doNothing().when( schedulerService.scheduler ).triggerNow( anyString() );
 
     //Test 1
-    Job resultJob1 = schedulerService.triggerNow( jobRequest );
+    Job resultJob1 = schedulerService.triggerNow( jobRequest.getJobId() );
 
     assertEquals( job, resultJob1 );
 
@@ -282,7 +282,7 @@ public class SchedulerServiceTest {
     doReturn( "test" ).when( pentahoSession ).getName();
     doReturn( pentahoSession ).when( schedulerService ).getSession();
 
-    Job resultJob2 = schedulerService.triggerNow( jobRequest );
+    Job resultJob2 = schedulerService.triggerNow( jobRequest.getJobId() );
 
     assertEquals( job, resultJob2 );
 


### PR DESCRIPTION
Removed scheduler, policy, repository references from SchedulerResource
Moved all remaining business logic to SchedulerService
Converted uses of jobRequest to jobId to simplify SchedulerService for API use
Added StatusCodes to several endpoints
