### PR TITLE
[BACKLOG-197] Fixing REST issue with isAuthenticated and isAdministrator

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/UserConsoleResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/UserConsoleResource.java
@@ -102,7 +102,7 @@ public class UserConsoleResource extends AbstractJaxRSResource {
           @ResponseCode( code = 200, condition = "Returns the boolean response"),
   })
   public Response isAdministrator() {
-    return buildOkResponse( userConsoleService.isAdministrator() );
+    return buildOkResponse( "" + userConsoleService.isAdministrator() );
   }
 
   /**
@@ -120,7 +120,7 @@ public class UserConsoleResource extends AbstractJaxRSResource {
           @ResponseCode( code = 200, condition = "Returns the boolean response"),
   })
   public Response isAuthenticated() {
-    return buildOkResponse( userConsoleService.isAuthenticated() );
+    return buildOkResponse( "" + userConsoleService.isAuthenticated() );
   }
 
   /**

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserConsoleResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserConsoleResourceTest.java
@@ -49,13 +49,13 @@ public class UserConsoleResourceTest {
     doReturn( isAdministrator ).when( userConsoleResource.userConsoleService ).isAdministrator();
 
     Response mockResponse = mock( Response.class );
-    doReturn( mockResponse ).when( userConsoleResource ).buildOkResponse( isAdministrator );
+    doReturn( mockResponse ).when( userConsoleResource ).buildOkResponse( "" + isAdministrator );
 
     Response testResponse = userConsoleResource.isAdministrator();
     assertEquals( mockResponse, testResponse );
 
     verify( userConsoleResource.userConsoleService, times( 1 ) ).isAdministrator();
-    verify( userConsoleResource, times( 1 ) ).buildOkResponse( isAdministrator );
+    verify( userConsoleResource, times( 1 ) ).buildOkResponse( "" + isAdministrator );
   }
 
   @Test
@@ -64,12 +64,12 @@ public class UserConsoleResourceTest {
     doReturn( isAuthenticated ).when( userConsoleResource.userConsoleService ).isAuthenticated();
 
     Response mockResponse = mock( Response.class );
-    doReturn( mockResponse ).when( userConsoleResource ).buildOkResponse( isAuthenticated );
+    doReturn( mockResponse ).when( userConsoleResource ).buildOkResponse( "" + isAuthenticated );
 
     Response testResponse = userConsoleResource.isAuthenticated();
     assertEquals( mockResponse, testResponse );
 
     verify( userConsoleResource.userConsoleService, times( 1 ) ).isAuthenticated();
-    verify( userConsoleResource, times( 1 ) ).buildOkResponse( isAuthenticated );
+    verify( userConsoleResource, times( 1 ) ).buildOkResponse( "" + isAuthenticated );
   }
 }


### PR DESCRIPTION
Jersey is not enjoying the change from String to Boolean for the Response entity, this change also broke the contract we had with the client (PUC).  I have changed it back to a string and have updated the appropriate unit test.
