### PR TITLE
[BACKLOG-5] [BACKLOG-16] Removing the setting of parent context for WS servlet

### DIFF
--- a/extensions/src/org/pentaho/platform/web/servlet/PentahoWSSpringServlet.java
+++ b/extensions/src/org/pentaho/platform/web/servlet/PentahoWSSpringServlet.java
@@ -74,15 +74,13 @@ public class PentahoWSSpringServlet extends HttpServlet {
   }
 
   protected ApplicationContext getAppContext() {
-    WebApplicationContext parent = WebApplicationContextUtils.getRequiredWebApplicationContext( getServletContext() );
-
     ConfigurableWebApplicationContext wac = new XmlWebApplicationContext() {
       @Override
       protected Resource getResourceByPath( String path ) {
         return new FileSystemResource( new File( path ) );
       }
     };
-    wac.setParent( parent );
+
     wac.setServletContext( getServletContext() );
     wac.setServletConfig( getServletConfig() );
     wac.setNamespace( getServletName() );


### PR DESCRIPTION
Removing the setting of parent context as it confuses bean initialization for this servlet
