### PR TITLE
[BACKLOG-321] Use catalog's name for display for user, not a schema name

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper.java
@@ -108,11 +108,6 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
   private String dataSourcesConfig;
 
   /**
-   * true to use schema name from catalog definition (aka schema file) as catalog name.
-   */
-  private boolean useSchemaNameAsCatalogName = true;
-
-  /**
    * Holds the additional catalog information
    */
   private Map<String, MondrianCatalogComplementInfo> catalogComplementInfoMap;
@@ -747,8 +742,7 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
             MondrianSchema schema = makeSchema( docAtUrlToString( catalog.definition, pentahoSession ) );
 
             MondrianCatalog mondrianCatalog =
-              new MondrianCatalog( useSchemaNameAsCatalogName ? schema.getName() : catalog.name,
-                catalog.dataSourceInfo, catalog.definition, schema );
+              new MondrianCatalog( catalog.name, catalog.dataSourceInfo, catalog.definition, schema );
 
             catalogs.put( mondrianCatalog.getName(), mondrianCatalog );
             catalogs.put( mondrianCatalog.getDefinition(), mondrianCatalog );
@@ -784,7 +778,7 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
             MondrianCatalogComplementInfo catalogComplementInfo = getCatalogComplementInfoMap( catalog.definition );
 
             MondrianCatalog mondrianCatalog =
-              new MondrianCatalog( useSchemaNameAsCatalogName ? schema.getName() : catalog.name,
+              new MondrianCatalog( catalog.name,
                 catalog.dataSourceInfo, catalog.definition, schema, catalogComplementInfo );
 
             localCatalogs.add( mondrianCatalog );
@@ -960,11 +954,10 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
   }
 
   public boolean isUseSchemaNameAsCatalogName() {
-    return useSchemaNameAsCatalogName;
+    return true;
   }
 
   public void setUseSchemaNameAsCatalogName( final boolean useSchemaNameAsCatalogName ) {
-    this.useSchemaNameAsCatalogName = useSchemaNameAsCatalogName;
   }
 
   public static int addToCatalog( String baseUrl, boolean enableXmla, String schemaSolutionPath,


### PR DESCRIPTION
It will allows to remove configs where schema name is not equals to catalog name.
Catalog name should be imported from schema name on the loading process.
It will be visible only for old schemas for users who was able to import invalid schemas with XML encodings issues.
