### PR TITLE
BACKLOG-618 - CLONE - BA Server is telling browser to request content using http even when using an Apache+SSL as reverse proxy.

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/jsp/PUCLogin.jsp
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/jsp/PUCLogin.jsp
@@ -69,8 +69,7 @@
   Object reqObj = request.getSession().getAttribute(AbstractProcessingFilter.SPRING_SECURITY_SAVED_REQUEST_KEY);
   String requestedURL = "";
   if (reqObj != null) {
-    requestedURL = ((SavedRequest) reqObj).getFullRequestUrl();
-
+    requestedURL = ((SavedRequest) reqObj).getRequestURI();  
     String lookFor;
     for (int i=0; i<send401RequestList.size(); i++) {
       lookFor = send401RequestList.get(i);

--- a/user-console/source/org/pentaho/mantle/public/home/content/welcome/index.html
+++ b/user-console/source/org/pentaho/mantle/public/home/content/welcome/index.html
@@ -13,7 +13,7 @@
         padding-bottom: 40px;
       }
     </style>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="css/main.css">
 
   </head>


### PR DESCRIPTION
@pminutillo @mdamour1976 please review. We remove protocol and it saves the original protocol from first request. 
