### PR TITLE
[BISERVER-12106] -  Check for empty class name and dialect information before creating datasource or pooling connection

### DIFF
--- a/core/src/org/pentaho/platform/engine/services/messages/messages.properties
+++ b/core/src/org/pentaho/platform/engine/services/messages/messages.properties
@@ -297,3 +297,12 @@ ActionSequenceJCRHelper.ERROR_0009_INVALID_DOCUMENT=The solution document {0} is
 ActionSequenceJCRHelper.WARN_MISSING_RESOURCE_PROPERTY=Missing property "{0}" in resource file "{1}" for "{2}"
 ActionSequenceJCRHelper.ERROR_0007_COULD_NOT_READ_PROPERTIES=Could not read properties file {0}
 ActionSequenceJCRHelper.ERROR_0001_INVALID_REPOSITORY=Could not retrieve a repository from the session
+
+PooledDatasourceHelper.ERROR_0001_DATASOURCE_CREATE_ERROR_NO_DIALECT=Unable to create Data Source for connection [ {0} ]. No dialect information is available.
+PooledDatasourceHelper.ERROR_0002_DATASOURCE_CREATE_ERROR_NO_CLASSNAME=Unable to create Data Source for connection [ {0} ]. No driver class name is available.
+PooledDatasourceHelper.ERROR_0003_DATASOURCE_CREATE_ERROR_NO_DRIVER=Unable to create Data Source for connection [ {0} ]. Unable to get driver information from dialect.
+
+PooledDatasourceHelper.ERROR_0004_UNABLE_TO_POOL_DATASOURCE_NO_DIALECT=Unable to pool Data Source [ {0} ]. No dialect information is available.
+PooledDatasourceHelper.ERROR_0005_UNABLE_TO_POOL_DATASOURCE_NO_DIALECT_SERVICE=Unable to pool Data Source [ {0} ]. No dialect service is available.
+PooledDatasourceHelper.ERROR_0006_UNABLE_TO_POOL_DATASOURCE_NO_CLASSNAME=Unable to pool Data Source  [ {0} ]. No driver class name is available.
+PooledDatasourceHelper.ERROR_0007_UNABLE_TO_POOL_DATASOURCE_NO_DRIVER=Unable to pool Data Source [ {0} ]. Unable to get driver information from dialect.

--- a/core/test-src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelperTest.java
+++ b/core/test-src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelperTest.java
@@ -1,0 +1,159 @@
+package org.pentaho.platform.engine.services.connection.datasource.dbcp;
+
+import java.sql.Connection;
+import java.util.HashMap;
+
+import javax.sql.DataSource;
+
+import junit.framework.TestCase;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.apache.commons.dbcp.PoolingDataSource;
+import org.pentaho.database.model.DatabaseAccessType;
+import org.pentaho.database.model.DatabaseConnection;
+import org.pentaho.database.service.DatabaseDialectService;
+import org.pentaho.database.service.IDatabaseDialectService;
+import org.pentaho.database.util.DatabaseTypeHelper;
+import org.pentaho.platform.api.data.DBDatasourceServiceException;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
+
+public class PooledDatasourceHelperTest extends TestCase {
+  MicroPlatform mp;
+
+  public PooledDatasourceHelperTest() {
+  }
+
+  protected void setUp() throws Exception {
+  }
+
+  public void testCreatePoolNoDialectService() throws Exception {
+    DatabaseDialectService dialectService = new DatabaseDialectService( false );
+    final DatabaseTypeHelper databaseTypeHelper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
+    final DatabaseConnection con = new DatabaseConnection();
+    con.setId( "Postgres" );
+    con.setName( "Postgres" );
+    con.setAccessType( DatabaseAccessType.NATIVE );
+    con.setDatabaseType( databaseTypeHelper.getDatabaseTypeByShortName( "GENERIC" ) );
+    con.setUsername( "pentaho_user" );
+    con.setPassword( "password" );
+    final HashMap<String, String> attrs = new HashMap<String, String>();
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_DRIVER_CLASS, "org.postgresql.Driver" );
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_URL, "jdbc:postgresql://localhost:5432/hibernate" );
+    con.setAttributes( attrs );
+    try {
+      final PoolingDataSource poolingDataSource = PooledDatasourceHelper.setupPooledDataSource( con );
+      fail( "Expecting the exception to be thrown" );
+    } catch ( DBDatasourceServiceException ex ) {
+      assertNotNull( ex );
+    }
+  }
+
+  public void testCreatePoolNoDialect() throws Exception {
+    DatabaseDialectService dialectService = new DatabaseDialectService( false );
+    final DatabaseTypeHelper databaseTypeHelper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
+    mp = new MicroPlatform();
+    mp.defineInstance( IDatabaseDialectService.class, dialectService );
+    mp.start();
+
+    final DatabaseConnection con = new DatabaseConnection();
+    con.setId( "Postgres" );
+    con.setName( "Postgres" );
+    con.setAccessType( DatabaseAccessType.NATIVE );
+    con.setUsername( "pentaho_user" );
+    con.setPassword( "password" );
+    final HashMap<String, String> attrs = new HashMap<String, String>();
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_DRIVER_CLASS, "" );
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_URL, "jdbc:postgresql://localhost:5432/hibernate" );
+    con.setAttributes( attrs );
+
+    try {
+      final PoolingDataSource poolingDataSource = PooledDatasourceHelper.setupPooledDataSource( con );
+      fail( "Expecting the exception to be thrown" );
+    } catch ( DBDatasourceServiceException ex ) {
+      assertNotNull( ex );
+    }
+
+  }
+
+  public void testCreatePoolNoClassName() throws Exception {
+    DatabaseDialectService dialectService = new DatabaseDialectService( false );
+    final DatabaseTypeHelper databaseTypeHelper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
+    mp = new MicroPlatform();
+    mp.defineInstance( IDatabaseDialectService.class, dialectService );
+    mp.start();
+
+    final DatabaseConnection con = new DatabaseConnection();
+    con.setId( "Postgres" );
+    con.setName( "Postgres" );
+    con.setAccessType( DatabaseAccessType.NATIVE );
+    con.setDatabaseType( databaseTypeHelper.getDatabaseTypeByShortName( "GENERIC" ) );
+    con.setUsername( "pentaho_user" );
+    con.setPassword( "password" );
+    final HashMap<String, String> attrs = new HashMap<String, String>();
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_DRIVER_CLASS, "" );
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_URL, "jdbc:postgresql://localhost:5432/hibernate" );
+    con.setAttributes( attrs );
+
+    try {
+      final PoolingDataSource poolingDataSource = PooledDatasourceHelper.setupPooledDataSource( con );
+      fail( "Expecting the exception to be thrown" );
+    } catch ( DBDatasourceServiceException ex ) {
+      assertNotNull( ex );
+    }
+
+  }
+
+  public void testCreateDatasourceNoDialect() throws Exception {
+    DatabaseDialectService dialectService = new DatabaseDialectService( false );
+    final DatabaseTypeHelper databaseTypeHelper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
+    mp = new MicroPlatform();
+    mp.defineInstance( IDatabaseDialectService.class, dialectService );
+    mp.start();
+    final DatabaseConnection con = new DatabaseConnection();
+    con.setId( "Postgres" );
+    con.setName( "Postgres" );
+    con.setAccessType( DatabaseAccessType.NATIVE );
+    con.setUsername( "pentaho_user" );
+    con.setPassword( "password" );
+    final HashMap<String, String> attrs = new HashMap<String, String>();
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_DRIVER_CLASS, "org.postgresql.Driver" );
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_URL, "jdbc:postgresql://localhost:5432/hibernate" );
+    con.setAttributes( attrs );
+    try {
+      final DataSource dataSource = PooledDatasourceHelper.convert( con );
+      fail( "Expecting the exception to be thrown" );
+    } catch ( DBDatasourceServiceException ex ) {
+      assertNotNull( ex );
+    }
+  }
+
+  public void testCreateDatasourceNoClassName() throws Exception {
+    DatabaseDialectService dialectService = new DatabaseDialectService( false );
+    final DatabaseTypeHelper databaseTypeHelper = new DatabaseTypeHelper( dialectService.getDatabaseTypes() );
+    mp = new MicroPlatform();
+    mp.defineInstance( IDatabaseDialectService.class, dialectService );
+    mp.start();
+
+    final DatabaseConnection con = new DatabaseConnection();
+    con.setId( "Postgres" );
+    con.setName( "Postgres" );
+    con.setAccessType( DatabaseAccessType.NATIVE );
+    con.setDatabaseType( databaseTypeHelper.getDatabaseTypeByShortName( "GENERIC" ) );
+    con.setUsername( "pentaho_user" );
+    con.setPassword( "password" );
+    final HashMap<String, String> attrs = new HashMap<String, String>();
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_DRIVER_CLASS, "" );
+    attrs.put( DatabaseConnection.ATTRIBUTE_CUSTOM_URL, "jdbc:postgresql://localhost:5432/hibernate" );
+    con.setAttributes( attrs );
+
+    try {
+      final DataSource dataSource = PooledDatasourceHelper.convert( con );
+      fail( "Expecting the exception to be thrown" );
+    } catch ( DBDatasourceServiceException ex ) {
+      assertNotNull( ex );
+    }
+
+  }
+
+}


### PR DESCRIPTION
Added exception handling for scenarios
-- Database Dialect is not available
-- Class name is not available
-- Driver name is not available

All these scenarios results in a DBDatasourceService exception. The listeners logs the exception and moves on
Tested Pooled and NonPooled cases
