### PR TITLE
Fix OutOfMemory bug by releasing writeAppender after importing template

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/importexport/Log4JRepositoryImportLog.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importexport/Log4JRepositoryImportLog.java
@@ -95,7 +95,7 @@ public class Log4JRepositoryImportLog {
       System.out.println( e );
       // Don't try logging a log error.
     }
-    logger.removeAppender( logName );
+    logger.removeAppender( writeAppender );
   }
 
   private String getThreadName() {


### PR DESCRIPTION
The statement logger.removeAppender( logName ) will not remove writeAppender. The result is that the BI server will hold a lot of unused writeAppender, which will eventually lead to OutOfMemory situation after importing a large number of templates.
