### PR TITLE
BISERVER-12041 REGRESSION: Order of Users and Roles shown in "Select User or Role" window in PUC are re-ordered non-alphabetically - JDBC Auth and LDAP

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/security/userrole/CachingUserRoleListServiceDecorator.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/security/userrole/CachingUserRoleListServiceDecorator.java
@@ -5,6 +5,7 @@ import org.pentaho.platform.api.engine.IUserRoleListService;
 import org.pentaho.platform.api.mt.ITenant;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -57,13 +58,15 @@ public class CachingUserRoleListServiceDecorator implements IUserRoleListService
 
   @SuppressWarnings( "unchecked" )
   private List<String> performOperation( String cacheEntry, DelegateOperation operation ) {
+      List<String> results = null;
     Object fromRegionCache = cacheManager.getFromRegionCache( REGION, cacheEntry );
-    if ( fromRegionCache != null && fromRegionCache instanceof List ) {
-      return (List<String>) fromRegionCache;
+    if (fromRegionCache instanceof List ) {
+        results = (List<String>) fromRegionCache;
+    }else{
+        results = operation.perform();
+        cacheManager.putInRegionCache( REGION, cacheEntry, results );
     }
-    List<String> results = operation.perform();
-    cacheManager.putInRegionCache( REGION, cacheEntry, results );
-    return Collections.unmodifiableList( results );
+    return new ArrayList<String>(results);
   }
 
 

--- a/extensions/src/org/pentaho/platform/plugin/services/security/userrole/CompositeUserRoleListService.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/security/userrole/CompositeUserRoleListService.java
@@ -17,13 +17,11 @@
 
 package org.pentaho.platform.plugin.services.security.userrole;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.pentaho.platform.api.engine.IUserRoleListService;
 import org.pentaho.platform.api.mt.ITenant;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * This class delgates calls to a configured list of IUserRoleListService delegates. The results are determined by the
@@ -116,22 +114,17 @@ public class CompositeUserRoleListService implements IUserRoleListService {
   }
 
   private List<String> collectResultsForOperation( CompositeOperation operation ) {
-    Set<String> returnVal = new HashSet<String>();
     for ( IUserRoleListService delegate : delegates ) {
-      List<String> allFromDelegate;
       try {
-        allFromDelegate = operation.perform( delegate );
+          List<String> allFromDelegate = operation.perform( delegate );
+          if (!CollectionUtils.isEmpty(allFromDelegate)) {
+              return allFromDelegate;
+          }
       } catch ( UnsupportedOperationException ignored ) {
         continue;
       }
-      if ( allFromDelegate != null && allFromDelegate.size() > 0 ) {
-        returnVal.addAll( allFromDelegate );
-        if ( activeStrategy == STRATEGY.FIRST_MATCH ) {
-          return new ArrayList<String>( returnVal );
-        }
-      }
     }
-    return new ArrayList<String>( returnVal );
+    return Collections.emptyList();
   }
 
   private interface CompositeOperation {

--- a/extensions/src/org/pentaho/platform/plugin/services/security/userrole/jdbc/JdbcUserRoleListService.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/security/userrole/jdbc/JdbcUserRoleListService.java
@@ -43,12 +43,12 @@ public class JdbcUserRoleListService extends JdbcDaoSupport implements IUserRole
 
   // ~ Static fields/initializers
   // =============================================
-  public static final String DEF_ALL_AUTHORITIES_QUERY = "SELECT distinct(authority) as authority FROM authorities"; //$NON-NLS-1$
+  public static final String DEF_ALL_AUTHORITIES_QUERY = "SELECT distinct(authority) as authority FROM authorities ORDER BY authority"; //$NON-NLS-1$
 
-  public static final String DEF_ALL_USERNAMES_QUERY = "SELECT distinct(username) as username FROM users"; //$NON-NLS-1$
+  public static final String DEF_ALL_USERNAMES_QUERY = "SELECT distinct(username) as username FROM users ORDER BY username"; //$NON-NLS-1$
 
   public static final String DEF_ALL_USERNAMES_IN_ROLE_QUERY =
-      "SELECT distinct(username) as username FROM authorities where authority = ?"; //$NON-NLS-1$
+      "SELECT distinct(username) as username FROM authorities WHERE authority = ?"; //$NON-NLS-1$
 
   // ~ Instance fields
   // ========================================================
@@ -105,9 +105,9 @@ public class JdbcUserRoleListService extends JdbcDaoSupport implements IUserRole
 
   /**
    * Allows the default query string used to retrieve all user names in a role to be overriden, if default table or
-   * column names need to be changed. The default query is {@link #DEF_ALL_USERS_QUERY}; when modifying this query,
+   * column names need to be changed. The default query is {@link #DEF_ALL_USERNAMES_QUERY}; when modifying this query,
    * ensure that all returned columns are mapped back to the same column names as in the default query.
-   * 
+   *
    * @param queryString
    *          The query string to set
    */
@@ -121,7 +121,7 @@ public class JdbcUserRoleListService extends JdbcDaoSupport implements IUserRole
 
   /**
    * Allows the default query string used to retrieve all user names to be overriden, if default table or column names
-   * need to be changed. The default query is {@link #DEF_ALL_USERS_IN_ROLE_QUERY}; when modifying this query, ensure
+   * need to be changed. The default query is {@link #DEF_ALL_USERNAMES_IN_ROLE_QUERY}; when modifying this query, ensure
    * that all returned columns are mapped back to the same column names as in the default query.
    * 
    * @param queryString

--- a/extensions/src/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapUserRoleListService.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapUserRoleListService.java
@@ -105,7 +105,7 @@ public class DefaultLdapUserRoleListService implements IUserRoleListService, Ini
 
   @Override
   public List<String> getAllRoles() {
-    List<GrantedAuthority> results = allAuthoritiesSearch.search( new Object[ 0 ] );
+    List<GrantedAuthority> results = allAuthoritiesSearch.search( new Object[0] );
     List<String> roles = new ArrayList<String>( results.size() );
     for ( GrantedAuthority role : results ) {
       String roleString =
@@ -155,6 +155,7 @@ public class DefaultLdapUserRoleListService implements IUserRoleListService, Ini
     for ( GrantedAuthority role : results ) {
       roles.add( role.getAuthority() );
     }
+    // TODO don't set the comparator from spring xml for build 6.0. UserRoleListService sorting roles after that.
     if ( null != roleComparator ) {
       Collections.sort( roles, roleComparator );
     }
@@ -178,7 +179,6 @@ public class DefaultLdapUserRoleListService implements IUserRoleListService, Ini
   }
 
   public void setRoleComparator( final Comparator<String> roleComparator ) {
-    Assert.notNull( roleComparator );
     this.roleComparator = roleComparator;
   }
 

--- a/extensions/src/org/pentaho/platform/plugin/services/security/userrole/ldap/search/GenericLdapSearch.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/security/userrole/ldap/search/GenericLdapSearch.java
@@ -27,11 +27,7 @@ import org.springframework.util.Assert;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.SearchResult;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class GenericLdapSearch implements LdapSearch, InitializingBean {
 
@@ -43,7 +39,7 @@ public class GenericLdapSearch implements LdapSearch, InitializingBean {
   /**
    * Generates disposable instances of search parameters. Factory should be thread-safe (i.e. no mutable instance
    * variables).
-   * 
+   *
    * @see LdapSearchParams
    */
   private LdapSearchParamsFactory paramsFactory;

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleListResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleListResource.java
@@ -35,6 +35,7 @@ import org.codehaus.enunciate.jaxrs.ResponseCode;
 import org.codehaus.enunciate.jaxrs.StatusCodes;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.security.DefaultRoleComparator;
 import org.pentaho.platform.web.http.api.resources.services.UserRoleListService;
 import org.pentaho.platform.web.http.api.resources.services.UserRoleListService.UnauthorizedException;
 
@@ -74,6 +75,7 @@ public class UserRoleListResource extends AbstractJaxRSResource {
     userRoleListService = new UserRoleListService();
     userRoleListService.setExtraRoles( extraRoles );
     userRoleListService.setSystemRoles( systemRoles );
+    userRoleListService.setRoleComparator( new DefaultRoleComparator() );
   }
 
   /**

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
@@ -27,6 +27,8 @@ import org.pentaho.platform.web.http.api.resources.RoleListWrapper;
 import org.pentaho.platform.web.http.api.resources.UserListWrapper;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class UserRoleListService {
@@ -36,6 +38,8 @@ public class UserRoleListService {
   private ArrayList<String> extraRoles;
 
   private ArrayList<String> systemRoles;
+
+  private Comparator<String> roleComparator;
 
   public String doGetRolesForUser( String user ) throws Exception {
     if ( canAdminister() ) {
@@ -89,6 +93,9 @@ public class UserRoleListService {
         }
       }
     }
+    if ( null != roleComparator ) {
+      Collections.sort( allRoles, roleComparator );
+    }
     return new RoleListWrapper( allRoles );
   }
 
@@ -123,6 +130,10 @@ public class UserRoleListService {
 
   public void setSystemRoles( ArrayList<String> systemRoles ) {
     this.systemRoles = systemRoles;
+  }
+
+  public void setRoleComparator( Comparator<String> roleComparator ) {
+    this.roleComparator = roleComparator;
   }
 
   public ArrayList<String> getExtraRoles() {


### PR DESCRIPTION
sorting for roles & users was fixed
