### PR TITLE
[BACKLOG-824] - Adding a configuration for multibyte encoding

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/repository.spring.properties
+++ b/assembly/package-res/biserver/pentaho-solutions/system/repository.spring.properties
@@ -12,3 +12,4 @@ systemTenantAdminUserName=system
 systemTenantAdminPassword=cGFzc3dvcmQ=
 cache-size=100
 cache-ttl=300
+useMultiByteEncoding=false

--- a/assembly/package-res/biserver/pentaho-solutions/system/repository.spring.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/repository.spring.xml
@@ -947,4 +947,9 @@
     <constructor-arg ref="repositoryFileDao"/>
   </bean>
   <!-- end authorization policy -->
+  
+  <bean class="java.lang.Boolean" id="useMultiByteEncoding">
+    <constructor-arg value="${repository.useMultiByteEncoding}"/>
+    <pen:publish as-type="INTERFACES"/>
+  </bean>
 </beans>

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelper.java
@@ -55,19 +55,18 @@ import java.util.Set;
  * Default implementation of {@link IDeleteHelper}.
  * <p/>
  * <p>
- * If user {@code suzy} in tenant {@code acme} deletes a file with id {@code testFileId} and named {@code testFile}
- * in folder with id {@code testFolderId} and named {@code testFolder} then this implementation upon a
- * non-permanent delete will move the file such that the new absolute path and properties of the "deleted" node
- * will be as follows.
+ * If user {@code suzy} in tenant {@code acme} deletes a file with id {@code testFileId} and named {@code testFile} in
+ * folder with id {@code testFolderId} and named {@code testFolder} then this implementation upon a non-permanent delete
+ * will move the file such that the new absolute path and properties of the "deleted" node will be as follows.
  * </p>
  * <p/>
  * <p>
  * Trash Structure 2
  * </p>
  * Uses JCR XPath queries for iteration and filtering. File ID nodes exist to prevent same-name sibling conflicts.
- * Original parent folder path stored in property. All delete-related properties stored in file ID node to avoid
- * the need to checkout versioned files when they are deleted. Note that use of JCR XPath queries may require
- * enabling features in the JCR implementation.
+ * Original parent folder path stored in property. All delete-related properties stored in file ID node to avoid the
+ * need to checkout versioned files when they are deleted. Note that use of JCR XPath queries may require enabling
+ * features in the JCR implementation.
  * 
  * <pre>
  * /pentaho/acme/home/suzy/.trash/pho:testFileId/testFile
@@ -98,8 +97,8 @@ import java.util.Set;
  * <p/>
  * <p>
  * By storing deleted files inside the user's home folder, the user's recycle bin is effectively private. This is
- * desirable because a deleted file with confidential information should not be seen by anyone else except the
- * deleting user.
+ * desirable because a deleted file with confidential information should not be seen by anyone else except the deleting
+ * user.
  * </p>
  * 
  * @author mlowery
@@ -147,8 +146,8 @@ public class DefaultDeleteHelper implements IDeleteHelper {
   }
 
   /**
-   * Creates and/or returns an internal folder to store a single deleted file. This folder is uniquely named and
-   * thus prevents same-name sibling conflicts.
+   * Creates and/or returns an internal folder to store a single deleted file. This folder is uniquely named and thus
+   * prevents same-name sibling conflicts.
    * 
    * @param fileId
    *          id of file to delete
@@ -166,8 +165,8 @@ public class DefaultDeleteHelper implements IDeleteHelper {
   }
 
   /**
-   * Returns an internal folder to store all files deleted from a given folder. Provides fast access when searching
-   * for files deleted from a given folder.
+   * Returns an internal folder to store all files deleted from a given folder. Provides fast access when searching for
+   * files deleted from a given folder.
    */
   private Node legacyGetTrashFolderIdNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
       final String origParentFolderPath ) throws RepositoryException {
@@ -194,13 +193,21 @@ public class DefaultDeleteHelper implements IDeleteHelper {
    * Creates and/or returns an internal folder called {@code .trash} located just below the user's home folder.
    */
   private Node
-  getOrCreateTrashInternalFolderNode( final Session session, final PentahoJcrConstants pentahoJcrConstants )
-    throws RepositoryException {
+    getOrCreateTrashInternalFolderNode( final Session session, final PentahoJcrConstants pentahoJcrConstants )
+      throws RepositoryException {
     IPentahoSession pentahoSession = PentahoSessionHolder.getSession();
     String tenantId = (String) pentahoSession.getAttribute( IPentahoSession.TENANT_ID_KEY );
-    Node userHomeFolderNode =
-        (Node) session.getItem( ServerRepositoryPaths.getUserHomeFolderPath( new Tenant( tenantId, true ),
-            JcrStringHelper.fileNameEncode( PentahoSessionHolder.getSession().getName() ) ) );
+    Node userHomeFolderNode = null;
+    try {
+      userHomeFolderNode =
+          (Node) session.getItem( ServerRepositoryPaths.getUserHomeFolderPath( new Tenant( tenantId, true ),
+              JcrStringHelper.fileNameEncode( PentahoSessionHolder.getSession().getName() ) ) );
+    } catch ( Throwable th ) {
+      userHomeFolderNode =
+          (Node) session.getItem( ServerRepositoryPaths.getUserHomeFolderPath( new Tenant( tenantId, true ),
+              JcrStringHelper.fileNameEncode( PentahoSessionHolder.getSession().getName(), !JcrStringHelper
+                  .isMultiByteEncodingEnabled() ) ) );
+    }
     if ( userHomeFolderNode.hasNode( FOLDER_NAME_TRASH ) ) {
       return userHomeFolderNode.getNode( FOLDER_NAME_TRASH );
     } else {
@@ -342,7 +349,7 @@ public class DefaultDeleteHelper implements IDeleteHelper {
         originalParentFolderPath ).build();
   }
 
-  //returns encoded path
+  // returns encoded path
   private String getOriginalParentFolderPath( final Session session, final PentahoJcrConstants pentahoJcrConstants,
       final Node trashFileNode, final boolean relative ) throws RepositoryException {
     if ( trashFileNode.getParent().hasProperty( pentahoJcrConstants.getPHO_ORIGPARENTFOLDERPATH() ) ) {
@@ -445,8 +452,7 @@ public class DefaultDeleteHelper implements IDeleteHelper {
       final Serializable fileId ) throws RepositoryException {
     Node fileToUndeleteNode = session.getNodeByIdentifier( fileId.toString() );
     String trashFileIdNodePath = fileToUndeleteNode.getParent().getPath();
-    String origParentFolderPath = getOriginalParentFolderPath( session, pentahoJcrConstants
-      , fileToUndeleteNode, false );
+    String origParentFolderPath = getOriginalParentFolderPath( session, pentahoJcrConstants, fileToUndeleteNode, false );
 
     String absDestPath = origParentFolderPath + RepositoryFile.SEPARATOR + fileToUndeleteNode.getName();
 
@@ -466,7 +472,7 @@ public class DefaultDeleteHelper implements IDeleteHelper {
    */
   public String getOriginalParentFolderPath( final Session session, final PentahoJcrConstants pentahoJcrConstants,
       final Serializable fileId ) throws RepositoryException {
-    return JcrStringHelper.pathDecode( getOriginalParentFolderPath( session, pentahoJcrConstants, session.getNodeByIdentifier( fileId.toString() ),
-        false ) );
+    return JcrStringHelper.pathDecode( getOriginalParentFolderPath( session, pentahoJcrConstants, session
+        .getNodeByIdentifier( fileId.toString() ), false ) );
   }
 }

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -99,26 +99,25 @@ public class JcrRepositoryFileUtils {
   private static boolean versionCommentsEnabled = true;
 
   /**
-   * Try to get parameters from PentahoSystem,
-   * otherwise use default
+   * Try to get parameters from PentahoSystem, otherwise use default
    */
   static {
     List<Character> newOverrideReservedChars =
-      PentahoSystem.get( ArrayList.class, "reservedChars", PentahoSessionHolder.getSession() );
+        PentahoSystem.get( ArrayList.class, "reservedChars", PentahoSessionHolder.getSession() );
 
     if ( newOverrideReservedChars != null ) {
       reservedChars = newOverrideReservedChars;
     }
 
-    Boolean systemVersioningEnabled = PentahoSystem.get( Boolean.class,
-      "versioningEnabled", PentahoSessionHolder.getSession() );
+    Boolean systemVersioningEnabled =
+        PentahoSystem.get( Boolean.class, "versioningEnabled", PentahoSessionHolder.getSession() );
 
     if ( systemVersioningEnabled != null ) {
       versioningEnabled = systemVersioningEnabled;
     }
 
-    Boolean systemVersionCommentsEnabled = PentahoSystem.get( Boolean.class,
-      "versionCommentsEnabled", PentahoSessionHolder.getSession() );
+    Boolean systemVersionCommentsEnabled =
+        PentahoSystem.get( Boolean.class, "versionCommentsEnabled", PentahoSessionHolder.getSession() );
 
     if ( systemVersionCommentsEnabled != null ) {
       versionCommentsEnabled = systemVersionCommentsEnabled;
@@ -141,8 +140,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static RepositoryFile getFileById( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                            final IPathConversionHelper pathConversionHelper,
-                                            final ILockHelper lockHelper, final Serializable fileId )
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final Serializable fileId )
     throws RepositoryException {
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
     Assert.notNull( fileNode );
@@ -150,8 +148,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static RepositoryFile nodeToFile( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                           final IPathConversionHelper pathConversionHelper,
-                                           final ILockHelper lockHelper, final Node node )
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final Node node )
     throws RepositoryException {
     return nodeToFile( session, pentahoJcrConstants, pathConversionHelper, lockHelper, node, false, null );
   }
@@ -159,16 +156,14 @@ public class JcrRepositoryFileUtils {
   private static RepositoryFile getRootFolder( final Session session ) throws RepositoryException {
     Node node = session.getRootNode();
     RepositoryFile file =
-      new RepositoryFile.Builder( node.getIdentifier(), "" ).folder( true ).versioned( false ).path( //$NON-NLS-1$
-        JcrStringHelper.pathDecode( node.getPath() ) ).build();
+        new RepositoryFile.Builder( node.getIdentifier(), "" ).folder( true ).versioned( false ).path( //$NON-NLS-1$
+            JcrStringHelper.pathDecode( node.getPath() ) ).build();
     return file;
   }
 
   public static RepositoryFile nodeToFileOld( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                              final IPathConversionHelper pathConversionHelper,
-                                              final ILockHelper lockHelper, final Node node,
-                                              final boolean loadMaps, IPentahoLocale pentahoLocale )
-    throws RepositoryException {
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final Node node,
+      final boolean loadMaps, IPentahoLocale pentahoLocale ) throws RepositoryException {
 
     if ( session.getRootNode().isSame( node ) ) {
       return getRootFolder( session );
@@ -201,8 +196,7 @@ public class JcrRepositoryFileUtils {
 
     path = pathConversionHelper.absToRel( ( getAbsolutePath( session, pentahoJcrConstants, node ) ) );
     // if the rel path is / then name the folder empty string instead of its true name (this hides the tenant name)
-    name =
-      RepositoryFile.SEPARATOR.equals( path ) ? "" : getNodeName( session, pentahoJcrConstants, node ); //$NON-NLS-1$
+    name = RepositoryFile.SEPARATOR.equals( path ) ? "" : getNodeName( session, pentahoJcrConstants, node ); //$NON-NLS-1$
 
     if ( isPentahoFolder( pentahoJcrConstants, node ) ) {
       folder = true;
@@ -250,7 +244,7 @@ public class JcrRepositoryFileUtils {
       if ( node.hasNode( pentahoJcrConstants.getPHO_LOCALES() ) ) {
         // Expensive
         localePropertiesMap =
-          getLocalePropertiesMap( session, pentahoJcrConstants, node.getNode( pentahoJcrConstants.getPHO_LOCALES() ) );
+            getLocalePropertiesMap( session, pentahoJcrConstants, node.getNode( pentahoJcrConstants.getPHO_LOCALES() ) );
 
         // [BISERVER-8337] localize title and description
         LocalePropertyResolver lpr = new LocalePropertyResolver( name );
@@ -272,13 +266,13 @@ public class JcrRepositoryFileUtils {
       // found
       if ( title == null && node.hasNode( pentahoJcrConstants.getPHO_TITLE() ) ) {
         title =
-          getLocalizedString( session, pentahoJcrConstants, node.getNode( pentahoJcrConstants.getPHO_TITLE() ),
-            pentahoLocale );
+            getLocalizedString( session, pentahoJcrConstants, node.getNode( pentahoJcrConstants.getPHO_TITLE() ),
+                pentahoLocale );
       }
       if ( description == null && node.hasNode( pentahoJcrConstants.getPHO_DESCRIPTION() ) ) {
         description =
-          getLocalizedString( session, pentahoJcrConstants, node.getNode( pentahoJcrConstants.getPHO_DESCRIPTION() ),
-            pentahoLocale );
+            getLocalizedString( session, pentahoJcrConstants, node.getNode( pentahoJcrConstants.getPHO_DESCRIPTION() ),
+                pentahoLocale );
       }
 
     }
@@ -301,20 +295,18 @@ public class JcrRepositoryFileUtils {
     }
 
     RepositoryFile file =
-      new RepositoryFile.Builder( id, name ).createdDate( created ).creatorId( creatorId ).lastModificationDate(
-        lastModified ).folder( folder ).versioned( versioned ).path( path ).versionId( versionId ).fileSize(
-        fileSize ).locked( locked ).lockDate( lockDate ).hidden( hidden ).lockMessage( lockMessage ).lockOwner(
-        lockOwner ).title( title ).description( description ).locale( pentahoLocale.toString() )
-        .localePropertiesMap( localePropertiesMap ).build();
+        new RepositoryFile.Builder( id, name ).createdDate( created ).creatorId( creatorId ).lastModificationDate(
+            lastModified ).folder( folder ).versioned( versioned ).path( path ).versionId( versionId ).fileSize(
+            fileSize ).locked( locked ).lockDate( lockDate ).hidden( hidden ).lockMessage( lockMessage ).lockOwner(
+            lockOwner ).title( title ).description( description ).locale( pentahoLocale.toString() )
+            .localePropertiesMap( localePropertiesMap ).build();
 
     return file;
   }
 
   public static RepositoryFile nodeToFile( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                           final IPathConversionHelper pathConversionHelper,
-                                           final ILockHelper lockHelper, final Node node,
-                                           final boolean loadMaps, IPentahoLocale pentahoLocale )
-    throws RepositoryException {
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final Node node,
+      final boolean loadMaps, IPentahoLocale pentahoLocale ) throws RepositoryException {
 
     if ( session.getRootNode().isSame( node ) ) {
       return getRootFolder( session );
@@ -341,8 +333,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static String getLocalizedString( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                           final Node localizedStringNode, IPentahoLocale pentahoLocale )
-    throws RepositoryException {
+      final Node localizedStringNode, IPentahoLocale pentahoLocale ) throws RepositoryException {
     Assert.isTrue( isLocalizedString( session, pentahoJcrConstants, localizedStringNode ) );
 
     boolean isLocaleNull = pentahoLocale == null;
@@ -363,7 +354,7 @@ public class JcrRepositoryFileUtils {
 
     if ( hasVariant ) {
       candidatePropertyNames.add( locale.getLanguage() + UNDERSCORE + locale.getCountry() + UNDERSCORE
-        + locale.getVariant() );
+          + locale.getVariant() );
     }
     if ( hasCountry ) {
       candidatePropertyNames.add( locale.getLanguage() + UNDERSCORE + locale.getCountry() );
@@ -387,8 +378,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static Map<String, Properties> getLocalePropertiesMap( final Session session,
-                                                                final PentahoJcrConstants pentahoJcrConstants,
-                                                                final Node localesNode ) throws RepositoryException {
+      final PentahoJcrConstants pentahoJcrConstants, final Node localesNode ) throws RepositoryException {
 
     String prefix = session.getNamespacePrefix( PentahoJcrConstants.PHO_NS );
     Assert.hasText( prefix );
@@ -414,9 +404,7 @@ public class JcrRepositoryFileUtils {
   }
 
   private static void setLocalePropertiesMap( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                              final Node localeRootNode,
-                                              final Map<String, Properties> localePropertiesMap )
-    throws RepositoryException {
+      final Node localeRootNode, final Map<String, Properties> localePropertiesMap ) throws RepositoryException {
     String prefix = session.getNamespacePrefix( PentahoJcrConstants.PHO_NS );
     Assert.hasText( prefix );
 
@@ -445,9 +433,7 @@ public class JcrRepositoryFileUtils {
   }
 
   private static Map<String, String> getLocalizedStringMap( final Session session,
-                                                            final PentahoJcrConstants pentahoJcrConstants,
-                                                            final Node localizedStringNode )
-    throws RepositoryException {
+      final PentahoJcrConstants pentahoJcrConstants, final Node localizedStringNode ) throws RepositoryException {
     Assert.isTrue( isLocalizedString( session, pentahoJcrConstants, localizedStringNode ) );
 
     String prefix = session.getNamespacePrefix( PentahoJcrConstants.PHO_NS );
@@ -471,8 +457,7 @@ public class JcrRepositoryFileUtils {
    * Sets localized string.
    */
   private static void setLocalizedStringMap( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                             final Node localizedStringNode, final Map<String, String> map )
-    throws RepositoryException {
+      final Node localizedStringNode, final Map<String, String> map ) throws RepositoryException {
     Assert.isTrue( isLocalizedString( session, pentahoJcrConstants, localizedStringNode ) );
 
     String prefix = session.getNamespacePrefix( PentahoJcrConstants.PHO_NS );
@@ -491,17 +476,17 @@ public class JcrRepositoryFileUtils {
   }
 
   public static String getAbsolutePath( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                        final Node node ) throws RepositoryException {
+      final Node node ) throws RepositoryException {
     if ( node.isNodeType( pentahoJcrConstants.getNT_FROZENNODE() ) ) {
       return JcrStringHelper.pathDecode( session.getNodeByIdentifier(
-        node.getProperty( pentahoJcrConstants.getJCR_FROZENUUID() ).getString() ).getPath() );
+          node.getProperty( pentahoJcrConstants.getJCR_FROZENUUID() ).getString() ).getPath() );
     }
 
     return JcrStringHelper.pathDecode( node.getPath() );
   }
 
   public static Serializable getNodeId( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                        final Node node ) throws RepositoryException {
+      final Node node ) throws RepositoryException {
     if ( node.isNodeType( pentahoJcrConstants.getNT_FROZENNODE() ) ) {
       return node.getProperty( pentahoJcrConstants.getJCR_FROZENUUID() ).getString();
     }
@@ -510,17 +495,17 @@ public class JcrRepositoryFileUtils {
   }
 
   public static String getNodeName( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                    final Node node ) throws RepositoryException {
+      final Node node ) throws RepositoryException {
     if ( node.isNodeType( pentahoJcrConstants.getNT_FROZENNODE() ) ) {
       return JcrStringHelper.fileNameDecode( session.getNodeByIdentifier(
-        node.getProperty( pentahoJcrConstants.getJCR_FROZENUUID() ).getString() ).getName() );
+          node.getProperty( pentahoJcrConstants.getJCR_FROZENUUID() ).getString() ).getName() );
     }
 
     return JcrStringHelper.fileNameDecode( node.getName() );
   }
 
   public static String getVersionId( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                     final Node node ) throws RepositoryException {
+      final Node node ) throws RepositoryException {
     if ( node.isNodeType( pentahoJcrConstants.getNT_FROZENNODE() ) ) {
       return JcrStringHelper.fileNameDecode( node.getParent().getName() );
     }
@@ -550,8 +535,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static Node createFolderNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                       final Serializable parentFolderId, final RepositoryFile folder )
-    throws RepositoryException {
+      final Serializable parentFolderId, final RepositoryFile folder ) throws RepositoryException {
     checkName( folder.getName() );
     Node parentFolderNode;
     if ( parentFolderId != null ) {
@@ -588,9 +572,8 @@ public class JcrRepositoryFileUtils {
   }
 
   public static Node createFileNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                     final Serializable parentFolderId, final RepositoryFile file,
-                                     final IRepositoryFileData content,
-                                     final ITransformer<IRepositoryFileData> transformer ) throws RepositoryException {
+      final Serializable parentFolderId, final RepositoryFile file, final IRepositoryFileData content,
+      final ITransformer<IRepositoryFileData> transformer ) throws RepositoryException {
 
     checkName( file.getName() );
     String encodedFileName = JcrStringHelper.fileNameEncode( file.getName() );
@@ -611,7 +594,7 @@ public class JcrRepositoryFileUtils {
     fileNode.setProperty( pentahoJcrConstants.getPHO_FILESIZE(), content.getDataSize() );
     if ( file.getLocalePropertiesMap() != null && !file.getLocalePropertiesMap().isEmpty() ) {
       Node localeNodes =
-        fileNode.addNode( pentahoJcrConstants.getPHO_LOCALES(), pentahoJcrConstants.getPHO_NT_LOCALE() );
+          fileNode.addNode( pentahoJcrConstants.getPHO_LOCALES(), pentahoJcrConstants.getPHO_NT_LOCALE() );
       setLocalePropertiesMap( session, pentahoJcrConstants, localeNodes, file.getLocalePropertiesMap() );
     }
     Node metaNode = fileNode.addNode( pentahoJcrConstants.getPHO_METADATA(), JcrConstants.NT_UNSTRUCTURED );
@@ -629,21 +612,21 @@ public class JcrRepositoryFileUtils {
   }
 
   private static void preventLostUpdate( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                         final RepositoryFile file ) throws RepositoryException {
+      final RepositoryFile file ) throws RepositoryException {
     Node fileNode = session.getNodeByIdentifier( file.getId().toString() );
     // guard against using a file retrieved from a more lenient session inside a more strict session
     Assert.notNull( fileNode );
     if ( isVersioned( session, pentahoJcrConstants, fileNode ) ) {
       Assert.notNull( file.getVersionId(), "updating a versioned file requires a non-null version id" ); //$NON-NLS-1$
       Assert.state( session.getWorkspace().getVersionManager().getBaseVersion( fileNode.getPath() ).getName().equals(
-        file.getVersionId().toString() ), "update to this file has occurred since its last read" ); //$NON-NLS-1$
+          file.getVersionId().toString() ), "update to this file has occurred since its last read" ); //$NON-NLS-1$
     }
   }
 
   public static Node
-  updateFileNode( final Session session, final PentahoJcrConstants pentahoJcrConstants, final RepositoryFile file,
-                  final IRepositoryFileData content, final ITransformer<IRepositoryFileData> transformer )
-    throws RepositoryException {
+    updateFileNode( final Session session, final PentahoJcrConstants pentahoJcrConstants, final RepositoryFile file,
+        final IRepositoryFileData content, final ITransformer<IRepositoryFileData> transformer )
+      throws RepositoryException {
 
     Node fileNode = session.getNodeByIdentifier( file.getId().toString() );
     // guard against using a file retrieved from a more lenient session inside a more strict session
@@ -659,7 +642,7 @@ public class JcrRepositoryFileUtils {
       Node localePropertiesMapNode = null;
       if ( !fileNode.hasNode( pentahoJcrConstants.getPHO_LOCALES() ) ) {
         localePropertiesMapNode =
-          fileNode.addNode( pentahoJcrConstants.getPHO_LOCALES(), pentahoJcrConstants.getPHO_NT_LOCALE() );
+            fileNode.addNode( pentahoJcrConstants.getPHO_LOCALES(), pentahoJcrConstants.getPHO_NT_LOCALE() );
       } else {
         localePropertiesMapNode = fileNode.getNode( pentahoJcrConstants.getPHO_LOCALES() );
       }
@@ -680,7 +663,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static Node updateFolderNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                       final RepositoryFile folder ) throws RepositoryException {
+      final RepositoryFile folder ) throws RepositoryException {
 
     Node folderNode = session.getNodeByIdentifier( folder.getId().toString() );
     // guard against using a file retrieved from a more lenient session inside a more strict session
@@ -693,7 +676,7 @@ public class JcrRepositoryFileUtils {
       Node localePropertiesMapNode = null;
       if ( !folderNode.hasNode( pentahoJcrConstants.getPHO_LOCALES() ) ) {
         localePropertiesMapNode =
-          folderNode.addNode( pentahoJcrConstants.getPHO_LOCALES(), pentahoJcrConstants.getPHO_NT_LOCALE() );
+            folderNode.addNode( pentahoJcrConstants.getPHO_LOCALES(), pentahoJcrConstants.getPHO_NT_LOCALE() );
       } else {
         localePropertiesMapNode = folderNode.getNode( pentahoJcrConstants.getPHO_LOCALES() );
       }
@@ -703,8 +686,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static IRepositoryFileData getContent( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                                final Serializable fileId, final Serializable versionId,
-                                                final ITransformer<IRepositoryFileData> transformer )
+      final Serializable fileId, final Serializable versionId, final ITransformer<IRepositoryFileData> transformer )
     throws RepositoryException {
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
     if ( isVersioned( session, pentahoJcrConstants, fileNode ) ) {
@@ -722,12 +704,9 @@ public class JcrRepositoryFileUtils {
     return transformer.fromContentNode( session, pentahoJcrConstants, fileNode );
   }
 
-
   public static List<RepositoryFile> getChildren( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                                  final IPathConversionHelper pathConversionHelper,
-                                                  final ILockHelper lockHelper,
-                                                  final RepositoryRequest repositoryRequest )
-    throws RepositoryException {
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper,
+      final RepositoryRequest repositoryRequest ) throws RepositoryException {
     Node folderNode = session.getNodeByIdentifier( JcrStringHelper.idEncode( repositoryRequest.getPath() ) );
 
     Assert.isTrue( isPentahoFolder( pentahoJcrConstants, folderNode ) );
@@ -761,18 +740,15 @@ public class JcrRepositoryFileUtils {
 
   @Deprecated
   public static List<RepositoryFile> getChildren( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                                  final IPathConversionHelper pathConversionHelper,
-                                                  final ILockHelper lockHelper, final Serializable folderId,
-                                                  final String filter ) throws RepositoryException {
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final Serializable folderId,
+      final String filter ) throws RepositoryException {
     return getChildren( session, pentahoJcrConstants, pathConversionHelper, lockHelper, folderId, filter, null );
   }
 
   @Deprecated
   public static List<RepositoryFile> getChildren( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                                  final IPathConversionHelper pathConversionHelper,
-                                                  final ILockHelper lockHelper, final Serializable folderId,
-                                                  final String filter, Boolean showHiddenFiles )
-    throws RepositoryException {
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final Serializable folderId,
+      final String filter, Boolean showHiddenFiles ) throws RepositoryException {
     RepositoryRequest repositoryRequest = new RepositoryRequest( folderId.toString(), showHiddenFiles, 0, filter );
     return getChildren( session, pentahoJcrConstants, pathConversionHelper, lockHelper, repositoryRequest );
   }
@@ -789,13 +765,13 @@ public class JcrRepositoryFileUtils {
   }
 
   public static boolean isPentahoHierarchyNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                                final Node node ) throws RepositoryException {
+      final Node node ) throws RepositoryException {
     Assert.notNull( node );
     if ( node.isNodeType( pentahoJcrConstants.getNT_FROZENNODE() ) ) {
       String nodeTypeName = node.getProperty( pentahoJcrConstants.getJCR_FROZENPRIMARYTYPE() ).getString();
       // TODO mlowery add PENTAHOLINKEDFILE here when it is available
       return pentahoJcrConstants.getPHO_NT_PENTAHOFOLDER().equals( nodeTypeName )
-        || pentahoJcrConstants.getPHO_NT_PENTAHOFILE().equals( nodeTypeName );
+          || pentahoJcrConstants.getPHO_NT_PENTAHOFILE().equals( nodeTypeName );
     }
 
     return node.isNodeType( pentahoJcrConstants.getPHO_NT_PENTAHOHIERARCHYNODE() );
@@ -830,7 +806,7 @@ public class JcrRepositoryFileUtils {
   }
 
   private static boolean isLocalizedString( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                            final Node node ) throws RepositoryException {
+      final Node node ) throws RepositoryException {
     Assert.notNull( node );
     if ( node.isNodeType( pentahoJcrConstants.getNT_FROZENNODE() ) ) {
       String frozenPrimaryType = node.getProperty( pentahoJcrConstants.getJCR_FROZENPRIMARYTYPE() ).getString();
@@ -844,7 +820,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static boolean isVersioned( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                     final Node node ) throws RepositoryException {
+      final Node node ) throws RepositoryException {
     Assert.notNull( node );
     if ( node.isNodeType( pentahoJcrConstants.getNT_FROZENNODE() ) ) {
       // frozen nodes represent the nodes at a particular version; so yes, they are versioned!
@@ -860,19 +836,18 @@ public class JcrRepositoryFileUtils {
     if ( node.isNodeType( pentahoJcrConstants.getNT_FROZENNODE() ) ) {
       String nodeTypeName = node.getProperty( pentahoJcrConstants.getJCR_FROZENPRIMARYTYPE() ).getString();
       return pentahoJcrConstants.getPHO_NT_PENTAHOFILE().equals( nodeTypeName )
-        || pentahoJcrConstants.getPHO_NT_PENTAHOFOLDER().equals( nodeTypeName );
+          || pentahoJcrConstants.getPHO_NT_PENTAHOFOLDER().equals( nodeTypeName );
     }
 
     return node.isNodeType( pentahoJcrConstants.getPHO_NT_PENTAHOFILE() )
-      || node.isNodeType( pentahoJcrConstants.getPHO_NT_PENTAHOFOLDER() );
+        || node.isNodeType( pentahoJcrConstants.getPHO_NT_PENTAHOFOLDER() );
   }
 
   /**
    * Conditionally checks out node representing file if node is versionable.
    */
   public static void checkoutNearestVersionableFileIfNecessary( final Session session,
-                                                                final PentahoJcrConstants pentahoJcrConstants,
-                                                                final Serializable fileId ) throws RepositoryException {
+      final PentahoJcrConstants pentahoJcrConstants, final Serializable fileId ) throws RepositoryException {
     // file could be null meaning the caller is using null as the parent folder; that's OK; in this case the node
     // in
     // question would be the repository root node and that is never versioned
@@ -886,8 +861,7 @@ public class JcrRepositoryFileUtils {
    * Conditionally checks out node if node is versionable.
    */
   public static void checkoutNearestVersionableNodeIfNecessary( final Session session,
-                                                                final PentahoJcrConstants pentahoJcrConstants,
-                                                                final Node node ) throws RepositoryException {
+      final PentahoJcrConstants pentahoJcrConstants, final Node node ) throws RepositoryException {
     Assert.notNull( node );
 
     Node versionableNode = findNearestVersionableNode( session, pentahoJcrConstants, node );
@@ -898,8 +872,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static void checkinNearestVersionableFileIfNecessary( final Session session,
-                                                               final PentahoJcrConstants pentahoJcrConstants,
-                                                               final Serializable fileId, final String versionMessage )
+      final PentahoJcrConstants pentahoJcrConstants, final Serializable fileId, final String versionMessage )
     throws RepositoryException {
     checkinNearestVersionableFileIfNecessary( session, pentahoJcrConstants, fileId, versionMessage, null, false );
   }
@@ -908,23 +881,20 @@ public class JcrRepositoryFileUtils {
    * Conditionally checks in node representing file if node is versionable.
    */
   public static void checkinNearestVersionableFileIfNecessary( final Session session,
-                                                               final PentahoJcrConstants pentahoJcrConstants,
-                                                               final Serializable fileId, final String versionMessage,
-                                                               final Date versionDate, final boolean aclOnlyChange )
-    throws RepositoryException {
+      final PentahoJcrConstants pentahoJcrConstants, final Serializable fileId, final String versionMessage,
+      final Date versionDate, final boolean aclOnlyChange ) throws RepositoryException {
     // file could be null meaning the caller is using null as the parent folder; that's OK; in this case the node
     // in
     // question would be the repository root node and that is never versioned
     if ( fileId != null ) {
       Node node = session.getNodeByIdentifier( fileId.toString() );
       checkinNearestVersionableNodeIfNecessary( session, pentahoJcrConstants, node, versionMessage, versionDate,
-        aclOnlyChange );
+          aclOnlyChange );
     }
   }
 
   public static void checkinNearestVersionableNodeIfNecessary( final Session session,
-                                                               final PentahoJcrConstants pentahoJcrConstants,
-                                                               final Node node, final String versionMessage )
+      final PentahoJcrConstants pentahoJcrConstants, final Node node, final String versionMessage )
     throws RepositoryException {
     checkinNearestVersionableNodeIfNecessary( session, pentahoJcrConstants, node, versionMessage, null, false );
   }
@@ -935,11 +905,8 @@ public class JcrRepositoryFileUtils {
    * TODO mlowery move commented out version labeling to its own method
    */
   public static void checkinNearestVersionableNodeIfNecessary( final Session session,
-                                                               final PentahoJcrConstants pentahoJcrConstants,
-                                                               final Node node, final String versionMessage,
-                                                               Date versionDate,
-                                                               final boolean aclOnlyChange )
-    throws RepositoryException {
+      final PentahoJcrConstants pentahoJcrConstants, final Node node, final String versionMessage, Date versionDate,
+      final boolean aclOnlyChange ) throws RepositoryException {
     Assert.notNull( node );
     session.save();
     /*
@@ -980,16 +947,17 @@ public class JcrRepositoryFileUtils {
       // prevent the number of versions from increasing. We still need a versioned node
       if ( Boolean.FALSE.equals( versioningEnabled ) ) {
 
-        List<VersionSummary> versionSummaries = (List<VersionSummary>)
-          getVersionSummaries( session, pentahoJcrConstants, versionableNode.getIdentifier(), Boolean.TRUE );
+        List<VersionSummary> versionSummaries =
+            (List<VersionSummary>) getVersionSummaries( session, pentahoJcrConstants, versionableNode.getIdentifier(),
+                Boolean.TRUE );
 
         if ( ( versionSummaries != null ) && ( versionSummaries.size() > 1 ) ) {
-          VersionSummary versionSummary = (VersionSummary) versionSummaries.toArray()[ versionSummaries.size() - 2 ];
+          VersionSummary versionSummary = (VersionSummary) versionSummaries.toArray()[versionSummaries.size() - 2];
 
           if ( versionSummary != null ) {
             String versionId = (String) versionSummary.getId();
             session.getWorkspace().getVersionManager().getVersionHistory( versionableNode.getPath() ).removeVersion(
-              versionId );
+                versionId );
             session.save();
           }
         }
@@ -1007,7 +975,7 @@ public class JcrRepositoryFileUtils {
    * Returns the nearest versionable node (possibly the node itself) or {@code null} if the root is reached.
    */
   private static Node findNearestVersionableNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                                  final Node node ) throws RepositoryException {
+      final Node node ) throws RepositoryException {
     Node currentNode = node;
     while ( !currentNode.isNodeType( pentahoJcrConstants.getPHO_MIX_VERSIONABLE() ) ) {
       try {
@@ -1021,8 +989,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static void deleteFile( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                 final Serializable fileId, final ILockHelper lockTokenHelper )
-    throws RepositoryException {
+      final Serializable fileId, final ILockHelper lockTokenHelper ) throws RepositoryException {
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
     // guard against using a file retrieved from a more lenient session inside a more strict session
     Assert.notNull( fileNode );
@@ -1038,16 +1005,14 @@ public class JcrRepositoryFileUtils {
   }
 
   public static RepositoryFile nodeIdToFile( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                             final IPathConversionHelper pathConversionHelper,
-                                             final ILockHelper lockHelper, final Serializable fileId )
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final Serializable fileId )
     throws RepositoryException {
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
     return nodeToFile( session, pentahoJcrConstants, pathConversionHelper, lockHelper, fileNode );
   }
 
   public static Object getVersionSummaries( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                            final Serializable fileId, final boolean includeAclOnlyChanges )
-    throws RepositoryException {
+      final Serializable fileId, final boolean includeAclOnlyChanges ) throws RepositoryException {
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
     VersionHistory versionHistory = session.getWorkspace().getVersionManager().getVersionHistory( fileNode.getPath() );
     // get root version but don't include it in version summaries; from JSR-170 specification section 8.2.5:
@@ -1060,7 +1025,7 @@ public class JcrRepositoryFileUtils {
     Version[] successors = version.getSuccessors();
     List<VersionSummary> versionSummaries = new ArrayList<VersionSummary>();
     while ( successors != null && successors.length > 0 ) {
-      version = successors[ 0 ]; // branching not supported
+      version = successors[0]; // branching not supported
       VersionSummary sum = toVersionSummary( pentahoJcrConstants, versionHistory, version );
       if ( !sum.isAclOnlyChange() || ( includeAclOnlyChanges && sum.isAclOnlyChange() ) ) {
         versionSummaries.add( sum );
@@ -1071,8 +1036,7 @@ public class JcrRepositoryFileUtils {
   }
 
   private static VersionSummary toVersionSummary( final PentahoJcrConstants pentahoJcrConstants,
-                                                  final VersionHistory versionHistory, final Version version )
-    throws RepositoryException {
+      final VersionHistory versionHistory, final Version version ) throws RepositoryException {
     List<String> labels = Arrays.asList( versionHistory.getVersionLabels( version ) );
     // get custom Pentaho properties (i.e. author and message)
     Node nodeAtVersion = getNodeAtVersion( pentahoJcrConstants, version );
@@ -1086,17 +1050,18 @@ public class JcrRepositoryFileUtils {
     }
     boolean aclOnlyChange = false;
     if ( nodeAtVersion.hasProperty( pentahoJcrConstants.getPHO_ACLONLYCHANGE() )
-      && nodeAtVersion.getProperty( pentahoJcrConstants.getPHO_ACLONLYCHANGE() ).getBoolean() ) {
+        && nodeAtVersion.getProperty( pentahoJcrConstants.getPHO_ACLONLYCHANGE() ).getBoolean() ) {
       aclOnlyChange = true;
     }
     return new VersionSummary( version.getName(), versionHistory.getVersionableIdentifier(), aclOnlyChange, version
-      .getCreated().getTime(), author, message, labels );
+        .getCreated().getTime(), author, message, labels );
   }
 
   /**
    * Returns the node as it was at the given version.
    *
-   * @param version version to get
+   * @param version
+   *          version to get
    * @return node at version
    */
   private static Node getNodeAtVersion( final PentahoJcrConstants pentahoJcrConstants, final Version version )
@@ -1105,29 +1070,27 @@ public class JcrRepositoryFileUtils {
   }
 
   public static RepositoryFile getFileAtVersion( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                                 final IPathConversionHelper pathConversionHelper,
-                                                 final ILockHelper lockHelper, final Serializable fileId,
-                                                 final Serializable versionId ) throws RepositoryException {
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final Serializable fileId,
+      final Serializable versionId ) throws RepositoryException {
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
     Version version =
-      session.getWorkspace().getVersionManager().getVersionHistory( fileNode.getPath() ).getVersion(
-        versionId.toString() );
+        session.getWorkspace().getVersionManager().getVersionHistory( fileNode.getPath() ).getVersion(
+            versionId.toString() );
     return nodeToFile( session, pentahoJcrConstants, pathConversionHelper, lockHelper, getNodeAtVersion(
-      pentahoJcrConstants, version ) );
+        pentahoJcrConstants, version ) );
   }
 
   /**
    * Returns the metadata regarding that identifies what transformer wrote this file's data.
    */
   public static String getFileContentType( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                           final Serializable fileId, final Serializable versionId )
-    throws RepositoryException {
+      final Serializable fileId, final Serializable versionId ) throws RepositoryException {
     Assert.notNull( fileId );
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
     if ( versionId != null ) {
       Version version =
-        session.getWorkspace().getVersionManager().getVersionHistory( fileNode.getPath() ).getVersion(
-          versionId.toString() );
+          session.getWorkspace().getVersionManager().getVersionHistory( fileNode.getPath() ).getVersion(
+              versionId.toString() );
       Node nodeAtVersion = getNodeAtVersion( pentahoJcrConstants, version );
       return nodeAtVersion.getProperty( pentahoJcrConstants.getPHO_CONTENTTYPE() ).getString();
     }
@@ -1135,8 +1098,7 @@ public class JcrRepositoryFileUtils {
     return fileNode.getProperty( pentahoJcrConstants.getPHO_CONTENTTYPE() ).getString();
   }
 
-  public static Serializable getParentId( final Session session, final Serializable fileId )
-    throws RepositoryException {
+  public static Serializable getParentId( final Session session, final Serializable fileId ) throws RepositoryException {
     Node node = session.getNodeByIdentifier( fileId.toString() );
     return node.getParent().getIdentifier();
   }
@@ -1148,8 +1110,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static Object getVersionSummary( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                          final Serializable fileId, final Serializable versionId )
-    throws RepositoryException {
+      final Serializable fileId, final Serializable versionId ) throws RepositoryException {
     VersionManager vMgr = session.getWorkspace().getVersionManager();
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
     VersionHistory versionHistory = vMgr.getVersionHistory( fileNode.getPath() );
@@ -1181,70 +1142,76 @@ public class JcrRepositoryFileUtils {
   }
 
   public static RepositoryFileTree getTree( final Session session, final PentahoJcrConstants pentahoJcrConstants,
-                                            final IPathConversionHelper pathConversionHelper,
-                                            final ILockHelper lockHelper, final String absPath,
-                                            final RepositoryRequest repositoryRequest,
-                                            IRepositoryAccessVoterManager accessVoterManager )
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final String absPath,
+      final RepositoryRequest repositoryRequest, IRepositoryAccessVoterManager accessVoterManager )
     throws RepositoryException {
+    Item fileItem = null;
+    try {
+      fileItem = session.getItem( JcrStringHelper.pathEncode( absPath ) );
+    } catch ( Throwable th ) {
+      fileItem = session.getItem( JcrStringHelper.pathEncode( absPath, !JcrStringHelper.isMultiByteEncodingEnabled() ) );
+    }
 
-    Item fileItem = session.getItem( JcrStringHelper.pathEncode( absPath ) );
     // items are nodes or properties; this must be a node
     Assert.isTrue( fileItem.isNode() );
     Node fileNode = (Node) fileItem;
 
     return getTreeByNode( session, pentahoJcrConstants, pathConversionHelper, lockHelper, fileNode, repositoryRequest
         .getDepth(), repositoryRequest.getChildNodeFilter(), repositoryRequest.isShowHidden(), accessVoterManager,
-      repositoryRequest.getTypes(), new MutableBoolean( false ) );
+        repositoryRequest.getTypes(), new MutableBoolean( false ) );
 
   }
 
   /**
-   * Returns a RepositoryFileTree for a given node.  This method will be called recursively for each folder it
-   * processes.  The childNodeFilter is a filter used directly by the JCR jar to filter node names. Since JCR does not
-   * know a folder from a file (that is our construct), it is not capable of filtering out filenames but not folder
-   * names.  Therefore, this logic will create two sets of children nodes.  The <code>filteredChildrenSet</code> keeps
-   * the child nodes that satisfied the childNodeFilter.  The <code> childrenFolderSet</code> keeps a set of all child
-   * folder nodes regardless of the value of the filter.  We use the <code>childrenFolderSet</code> to know what folders
-   * to traverse, but we use the <code>filteredChildrenSet </code> to determine what actual files to include in the
-   * returned tree. <p>Just because we process a folder node does not necessarily mean the folder will be reported in
-   * the tree.  It must first find a file that satisfies the criteria of the <code>childNodeFilter</code> mask.  A file
-   * meeting the criteria may be any number of folders down the repository structure, so the <code>foundFiltered</code>
-   * MutableBoolean tells the caller if a file was found, at any level, meeting that criteria.
+   * Returns a RepositoryFileTree for a given node. This method will be called recursively for each folder it processes.
+   * The childNodeFilter is a filter used directly by the JCR jar to filter node names. Since JCR does not know a folder
+   * from a file (that is our construct), it is not capable of filtering out filenames but not folder names. Therefore,
+   * this logic will create two sets of children nodes. The <code>filteredChildrenSet</code> keeps the child nodes that
+   * satisfied the childNodeFilter. The <code> childrenFolderSet</code> keeps a set of all child folder nodes regardless
+   * of the value of the filter. We use the <code>childrenFolderSet</code> to know what folders to traverse, but we use
+   * the <code>filteredChildrenSet </code> to determine what actual files to include in the returned tree.
+   * <p>
+   * Just because we process a folder node does not necessarily mean the folder will be reported in the tree. It must
+   * first find a file that satisfies the criteria of the <code>childNodeFilter</code> mask. A file meeting the criteria
+   * may be any number of folders down the repository structure, so the <code>foundFiltered</code> MutableBoolean tells
+   * the caller if a file was found, at any level, meeting that criteria.
    *
-   * @param session              The current session in progress
+   * @param session
+   *          The current session in progress
    * @param pentahoJcrConstants
    * @param pathConversionHelper
    * @param lockHelper
-   * @param fileNode             The node which will serve as the root of the tree
-   * @param depth                how many levels do we go down.
-   * @param childNodeFilter      The filter sent to JCR to retrieve defining which files are in scope
-   * @param showHidden           Whether to return hidden files
-   * @param accessVoterManager   See IRepositoryAccessVoterManager
-   * @param types                <code>FILE_TYPE_FILTERS</code> Types of files to return including FILES, FOLDERS,
-   *                             FILES_FOLDERS
-   * @param foundFiltered        This <code>MutableBoolean</code> will tell the caller if there was a file encountered,
-   *                             (at any level up to the depth), that was compliant with the childNodeFilter.  This will
-   *                             determine if this node, (and its children), should be discarded because there are no
-   *                             relevant files.
+   * @param fileNode
+   *          The node which will serve as the root of the tree
+   * @param depth
+   *          how many levels do we go down.
+   * @param childNodeFilter
+   *          The filter sent to JCR to retrieve defining which files are in scope
+   * @param showHidden
+   *          Whether to return hidden files
+   * @param accessVoterManager
+   *          See IRepositoryAccessVoterManager
+   * @param types
+   *          <code>FILE_TYPE_FILTERS</code> Types of files to return including FILES, FOLDERS, FILES_FOLDERS
+   * @param foundFiltered
+   *          This <code>MutableBoolean</code> will tell the caller if there was a file encountered, (at any level up to
+   *          the depth), that was compliant with the childNodeFilter. This will determine if this node, (and its
+   *          children), should be discarded because there are no relevant files.
    * @return A RepositoryFileTree representing the entire tree at and below the given node that complies with file
-   * filtering and other parameters of the tree request.
+   *         filtering and other parameters of the tree request.
    * @throws RepositoryException
    */
   private static RepositoryFileTree getTreeByNode( final Session session,
-                                                   final PentahoJcrConstants pentahoJcrConstants,
-                                                   final IPathConversionHelper pathConversionHelper,
-                                                   final ILockHelper lockHelper, final Node fileNode, final int depth,
-                                                   final String childNodeFilter,
-                                                   final boolean showHidden,
-                                                   IRepositoryAccessVoterManager accessVoterManager,
-                                                   RepositoryRequest.FILES_TYPE_FILTER types,
-                                                   MutableBoolean foundFiltered ) throws RepositoryException {
+      final PentahoJcrConstants pentahoJcrConstants, final IPathConversionHelper pathConversionHelper,
+      final ILockHelper lockHelper, final Node fileNode, final int depth, final String childNodeFilter,
+      final boolean showHidden, IRepositoryAccessVoterManager accessVoterManager,
+      RepositoryRequest.FILES_TYPE_FILTER types, MutableBoolean foundFiltered ) throws RepositoryException {
 
     RepositoryFile rootFile =
-      nodeToFile( session, pentahoJcrConstants, pathConversionHelper, lockHelper, fileNode, false, null );
+        nodeToFile( session, pentahoJcrConstants, pathConversionHelper, lockHelper, fileNode, false, null );
     if ( ( !showHidden && rootFile.isHidden() )
-      || ( !accessVoterManager.hasAccess( rootFile, RepositoryFilePermission.READ, JcrRepositoryFileAclUtils.getAcl(
-        session, pentahoJcrConstants, rootFile.getId() ), PentahoSessionHolder.getSession() ) ) ) {
+        || ( !accessVoterManager.hasAccess( rootFile, RepositoryFilePermission.READ, JcrRepositoryFileAclUtils.getAcl(
+            session, pentahoJcrConstants, rootFile.getId() ), PentahoSessionHolder.getSession() ) ) ) {
       return null;
     }
     List<RepositoryFileTree> children;
@@ -1264,7 +1231,7 @@ public class JcrRepositoryFileUtils {
 
         boolean pentahoFolder = isPentahoFolder( pentahoJcrConstants, childNode );
         if ( !( !pentahoFolder && types == RepositoryRequest.FILES_TYPE_FILTER.FOLDERS || pentahoFolder
-          && types == RepositoryRequest.FILES_TYPE_FILTER.FILES ) ) {
+            && types == RepositoryRequest.FILES_TYPE_FILTER.FILES ) ) {
           filteredChildrenSet.add( childNode );
         }
       }
@@ -1288,14 +1255,14 @@ public class JcrRepositoryFileUtils {
       // tree
       for ( Node childNode : childrenFolderSet ) {
         checkNodeForTree( childNode, children, session, pentahoJcrConstants, pathConversionHelper, childNodeFilter,
-          lockHelper, depth, showHidden, accessVoterManager, types, foundFiltered, false );
+            lockHelper, depth, showHidden, accessVoterManager, types, foundFiltered, false );
       }
 
       // And finally, add Children in filtered
       for ( Node childNode : filteredChildrenSet ) {
         foundFiltered.setValue( true );
         checkNodeForTree( childNode, children, session, pentahoJcrConstants, pathConversionHelper, childNodeFilter,
-          lockHelper, depth, showHidden, accessVoterManager, types, foundFiltered, true );
+            lockHelper, depth, showHidden, accessVoterManager, types, foundFiltered, true );
       }
 
       Collections.sort( children );
@@ -1306,32 +1273,27 @@ public class JcrRepositoryFileUtils {
   }
 
   /**
-   * This method is called twice by <code>getTreeNode</code>.  It's job is to determine whether the current child node
-   * should be added to the list of children for the node being processed.  It is a separate method simply because
-   * it is
-   * too much code to appear twice in the above <code>getTreeNode</code> method.  It also makes the recursive call back
+   * This method is called twice by <code>getTreeNode</code>. It's job is to determine whether the current child node
+   * should be added to the list of children for the node being processed. It is a separate method simply because it is
+   * too much code to appear twice in the above <code>getTreeNode</code> method. It also makes the recursive call back
    * getTreeByNode to process the next lower level of folder node (it must process the lower levels to know if the
-   * folder should be added).  Finally, it returns the foundFiltered boolean to let the caller know if a file was found
+   * folder should be added). Finally, it returns the foundFiltered boolean to let the caller know if a file was found
    * that satisfied the childNodeFilter.
    */
   private static void checkNodeForTree( final Node childNode, List<RepositoryFileTree> children, final Session session,
-                                        final PentahoJcrConstants pentahoJcrConstants,
-                                        final IPathConversionHelper pathConversionHelper,
-                                        final String childNodeFilter, final ILockHelper lockHelper, final int depth,
-                                        final boolean showHidden,
-                                        final IRepositoryAccessVoterManager accessVoterManager,
-                                        RepositoryRequest.FILES_TYPE_FILTER types,
-                                        MutableBoolean foundFiltered, boolean isRootFiltered )
-    throws RepositoryException {
+      final PentahoJcrConstants pentahoJcrConstants, final IPathConversionHelper pathConversionHelper,
+      final String childNodeFilter, final ILockHelper lockHelper, final int depth, final boolean showHidden,
+      final IRepositoryAccessVoterManager accessVoterManager, RepositoryRequest.FILES_TYPE_FILTER types,
+      MutableBoolean foundFiltered, boolean isRootFiltered ) throws RepositoryException {
 
     RepositoryFile file = nodeToFile( session, pentahoJcrConstants, pathConversionHelper, lockHelper, childNode );
     if ( isSupportedNodeType( pentahoJcrConstants, childNode )
-      && ( accessVoterManager.hasAccess( file, RepositoryFilePermission.READ, JcrRepositoryFileAclUtils.getAcl(
-        session, pentahoJcrConstants, file.getId() ), PentahoSessionHolder.getSession() ) ) ) {
+        && ( accessVoterManager.hasAccess( file, RepositoryFilePermission.READ, JcrRepositoryFileAclUtils.getAcl(
+            session, pentahoJcrConstants, file.getId() ), PentahoSessionHolder.getSession() ) ) ) {
       MutableBoolean foundFilteredAtomic = new MutableBoolean( !isPentahoFolder( pentahoJcrConstants, childNode ) );
       RepositoryFileTree repositoryFileTree =
-        getTreeByNode( session, pentahoJcrConstants, pathConversionHelper, lockHelper, childNode, depth - 1,
-          childNodeFilter, showHidden, accessVoterManager, types, foundFilteredAtomic );
+          getTreeByNode( session, pentahoJcrConstants, pathConversionHelper, lockHelper, childNode, depth - 1,
+              childNodeFilter, showHidden, accessVoterManager, types, foundFilteredAtomic );
       if ( repositoryFileTree != null && ( foundFilteredAtomic.booleanValue() || isRootFiltered ) ) {
         foundFiltered.setValue( true );
         children.add( repositoryFileTree );
@@ -1340,7 +1302,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static Node updateFileLocaleProperties( final Session session, final Serializable fileId, String locale,
-                                                 Properties properties ) throws RepositoryException {
+      Properties properties ) throws RepositoryException {
 
     PentahoJcrConstants pentahoJcrConstants = new PentahoJcrConstants( session );
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
@@ -1393,8 +1355,7 @@ public class JcrRepositoryFileUtils {
   }
 
   public static void setFileMetadata( final Session session, final Serializable fileId,
-                                      Map<String, Serializable> metadataMap )
-    throws ItemNotFoundException, RepositoryException {
+      Map<String, Serializable> metadataMap ) throws ItemNotFoundException, RepositoryException {
     PentahoJcrConstants pentahoJcrConstants = new PentahoJcrConstants( session );
 
     Node fileNode = session.getNodeByIdentifier( fileId.toString() );
@@ -1416,8 +1377,7 @@ public class JcrRepositoryFileUtils {
   }
 
   private static void setMetadataItemForFile( final Session session, final String metadataKey,
-                                              final Serializable metadataObj, final Node metadataNode )
-    throws ItemNotFoundException, RepositoryException {
+      final Serializable metadataObj, final Node metadataNode ) throws ItemNotFoundException, RepositoryException {
     checkName( metadataKey );
     Assert.notNull( metadataNode );
     String prefix = session.getNamespacePrefix( PentahoJcrConstants.PHO_NS );
@@ -1453,7 +1413,7 @@ public class JcrRepositoryFileUtils {
       Property property = iter.nextProperty();
       String key = property.getName().substring( property.getName().indexOf( ':' ) + 1 );
       Serializable value = null;
-      switch( property.getType() ) {
+      switch ( property.getType() ) {
         case PropertyType.STRING:
           value = property.getString();
           break;
@@ -1493,44 +1453,40 @@ public class JcrRepositoryFileUtils {
   public static void checkName( final String name ) {
     Pattern containsReservedCharsPattern = makePattern( getReservedChars() );
     if ( !StringUtils.hasLength( name ) || // not null, not empty, and not all whitespace
-      !name.trim().equals( name ) || // no leading or trailing whitespace
-      containsReservedCharsPattern.matcher( name ).matches() || // no reserved characters
-      ".".equals( name ) || // no . //$NON-NLS-1$
-      "..".equals( name ) ) { // no .. //$NON-NLS-1$
+        !name.trim().equals( name ) || // no leading or trailing whitespace
+        containsReservedCharsPattern.matcher( name ).matches() || // no reserved characters
+        ".".equals( name ) || // no . //$NON-NLS-1$
+        "..".equals( name ) ) { // no .. //$NON-NLS-1$
       throw new RepositoryFileDaoMalformedNameException( name );
     }
   }
 
   public static RepositoryFile createFolder( final Session session,
-                                             final CredentialsStrategySessionFactory sessionFactory,
-                                             final RepositoryFile parentFolder,
-                                             final RepositoryFile folder, final boolean inheritAces,
-                                             final RepositoryFileSid ownerSid,
-                                             final IPathConversionHelper pathConversionHelper,
-                                             final String versionMessage ) throws RepositoryException {
+      final CredentialsStrategySessionFactory sessionFactory, final RepositoryFile parentFolder,
+      final RepositoryFile folder, final boolean inheritAces, final RepositoryFileSid ownerSid,
+      final IPathConversionHelper pathConversionHelper, final String versionMessage ) throws RepositoryException {
     Serializable parentFolderId = parentFolder == null ? null : parentFolder.getId();
     PentahoJcrConstants pentahoJcrConstants = new PentahoJcrConstants( session );
     JcrRepositoryFileUtils.checkoutNearestVersionableFileIfNecessary( session, pentahoJcrConstants, parentFolderId );
     Node folderNode = createFolderNode( session, pentahoJcrConstants, parentFolderId, folder );
     session.save();
     JcrRepositoryFileAclUtils.createAcl( session, pentahoJcrConstants, folderNode.getIdentifier(),
-      new RepositoryFileAcl.Builder( ownerSid ).entriesInheriting( inheritAces ).build() );
+        new RepositoryFileAcl.Builder( ownerSid ).entriesInheriting( inheritAces ).build() );
     session.save();
     if ( folder.isVersioned() ) {
       JcrRepositoryFileUtils.checkinNearestVersionableNodeIfNecessary( session, pentahoJcrConstants, folderNode,
-        versionMessage );
+          versionMessage );
     }
     JcrRepositoryFileUtils.checkinNearestVersionableFileIfNecessary( session, pentahoJcrConstants, parentFolderId,
-      Messages.getInstance().getString( "JcrRepositoryFileDao.USER_0001_VER_COMMENT_ADD_FOLDER", folder.getName(),
-        ( parentFolderId == null ? "root" : parentFolderId.toString() ) ) ); //$NON-NLS-1$ //$NON-NLS-2$
+        Messages.getInstance().getString( "JcrRepositoryFileDao.USER_0001_VER_COMMENT_ADD_FOLDER", folder.getName(),
+            ( parentFolderId == null ? "root" : parentFolderId.toString() ) ) ); //$NON-NLS-1$ //$NON-NLS-2$
     return JcrRepositoryFileUtils.getFileById( session, pentahoJcrConstants, pathConversionHelper, null, folderNode
-      .getIdentifier() );
+        .getIdentifier() );
   }
 
   public static RepositoryFile getFileByAbsolutePath( final Session session, final String absPath,
-                                                      final IPathConversionHelper pathConversionHelper,
-                                                      final ILockHelper lockHelper, final boolean loadMaps,
-                                                      final IPentahoLocale locale ) throws RepositoryException {
+      final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper, final boolean loadMaps,
+      final IPentahoLocale locale ) throws RepositoryException {
 
     PentahoJcrConstants pentahoJcrConstants = new PentahoJcrConstants( session );
     Item fileNode;
@@ -1539,10 +1495,16 @@ public class JcrRepositoryFileUtils {
       // items are nodes or properties; this must be a node
       Assert.isTrue( fileNode.isNode() );
     } catch ( PathNotFoundException e ) {
-      fileNode = null;
+      try {
+        fileNode = session.getItem( JcrStringHelper.pathEncode( absPath ) );
+        // items are nodes or properties; this must be a node
+        Assert.isTrue( fileNode.isNode() );
+      } catch ( PathNotFoundException ex ) {
+        fileNode = null;
+      }
     }
     return fileNode != null ? nodeToFile( session, pentahoJcrConstants, pathConversionHelper, lockHelper,
-      (Node) fileNode, loadMaps, locale ) : null;
+        (Node) fileNode, loadMaps, locale ) : null;
   }
 
   /**

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/NodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/NodeHelper.java
@@ -27,6 +27,7 @@ public class NodeHelper {
 
   /**
    * Encapsulate hasNode calls here to ensure we are encoding the parameter
+   * 
    * @param parentNode
    * @param nodeName
    * @return
@@ -38,6 +39,7 @@ public class NodeHelper {
 
   /**
    * Encapsulate hasNode calls here to ensure we are encoding the parameter
+   * 
    * @param parentNode
    * @param nodeNamePrefix
    * @param nodeName
@@ -45,11 +47,18 @@ public class NodeHelper {
    * @throws RepositoryException
    */
   public static boolean hasNode( Node parentNode, String nodeNamePrefix, String nodeName ) throws RepositoryException {
-    return checkHasNode( parentNode, nodeNamePrefix + JcrStringHelper.fileNameEncode( nodeName ));
+    boolean found = checkHasNode( parentNode, nodeNamePrefix + JcrStringHelper.fileNameEncode( nodeName ) );
+    if ( !found ) {
+      found =
+          checkHasNode( parentNode, nodeNamePrefix
+              + JcrStringHelper.fileNameEncode( nodeName, !JcrStringHelper.isMultiByteEncodingEnabled() ) );
+    }
+    return found;
   }
 
   /**
    * Encapsulate addNode calls here to ensure we are encoding the parameter
+   * 
    * @param parentNode
    * @param nodeName
    * @return
@@ -61,6 +70,7 @@ public class NodeHelper {
 
   /**
    * Encapsulate addNode calls here to ensure we are encoding the parameter
+   * 
    * @param parentNode
    * @param nodeNamePrefix
    * @param nodeName
@@ -73,29 +83,34 @@ public class NodeHelper {
 
   /**
    * Encapsulate addNode calls here to ensure we are encoding the parameter
+   * 
    * @param parentNode
    * @param nodeNamePrefix
    * @param nodeName
    * @return
    * @throws RepositoryException
    */
-  public static Node addNode( Node parentNode, String nodeNamePrefix, String nodeName, String nodeParameter ) throws RepositoryException {
+  public static Node addNode( Node parentNode, String nodeNamePrefix, String nodeName, String nodeParameter )
+    throws RepositoryException {
     return checkAddNode( parentNode, nodeNamePrefix + JcrStringHelper.fileNameEncode( nodeName ), nodeParameter );
   }
 
   /**
    * Encapsulate addNode calls here to ensure we are encoding the parameter
+   * 
    * @param parentNode
    * @param nodeName
    * @return
    * @throws RepositoryException
    */
-  protected static Node checkAddNode( Node parentNode, String nodeName, String nodeParameter ) throws RepositoryException {
+  protected static Node checkAddNode( Node parentNode, String nodeName, String nodeParameter )
+    throws RepositoryException {
     return parentNode.addNode( nodeName, nodeParameter );
   }
 
   /**
    * Encapsulate getNode calls here to ensure we are encoding the parameter
+   * 
    * @param parentNode
    * @param nodeName
    * @return
@@ -107,6 +122,7 @@ public class NodeHelper {
 
   /**
    * Encapsulate getNode calls here to ensure we are encoding the parameter
+   * 
    * @param parentNode
    * @param nodeNamePrefix
    * @param nodeName
@@ -114,15 +130,22 @@ public class NodeHelper {
    * @throws RepositoryException
    */
   public static Node getNode( Node parentNode, String nodeNamePrefix, String nodeName ) throws RepositoryException {
-    return checkGetNode( parentNode, nodeNamePrefix + JcrStringHelper.fileNameEncode( nodeName ) );
+    Node node = checkGetNode( parentNode, nodeNamePrefix + JcrStringHelper.fileNameEncode( nodeName ) );
+    if ( node == null ) {
+      node =
+          checkGetNode( parentNode, nodeNamePrefix
+              + JcrStringHelper.fileNameEncode( nodeName, !JcrStringHelper.isMultiByteEncodingEnabled() ) );
+    }
+    return node;
   }
 
   /**
    * Safely create data node with jcr encoded name
+   * 
    * @param name
    * @return
    */
-  public static DataNode createDataNode( String name ){
-    return new DataNode( JcrStringHelper.fileNameEncode( name ));
+  public static DataNode createDataNode( String name ) {
+    return new DataNode( JcrStringHelper.fileNameEncode( name ) );
   }
 }

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelperTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelperTest.java
@@ -19,8 +19,16 @@ package org.pentaho.platform.repository2.unified.jcr;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.mt.ITenantManager;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.boot.PlatformInitializationException;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
 
 public class JcrStringHelperTest {
 
@@ -39,7 +47,12 @@ public class JcrStringHelperTest {
   }
 
   @Test
-  public void testFilePathpecEncode() {
+  public void testFilePath_1EncodeUsingMultiByteEncoding() throws PlatformInitializationException {
+    MicroPlatform mp = new MicroPlatform();
+    mp.defineInstance( "useMultiByteEncoding", new Boolean( true ) );
+    // Start the micro-platform
+    mp.start();
+    JcrStringHelper.setMultiByteEncodingEnabled( true );
     String path = "/asdf/3err";
     String encodedPath = JcrStringHelper.pathEncode( path );
     assertFalse( path.equals( encodedPath ) );
@@ -47,10 +60,43 @@ public class JcrStringHelperTest {
   }
 
   @Test
-  public void testFilePathSpecEncodeDecode() {
+  public void testFilePath_1Encode() throws PlatformInitializationException {
+    MicroPlatform mp = new MicroPlatform();
+    mp.defineInstance( "useMultiByteEncoding", new Boolean( false ) );
+    // Start the micro-platform
+    mp.start();
+    JcrStringHelper.setMultiByteEncodingEnabled( false );
+    String path = "/asdf/3err";
+    String encodedPath = JcrStringHelper.pathEncode( path );
+    assertEquals( path, encodedPath );
+  }
+
+  @Test
+  public void testFilePathSpecEncodeDecodeUsingMultiByteEncoding() throws PlatformInitializationException {
+    MicroPlatform mp = new MicroPlatform();
+    mp.defineInstance( "useMultiByteEncoding", new Boolean( true ) );
+    // Start the micro-platform
+    mp.start();
+    JcrStringHelper.setMultiByteEncodingEnabled( true );
+
     String path = "/asdf/3err";
     String encodedPath = JcrStringHelper.pathEncode( path );
     assertFalse( path.equals( encodedPath ) );
+    String decodedPath = JcrStringHelper.fileNameDecode( encodedPath );
+    assertEquals( path, decodedPath );
+  }
+
+  @Test
+  public void testFilePathSpecEncodeDecode() throws PlatformInitializationException {
+    MicroPlatform mp = new MicroPlatform();
+    mp.defineInstance( "useMultiByteEncoding", new Boolean( false ) );
+    // Start the micro-platform
+    mp.start();
+    JcrStringHelper.setMultiByteEncodingEnabled( false );
+
+    String path = "/asdf/3err";
+    String encodedPath = JcrStringHelper.pathEncode( path );
+    assertEquals( path, encodedPath );
     String decodedPath = JcrStringHelper.fileNameDecode( encodedPath );
     assertEquals( path, decodedPath );
   }

--- a/repository/test-src/org/pentaho/platform/repository2/unified/webservices/jaxws/DefaultUnifiedRepositoryJaxwsWebServiceTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/webservices/jaxws/DefaultUnifiedRepositoryJaxwsWebServiceTest.java
@@ -19,6 +19,7 @@
 package org.pentaho.platform.repository2.unified.webservices.jaxws;
 
 import com.sun.xml.ws.developer.JAXWSProperties;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.api.JackrabbitWorkspace;
@@ -96,6 +97,7 @@ import javax.xml.ws.BindingProvider;
 import javax.xml.ws.Endpoint;
 import javax.xml.ws.Service;
 import javax.xml.ws.soap.SOAPBinding;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -245,7 +247,9 @@ public class DefaultUnifiedRepositoryJaxwsWebServiceTest implements ApplicationC
     mp.defineInstance( ITenantManager.class, tenantManager );
     mp.defineInstance( "roleAuthorizationPolicyRoleBindingDaoTarget", roleBindingDaoTarget );
     mp.defineInstance( "repositoryAdminUsername", repositoryAdminUsername );
-    mp.defineInstance( "RepositoryFileProxyFactory", new RepositoryFileProxyFactory(testJcrTemplate, repositoryFileDao) );
+    mp.defineInstance( "RepositoryFileProxyFactory",
+        new RepositoryFileProxyFactory(testJcrTemplate, repositoryFileDao) );
+    mp.defineInstance("useMultiByteEncoding", new Boolean( false ) );
     // Start the micro-platform
     mp.start();
     loginAsRepositoryAdmin();

--- a/repository/test-src/org/pentaho/platform/repository2/unified/webservices/jaxws/UnifiedRepositoryToWebServiceAdapterTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/webservices/jaxws/UnifiedRepositoryToWebServiceAdapterTest.java
@@ -74,6 +74,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Workspace;
 import javax.jcr.security.AccessControlException;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -154,6 +155,7 @@ public class UnifiedRepositoryToWebServiceAdapterTest implements ApplicationCont
     mp.defineInstance( "roleAuthorizationPolicyRoleBindingDaoTarget", roleBindingDaoTarget );
     mp.defineInstance( "repositoryAdminUsername", repositoryAdminUsername );
     mp.defineInstance( "RepositoryFileProxyFactory", new RepositoryFileProxyFactory(testJcrTemplate, repositoryFileDao) );
+    mp.defineInstance("useMultiByteEncoding", new Boolean(false) );
     // Start the micro-platform
     mp.start();
     setAclManagement();

--- a/repository/test-src/org/pentaho/test/platform/repository2/mt/RepositoryTenantManagerTest.java
+++ b/repository/test-src/org/pentaho/test/platform/repository2/mt/RepositoryTenantManagerTest.java
@@ -78,6 +78,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Workspace;
 import javax.jcr.security.AccessControlException;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -348,8 +349,9 @@ public class RepositoryTenantManagerTest implements ApplicationContextAware {
     mp.defineInstance( "repositoryAdminUsername", repositoryAdminUsername );
     mp.defineInstance( "roleAuthorizationPolicyRoleBindingDaoTarget", roleBindingDaoTarget );
     mp.defineInstance("ILockHelper", new DefaultLockHelper(userNameUtils));
-    mp.defineInstance("RepositoryFileProxyFactory", new RepositoryFileProxyFactory(this.jcrTemplate, this.repositoryFileDao));
-
+    mp.defineInstance("RepositoryFileProxyFactory"
+        , new RepositoryFileProxyFactory(this.jcrTemplate, this.repositoryFileDao));
+    mp.defineInstance("useMultiByteEncoding", new Boolean( false ) );
     // Start the micro-platform
     mp.start();
 

--- a/repository/test-src/org/pentaho/test/platform/security/userrole/ws/UserDetailsRoleListWebServiceTest.java
+++ b/repository/test-src/org/pentaho/test/platform/security/userrole/ws/UserDetailsRoleListWebServiceTest.java
@@ -40,6 +40,7 @@ public class UserDetailsRoleListWebServiceTest {
   public void init0() {
     microPlatform = new MicroPlatform();
     microPlatform.define( IUserRoleListService.class, MockUserRoleListService.class );
+    microPlatform.defineInstance("useMultiByteEncoding", new Boolean(false) );
   }
 
   public IUserRoleListWebService getUserRoleListWebService() {

--- a/repository/test-src/org/pentaho/test/platform/security/userroledao/UserRoleDaoUserDetailsServiceTest.java
+++ b/repository/test-src/org/pentaho/test/platform/security/userroledao/UserRoleDaoUserDetailsServiceTest.java
@@ -237,7 +237,10 @@ public class UserRoleDaoUserDetailsServiceTest implements ApplicationContextAwar
     mp.define( ITenant.class, Tenant.class );
     mp.defineInstance( "roleAuthorizationPolicyRoleBindingDaoTarget", roleAuthorizationPolicyRoleBindingDao );
     mp.defineInstance( "repositoryAdminUsername", repositoryAdminUsername );
-    mp.defineInstance( "RepositoryFileProxyFactory", new RepositoryFileProxyFactory(testJcrTemplate, repositoryFileDao) );
+    mp.defineInstance( "RepositoryFileProxyFactory"
+        , new RepositoryFileProxyFactory(testJcrTemplate, repositoryFileDao ) );
+    mp.defineInstance("useMultiByteEncoding", new Boolean( false ) );
+    
     // Start the micro-platform
     mp.start();
 

--- a/repository/test-src/org/pentaho/test/platform/security/userroledao/UserRoleDaoUserRoleListServiceTest.java
+++ b/repository/test-src/org/pentaho/test/platform/security/userroledao/UserRoleDaoUserRoleListServiceTest.java
@@ -229,7 +229,7 @@ public class UserRoleDaoUserRoleListServiceTest implements ApplicationContextAwa
     mp.defineInstance( "roleAuthorizationPolicyRoleBindingDaoTarget", roleAuthorizationPolicyRoleBindingDao );
     mp.defineInstance( "repositoryAdminUsername", repositoryAdminUsername );
     mp.defineInstance( "RepositoryFileProxyFactory", new RepositoryFileProxyFactory(testJcrTemplate, repositoryFileDao) );
-    
+    mp.defineInstance("useMultiByteEncoding", new Boolean(false) );
     // Start the micro-platform
     mp.start();
     loginAsRepositoryAdmin();


### PR DESCRIPTION
Added defensive code to use  both encoding to make sure we retrieve the specified properly
Added unit test to cover regular and multi-byte encoding

Tested:
Installed 5.1 and used contents from 5.1 in a 5.2 platform.
Configured 5.2 with useMultiByteEncoding to true and false and executed  and created contents
Created content with special characters

Platform Start Results
INFO: Server startup in 94882 ms
INFO: Server startup in 111833 ms  useMultiByteEncoding  = false
INFO: Server startup in 117089 ms  useMultiByteEncoding  = true

These are the average start time of the platform for the first time. This when all the content gets imported in the repository.
