### PR TITLE
[MONDRIAN-2141]: Roles defined in DSPs don't work in PUC

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper.java
@@ -777,6 +777,7 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
         MondrianCatalogHelper.logger.debug( "applyDSP: " + dsp ); //$NON-NLS-1$
       }
       DynamicSchemaProcessor dynProc = ClassResolver.INSTANCE.instantiateSafe( dsp );
+      pl.put( "Locale", getLocale().toString() );
       return dynProc.processSchema( catalogDefinition, pl );
     } else {
       return docAtUrlToString( catalogDefinition, ps );


### PR DESCRIPTION
Additional fix to take into consideration the Locale for LocalizingDynamicSchemaProcessor.
This was identified with unit test com.pentaho.analyzer.content.SelectSchemaBeanTest.testLocalizedCubeNames
