### PR TITLE
[TEST] Uncomment tests in MultipleComponentTest

### DIFF
--- a/extensions/test-src/classic-engine.properties
+++ b/extensions/test-src/classic-engine.properties
@@ -1,0 +1,1 @@
+org.pentaho.reporting.engine.classic.extensions.modules.PentahoTableDataFactory.Module=org.pentaho.platform.plugin.action.jfreereport.helper.PentahoTableDataFactoryModule

--- a/extensions/test-src/org/pentaho/platform/plugin/action/jfreereport/helper/meta-datafactory.xml
+++ b/extensions/test-src/org/pentaho/platform/plugin/action/jfreereport/helper/meta-datafactory.xml
@@ -1,0 +1,11 @@
+<meta-data xmlns="http://reporting.pentaho.org/namespaces/engine/classic/metadata/1.0">
+
+  <data-factory name="org.pentaho.platform.plugin.action.jfreereport.helper.PentahoDataFactory"
+                bundle-name="org.pentaho.reporting.engine.classic.core.metadata.messages"
+                hidden="false" expert="true"/>
+
+  <data-factory name="org.pentaho.platform.plugin.action.jfreereport.helper.PentahoTableDataFactory"
+                bundle-name="org.pentaho.reporting.engine.classic.core.metadata.messages"
+                hidden="false" expert="true"/>
+
+</meta-data>

--- a/extensions/test-src/solution/system/simple-jndi/jdbc.properties
+++ b/extensions/test-src/solution/system/simple-jndi/jdbc.properties
@@ -13,7 +13,8 @@
 # See the GNU Lesser General Public License for more details.
 SampleData/type=javax.sql.DataSource
 SampleData/driver=org.hsqldb.jdbcDriver
-SampleData/url=jdbc:hsqldb:file:test-src/solution/system/data/sampledata
+#should set to url readonly=true for fixing problem with locking file - test-src\solution\system\data\sampledata.lck is presumably locked by another process.  
+SampleData/url=jdbc:hsqldb:file:test-src/solution/system/data/sampledata;readonly=true
 SampleData/user=pentaho_user
 SampleData/password=password
 SampleDataAdmin/type=javax.sql.DataSource

--- a/extensions/test-src/solution/test/reporting/DynamicSQLSample.xaction
+++ b/extensions/test-src/solution/test/reporting/DynamicSQLSample.xaction
@@ -130,9 +130,9 @@
       <component-definition> 
         <script><![CDATA[
          query = "select " + deptorposn;
-         query += " as column1, sum(actual) from QUADRANT_ACTUALS where region={PREPARE:region} group by ";
-         query += deptorposn + " order by actual desc";]]></script> 
-      </component-definition> 
+         query += " as column1, sum(actual) as column2 from QUADRANT_ACTUALS where region={PREPARE:region} group by ";
+         query += "column1 order by column2 desc";]]></script> 
+      </component-definition>
     </action-definition>
   
     <action-definition> 

--- a/extensions/test-src/solution/test/reporting/SampleDynamicColumn.xml
+++ b/extensions/test-src/solution/test/reporting/SampleDynamicColumn.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <report name="SampleDynamicColumn" orientation="landscape" pageformat="LETTER" leftmargin="10" rightmargin="10" topmargin="10" bottommargin="10">
   <parser-config/>
+
   <reportheader fontname="SansSerif" fontsize="11" fontstyle="bold">
     <message-field height="18" alignment="center" width="100%" x="0%" y="0">Region: $(region)</message-field>
   </reportheader>
@@ -27,12 +27,12 @@
   <items color="#000000" fontname="SansSerif" fontsize="9" fontstyle="bold">
     <rectangle name="rowBandingElement" color="#E0E0E0" draw="false" fill="true" height="11" x="0%" width="100%" y="0"/>
     <string-field name="COLUMN1Element" fieldname="COLUMN1" vertical-alignment="middle" alignment="left" width="50%" x="0%" y="0" height="11"/>
-    <number-field name="ACTUALElement" fieldname="ACTUAL" vertical-alignment="middle" alignment="right" width="50%" x="50%" y="0" height="11"/>
+    <number-field name="ACTUALElement" fieldname="COLUMN2" vertical-alignment="middle" alignment="right" width="50%" x="50%" y="0" height="11"/>
   </items>
   <functions>
     <property-ref name="columnTitle"/>
     <property-ref name="region"/>
-    <function name="backgroundTrigger" class="org.pentaho.jfreereport.functions.ElementVisibilitySwitchFunction">
+    <function name="backgroundTrigger" class="org.pentaho.reporting.engine.classic.core.function.RowBandingFunction">
       <properties>
         <property name="element">rowBandingElement</property>
         <property name="numberOfElements">1</property>
@@ -56,8 +56,9 @@
     </expression>
     <expression class="org.jfree.report.function.ItemSumFunction" name="Summary_ACTUALExpression">
       <properties>
-        <property name="field">ACTUAL</property>
+        <property name="field">ACTUALElement</property>
       </properties>
     </expression>
   </functions>
+
 </report>


### PR DESCRIPTION
Recover tests xaction with jfree reports.

For correct process jfree reports are needed:
  1. ClassicEngineBoot.getInstance().start();
  2. classic-engine.properties in test-src;
  3. meta-datafactory.xml in org.pentaho.platform.plugin.action.jfreereport.helper

For resolve problem with lock sampledata file are needed use readonly=true:
  In extensions/test-src/solution/system/simple-jndi/jdbc.properties use property SampleData/url=jdbc:hsqldb:file:test-src/solution/system/data/sampledata;readonly=true

@rmansoor verify please