### PR TITLE
PDI-12301 - Encoding/Decoding - Not able to edit or delete a slave server with ':' in the name

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
@@ -885,7 +885,8 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
           Assert.isTrue( lastSlashIndex > 1, Messages.getInstance().getString(
               "JcrRepositoryFileDao.ERROR_0003_ILLEGAL_DEST_PATH" ) ); //$NON-NLS-1$
           String absPathToDestParentFolder = cleanDestAbsPath.substring( 0, lastSlashIndex );
-          JcrRepositoryFileUtils.checkName( cleanDestAbsPath.substring( lastSlashIndex + 1 ) );
+          // Not need to check the name if we encoded it
+          // JcrRepositoryFileUtils.checkName( cleanDestAbsPath.substring( lastSlashIndex + 1 ) );
           try {
             destParentFolderNode = (Node) session.getItem( JcrStringHelper.pathEncode( absPathToDestParentFolder ) );
           } catch ( PathNotFoundException e1 ) {

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -537,7 +537,8 @@ public class JcrRepositoryFileUtils {
 
   public static Node createFolderNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
       final Serializable parentFolderId, final RepositoryFile folder ) throws RepositoryException {
-    checkName( folder.getName() );
+    // Not need to check the name if we encoded it
+    // checkName( folder.getName() );
     Node parentFolderNode;
     if ( parentFolderId != null ) {
       parentFolderNode = session.getNodeByIdentifier( parentFolderId.toString() );
@@ -575,8 +576,8 @@ public class JcrRepositoryFileUtils {
   public static Node createFileNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
       final Serializable parentFolderId, final RepositoryFile file, final IRepositoryFileData content,
       final ITransformer<IRepositoryFileData> transformer ) throws RepositoryException {
-
-    checkName( file.getName() );
+    // Not need to check the name if we encoded it
+    // checkName( file.getName() );
     String encodedFileName = JcrStringHelper.fileNameEncode( file.getName() );
     Node parentFolderNode;
     if ( parentFolderId != null ) {

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/transform/NodeRepositoryFileDataTransformer.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/transform/NodeRepositoryFileDataTransformer.java
@@ -35,7 +35,6 @@ import org.pentaho.platform.api.repository2.unified.data.node.DataNodeRef;
 import org.pentaho.platform.api.repository2.unified.data.node.DataProperty;
 import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFileData;
 import org.pentaho.platform.repository2.unified.jcr.ITransformer;
-import org.pentaho.platform.repository2.unified.jcr.JcrRepositoryFileUtils;
 import org.pentaho.platform.repository2.unified.jcr.JcrStringHelper;
 import org.pentaho.platform.repository2.unified.jcr.NodeHelper;
 import org.pentaho.platform.repository2.unified.jcr.PentahoJcrConstants;
@@ -91,8 +90,8 @@ public class NodeRepositoryFileDataTransformer implements ITransformer<NodeRepos
     // get or create the node represented by dataNode
     Node jcrNode = null;
     String nodeName = dataNode.getName();
-
-    JcrRepositoryFileUtils.checkName( dataNode.getName() );
+    // Not need to check the name if we encoded it
+    // JcrRepositoryFileUtils.checkName( dataNode.getName() );
 
     nodeName = JcrStringHelper.fileNameEncode( nodeName );
 
@@ -105,8 +104,8 @@ public class NodeRepositoryFileDataTransformer implements ITransformer<NodeRepos
     for ( DataProperty dataProp : dataNode.getProperties() ) {
 
       String propName = dataProp.getName();
-
-      JcrRepositoryFileUtils.checkName( propName );
+      // Not need to check the name if we encoded it
+      // JcrRepositoryFileUtils.checkName( propName );
 
       propName = prefix + JcrStringHelper.fileNameEncode( propName );
 

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/jaxws/UnifiedRepositoryToWebServiceAdapter.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/jaxws/UnifiedRepositoryToWebServiceAdapter.java
@@ -272,7 +272,7 @@ public class UnifiedRepositoryToWebServiceAdapter implements IUnifiedRepository 
 
   @Override
   public RepositoryFile getFile( String path ) {
-    path = path.replaceAll( ";", "/" ); //$NON-NLS-1$ //$NON-NLS-2$
+    // path = path.replaceAll( ";", "/" ); //Why is it here?
     return repositoryFileAdapter.unmarshal( repoWebService.getFile( path, false, null ) );
   }
 

--- a/repository/test-src/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryContentTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryContentTest.java
@@ -33,10 +33,12 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -750,15 +752,16 @@ public class DefaultUnifiedRepositoryContentTest extends DefaultUnifiedRepositor
     login( USERNAME_SUZY, tenantAcme, new String[] { tenantAuthenticatedRoleName } );
 
     char[] jcrEncodedSymbols = { '%', '/', ':', '[', ']', '*', '|', '\t', '\r', '\n' };
-
-    for ( char symbol : JcrRepositoryFileUtils.getReservedChars() ) {
-      testSymbol( symbol, false );
+    Set<Character> generalSetSymbols = new LinkedHashSet<Character>();
+    for ( char c : jcrEncodedSymbols ) {
+      generalSetSymbols.add( c );
+    }
+    for ( char c : JcrRepositoryFileUtils.getReservedChars() ) {
+      generalSetSymbols.add( c );
     }
 
-    for ( char symbol : jcrEncodedSymbols ) {
-      if ( !JcrRepositoryFileUtils.getReservedChars().contains( symbol ) ) {
-        testSymbol( symbol, true );
-      }
+    for ( Character character : generalSetSymbols ) {
+      testSymbol( character, true );
     }
   }
 


### PR DESCRIPTION
was deleted call for checkName so encode/decode for name was implemented and no need to check it.

@rmansoor Ramaiz, please review.
