### PR TITLE
[SP-1564] - Backport of PDI-12301 - Encoding/Decoding - Not able to edit or delete a slave server with multiple special characters in the name (5.2 Suite)

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
@@ -885,7 +885,8 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
           Assert.isTrue( lastSlashIndex > 1, Messages.getInstance().getString(
               "JcrRepositoryFileDao.ERROR_0003_ILLEGAL_DEST_PATH" ) ); //$NON-NLS-1$
           String absPathToDestParentFolder = cleanDestAbsPath.substring( 0, lastSlashIndex );
-          JcrRepositoryFileUtils.checkName( cleanDestAbsPath.substring( lastSlashIndex + 1 ) );
+          // Not need to check the name if we encoded it
+          // JcrRepositoryFileUtils.checkName( cleanDestAbsPath.substring( lastSlashIndex + 1 ) );
           try {
             destParentFolderNode = (Node) session.getItem( JcrStringHelper.pathEncode( absPathToDestParentFolder ) );
           } catch ( PathNotFoundException e1 ) {

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -537,7 +537,8 @@ public class JcrRepositoryFileUtils {
 
   public static Node createFolderNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
       final Serializable parentFolderId, final RepositoryFile folder ) throws RepositoryException {
-    checkName( folder.getName() );
+    // Not need to check the name if we encoded it
+    // checkName( folder.getName() );
     Node parentFolderNode;
     if ( parentFolderId != null ) {
       parentFolderNode = session.getNodeByIdentifier( parentFolderId.toString() );
@@ -575,8 +576,8 @@ public class JcrRepositoryFileUtils {
   public static Node createFileNode( final Session session, final PentahoJcrConstants pentahoJcrConstants,
       final Serializable parentFolderId, final RepositoryFile file, final IRepositoryFileData content,
       final ITransformer<IRepositoryFileData> transformer ) throws RepositoryException {
-
-    checkName( file.getName() );
+    // Not need to check the name if we encoded it
+    // checkName( file.getName() );
     String encodedFileName = JcrStringHelper.fileNameEncode( file.getName() );
     Node parentFolderNode;
     if ( parentFolderId != null ) {

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/transform/NodeRepositoryFileDataTransformer.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/transform/NodeRepositoryFileDataTransformer.java
@@ -35,7 +35,7 @@ import org.pentaho.platform.api.repository2.unified.data.node.DataNodeRef;
 import org.pentaho.platform.api.repository2.unified.data.node.DataProperty;
 import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFileData;
 import org.pentaho.platform.repository2.unified.jcr.ITransformer;
-import org.pentaho.platform.repository2.unified.jcr.JcrRepositoryFileUtils;
+import org.pentaho.platform.repository2.unified.jcr.JcrStringHelper;
 import org.pentaho.platform.repository2.unified.jcr.NodeHelper;
 import org.pentaho.platform.repository2.unified.jcr.PentahoJcrConstants;
 import org.springframework.util.Assert;
@@ -90,9 +90,9 @@ public class NodeRepositoryFileDataTransformer implements ITransformer<NodeRepos
     // get or create the node represented by dataNode
     Node jcrNode = null;
     String nodeName = dataNode.getName();
-
-    JcrRepositoryFileUtils.checkName( dataNode.getName() );
-
+    // Not need to check the name if we encoded it
+    // JcrRepositoryFileUtils.checkName( dataNode.getName() );
+    nodeName = JcrStringHelper.fileNameEncode( nodeName );
     if ( NodeHelper.hasNode( jcrParentNode, prefix, nodeName ) ) {
       jcrNode = NodeHelper.getNode( jcrParentNode, prefix, nodeName );
     } else {
@@ -101,9 +101,10 @@ public class NodeRepositoryFileDataTransformer implements ITransformer<NodeRepos
     // set any properties represented by dataNode
     for ( DataProperty dataProp : dataNode.getProperties() ) {
 
-      JcrRepositoryFileUtils.checkName( dataProp.getName() );
+      // Not need to check the name if we encoded it
+      // JcrRepositoryFileUtils.checkName( dataProp.getName() );
 
-      String propName = prefix + dataProp.getName();
+      String propName = prefix + JcrStringHelper.fileNameEncode( dataProp.getName() );
 
       switch ( dataProp.getType() ) {
         case STRING: {

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/jaxws/UnifiedRepositoryToWebServiceAdapter.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/jaxws/UnifiedRepositoryToWebServiceAdapter.java
@@ -272,7 +272,8 @@ public class UnifiedRepositoryToWebServiceAdapter implements IUnifiedRepository 
 
   @Override
   public RepositoryFile getFile( String path ) {
-    path = path.replaceAll( ";", "/" ); //$NON-NLS-1$ //$NON-NLS-2$
+    // Why is it here?
+    // path = path.replaceAll( ";", "/" );
     return repositoryFileAdapter.unmarshal( repoWebService.getFile( path, false, null ) );
   }
 


### PR DESCRIPTION
was deleted call for checkName because encode/decode for name was implemented and no need to check it.

@rmansoor Ramaiz, please review.
