### PR TITLE
Add checkbox to schedule wizard for overwriting existing content

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/dialogs/scheduling/ScheduleParamsDialog.java
+++ b/user-console/source/org/pentaho/mantle/client/dialogs/scheduling/ScheduleParamsDialog.java
@@ -108,7 +108,12 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
   }
 
   public void initDialog() {
-    scheduleParamsWizardPanel = new ScheduleParamsWizardPanel( filePath );
+    scheduleParamsWizardPanel = new ScheduleParamsWizardPanel(filePath);
+    if (editJob != null) {
+      final String acufValue = editJob.getJobParamValue("autoCreateUniqueFilename");
+      scheduleParamsWizardPanel.setOverwriteOutput("false".equals(acufValue));
+    }
+
     IWizardPanel[] wizardPanels = { scheduleParamsWizardPanel };
     setWizardPanels( wizardPanels );
     setWidth( "800px" );
@@ -165,6 +170,15 @@ public class ScheduleParamsDialog extends AbstractWizardDialog {
     for ( int i = 0; i < schedulingParams.length(); i++ ) {
       params.set( i, new JSONObject( schedulingParams.get( i ) ) );
     }
+
+    final JsSchedulingParameter acufParam = (JsSchedulingParameter) JavaScriptObject.createObject().cast();
+    acufParam.setName("autoCreateUniqueFilename");
+    acufParam.setType("boolean");
+    final JsArrayString acufValue = (JsArrayString) JavaScriptObject.createArray().cast();
+    acufValue.push(scheduleParamsWizardPanel.isOverwriteOutput() ? "false" : "true");
+    acufParam.setStringValue(acufValue);
+    params.set(params.size(), new JSONObject(acufParam));
+
     return params;
   }
 

--- a/user-console/source/org/pentaho/mantle/client/dialogs/scheduling/ScheduleParamsWizardPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/dialogs/scheduling/ScheduleParamsWizardPanel.java
@@ -20,9 +20,7 @@ package org.pentaho.mantle.client.dialogs.scheduling;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Element;
-import com.google.gwt.user.client.ui.Frame;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwt.user.client.ui.*;
 import org.pentaho.gwt.widgets.client.wizards.AbstractWizardPanel;
 import org.pentaho.mantle.client.messages.Messages;
 
@@ -41,6 +39,9 @@ public class ScheduleParamsWizardPanel extends AbstractWizardPanel {
   Label scheduleDescription = new Label();
   Frame parametersFrame;
   String scheduledFilePath;
+
+  Label overwriteLabel = new Label();
+  CheckBox overwriteCheckBox = new CheckBox();
 
   public ScheduleParamsWizardPanel( String scheduledFile ) {
     super();
@@ -201,6 +202,14 @@ public class ScheduleParamsWizardPanel extends AbstractWizardPanel {
     this.add( scheduleParameterPanel, CENTER );
     this.setCellHeight( scheduleParameterPanel, "100%" );
     scheduleParameterPanel.setHeight( "100%" );
+
+    HorizontalPanel overwriteHP = new HorizontalPanel();
+    overwriteHP.setHorizontalAlignment(HasHorizontalAlignment.ALIGN_LEFT);
+    overwriteLabel.setText(Messages.getString("scheduleOverwriteContentColon"));
+    overwriteHP.add(overwriteLabel);
+    overwriteHP.setHorizontalAlignment(HasHorizontalAlignment.ALIGN_RIGHT);
+    overwriteHP.add(overwriteCheckBox);
+    this.add(overwriteHP, SOUTH);
   }
 
   /*
@@ -234,5 +243,13 @@ public class ScheduleParamsWizardPanel extends AbstractWizardPanel {
       }
       setRadioParameterValue( parametersFrame.getUrl() );
     }
+  }
+
+  public boolean isOverwriteOutput() {
+    return overwriteCheckBox.getValue();
+  }
+
+  public void setOverwriteOutput(boolean v) {
+    overwriteCheckBox.setValue(v);
   }
 }

--- a/user-console/source/org/pentaho/mantle/public/messages/mantleMessages.properties
+++ b/user-console/source/org/pentaho/mantle/public/messages/mantleMessages.properties
@@ -407,6 +407,7 @@ noSchedules=No schedules
 scheduleName=Schedule Name
 scheduleNameColon=Schedule Name:
 scheduleNameInfo=This will also be the name of the generated content.
+scheduleOverwriteContentColon=Overwrite existing content:
 editSchedule=Edit Schedule
 editBlockoutSchedule=Edit Blockout Schedule
 deleteBlockoutWarning=Are you sure you want to delete {0} blockout(s)?


### PR DESCRIPTION
This merge request is based on this forum thread:

http://forums.pentaho.com/showthread.php?176243-Overwrite-scheduled-report-output-from-5-0-7-CE

I've added a checkbox to the "job parameters" step of the schedule creation wizard which controls the "autoCreateUniqueFilename" job parameter ("overwrite existing content" seems easier to understand than "create unique filename"). Normally I would have put it in the first step, together with the output location and schedule name, but that'd require propagating the state of the checkbox through the rest of the steps of the wizard.