### PR TITLE
[SP-1592] - Backport of BISERVER-12205 - User security gets corrupted

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/mapper/MondrianAbstractPlatformUserRoleMapper.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/mapper/MondrianAbstractPlatformUserRoleMapper.java
@@ -18,6 +18,7 @@
 package org.pentaho.platform.plugin.action.mondrian.mapper;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,18 +32,19 @@ import org.olap4j.OlapConnection;
 import org.olap4j.OlapException;
 import org.pentaho.platform.api.engine.IConnectionUserRoleMapper;
 import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.IUserRoleListService;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.security.SecurityHelper;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianSchema;
 import org.pentaho.platform.plugin.action.olap.IOlapService;
 import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
+import org.pentaho.platform.repository2.unified.jcr.JcrTenantUtils;
 import org.springframework.security.Authentication;
 import org.springframework.security.GrantedAuthority;
-import org.springframework.security.context.SecurityContextHolder;
-import org.springframework.util.Assert;
 
 /**
  * @author mbatchelor
@@ -57,9 +59,11 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
 
   /**
    * Subclasses simply need to implement this one method to do the specific mapping desired.
-   *
-   * @param mondrianRoles Sorted list of roles defined in the catalog
-   * @param platformRoles Sorted list of the roles defined in the catalog
+   * 
+   * @param mondrianRoles
+   *          Sorted list of roles defined in the catalog
+   * @param platformRoles
+   *          Sorted list of the roles defined in the catalog
    * @return
    */
   protected abstract String[] mapRoles( String[] mondrianRoles, String[] platformRoles )
@@ -68,9 +72,11 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
   /**
    * This method returns the role names as found in the Mondrian schema. The returned names must be ordered (sorted) or
    * code down-stream will not work.
-   *
-   * @param userSession Users' session
-   * @param catalogName The name of the catalog
+   * 
+   * @param userSession
+   *          Users' session
+   * @param catalogName
+   *          The name of the catalog
    * @return Array of role names from the schema file
    */
   protected String[] getMondrianRolesFromCatalog( IPentahoSession userSession, String context ) {
@@ -117,9 +123,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
           Arrays.sort( roleArray );
           return roleArray;
         } catch ( OlapException e ) {
-          log.error(
-              "Failed to get a list of roles from olap connection " + context,
-              e );
+          log.error( "Failed to get a list of roles from olap connection " + context, e );
           throw new RuntimeException( e );
         } finally {
           if ( conn != null ) {
@@ -127,9 +131,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
               conn.close();
             } catch ( SQLException e ) {
               // OK to squash this one.
-              log.error(
-                  "Failed to get a list of roles from olap connection " + context,
-                  e );
+              log.error( "Failed to get a list of roles from olap connection " + context, e );
             }
           }
         }
@@ -143,32 +145,52 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
   /**
    * This method returns the users' roles as specified in the Spring Security authentication object. The role names
    * returned must be sorted for other code downstream to work properly.
-   *
-   * @param session The users' session
+   * 
+   * @param session
+   *          The users' session
    * @return Users' roles as defined in the authentication object
    */
   protected String[] getPlatformRolesFromSession( IPentahoSession session ) {
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    Assert.state( authentication != null );
+    // get 'anonymousUser' defined name from pentaho.xml's <anonymous-authentication> block
+    String anonymousUser = PentahoSystem.getSystemSetting( "anonymous-authentication/anonymous-user", "anonymousUser" ); //$NON-NLS-1$//$NON-NLS-2$
 
+    // Get the Spring Security authentication object
+    Authentication auth = SecurityHelper.getInstance().getAuthentication();
     String[] rtn = null;
-    // Get the authorities
-    GrantedAuthority[] gAuths = authentication.getAuthorities();
-    if ( ( gAuths != null ) && ( gAuths.length > 0 ) ) {
-      // Copy role names out of the Authentication
-      rtn = new String[gAuths.length];
-      for ( int i = 0; i < gAuths.length; i++ ) {
-        rtn[i] = gAuths[i].getAuthority();
+    List<String> runtimeRoles = new ArrayList<String>();
+    IUserRoleListService userRoleListService =
+        PentahoSystem.getInitializedOK() ? PentahoSystem.get( IUserRoleListService.class, session ) : null;
+    // Get the role from IUserRoleListService
+    if ( userRoleListService != null && !anonymousUser.equals( auth.getName() ) ) {
+      runtimeRoles = userRoleListService.getRolesForUser( JcrTenantUtils.getCurrentTenant(), auth.getName() );
+      if ( ( runtimeRoles != null ) && ( runtimeRoles.size() > 0 ) ) {
+        // Copy role names out of the Authentication
+        rtn = new String[runtimeRoles.size()];
+        for ( int i = 0; i < runtimeRoles.size(); i++ ) {
+          rtn[i] = runtimeRoles.get( i );
+        }
+        // Sort the returned list of roles
+        Arrays.sort( rtn );
       }
-      // Sort the returned list of roles
-      Arrays.sort( rtn );
+    } else {
+      // Get the authorities
+      GrantedAuthority[] gAuths = auth.getAuthorities();
+      if ( ( gAuths != null ) && ( gAuths.length > 0 ) ) {
+        // Copy role names out of the Authentication
+        rtn = new String[gAuths.length];
+        for ( int i = 0; i < gAuths.length; i++ ) {
+          rtn[i] = gAuths[i].getAuthority();
+        }
+        // Sort the returned list of roles
+        Arrays.sort( rtn );
+      }
     }
     return rtn;
   }
 
   /*
    * (non-Javadoc)
-   *
+   * 
    * @see org.pentaho.platform.api.engine.IConnectionUserRoleMapper#mapConnectionRoles(org.pentaho.platform.api.engine.
    * IPentahoSession, java.lang.String)
    */
@@ -187,7 +209,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
 
   /*
    * (non-Javadoc)
-   *
+   * 
    * @see org.pentaho.platform.api.engine.IConnectionUserRoleMapper#mapConnectionUser(org.pentaho.platform.api.engine.
    * IPentahoSession, java.lang.String)
    */


### PR DESCRIPTION
Main discussion thread - http://jira.pentaho.com/browse/ESR-4197
Implemented suggested approach: reverted changes in MondrianAbstractPlatformUserRoleMapper class. Now roles will be pulled from the session. 
Unit tests will be soon.
@pentaho-nbaker Nick, please review.
