### PR TITLE
[BACKLOG-1574] - Add the ability to provide configuration to store the d...

### DIFF
--- a/core/src/org/pentaho/platform/engine/core/system/PentahoSystem.java
+++ b/core/src/org/pentaho/platform/engine/core/system/PentahoSystem.java
@@ -175,6 +175,8 @@ public class PentahoSystem {
 
   private static final List logoutListeners = Collections.synchronizedList( new ArrayList() );
 
+  public static String aclNodeRoot = "public";
+
   // TODO even if logging is not configured messages need to make it out to
   // the console
 
@@ -302,6 +304,10 @@ public class PentahoSystem {
     } catch ( PentahoSystemException e1 ) {
       throw new RuntimeException( e1 ); // this is fatal
     }
+
+    // get alternative name for root node of the datasources ACL's
+    aclNodeRoot = getSystemSetting( "aclNodeRoot", "public" );
+
 
     // store a list of the system listeners
     try {


### PR DESCRIPTION
...ata source acl nodes.

Added tag <aclNodeRoot> in ..../pentaho-solutions/system/pentaho.xml.
It is available via "public static String aclNodeRoot" in PentahoSystem or by PentahoSystem.getSystemSetting( "aclNodeRoot", "public" ). Defaults to public.

@pentaho-nbaker @diogofscmariano Please review
