### PR TITLE
[SP-1592] - Backport of BISERVER-12205 - User security gets corrupted (5.2 Suite)

### DIFF
--- a/api/src/org/pentaho/platform/api/engine/IAuthenticatedPentahoSession.java
+++ b/api/src/org/pentaho/platform/api/engine/IAuthenticatedPentahoSession.java
@@ -1,0 +1,44 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+import org.springframework.security.Authentication;
+
+/**
+ * Interface for PentahoSession which includes Authentication object
+ * 
+ */
+
+public interface IAuthenticatedPentahoSession extends IPentahoSession {
+
+  /**
+   * Gets the authentication for this session
+   * 
+   * @return Authentication for this session
+   */
+  public Authentication getAuthentication();
+
+  /**
+   * Sets the authentication for this session
+   * 
+   * @param authentication
+   *          for this session
+   */
+  public void setAuthentication( Authentication authentication );
+
+}

--- a/core/src/org/pentaho/platform/engine/security/event/PentahoAuthenticationSuccessListener.java
+++ b/core/src/org/pentaho/platform/engine/security/event/PentahoAuthenticationSuccessListener.java
@@ -20,6 +20,7 @@ package org.pentaho.platform.engine.security.event;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.IAuthenticatedPentahoSession;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.engine.core.audit.AuditHelper;
 import org.pentaho.platform.engine.core.audit.MessageTypes;
@@ -28,14 +29,13 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.security.Authentication;
-import org.springframework.security.context.SecurityContextHolder;
 import org.springframework.security.event.authentication.AbstractAuthenticationEvent;
 import org.springframework.security.event.authentication.AuthenticationSuccessEvent;
 import org.springframework.util.Assert;
 
 /**
- * Synchronizes the Pentaho session's principal with the Spring Security {@code Authentication}. This listener
- * fires either on interactive or non-interactive logins.
+ * Synchronizes the Pentaho session's principal with the Spring Security {@code Authentication}. This listener fires
+ * either on interactive or non-interactive logins.
  * 
  * <p>
  * Replaces functionality from SecurityStartupFilter.
@@ -74,6 +74,9 @@ public class PentahoAuthenticationSuccessListener implements ApplicationListener
         IPentahoSession pentahoSession = PentahoSessionHolder.getSession();
         Assert.notNull( pentahoSession, "PentahoSessionHolder doesn't have a session" );
         pentahoSession.setAuthenticated( authentication.getName() );
+        if ( pentahoSession instanceof IAuthenticatedPentahoSession ) {
+          ( (IAuthenticatedPentahoSession) pentahoSession ).setAuthentication( authentication );
+        }
         // audit session creation
         AuditHelper.audit( pentahoSession.getId(), pentahoSession.getName(), pentahoSession.getActionName(),
             pentahoSession.getObjectName(), "", MessageTypes.SESSION_START, "", "", 0, null ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/mapper/MondrianAbstractPlatformUserRoleMapper.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/mapper/MondrianAbstractPlatformUserRoleMapper.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.olap4j.OlapConnection;
 import org.olap4j.OlapException;
+import org.pentaho.platform.api.engine.IAuthenticatedPentahoSession;
 import org.pentaho.platform.api.engine.IConnectionUserRoleMapper;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
@@ -57,9 +58,11 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
 
   /**
    * Subclasses simply need to implement this one method to do the specific mapping desired.
-   *
-   * @param mondrianRoles Sorted list of roles defined in the catalog
-   * @param platformRoles Sorted list of the roles defined in the catalog
+   * 
+   * @param mondrianRoles
+   *          Sorted list of roles defined in the catalog
+   * @param platformRoles
+   *          Sorted list of the roles defined in the catalog
    * @return
    */
   protected abstract String[] mapRoles( String[] mondrianRoles, String[] platformRoles )
@@ -68,9 +71,11 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
   /**
    * This method returns the role names as found in the Mondrian schema. The returned names must be ordered (sorted) or
    * code down-stream will not work.
-   *
-   * @param userSession Users' session
-   * @param catalogName The name of the catalog
+   * 
+   * @param userSession
+   *          Users' session
+   * @param catalogName
+   *          The name of the catalog
    * @return Array of role names from the schema file
    */
   protected String[] getMondrianRolesFromCatalog( IPentahoSession userSession, String context ) {
@@ -117,9 +122,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
           Arrays.sort( roleArray );
           return roleArray;
         } catch ( OlapException e ) {
-          log.error(
-              "Failed to get a list of roles from olap connection " + context,
-              e );
+          log.error( "Failed to get a list of roles from olap connection " + context, e );
           throw new RuntimeException( e );
         } finally {
           if ( conn != null ) {
@@ -127,9 +130,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
               conn.close();
             } catch ( SQLException e ) {
               // OK to squash this one.
-              log.error(
-                  "Failed to get a list of roles from olap connection " + context,
-                  e );
+              log.error( "Failed to get a list of roles from olap connection " + context, e );
             }
           }
         }
@@ -143,12 +144,18 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
   /**
    * This method returns the users' roles as specified in the Spring Security authentication object. The role names
    * returned must be sorted for other code downstream to work properly.
-   *
-   * @param session The users' session
+   * 
+   * @param session
+   *          The users' session
    * @return Users' roles as defined in the authentication object
    */
   protected String[] getPlatformRolesFromSession( IPentahoSession session ) {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    // This is a fix for ESR-4197. Trying to get authentication object from session because thread local implementation
+    // can return authentication object from other user.
+    if ( session instanceof IAuthenticatedPentahoSession ) {
+      authentication = ( (IAuthenticatedPentahoSession) session ).getAuthentication();
+    }
     Assert.state( authentication != null );
 
     String[] rtn = null;
@@ -168,7 +175,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
 
   /*
    * (non-Javadoc)
-   *
+   * 
    * @see org.pentaho.platform.api.engine.IConnectionUserRoleMapper#mapConnectionRoles(org.pentaho.platform.api.engine.
    * IPentahoSession, java.lang.String)
    */
@@ -187,7 +194,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
 
   /*
    * (non-Javadoc)
-   *
+   * 
    * @see org.pentaho.platform.api.engine.IConnectionUserRoleMapper#mapConnectionUser(org.pentaho.platform.api.engine.
    * IPentahoSession, java.lang.String)
    */

--- a/extensions/src/org/pentaho/platform/web/http/session/PentahoHttpSession.java
+++ b/extensions/src/org/pentaho/platform/web/http/session/PentahoHttpSession.java
@@ -17,9 +17,15 @@
 
 package org.pentaho.platform.web.http.session;
 
+import java.util.Iterator;
+import java.util.Locale;
+
+import javax.servlet.http.HttpSession;
+
 import org.apache.commons.collections.iterators.EnumerationIterator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.IAuthenticatedPentahoSession;
 import org.pentaho.platform.api.engine.IParameterProvider;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.engine.core.audit.AuditHelper;
@@ -27,18 +33,17 @@ import org.pentaho.platform.engine.core.audit.MessageTypes;
 import org.pentaho.platform.engine.core.solution.PentahoSessionParameterProvider;
 import org.pentaho.platform.engine.core.system.BaseSession;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.springframework.security.Authentication;
 
-import javax.servlet.http.HttpSession;
-import java.util.Iterator;
-import java.util.Locale;
-
-public class PentahoHttpSession extends BaseSession {
+public class PentahoHttpSession extends BaseSession implements IAuthenticatedPentahoSession {
 
   private static final long serialVersionUID = 1500696455420691764L;
 
   private HttpSession session;
 
   private long authenticationTime = 0L;
+
+  private Authentication authentication;
 
   private static final Log logger = LogFactory.getLog( PentahoHttpSession.class );
 
@@ -91,6 +96,16 @@ public class PentahoHttpSession extends BaseSession {
           "", MessageTypes.SESSION_END, "", "", ( ( System.currentTimeMillis() - authenticationTime ) / 1000F ), null ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
     super.destroy();
+  }
+
+  @Override
+  public Authentication getAuthentication() {
+    return authentication;
+  }
+
+  @Override
+  public void setAuthentication( Authentication authentication ) {
+    this.authentication = authentication;
   }
 
 }


### PR DESCRIPTION
Main discussion thread - http://jira.pentaho.com/browse/ESR-4197
Parent pull request https://github.com/pentaho/pentaho-platform/pull/2145
Added object Authentication into PentahoSession and pulled it in MondrianAbstractPlatformUserRoleMapper.
Unit tests will be soon.

@pentaho-nbaker Nick, I corrected the fix, please review.
