### PR TITLE
[SP-1592] - Backport of BISERVER-12205 - User security gets corrupted (5.2 Suite)

### DIFF
--- a/api/src/org/pentaho/platform/api/engine/IPentahoSession.java
+++ b/api/src/org/pentaho/platform/api/engine/IPentahoSession.java
@@ -22,8 +22,8 @@ import java.util.Locale;
 
 /**
  * Provides an overall representation of the concept of a session. Sessions are not necessarily user-based, but
- * typically wrap the HttpSession object and PortletSession object in a standard framework with methods that
- * session objects typically provide.
+ * typically wrap the HttpSession object and PortletSession object in a standard framework with methods that session
+ * objects typically provide.
  * 
  * @author jdixon
  * 
@@ -33,9 +33,11 @@ public interface IPentahoSession extends ILogger, IAuditable {
 
   public static final String TENANT_ID_KEY = "org.pentaho.tenantId"; //$NON-NLS-1$
 
+  public static final String SESSION_ROLES = "roles"; //$NON-NLS-1$
+
   /**
-   * Gets the name for this session, for example if this is an authenticated HTTP or Portlet session the name will
-   * be the name of the user
+   * Gets the name for this session, for example if this is an authenticated HTTP or Portlet session the name will be
+   * the name of the user
    * 
    * @return Name for this session
    */
@@ -121,9 +123,8 @@ public interface IPentahoSession extends ILogger, IAuditable {
   public boolean isAuthenticated();
 
   /**
-   * Sets the name of the session and indicates that the session is authenticated. If this is a HTTP or Portlet
-   * session the name should be the name of the user that is logged in (e.g. using
-   * <code>request.getRemoteUser()</code> )
+   * Sets the name of the session and indicates that the session is authenticated. If this is a HTTP or Portlet session
+   * the name should be the name of the user that is logged in (e.g. using <code>request.getRemoteUser()</code> )
    * 
    * @param name
    *          The name of the session
@@ -136,8 +137,7 @@ public interface IPentahoSession extends ILogger, IAuditable {
   public void setNotAuthenticated();
 
   /**
-   * Toggles on an alert condition indicating that the background execution of a task has completed during this
-   * session.
+   * Toggles on an alert condition indicating that the background execution of a task has completed during this session.
    * 
    */
   public void setBackgroundExecutionAlert();

--- a/core/src/org/pentaho/platform/engine/security/event/PentahoAuthenticationSuccessListener.java
+++ b/core/src/org/pentaho/platform/engine/security/event/PentahoAuthenticationSuccessListener.java
@@ -28,14 +28,13 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.security.Authentication;
-import org.springframework.security.context.SecurityContextHolder;
 import org.springframework.security.event.authentication.AbstractAuthenticationEvent;
 import org.springframework.security.event.authentication.AuthenticationSuccessEvent;
 import org.springframework.util.Assert;
 
 /**
- * Synchronizes the Pentaho session's principal with the Spring Security {@code Authentication}. This listener
- * fires either on interactive or non-interactive logins.
+ * Synchronizes the Pentaho session's principal with the Spring Security {@code Authentication}. This listener fires
+ * either on interactive or non-interactive logins.
  * 
  * <p>
  * Replaces functionality from SecurityStartupFilter.
@@ -74,6 +73,7 @@ public class PentahoAuthenticationSuccessListener implements ApplicationListener
         IPentahoSession pentahoSession = PentahoSessionHolder.getSession();
         Assert.notNull( pentahoSession, "PentahoSessionHolder doesn't have a session" );
         pentahoSession.setAuthenticated( authentication.getName() );
+        pentahoSession.setAttribute( IPentahoSession.SESSION_ROLES, authentication.getAuthorities() );
         // audit session creation
         AuditHelper.audit( pentahoSession.getId(), pentahoSession.getName(), pentahoSession.getActionName(),
             pentahoSession.getObjectName(), "", MessageTypes.SESSION_START, "", "", 0, null ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/mapper/MondrianAbstractPlatformUserRoleMapper.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/mapper/MondrianAbstractPlatformUserRoleMapper.java
@@ -57,9 +57,11 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
 
   /**
    * Subclasses simply need to implement this one method to do the specific mapping desired.
-   *
-   * @param mondrianRoles Sorted list of roles defined in the catalog
-   * @param platformRoles Sorted list of the roles defined in the catalog
+   * 
+   * @param mondrianRoles
+   *          Sorted list of roles defined in the catalog
+   * @param platformRoles
+   *          Sorted list of the roles defined in the catalog
    * @return
    */
   protected abstract String[] mapRoles( String[] mondrianRoles, String[] platformRoles )
@@ -68,9 +70,11 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
   /**
    * This method returns the role names as found in the Mondrian schema. The returned names must be ordered (sorted) or
    * code down-stream will not work.
-   *
-   * @param userSession Users' session
-   * @param catalogName The name of the catalog
+   * 
+   * @param userSession
+   *          Users' session
+   * @param catalogName
+   *          The name of the catalog
    * @return Array of role names from the schema file
    */
   protected String[] getMondrianRolesFromCatalog( IPentahoSession userSession, String context ) {
@@ -117,9 +121,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
           Arrays.sort( roleArray );
           return roleArray;
         } catch ( OlapException e ) {
-          log.error(
-              "Failed to get a list of roles from olap connection " + context,
-              e );
+          log.error( "Failed to get a list of roles from olap connection " + context, e );
           throw new RuntimeException( e );
         } finally {
           if ( conn != null ) {
@@ -127,9 +129,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
               conn.close();
             } catch ( SQLException e ) {
               // OK to squash this one.
-              log.error(
-                  "Failed to get a list of roles from olap connection " + context,
-                  e );
+              log.error( "Failed to get a list of roles from olap connection " + context, e );
             }
           }
         }
@@ -143,17 +143,21 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
   /**
    * This method returns the users' roles as specified in the Spring Security authentication object. The role names
    * returned must be sorted for other code downstream to work properly.
-   *
-   * @param session The users' session
+   * 
+   * @param session
+   *          The users' session
    * @return Users' roles as defined in the authentication object
    */
   protected String[] getPlatformRolesFromSession( IPentahoSession session ) {
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    Assert.state( authentication != null );
+    // Get the authorities
+    GrantedAuthority[] gAuths = (GrantedAuthority[]) session.getAttribute( IPentahoSession.SESSION_ROLES );
+    if ( gAuths == null ) {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      gAuths = authentication.getAuthorities();
+      Assert.state( authentication != null );
+    }
 
     String[] rtn = null;
-    // Get the authorities
-    GrantedAuthority[] gAuths = authentication.getAuthorities();
     if ( ( gAuths != null ) && ( gAuths.length > 0 ) ) {
       // Copy role names out of the Authentication
       rtn = new String[gAuths.length];
@@ -168,7 +172,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
 
   /*
    * (non-Javadoc)
-   *
+   * 
    * @see org.pentaho.platform.api.engine.IConnectionUserRoleMapper#mapConnectionRoles(org.pentaho.platform.api.engine.
    * IPentahoSession, java.lang.String)
    */
@@ -187,7 +191,7 @@ public abstract class MondrianAbstractPlatformUserRoleMapper implements IConnect
 
   /*
    * (non-Javadoc)
-   *
+   * 
    * @see org.pentaho.platform.api.engine.IConnectionUserRoleMapper#mapConnectionUser(org.pentaho.platform.api.engine.
    * IPentahoSession, java.lang.String)
    */


### PR DESCRIPTION
Main discussion thread - http://jira.pentaho.com/browse/ESR-4197
Added roles into PentahoSession and extracted them in MondrianAbstractPlatformUserRoleMapper.

@pentaho-nbaker Nick, I corrected the fix, please review again.
