### PR TITLE
[BACKLOG-1574] - Add the ability to provide configuration to store the data source acl nodes.

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/repository.spring.properties
+++ b/assembly/package-res/biserver/pentaho-solutions/system/repository.spring.properties
@@ -16,3 +16,4 @@ cache-ttl=300
 # This property can only be changed to "true" if you are installing it fresh. For upgrades,
 # this must be set to false. 
 useMultiByteEncoding=false
+aclNodeFolder=/public

--- a/extensions/src/repository.spring.xml
+++ b/extensions/src/repository.spring.xml
@@ -807,5 +807,5 @@
   <bean class="java.lang.Boolean" id="useMultiByteEncoding">
     <constructor-arg value="${repository.useMultiByteEncoding}"/>
     <pen:publish as-type="INTERFACES"/>
-  </bean>  
+  </bean>
 </beans>

--- a/repository/src/repository.spring.properties
+++ b/repository/src/repository.spring.properties
@@ -14,3 +14,4 @@ systemTenantAdminPassword=cGFzc3dvcmQ=
 # This property can only be changed to "true" if you are installing it fresh. For upgrades,
 # this must be set to false. 
 useMultiByteEncoding=false
+aclNodeFolder=/public


### PR DESCRIPTION
@CodeOnCoffee Please review

Property aclNodeFolder added. 
Can be retrived via PentahoSystem.get( ISystemConfig.class ).getProperty(repository.aclNodeFolder);
