### PR TITLE
[BISERVER-10354] - Adding the requestParameterProcessingFilter filter to...

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security.xml
@@ -19,8 +19,8 @@
         <![CDATA[CONVERT_URL_TO_LOWERCASE_BEFORE_COMPARISON
         PATTERN_TYPE_APACHE_ANT
         /webservices/**=securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,anonymousProcessingFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS
-        /api/**=securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,anonymousProcessingFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS
-        /plugin/**=securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,anonymousProcessingFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS
+        /api/**=securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS
+        /plugin/**=securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS
         /**=securityContextHolderAwareRequestFilter,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,httpSessionReuseDetectionFilter,logoutFilter,authenticationProcessingFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,exceptionTranslationFilter,filterInvocationInterceptor]]>
       </value>
     </property>

--- a/assembly/package-res/biserver/pentaho-solutions/system/security.properties
+++ b/assembly/package-res/biserver/pentaho-solutions/system/security.properties
@@ -1,1 +1,2 @@
 provider=jackrabbit
+requestParameterAuthenticationEnabled=false

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/JerseyUtil.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/JerseyUtil.java
@@ -39,6 +39,16 @@ public class JerseyUtil {
         formParamsHashMap.put( key, value );
       }
     }
+    
+    Map mapParams = httpServletRequest.getParameterMap();
+    for ( Object key : mapParams.keySet() ) {
+      Object value = mapParams.get( key );
+      if ( value instanceof List ) {
+        formParamsHashMap.put( (String) key, ( (List<?>) value ).toArray() );
+      } else {
+        formParamsHashMap.put( (String) key, value );
+      }
+    }
 
     HttpServletRequestWrapper requestWrapper = new HttpServletRequestWrapper( httpServletRequest ) {
       @Override

--- a/extensions/src/org/pentaho/platform/web/http/security/RequestParameterAuthenticationFilter.java
+++ b/extensions/src/org/pentaho/platform/web/http/security/RequestParameterAuthenticationFilter.java
@@ -42,6 +42,9 @@ import org.springframework.security.providers.UsernamePasswordAuthenticationToke
 import org.springframework.security.ui.AuthenticationEntryPoint;
 import org.springframework.security.ui.WebAuthenticationDetails;
 import org.springframework.util.Assert;
+import org.pentaho.platform.api.engine.IConfiguration;
+import org.pentaho.platform.api.engine.ISystemConfig;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 
 /**
  * Processes Request Parameter authorization, putting the result into the <code>SecurityContextHolder</code>.
@@ -88,6 +91,11 @@ public class RequestParameterAuthenticationFilter implements Filter, Initializin
 
   private String passwordParameter = RequestParameterAuthenticationFilter.DefaultPasswordParameter;
 
+  private ISystemConfig systemConfig = PentahoSystem.get( ISystemConfig.class );
+  
+  private boolean isRequestParameterAuthenticationEnabled;
+  private boolean isRequestAuthenticationParameterLoaded = false;
+ 
   // ~ Methods ================================================================
 
   public void afterPropertiesSet() throws Exception {
@@ -107,71 +115,83 @@ public class RequestParameterAuthenticationFilter implements Filter, Initializin
 
   public void doFilter( final ServletRequest request, final ServletResponse response, final FilterChain chain )
     throws IOException, ServletException {
-    if ( !( request instanceof HttpServletRequest ) ) {
-      throw new ServletException( Messages.getInstance().getErrorString(
-          "RequestParameterAuthenticationFilter.ERROR_0005_HTTP_SERVLET_REQUEST_REQUIRED" ) ); //$NON-NLS-1$
+    IConfiguration config = this.systemConfig.getConfiguration( "security" );
+    
+    if ( !isRequestAuthenticationParameterLoaded ) {
+      String strParameter = config.getProperties().getProperty( "requestParameterAuthenticationEnabled" );
+      isRequestParameterAuthenticationEnabled = Boolean.valueOf( strParameter );
+      isRequestAuthenticationParameterLoaded = true;
     }
 
-    if ( !( response instanceof HttpServletResponse ) ) {
-      throw new ServletException( Messages.getInstance().getErrorString(
-          "RequestParameterAuthenticationFilter.ERROR_0006_HTTP_SERVLET_RESPONSE_REQUIRED" ) ); //$NON-NLS-1$
-    }
+    if ( isRequestParameterAuthenticationEnabled ) {
+      if ( !( request instanceof HttpServletRequest ) ) {
+        throw new ServletException( Messages.getInstance().getErrorString(
+            "RequestParameterAuthenticationFilter.ERROR_0005_HTTP_SERVLET_REQUEST_REQUIRED" ) ); //$NON-NLS-1$
+      }
 
-    HttpServletRequest httpRequest = (HttpServletRequest) request;
+      if ( !( response instanceof HttpServletResponse ) ) {
+        throw new ServletException( Messages.getInstance().getErrorString(
+            "RequestParameterAuthenticationFilter.ERROR_0006_HTTP_SERVLET_RESPONSE_REQUIRED" ) ); //$NON-NLS-1$
+      }
 
-    MultiReadHttpServletRequest wrapper = new MultiReadHttpServletRequest( httpRequest );
+      HttpServletRequest httpRequest = (HttpServletRequest) request;
 
-    String username = wrapper.getParameter( this.userNameParameter );
-    String password = wrapper.getParameter( this.passwordParameter );
+      MultiReadHttpServletRequest wrapper = new MultiReadHttpServletRequest( httpRequest );
 
-    if ( RequestParameterAuthenticationFilter.logger.isDebugEnabled() ) {
-      RequestParameterAuthenticationFilter.logger.debug( Messages.getInstance().getString(
-          "RequestParameterAuthenticationFilter.DEBUG_AUTH_USERID", username ) ); //$NON-NLS-1$
-    }
+      String username = wrapper.getParameter( this.userNameParameter );
+      String password = wrapper.getParameter( this.passwordParameter );
 
-    if ( ( username != null ) && ( password != null ) ) {
-      // Only reauthenticate if username doesn't match SecurityContextHolder and user isn't authenticated (see SEC-53)
-      Authentication existingAuth = SecurityContextHolder.getContext().getAuthentication();
+      if ( RequestParameterAuthenticationFilter.logger.isDebugEnabled() ) {
+        RequestParameterAuthenticationFilter.logger.debug( Messages.getInstance().getString(
+            "RequestParameterAuthenticationFilter.DEBUG_AUTH_USERID", username ) ); //$NON-NLS-1$
+      }
 
-      password = Encr.decryptPasswordOptionallyEncrypted( password );
+      if ( ( username != null ) && ( password != null ) ) {
+        // Only reauthenticate if username doesn't match SecurityContextHolder and user isn't authenticated (see SEC-53)
+        Authentication existingAuth = SecurityContextHolder.getContext().getAuthentication();
 
-      if ( ( existingAuth == null ) || !existingAuth.getName().equals( username ) || !existingAuth.isAuthenticated() ) {
-        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken( username, password );
-        authRequest.setDetails( new WebAuthenticationDetails( httpRequest ) );
+        password = Encr.decryptPasswordOptionallyEncrypted( password );
 
-        Authentication authResult;
+        if ( ( existingAuth == null ) || !existingAuth.getName().equals( username ) || !existingAuth.isAuthenticated() ) {
+          UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken( username, password );
+          authRequest.setDetails( new WebAuthenticationDetails( httpRequest ) );
 
-        try {
-          authResult = authenticationManager.authenticate( authRequest );
-        } catch ( AuthenticationException failed ) {
-          // Authentication failed
+          Authentication authResult;
+
+          try {
+            authResult = authenticationManager.authenticate( authRequest );
+          } catch ( AuthenticationException failed ) {
+            // Authentication failed
+            if ( RequestParameterAuthenticationFilter.logger.isDebugEnabled() ) {
+              RequestParameterAuthenticationFilter.logger.debug( Messages.getInstance().getString(
+                  "RequestParameterAuthenticationFilter.DEBUG_AUTHENTICATION_REQUEST", username, failed.toString() ) ); //$NON-NLS-1$
+            }
+
+            SecurityContextHolder.getContext().setAuthentication( null );
+
+            if ( ignoreFailure ) {
+              chain.doFilter( wrapper, response );
+            } else {
+              authenticationEntryPoint.commence( wrapper, response, failed );
+            }
+
+            return;
+          }
+
+          // Authentication success
           if ( RequestParameterAuthenticationFilter.logger.isDebugEnabled() ) {
             RequestParameterAuthenticationFilter.logger.debug( Messages.getInstance().getString(
-                "RequestParameterAuthenticationFilter.DEBUG_AUTHENTICATION_REQUEST", username, failed.toString() ) ); //$NON-NLS-1$
+                "RequestParameterAuthenticationFilter.DEBUG_AUTH_SUCCESS", authResult.toString() ) ); //$NON-NLS-1$
           }
 
-          SecurityContextHolder.getContext().setAuthentication( null );
-
-          if ( ignoreFailure ) {
-            chain.doFilter( wrapper, response );
-          } else {
-            authenticationEntryPoint.commence( wrapper, response, failed );
-          }
-
-          return;
+          SecurityContextHolder.getContext().setAuthentication( authResult );
         }
-
-        // Authentication success
-        if ( RequestParameterAuthenticationFilter.logger.isDebugEnabled() ) {
-          RequestParameterAuthenticationFilter.logger.debug( Messages.getInstance().getString(
-              "RequestParameterAuthenticationFilter.DEBUG_AUTH_SUCCESS", authResult.toString() ) ); //$NON-NLS-1$
-        }
-
-        SecurityContextHolder.getContext().setAuthentication( authResult );
       }
+      chain.doFilter( wrapper, response );
+    } else {
+      chain.doFilter( request, response );
     }
-
-    chain.doFilter( wrapper, response );
+    
   }
 
   public AuthenticationEntryPoint getAuthenticationEntryPoint() {


### PR DESCRIPTION
... the /api/** and /plugin/** pattern causes Analyzer to no longer work.

In case we use requestParameterProcessingFilter parameters of post request comes with httpServletRequest not with formParams (RepositoryResource. doFormPost)


Issue:
In case we use requestParameterProcessingFilter parameters of post request comes with httpServletRequest not with formParams (RepositoryResource. doFormPost).
Solution:
Add parameters from httpServletRequest to map of params.
Tested:
1.	Build pentaho-platformand put pentaho-platform-extensions-TRUNK-SNAPSHOT.jar at 
\biserver-ee\tomcat\webapps\pentaho\WEB-INF\lib\ 
2.	Run server. Open report Country Performance (heat grid). Verify it looks correct.
3.	Open applicationContext-spring-security.xml file and add requestParameterProcessingFilter to /api/** and /plugin/**
4.	 Run server. Open report Country Performance (heat grid). Verify it looks correct.
