### PR TITLE
Ds provision

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/messages/messages.properties
+++ b/repository/src/org/pentaho/platform/repository2/messages/messages.properties
@@ -102,3 +102,4 @@ JcrRepositoryFileDao.ERROR_0006_ACCESS_DENIED_DELETE=Access denied while deletin
 DefaultUnifiedRepository.ERROR_0001_ACCESS_DENIED_UPDATE_ACL=Access denied while updating permissions on file with id [ {0} ]
 AclNodeHelper.ERROR_0001_ROOT_FOLDER_NOT_AVAILABLE=Root folder {0} not available. Using default {1} instead
 AclNodeHelper.WARN_0001_REMOVE_ACL_NODE=Removing the ACL node:
+AclNodeHelper.WARN_0002_REMOVE_ACL_STORE=Removing the ACL store: {0}

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/IAclNodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/IAclNodeHelper.java
@@ -19,7 +19,8 @@ public interface IAclNodeHelper {
   boolean hasAccess( String dataSourceName, DatasourceType type );
 
   /**
-   * Returns an ACL rules for <tt>dataSourceName</tt>. If none exists, <tt>null</tt> is returned.
+   * Returns an ACL rules for <tt>dataSourceName</tt>. If none exists, <tt>null</tt> is returned. <b>Note:</b> this
+   * method should be invoked with 'repository admin' privileges.
    *
    * @param dataSourceName data source
    * @param type           data source's type
@@ -29,7 +30,8 @@ public interface IAclNodeHelper {
 
   /**
    * Sets <tt>acl</tt> for <tt>dataSourceName</tt>. If a ACL node does not exist, it is created. If <tt>acl</tt> is
-   * <tt>null</tt>, the ACL node is removed.
+   * <tt>null</tt>, the ACL node is removed. <b>Note:</b> this method should be invoked with 'repository admin'
+   * privileges.
    *
    * @param dataSourceName data source
    * @param type           data source's type
@@ -38,7 +40,8 @@ public interface IAclNodeHelper {
   void setAclFor( String dataSourceName, DatasourceType type, RepositoryFileAcl acl );
 
   /**
-   * Makes the <tt>dataSourceName</tt> public by removing corresponding ACL node.
+   * Makes the <tt>dataSourceName</tt> public by removing corresponding ACL node. <b>Note:</b> this method should be
+   * invoked with 'repository admin' privileges.
    *
    * @param dataSourceName data source
    * @param type           data source's type
@@ -47,7 +50,7 @@ public interface IAclNodeHelper {
 
   /**
    * Removes, if it exists, a ACL node related to the <tt>dataSourceName</tt>. Internally it simply calls
-   * <code>setAcl(null)</code>.
+   * <code>setAcl(null)</code>. <b>Note:</b> this method should be invoked with 'repository admin' privileges.
    *
    * @param dataSourceName data source
    * @param type           data source's type

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
@@ -6,21 +6,25 @@ import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
-import org.pentaho.platform.api.repository2.unified.data.sample.SampleRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
-import org.pentaho.platform.engine.security.SecurityHelper;
-import org.pentaho.platform.repository.RepositoryFilenameUtils;
 import org.pentaho.platform.repository.messages.Messages;
 import org.pentaho.platform.repository2.unified.ServerRepositoryPaths;
 
 import java.io.ByteArrayInputStream;
-import java.util.concurrent.Callable;
+import java.util.EnumSet;
+
+import static org.pentaho.platform.repository.RepositoryFilenameUtils.normalize;
 
 /**
  * @author Andrey Khayrutdinov
  */
 public class JcrAclNodeHelper implements IAclNodeHelper {
   private static final Log logger = LogFactory.getLog( JcrAclNodeHelper.class );
+
+  private static final String AUTHENTICATED_ROLE = "Authenticated";
+  private static final String ACL_STORE = "acl.store";
 
   private final IUnifiedRepository unifiedRepository;
   private final String aclNodeFolder;
@@ -31,38 +35,113 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
     this.aclNodeFolder = StringUtils.defaultIfEmpty( aclNodeFolder, ServerRepositoryPaths.getAclNodeFolderPath() );
   }
 
+  private String getAclNodePath( String filename ) {
+    return normalize( getAclNodeFolder() + RepositoryFile.SEPARATOR + filename );
+  }
+
+  private String getAclStorePath( String filename ) {
+    return normalize( getAclNodePath( filename ) + RepositoryFile.SEPARATOR + ACL_STORE );
+  }
+
+  private RepositoryFile getAclNode( String filename ) {
+    return unifiedRepository.getFile( getAclNodePath( filename ) );
+  }
+
+  private RepositoryFile createAclNodeInternal( RepositoryFile folder, String filename ) {
+    return unifiedRepository.createFolder(
+      folder.getId(),
+      new RepositoryFile.Builder( filename ).folder( true ).aclNode( true ).build(),
+      ""
+    );
+  }
+
+  private RepositoryFile getAclNodeRepositoryFolder() {
+    RepositoryFile folder;
+    try {
+      folder = unifiedRepository.getFile( getAclNodeFolder() );
+    } catch ( Exception t ) {
+      logger.error( Messages.getInstance().getString( "AclNodeHelper.ERROR_0001_ROOT_FOLDER_NOT_AVAILABLE",
+        aclNodeFolder, ServerRepositoryPaths.getAclNodeFolderPath() ) );
+      folder = unifiedRepository.getFile( ServerRepositoryPaths.getAclNodeFolderPath() );
+    }
+    return folder;
+  }
+
+  private RepositoryFile createAclNode( String filename ) {
+    RepositoryFile folder = getAclNodeRepositoryFolder();
+
+    RepositoryFile aclNode = createAclNodeInternal( folder, filename );
+    RepositoryFileAcl aclNodeAcl = new RepositoryFileAcl.Builder( unifiedRepository.getAcl( aclNode.getId() ) )
+      .ace( AUTHENTICATED_ROLE, RepositoryFileSid.Type.ROLE, EnumSet.of( RepositoryFilePermission.ALL ) )
+      .build();
+    unifiedRepository.updateAcl( aclNodeAcl );
+    return aclNode;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   @Override public boolean hasAccess( String dataSourceName, DatasourceType type ) {
-    try {
-      FindAclNodeCommand command =
-        new FindAclNodeCommand( unifiedRepository, getAclNodeFolder(), type.resolveName( dataSourceName ) );
-      boolean nodeExists = SecurityHelper.getInstance().runAsSystem( command );
+    String resolveName = type.resolveName( dataSourceName );
 
-      return !nodeExists || command.call();
-    } catch ( Exception e ) {
-      logger.error( e );
-      throw new RuntimeException( e );
-    }
+    String aclNodePath = getAclNodePath( resolveName );
+    boolean nodeExists = unifiedRepository.hasAccess( aclNodePath, EnumSet.of( RepositoryFilePermission.READ ) );
+
+    return !nodeExists ||
+      unifiedRepository.hasAccess( getAclStorePath( resolveName ), EnumSet.of( RepositoryFilePermission.READ ) );
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override public RepositoryFileAcl getAclFor( String dataSourceName, DatasourceType type ) {
-    try {
-      GetAclCommand command =
-        new GetAclCommand( unifiedRepository, getAclNodeFolder(), type.resolveName( dataSourceName ) );
-      return SecurityHelper.getInstance().runAsSystem( command );
-    } catch ( Exception e ) {
-      logger.error( e );
-      throw new RuntimeException( e );
+    String resolvedDsName = type.resolveName( dataSourceName );
+    RepositoryFile aclNode = getAclNode( resolvedDsName );
+    if ( aclNode == null ) {
+      return null;
     }
+
+    RepositoryFile aclStore = unifiedRepository.getFile( getAclStorePath( resolvedDsName ) );
+    return ( aclStore == null ) ? null : unifiedRepository.getAcl( aclStore.getId() );
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override public void setAclFor( String dataSourceName, DatasourceType type, RepositoryFileAcl acl ) {
-    try {
-      SetAclCommand command =
-        new SetAclCommand( unifiedRepository, getAclNodeFolder(), type.resolveName( dataSourceName ), acl );
-      SecurityHelper.getInstance().runAsSystem( command );
-    } catch ( Exception e ) {
-      logger.error( e );
-      throw new RuntimeException( e );
+    String resolvedName = type.resolveName( dataSourceName );
+
+    RepositoryFile aclNode = getAclNode( resolvedName );
+
+    if ( acl == null ) {
+      if ( aclNode != null ) {
+        RepositoryFile aclStore = unifiedRepository.getFile( getAclStorePath( resolvedName ) );
+        if ( aclStore != null ) {
+          unifiedRepository.deleteFile( aclStore.getId(), true,
+            Messages.getInstance().getString( "AclNodeHelper.WARN_0002_REMOVE_ACL_STORE", aclStore.getPath() ) );
+        }
+
+        unifiedRepository.deleteFile( aclNode.getId(), true,
+          Messages.getInstance().getString( "AclNodeHelper.WARN_0001_REMOVE_ACL_NODE", aclNode.getPath() ) );
+      }
+    } else {
+      if ( aclNode == null ) {
+        aclNode = createAclNode( resolvedName );
+      }
+
+      String aclStoreName = getAclStorePath( resolvedName );
+      RepositoryFile aclStore = getAclNode( aclStoreName );
+      if ( aclStore == null ) {
+        aclStore = unifiedRepository.createFile(
+          aclNode.getId(),
+          new RepositoryFile.Builder( ACL_STORE ).aclNode( true ).build(),
+          new SimpleRepositoryFileData( new ByteArrayInputStream( new byte[ 0 ] ), "", "" ),
+          ""
+        );
+      }
+      RepositoryFileAcl existing = unifiedRepository.getAcl( aclStore.getId() );
+      RepositoryFileAcl updated = new RepositoryFileAcl.Builder( existing ).aces( acl.getAces() ).build();
+      unifiedRepository.updateAcl( updated );
     }
   }
 
@@ -76,94 +155,5 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
 
   @Override public String getAclNodeFolder() {
     return aclNodeFolder;
-  }
-}
-
-abstract class AbstractCommand<T> implements Callable<T> {
-  private static final Log logger = LogFactory.getLog( AbstractCommand.class );
-
-  final IUnifiedRepository repository;
-  String aclNodeFolder;
-  final String resolvedDsName;
-
-  public AbstractCommand( IUnifiedRepository repository, String aclNodeFolder, String resolvedDsName ) {
-    this.repository = repository;
-    this.aclNodeFolder = aclNodeFolder;
-    this.resolvedDsName = resolvedDsName;
-  }
-
-  RepositoryFile getAclNode() {
-    return repository.getFile( RepositoryFilenameUtils.normalize( aclNodeFolder + RepositoryFile.SEPARATOR
-        + resolvedDsName ) );
-  }
-
-  RepositoryFile createAclNode() {
-    RepositoryFile folder;
-
-    try {
-      folder = repository.getFile( aclNodeFolder );
-    } catch ( Throwable t ) {
-      logger.error( Messages.getInstance().getString( "AclNodeHelper.ERROR_0001_ROOT_FOLDER_NOT_AVAILABLE",
-          aclNodeFolder, ServerRepositoryPaths.getAclNodeFolderPath() ) );
-      aclNodeFolder = ServerRepositoryPaths.getAclNodeFolderPath();
-      folder = repository.getFile( aclNodeFolder );
-    }
-
-    return repository.createFile( folder.getId(), new RepositoryFile.Builder( resolvedDsName ).aclNode( true ).build(),
-      new SimpleRepositoryFileData( new ByteArrayInputStream( new byte[0] ), "", "" ), "" );
-  }
-}
-
-class FindAclNodeCommand extends AbstractCommand<Boolean> {
-  public FindAclNodeCommand( IUnifiedRepository repository, String aclNodeFolder, String resolvedDsName ) {
-    super( repository, aclNodeFolder, resolvedDsName );
-  }
-
-  @Override public Boolean call() throws Exception {
-    return getAclNode() != null;
-  }
-}
-
-class GetAclCommand extends AbstractCommand<RepositoryFileAcl> {
-  public GetAclCommand( IUnifiedRepository repository, String aclNodeFolder, String resolvedDsName ) {
-    super( repository, aclNodeFolder, resolvedDsName );
-  }
-
-  @Override public RepositoryFileAcl call() throws Exception {
-    RepositoryFile aclNode = getAclNode();
-    if ( aclNode == null ) {
-      return null;
-    }
-    return repository.getAcl( aclNode.getId() );
-  }
-}
-
-class SetAclCommand extends AbstractCommand<RepositoryFileAcl> {
-  final RepositoryFileAcl acl;
-
-  public SetAclCommand( IUnifiedRepository repository, String aclNodeFolder, String resolvedDsName,
-                        RepositoryFileAcl acl ) {
-    super( repository, aclNodeFolder, resolvedDsName );
-    this.acl = acl;
-  }
-
-  @Override public RepositoryFileAcl call() throws Exception {
-    RepositoryFile aclNode = getAclNode();
-
-    if ( acl == null ) {
-      if ( aclNode != null ) {
-        repository.deleteFile( aclNode.getId(), true,
-            Messages.getInstance().getString( "AclNodeHelper.WARN_0001_REMOVE_ACL_NODE", aclNode.getPath() ) );
-      }
-    } else {
-      if ( aclNode == null ) {
-        aclNode = createAclNode();
-      }
-      RepositoryFileAcl existing = repository.getAcl( aclNode.getId() );
-      RepositoryFileAcl updated = new RepositoryFileAcl.Builder( existing ).aces( acl.getAces() ).build();
-      return repository.updateAcl( updated );
-    }
-
-    return null;
   }
 }

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperTest.java
@@ -27,7 +27,7 @@ import static org.pentaho.platform.repository2.unified.jcr.IAclNodeHelper.Dataso
 
 @RunWith( SpringJUnit4ClassRunner.class )
 @ContextConfiguration( locations = { "classpath:/repository.spring.xml",
-    "classpath:/repository-test-override.spring.xml" } )
+  "classpath:/repository-test-override.spring.xml" } )
 public class JcrAclNodeHelperTest extends DefaultUnifiedRepositoryBase {
 
   private static final String DS_NAME = "test.txt";
@@ -67,7 +67,7 @@ public class JcrAclNodeHelperTest extends DefaultUnifiedRepositoryBase {
     loginAsSysTenantAdmin();
 
     ITenant defaultTenant = tenantManager.getTenant( "/" + ServerRepositoryPaths.getPentahoRootFolderName() + "/"
-        + TenantUtils.getDefaultTenant() );
+      + TenantUtils.getDefaultTenant() );
     if ( defaultTenant != null ) {
       cleanupUserAndRoles( defaultTenant );
     }
@@ -121,16 +121,23 @@ public class JcrAclNodeHelperTest extends DefaultUnifiedRepositoryBase {
   @Test
   public void aclNodeIsCreated() {
     makeDsPrivate();
+
     loginAsSuzy();
     assertNotNull( repo.getFile( helper.getAclNodeFolder() + "/" + MONDRIAN.resolveName( DS_NAME ) ) );
+
+    loginAsRepositoryAdmin();
+    assertNotNull(
+      repo.getFile( helper.getAclNodeFolder() + "/" + MONDRIAN.resolveName( DS_NAME ) + "/" + "acl.store" ) );
   }
 
   @Test
   public void aclNodeIsRemoved() {
     makeDsPrivate();
-    loginAsSuzy();
+
+    loginAsRepositoryAdmin();
     helper.setAclFor( DS_NAME, MONDRIAN, null );
     assertNull( repo.getFile( helper.getAclNodeFolder() + "/" + MONDRIAN.resolveName( DS_NAME ) ) );
+    assertNull( repo.getFile( helper.getAclNodeFolder() + "/" + MONDRIAN.resolveName( DS_NAME ) + "/" + "acl.store" ) );
   }
 
 
@@ -138,7 +145,7 @@ public class JcrAclNodeHelperTest extends DefaultUnifiedRepositoryBase {
     loginAsRepositoryAdmin();
     RepositoryFileSid userSid = new RepositoryFileSid( USERNAME_SUZY, RepositoryFileSid.Type.USER );
     RepositoryFileAcl acl = new RepositoryFileAcl.Builder( USERNAME_SUZY ).ace( userSid,
-        EnumSet.of( RepositoryFilePermission.ALL ) ).entriesInheriting( false ).build();
+      EnumSet.of( RepositoryFilePermission.ALL ) ).entriesInheriting( false ).build();
 
     helper.setAclFor( DS_NAME, MONDRIAN, acl );
   }
@@ -150,7 +157,7 @@ public class JcrAclNodeHelperTest extends DefaultUnifiedRepositoryBase {
       RepositoryFile folder = repo.getFile( folderName );
       if ( folder == null ) {
         folder = repo.createFolder( repo.getFile( "/" ).getId(), new RepositoryFile.Builder( folderName ).
-                folder( true ).build(), "" );
+          folder( true ).build(), "" );
       }
       return folder;
     } finally {


### PR DESCRIPTION
@pentaho-nbaker, please review this PR

The first commit fixes a raising NPE and is pretty simple.

The second is shipped with the re-implementation of AclNodeHelper. Now, it does not call runAsSystem(). Instead it utilises a two-level hierarchy. The top of it is an ACL Node, that is always visible for Authenticated users. The second level, I have called it ACL store, just stores the ACL.

I also updated the interface's javadocs pointing out that most of the methods should be called with repository administrator role. And last but not least - I've updated the corresponding test
