### PR TITLE
[BISERVER-12105] - Import-export.sh utility doesnt work if a folder/file name has spaces in it

### DIFF
--- a/assembly/package-res/biserver/import-export.sh
+++ b/assembly/package-res/biserver/import-export.sh
@@ -9,4 +9,4 @@ setPentahoEnv
 
 # uses Java 6 classpath wildcards
 # quotes required around classpath to prevent shell expansion
-"$_PENTAHO_JAVA" -Xmx2048m -XX:MaxPermSize=256m -classpath "$DIR/tomcat/webapps/pentaho/WEB-INF/lib/*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor $@
+"$_PENTAHO_JAVA" -Xmx2048m -XX:MaxPermSize=256m -classpath "$DIR/tomcat/webapps/pentaho/WEB-INF/lib/*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor ${1+"$@"}


### PR DESCRIPTION
I accepted Peter's solution and validate it on Ubuntu OS.

@pminutillo Peter, could you please review my fix?
