### PR TITLE
[BACKLOG-1561] - Add the ability to get security/ACL information about a...

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/IAclAwareMondrianCatalogService.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/IAclAwareMondrianCatalogService.java
@@ -26,9 +26,7 @@ public interface IAclAwareMondrianCatalogService extends IMondrianCatalogService
   void addCatalog( InputStream inputStream, MondrianCatalog catalog, boolean overwriteInRepository,
                    RepositoryFileAcl acl, IPentahoSession session );
 
-  /**
-   * Never returns <tt>null</tt>.
-   * @return    an ACL helper instance
-   */
-  IAclNodeHelper getAclHelper();
+  void setAclFor( String catalogName, RepositoryFileAcl acl );
+
+  RepositoryFileAcl getAclFor( String catalogName );
 }

--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper.java
@@ -227,7 +227,7 @@ public class MondrianCatalogHelper implements IAclAwareMondrianCatalogService {
 
   @VisibleForTesting
   @Deprecated
-  public MondrianCatalogHelper(IAclNodeHelper aclHelper) {
+  public MondrianCatalogHelper( IAclNodeHelper aclHelper ) {
     this();
     this.aclHelper = aclHelper;
   }
@@ -643,7 +643,7 @@ public class MondrianCatalogHelper implements IAclAwareMondrianCatalogService {
     }
     reInit( pentahoSession );
 
-    getAclHelper().setAclFor( getMondrianCatalogRepositoryHelper().getMondrianCatalogFile( catalog.getName() ), acl );
+    setAclFor( catalog.getName(), acl );
   }
 
   protected IUnifiedRepository getRepository() {
@@ -651,17 +651,27 @@ public class MondrianCatalogHelper implements IAclAwareMondrianCatalogService {
   }
 
   protected synchronized MondrianCatalogRepositoryHelper getMondrianCatalogRepositoryHelper() {
-    if (catalogRepositoryHelper == null) {
+    if ( catalogRepositoryHelper == null ) {
       catalogRepositoryHelper = new MondrianCatalogRepositoryHelper( PentahoSystem.get( IUnifiedRepository.class ) );
     }
     return catalogRepositoryHelper;
   }
 
-  public synchronized IAclNodeHelper getAclHelper() {
+  protected synchronized IAclNodeHelper getAclHelper() {
     if ( aclHelper == null ) {
       aclHelper = new JcrAclNodeHelper( PentahoSystem.get( IUnifiedRepository.class ) );
     }
     return aclHelper;
+  }
+
+  @Override
+  public void setAclFor( String catalogName, RepositoryFileAcl acl ) {
+    getAclHelper().setAclFor( getMondrianCatalogRepositoryHelper().getMondrianCatalogFile( catalogName ), acl );
+  }
+
+  @Override
+  public RepositoryFileAcl getAclFor( String catalogName ) {
+    return getAclHelper().getAclFor( getMondrianCatalogRepositoryHelper().getMondrianCatalogFile( catalogName ) );
   }
 
   public void importSchema( File mondrianFile, String databaseConnection, String parameters ) {

--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/IAclAwarePentahoMetadataDomainRepositoryImporter.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/IAclAwarePentahoMetadataDomainRepositoryImporter.java
@@ -20,11 +20,9 @@ public interface IAclAwarePentahoMetadataDomainRepositoryImporter extends IPenta
   void storeDomain( InputStream inputStream, String domainId, boolean overwrite, RepositoryFileAcl acl )
     throws DomainIdNullException, DomainAlreadyExistsException, DomainStorageException;
 
-  /**
-   * Never returns <tt>null</tt>.
-   * @return    an ACL helper instance
-   */
-  IAclNodeHelper getAclHelper();
+  void setAclFor( String domainId, RepositoryFileAcl acl );
 
-  RepositoryFile getDomainRepositoryFile( String domainId );
+  RepositoryFileAcl getAclFor( String domainId );
+
+  boolean hasAccessFor( String domainId );
 }

--- a/extensions/test-src/org/pentaho/test/platform/plugin/services/metadata/SessionCachingMetadataDomainRepositoryTest.java
+++ b/extensions/test-src/org/pentaho/test/platform/plugin/services/metadata/SessionCachingMetadataDomainRepositoryTest.java
@@ -17,7 +17,6 @@
 
 package org.pentaho.test.platform.plugin.services.metadata;
 
-import org.mockito.Mockito;
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.repository.DomainAlreadyExistsException;
@@ -120,7 +119,7 @@ public class SessionCachingMetadataDomainRepositoryTest extends BaseTest {
     IAclNodeHelper aclNodeHelper = mock( IAclNodeHelper.class );
     when( aclNodeHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
 
-    MockAclAwareMetadataDomainRepository mock = new MockAclAwareMetadataDomainRepository(aclNodeHelper, null);
+    MockAclAwareMetadataDomainRepository mock = new MockAclAwareMetadataDomainRepository( aclNodeHelper, null );
     mock.storeDomain( getTestDomain( ID ), false );
 
     SessionCachingMetadataDomainRepository repo = new SessionCachingMetadataDomainRepository( mock );
@@ -455,7 +454,7 @@ public class SessionCachingMetadataDomainRepositoryTest extends BaseTest {
   }
 
   private static class MockAclAwareMetadataDomainRepository extends MockSessionAwareMetadataDomainRepository implements
-    IAclAwarePentahoMetadataDomainRepositoryImporter {
+      IAclAwarePentahoMetadataDomainRepositoryImporter {
 
     private final IAclNodeHelper aclNodeHelper;
     private final RepositoryFile repositoryFile;
@@ -472,12 +471,19 @@ public class SessionCachingMetadataDomainRepositoryTest extends BaseTest {
       // do nothing
     }
 
-    @Override public IAclNodeHelper getAclHelper() {
-      return aclNodeHelper;
+    @Override
+    public void setAclFor( String domainId, RepositoryFileAcl acl ) {
+      // do nothing
     }
 
-    @Override public RepositoryFile getDomainRepositoryFile( String domainId ) {
-      return repositoryFile;
+    @Override
+    public RepositoryFileAcl getAclFor( String domainId ) {
+      return null;
+    }
+
+    @Override
+    public boolean hasAccessFor( String domainId ) {
+      return aclNodeHelper.canAccess( null, null );
     }
 
     @Override public void storeDomain( InputStream inputStream, String domainId, boolean overwrite )


### PR DESCRIPTION
... datasource

add get/set methods to AclAware interfaces and realizations

@pentaho-nbaker this PR is for https://github.com/pentaho/data-access/pull/592

Diogo offered to add one more interface with common methods for IAclAwareMondrianCatalogService and IAclAwarePentahoMetadataDomainRepositoryImporter. Do you think we need to do this?