### PR TITLE
[BACKLOG-1493]

### DIFF
--- a/api/src/org/pentaho/platform/api/repository2/unified/IAclNodeHelper.java
+++ b/api/src/org/pentaho/platform/api/repository2/unified/IAclNodeHelper.java
@@ -1,0 +1,53 @@
+package org.pentaho.platform.api.repository2.unified;
+
+import java.util.EnumSet;
+
+/**
+ * <p>The interface for operations over ACL nodes.</p>
+ *
+ * <p>Certain entities, such as data sources, are stored in areas of the repository in which non-admin users have no
+ * natural access. In order to provide ACLs on these entities surrogate nodes are created which store the ACLs instead.
+ * Implementations of this class are responsible for storing and querying these surrogate ACL nodes.</p>
+ *
+ *
+ * @author Andrey Khayrutdinov
+ * @author Nick Baker
+ */
+public interface IAclNodeHelper {
+
+  /**
+   * Returns <code>true</code> if the current user has access to <code>repositoryFile</code> by way of ACL node.
+   *
+   * @param repositoryFile file for which to check access by ACL node
+   * @param permissions EnumSet of permissions to check against the repositoryFile
+   * @return <code>true</code> if the user can access the Repository File governed by this ACL node
+   */
+  boolean canAccess( RepositoryFile repositoryFile, EnumSet<RepositoryFilePermission> permissions );
+
+
+  /**
+   * Returns an ACL for <code>repositoryFile</code>. If none exists, <code>null</code> is returned. <b>Note:</b> this
+   * method should be invoked with 'repository admin' privileges.
+   *
+   * @param repositoryFile file for which to retrieve ACLs for
+   * @return ACL rules if exist or <code>null</code> otherwise
+   */
+  RepositoryFileAcl getAclFor( RepositoryFile repositoryFile );
+
+  /**
+   * Sets <code>acl</code> for <code>repositoryFile</code>. If a ACL node does not exist, it is created. If <code>acl</code> is
+   * <code>null</code>, the ACL node is removed.
+   *
+   * @param repositoryFile data source
+   * @param acl            an ACL rules for the data source
+   */
+  void setAclFor( RepositoryFile repositoryFile, RepositoryFileAcl acl );
+
+  /**
+   * Deletes the ACL node associated with the <code>repositoryFile</code> if it exists.
+   *
+   * @param repositoryFile data source
+   */
+  void removeAclFor( RepositoryFile repositoryFile );
+
+}

--- a/api/src/org/pentaho/platform/api/repository2/unified/RepositoryFile.java
+++ b/api/src/org/pentaho/platform/api/repository2/unified/RepositoryFile.java
@@ -141,6 +141,15 @@ public class RepositoryFile implements Comparable<RepositoryFile>, Serializable 
    */
   private final Map<String, Properties> localePropertiesMap;
 
+  /**
+   * A boolean describing if a repository file is acl node or not. The purpose of a acl node is to be a placeholder
+   * for ACLs on another node which cannot have such ACLs on it's own. An example of such a scenario is one where the
+   * node being shadowed is in an area of the repository which prevents any access (/etc/*). Subsystems can create a
+   * acl node in this case to store and check access rules (ACLs), while still preserving the original acled node
+   * in the restricted area.
+   */
+  private final boolean aclNode;
+
   // ~ Constructors
   // ===================================================================================================
 
@@ -151,7 +160,7 @@ public class RepositoryFile implements Comparable<RepositoryFile>, Serializable 
       Serializable versionId, String path, Date createdDate, Date lastModifiedDate, boolean locked, String lockOwner,
       String lockMessage, Date lockDate, String locale, String title, String description,
       String originalParentFolderPath, Date deletedDate, long fileSize, String creatorId,
-      Map<String, Properties> localePropertiesMap ) {
+      Map<String, Properties> localePropertiesMap, boolean aclNode ) {
     super();
     this.id = id;
     this.name = name;
@@ -177,6 +186,20 @@ public class RepositoryFile implements Comparable<RepositoryFile>, Serializable 
     this.creatorId = creatorId;
     this.localePropertiesMap =
         localePropertiesMap != null ? new HashMap<String, Properties>( localePropertiesMap ) : null;
+    this.aclNode = aclNode;
+  }
+
+  /*
+   * This assumes all Serializables are immutable (because they are not defensively copied).
+   */
+  public RepositoryFile( Serializable id, String name, boolean folder, boolean hidden, boolean versioned,
+      Serializable versionId, String path, Date createdDate, Date lastModifiedDate, boolean locked, String lockOwner,
+      String lockMessage, Date lockDate, String locale, String title, String description,
+      String originalParentFolderPath, Date deletedDate, long fileSize, String creatorId,
+      Map<String, Properties> localePropertiesMap ) {
+    this( id, name, folder, hidden, versioned, versionId, path, createdDate, lastModifiedDate, locked, lockOwner,
+        lockMessage, lockDate, locale, title, description, originalParentFolderPath, deletedDate, fileSize, creatorId,
+        localePropertiesMap, false );
   }
 
   // ~ Methods
@@ -281,6 +304,10 @@ public class RepositoryFile implements Comparable<RepositoryFile>, Serializable 
     return deletedDate != null ? new Date( deletedDate.getTime() ) : null;
   }
 
+  public boolean isAclNode() {
+    return aclNode;
+  }
+
   @Override
   public String toString() {
     return ToStringBuilder.reflectionToString( this );
@@ -330,6 +357,8 @@ public class RepositoryFile implements Comparable<RepositoryFile>, Serializable 
 
     private Date deletedDate;
 
+    private boolean aclNode;
+
     public Builder( final String name ) {
       this.name = name;
     }
@@ -349,14 +378,14 @@ public class RepositoryFile implements Comparable<RepositoryFile>, Serializable 
           other.getLockOwner() ).lockMessage( other.getLockMessage() ).title( other.getTitle() ).description(
           other.getDescription() ).locale( other.getLocale() ).originalParentFolderPath(
           other.getOriginalParentFolderPath() ).deletedDate( other.getDeletedDate() ).localePropertiesMap(
-          other.getLocalePropertiesMap() );
+          other.getLocalePropertiesMap() ).aclNode( other.isAclNode() );
     }
 
     public RepositoryFile build() {
       return new RepositoryFile( id, name, this.folder, this.hidden, this.versioned, this.versionId, this.path,
           this.createdDate, this.lastModifiedDate, this.locked, this.lockOwner, this.lockMessage, this.lockDate,
           this.locale, this.title, this.description, this.originalParentFolderPath, this.deletedDate, this.fileSize,
-          this.creatorId, this.localePropertiesMap );
+          this.creatorId, this.localePropertiesMap, this.aclNode );
     }
 
     public Builder createdDate( final Date createdDate1 ) {
@@ -519,6 +548,11 @@ public class RepositoryFile implements Comparable<RepositoryFile>, Serializable 
 
     public Builder locale( final String locale1 ) {
       this.locale = locale1;
+      return this;
+    }
+
+    public Builder aclNode( final boolean aclNode1 ) {
+      this.aclNode = aclNode1;
       return this;
     }
 

--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/IAclAwareMondrianCatalogService.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/IAclAwareMondrianCatalogService.java
@@ -1,0 +1,32 @@
+package org.pentaho.platform.plugin.action.mondrian.catalog;
+
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+
+import java.io.InputStream;
+
+/**
+ * This interface is a temporary solution created to keep backwards compatibility prior to 6.0<br><b>Note: This
+ * interface will be removed in 6.0</b>
+ *
+ * @author Andrey Khayrutdinov
+ */
+public interface IAclAwareMondrianCatalogService extends IMondrianCatalogService {
+
+  /**
+   * Pass the input stream directly from data access PUC and schema workbench
+   *
+   * @param inputStream           stream
+   * @param catalog               catalog
+   * @param overwriteInRepository flag, defining to overwrite existing or not
+   * @param acl                   catalog ACL, <tt>null</tt> means no ACL
+   * @param session               user session
+   */
+  void addCatalog( InputStream inputStream, MondrianCatalog catalog, boolean overwriteInRepository,
+                   RepositoryFileAcl acl, IPentahoSession session );
+
+  void setAclFor( String catalogName, RepositoryFileAcl acl );
+
+  RepositoryFileAcl getAclFor( String catalogName );
+}

--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper.java
@@ -53,8 +53,11 @@ import org.pentaho.platform.api.data.IDBDatasourceService;
 import org.pentaho.platform.api.engine.ICacheManager;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.ObjectFactoryException;
+import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.api.repository2.unified.data.node.DataNode;
 import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFileData;
 import org.pentaho.platform.api.util.XmlParseException;
@@ -64,9 +67,11 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.services.solution.PentahoEntityResolver;
 import org.pentaho.platform.plugin.action.messages.Messages;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogServiceException.Reason;
+import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
 import org.pentaho.platform.repository.solution.filebased.MondrianVfs;
 import org.pentaho.platform.repository.solution.filebased.SolutionRepositoryVfsFileObject;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
+import org.pentaho.platform.repository2.unified.jcr.JcrAclNodeHelper;
 import org.pentaho.platform.util.logging.Logger;
 import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.platform.util.xml.dom4j.XmlDom4JHelper;
@@ -90,6 +95,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -100,7 +106,7 @@ import java.util.Map;
  *
  * @author mlowery
  */
-public class MondrianCatalogHelper implements IMondrianCatalogService {
+public class MondrianCatalogHelper implements IAclAwareMondrianCatalogService {
 
   // ~ Static fields/initializers ======================================================================================
 
@@ -129,12 +135,15 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
    */
   private final boolean useLegacyDbName;
 
+  private IAclNodeHelper aclHelper;
+  private MondrianCatalogRepositoryHelper catalogRepositoryHelper;
+
   public static final String MONDRIAN_DATASOURCE_FOLDER = "mondrian"; //$NON-NLS-1$
 
   // ~ Constructors ====================================================================================================
 
   @SuppressWarnings( "unchecked" )
-  private List<MondrianCatalog> getCatalogs( IPentahoSession pentahoSession ) {
+  protected List<MondrianCatalog> getCatalogs( IPentahoSession pentahoSession ) {
 
     Map<String, MondrianCatalog> catalogsMap =
         (Map<String, MondrianCatalog>) PentahoSystem.getCacheManager( pentahoSession ).getFromRegionCache(
@@ -166,7 +175,7 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
    * @param pentahoSession The session with which this request is associated (Used to locate the cache)
    * @return True if an existing match has been found for the catalog
    */
-  private boolean catalogExists( MondrianCatalog catalog, IPentahoSession pentahoSession ) {
+  protected boolean catalogExists( MondrianCatalog catalog, IPentahoSession pentahoSession ) {
     if ( catalog != null ) {
       MondrianCatalog foundCatalog = getCatalogFromCache( catalog.getName(), pentahoSession );
       // Was the catalog found by name?
@@ -191,7 +200,7 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
     return false;
   }
 
-  private static final MondrianCatalog getCatalogFromCache( String context, IPentahoSession pentahoSession ) {
+  protected MondrianCatalog getCatalogFromCache( String context, IPentahoSession pentahoSession ) {
     // NOTE that the context can be the catalog name or the definition string for the catalog. If you are using the
     // definition string to
     // retrieve the catalog form the cache, you cannot be guaranteed what datasource is in play; so under these
@@ -214,6 +223,13 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
     // IMondrianCatalogService is a singleton; IPentahoSession not required
     return (MondrianCatalogHelper) PentahoSystem
         .get( IMondrianCatalogService.class, "IMondrianCatalogService", null ); //$NON-NLS-1$
+  }
+
+  @VisibleForTesting
+  @Deprecated
+  public MondrianCatalogHelper( IAclNodeHelper aclHelper ) {
+    this();
+    this.aclHelper = aclHelper;
   }
 
   public MondrianCatalogHelper() {
@@ -424,9 +440,9 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
       return new DataSourcesConfig.DataSources( doc );
 
     } catch ( XOMException e ) {
-      throw Util.newError( e, Messages.getInstance().getErrorString(
-          "MondrianCatalogHelper.ERROR_0002_FAILED_TO_PARSE_DATASOURCE_CONFIG",
-          dataSourcesConfigString ) ); //$NON-NLS-1$
+      throw Util.newError( e, Messages.getInstance()
+          .getErrorString( "MondrianCatalogHelper.ERROR_0002_FAILED_TO_PARSE_DATASOURCE_CONFIG",
+              dataSourcesConfigString ) ); //$NON-NLS-1$
     }
   }
 
@@ -550,31 +566,31 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public void addCatalog( InputStream inputStream, MondrianCatalog catalog, boolean overwriteInRepossitory,
+                                    IPentahoSession session ) {
+    addCatalog( inputStream, catalog, overwriteInRepossitory, null, session );
+  }
+
+  /**
    * new method to pass the input stream directly from data access put and post schema
    *
    * @param schemaInputStream
    * @param catalog
    * @param overwrite
+   * @param acl                 catalog ACL
    * @param pentahoSession
    * @throws MondrianCatalogServiceException
    */
   public synchronized void addCatalog( InputStream schemaInputStream, final MondrianCatalog catalog,
-      final boolean overwrite, final IPentahoSession pentahoSession )
+      final boolean overwrite, RepositoryFileAcl acl, final IPentahoSession pentahoSession )
     throws MondrianCatalogServiceException {
     if ( MondrianCatalogHelper.logger.isDebugEnabled() ) {
       MondrianCatalogHelper.logger.debug( "addCatalog" ); //$NON-NLS-1$
     }
 
     init( pentahoSession );
-
-    // do an access check first
-    if ( !hasAccess( catalog, CatalogPermission.WRITE, pentahoSession ) ) {
-      if ( MondrianCatalogHelper.logger.isDebugEnabled() ) {
-        MondrianCatalogHelper.logger.debug( "user does not have access; throwing exception" ); //$NON-NLS-1$
-      }
-      throw new MondrianCatalogServiceException( Messages.getInstance().getErrorString(
-          "MondrianCatalogHelper.ERROR_0003_INSUFFICIENT_PERMISSION" ), Reason.ACCESS_DENIED ); //$NON-NLS-1$
-    }
 
     // check for existing dataSourceInfo+catalog
     if ( catalogExists( catalog, pentahoSession ) && !overwrite ) {
@@ -601,9 +617,7 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
           Reason.XMLA_SCHEMA_NAME_EXISTS );
     }
     try {
-      org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper helper =
-          new org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper( PentahoSystem
-              .get( IUnifiedRepository.class ) );
+      MondrianCatalogRepositoryHelper helper = getMondrianCatalogRepositoryHelper();
       helper.addHostedCatalog( schemaInputStream, catalog.getName(), catalog.getDataSourceInfo() );
     } catch ( Exception e ) {
       throw new MondrianCatalogServiceException( Messages.getInstance().getErrorString(
@@ -616,6 +630,36 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
           .debug( "refreshing from dataSourcesConfig (" + dataSourcesConfig + ")" ); //$NON-NLS-1$ //$NON-NLS-2$
     }
     reInit( pentahoSession );
+
+    setAclFor( catalog.getName(), acl );
+  }
+
+  protected IUnifiedRepository getRepository() {
+    return PentahoSystem.get( IUnifiedRepository.class );
+  }
+
+  protected synchronized MondrianCatalogRepositoryHelper getMondrianCatalogRepositoryHelper() {
+    if ( catalogRepositoryHelper == null ) {
+      catalogRepositoryHelper = new MondrianCatalogRepositoryHelper( PentahoSystem.get( IUnifiedRepository.class ) );
+    }
+    return catalogRepositoryHelper;
+  }
+
+  protected synchronized IAclNodeHelper getAclHelper() {
+    if ( aclHelper == null ) {
+      aclHelper = new JcrAclNodeHelper( PentahoSystem.get( IUnifiedRepository.class ) );
+    }
+    return aclHelper;
+  }
+
+  @Override
+  public void setAclFor( String catalogName, RepositoryFileAcl acl ) {
+    getAclHelper().setAclFor( getMondrianCatalogRepositoryHelper().getMondrianCatalogFile( catalogName ), acl );
+  }
+
+  @Override
+  public RepositoryFileAcl getAclFor( String catalogName ) {
+    return getAclHelper().getAclFor( getMondrianCatalogRepositoryHelper().getMondrianCatalogFile( catalogName ) );
   }
 
   public void importSchema( File mondrianFile, String databaseConnection, String parameters ) {
@@ -712,7 +756,7 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
 
     MondrianCatalog cat = getCatalogFromCache( context, pentahoSession );
     if ( null != cat ) {
-      if ( hasAccess( cat, CatalogPermission.READ, pentahoSession ) ) {
+      if ( hasAccess( cat, RepositoryFilePermission.READ ) ) {
         return cat;
       } else {
         if ( MondrianCatalogHelper.logger.isDebugEnabled() ) {
@@ -976,7 +1020,7 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
       final boolean jndiOnly ) {
     List<MondrianCatalog> filtered = new ArrayList<MondrianCatalog>();
     for ( MondrianCatalog orig : origList ) {
-      if ( hasAccess( orig, CatalogPermission.READ, pentahoSession ) && ( !jndiOnly || orig.isJndi() ) ) {
+      if ( hasAccess( orig, RepositoryFilePermission.READ ) && ( !jndiOnly || orig.isJndi() ) ) {
         filtered.add( orig );
       }
     }
@@ -990,11 +1034,8 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
    * <p/>
    * Why is this class even enforcing security anyway!?
    */
-  protected boolean hasAccess( final MondrianCatalog cat, final CatalogPermission perm,
-      final IPentahoSession pentahoSession ) {
-    // IUnifiedRepository unifiedRepository = PentahoSystem.get(IUnifiedRepository.class);
-    // unifiedRepository.hasAccess(null, null);
-    return true;
+  protected boolean hasAccess( MondrianCatalog cat, RepositoryFilePermission permission ) {
+    return getAclHelper().canAccess( getMondrianCatalogRepositoryHelper().getMondrianCatalogFile( cat.getName() ), EnumSet.of( permission ) );
   }
 
   protected String getSolutionRepositoryRelativePath( final String path, final IPentahoSession pentahoSession ) {
@@ -1105,7 +1146,7 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
     // do an access check first
     //
 
-    if ( !hasAccess( catalog, CatalogPermission.WRITE, pentahoSession ) ) {
+    if ( !hasAccess( catalog, RepositoryFilePermission.WRITE ) ) {
       if ( MondrianCatalogHelper.logger.isDebugEnabled() ) {
         MondrianCatalogHelper.logger.debug( "user does not have access; throwing exception" ); //$NON-NLS-1$
       }
@@ -1113,10 +1154,13 @@ public class MondrianCatalogHelper implements IMondrianCatalogService {
           "MondrianCatalogHelper.ERROR_0003_INSUFFICIENT_PERMISSION" ), Reason.ACCESS_DENIED ); //$NON-NLS-1$
     }
 
-    IUnifiedRepository solutionRepository = PentahoSystem.get( IUnifiedRepository.class );
+    getAclHelper().removeAclFor( getMondrianCatalogRepositoryHelper().getMondrianCatalogFile( catalog.getName() ) );
+
+    IUnifiedRepository solutionRepository = getRepository();
     RepositoryFile deletingFile = solutionRepository.getFile( RepositoryFile.SEPARATOR + "etc" //$NON-NLS-1$
         + RepositoryFile.SEPARATOR + "mondrian" + RepositoryFile.SEPARATOR + catalog.getName() ); //$NON-NLS-1$
     solutionRepository.deleteFile( deletingFile.getId(), true, "" ); //$NON-NLS-1$
     reInit( pentahoSession );
+
   }
 }

--- a/extensions/src/org/pentaho/platform/plugin/services/importer/MetadataImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/MetadataImportHandler.java
@@ -29,6 +29,7 @@ import org.pentaho.metadata.repository.DomainStorageException;
 import org.pentaho.metadata.util.XmiParser;
 import org.pentaho.platform.plugin.services.importer.mimeType.MimeType;
 import org.pentaho.platform.plugin.services.importexport.PentahoMetadataFileInfo;
+import org.pentaho.platform.plugin.services.metadata.IAclAwarePentahoMetadataDomainRepositoryImporter;
 import org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryImporter;
 import org.pentaho.platform.repository.RepositoryFilenameUtils;
 import org.pentaho.platform.repository.messages.Messages;
@@ -99,7 +100,15 @@ public class MetadataImportHandler implements IPlatformImportHandler {
         inputStream = StripDswFromStream( bundle.getInputStream() );
       }
 
-      metadataRepositoryImporter.storeDomain( inputStream, domainId, bundle.overwriteInRepository() );
+      if ( metadataRepositoryImporter instanceof IAclAwarePentahoMetadataDomainRepositoryImporter ) {
+        IAclAwarePentahoMetadataDomainRepositoryImporter importer =
+          (IAclAwarePentahoMetadataDomainRepositoryImporter) metadataRepositoryImporter;
+
+        importer.storeDomain( inputStream, domainId, bundle.overwriteInRepository(),
+          bundle.isApplyAclSettings() ? bundle.getAcl() : null );
+      } else {
+        metadataRepositoryImporter.storeDomain( inputStream, domainId, bundle.overwriteInRepository() );
+      }
       return domainId;
     } catch ( DomainIdNullException dine ) {
       throw new PlatformImportException( dine.getMessage(), PlatformImportException.PUBLISH_TO_SERVER_FAILED, dine );

--- a/extensions/src/org/pentaho/platform/plugin/services/importexport/legacy/MondrianCatalogRepositoryHelper.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importexport/legacy/MondrianCatalogRepositoryHelper.java
@@ -435,6 +435,10 @@ public class MondrianCatalogRepositoryHelper {
     return values;
   }
 
+  public RepositoryFile getMondrianCatalogFile(String catalogName) {
+    return repository.getFile( ETC_MONDRIAN_JCR_FOLDER + RepositoryFile.SEPARATOR + catalogName );
+  }
+
   /*
    * Creates "/etc/mondrian/<catalog>"
    */
@@ -445,9 +449,9 @@ public class MondrianCatalogRepositoryHelper {
      * alternate implementation. Use catalog name.
      */
 
-    RepositoryFile etcMondrian = repository.getFile( ETC_MONDRIAN_JCR_FOLDER );
-    RepositoryFile catalog = repository.getFile( ETC_MONDRIAN_JCR_FOLDER + RepositoryFile.SEPARATOR + catalogName );
+    RepositoryFile catalog = getMondrianCatalogFile( catalogName );
     if ( catalog == null ) {
+      RepositoryFile etcMondrian = repository.getFile( ETC_MONDRIAN_JCR_FOLDER );
       catalog =
           repository.createFolder( etcMondrian.getId(), new RepositoryFile.Builder( catalogName ).folder( true )
               .build(), "" );

--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/CachingPentahoMetadataDomainRepository.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/CachingPentahoMetadataDomainRepository.java
@@ -122,7 +122,8 @@ public class CachingPentahoMetadataDomainRepository extends PentahoMetadataDomai
   @Override
   public void reloadDomains() {
     flushDomains();
-    getDomainIds();
+    // it causes stack overflow
+    //getDomainIds();
   }
 
   /**

--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/IAclAwarePentahoMetadataDomainRepositoryImporter.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/IAclAwarePentahoMetadataDomainRepositoryImporter.java
@@ -1,0 +1,28 @@
+package org.pentaho.platform.plugin.services.metadata;
+
+import org.pentaho.metadata.repository.DomainAlreadyExistsException;
+import org.pentaho.metadata.repository.DomainIdNullException;
+import org.pentaho.metadata.repository.DomainStorageException;
+import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.plugin.action.mondrian.catalog.IAclAwareMondrianCatalogService;
+
+import java.io.InputStream;
+
+/**
+ * This interface is a temporary solution created to keep backwards compatibility prior to 6.0<br><b>Note: This
+ * interface will be removed in 6.0</b>
+ * @author Andrey Khayrutdinov
+ */
+public interface IAclAwarePentahoMetadataDomainRepositoryImporter extends IPentahoMetadataDomainRepositoryImporter {
+
+  void storeDomain( InputStream inputStream, String domainId, boolean overwrite, RepositoryFileAcl acl )
+    throws DomainIdNullException, DomainAlreadyExistsException, DomainStorageException;
+
+  void setAclFor( String domainId, RepositoryFileAcl acl );
+
+  RepositoryFileAcl getAclFor( String domainId );
+
+  boolean hasAccessFor( String domainId );
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/SessionCachingMetadataDomainRepository.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/SessionCachingMetadataDomainRepository.java
@@ -30,6 +30,7 @@ import org.pentaho.metadata.util.SecurityHelper;
 import org.pentaho.platform.api.engine.ICacheManager;
 import org.pentaho.platform.api.engine.ILogoutListener;
 import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 
@@ -40,13 +41,14 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * This is the platform implementation which provides session-based caching for an existing
- * {@link IMetadataDomainRepository}.
- * 
+ * This is the platform implementation which provides session-based caching for an existing {@link
+ * IMetadataDomainRepository}.
+ *
  * @author Jordan Ganoff (jganoff@pentaho.com)
  */
 public class SessionCachingMetadataDomainRepository implements IMetadataDomainRepository,
-    org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter, ILogoutListener {
+    org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter, ILogoutListener,
+    IAclAwarePentahoMetadataDomainRepositoryImporter {
 
   private static final Log logger = LogFactory.getLog( SessionCachingMetadataDomainRepository.class );
 
@@ -57,7 +59,7 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
 
   private ICacheManager cacheManager;
 
-  private IMetadataDomainRepository delegate;
+  private final IMetadataDomainRepository delegate;
   private static final String DOMAIN_CACHE_KEY_PREDICATE = "domain-id-cache-for-session:";
 
   /**
@@ -69,7 +71,8 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
     public String sessionId;
     public String domainId;
 
-    protected CacheKey() { }
+    protected CacheKey() {
+    }
 
     public CacheKey( String sessionId, String domainId ) {
       this.sessionId = sessionId;
@@ -118,6 +121,7 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
       throw new NullPointerException();
     }
     this.delegate = delegate;
+
     cacheManager = PentahoSystem.getCacheManager( null ); // cache manager gets loaded just once...
     if ( cacheManager != null ) {
       if ( !cacheManager.cacheEnabled( CACHE_REGION ) ) {
@@ -127,7 +131,8 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
       }
     }
     if ( cacheManager == null ) {
-      throw new IllegalStateException( getClass().getSimpleName() + " (" + CACHE_REGION + ") cannot be initialized" ); //$NON-NLS-1$ //$NON-NLS-2$
+      throw new IllegalStateException(
+        getClass().getSimpleName() + " (" + CACHE_REGION + ") cannot be initialized" ); //$NON-NLS-1$ //$NON-NLS-2$
     }
     PentahoSystem.addLogoutListener( this ); // So you can remove a users' region when their session disappears
   }
@@ -138,11 +143,9 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
   protected static interface CacheIteratorCallback {
     /**
      * Will be called for each cache key found
-     * 
-     * @param cacheManager
-     *          The cache manager we're iterating through
-     * @param key
-     *          Key from cache manager
+     *
+     * @param cacheManager The cache manager we're iterating through
+     * @param key          Key from cache manager
      * @return Returning false will cause the look that is calling this callback to break
      */
     public Boolean call( final ICacheManager cacheManager, final CacheKey key );
@@ -164,9 +167,8 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
 
   /**
    * Calls the callback for every key in the cache region
-   * 
-   * @param callback
-   *          {@see CacheCallback}
+   *
+   * @param callback {@see CacheCallback}
    */
   protected void forAllKeys( final CacheIteratorCallback callback ) {
     try {
@@ -194,11 +196,9 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
 
   /**
    * Calls the callback for every key in the cache region whose session id matches the provided session's id.
-   * 
-   * @param session
-   *          Session to use for matching keys
-   * @param callback
-   *          {@see CacheCallback}
+   *
+   * @param session  Session to use for matching keys
+   * @param callback {@see CacheCallback}
    */
   protected void forAllKeysInSession( final IPentahoSession session, final CacheIteratorCallback callback ) {
     forAllKeys( new CacheIteratorCallback() {
@@ -223,6 +223,10 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
       if ( logger.isDebugEnabled() ) {
         logger.debug( "Found domain in cache: " + key ); //$NON-NLS-1$
       }
+      if ( delegate instanceof IAclAwarePentahoMetadataDomainRepositoryImporter && !( (IAclAwarePentahoMetadataDomainRepositoryImporter) delegate ).hasAccessFor( id ) ) {
+        purgeDomain( domain.getId() );
+        domain = null;
+      }
       return domain;
     }
     domain = delegate.getDomain( id );
@@ -240,9 +244,8 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
 
   /**
    * Remove all cache entries whose domain's id is equal to {@code domainId}.
-   * 
-   * @param domainId
-   *          Domain id to remove from cache
+   *
+   * @param domainId Domain id to remove from cache
    */
   private void purgeDomain( final String domainId ) {
     forAllKeys( new CacheIteratorCallback() {
@@ -305,7 +308,7 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
 
   /**
    * Remove domain ID cache for a given session
-   * 
+   *
    * @param session
    */
   protected void clearDomainIdsFromCache( IPentahoSession session ) {
@@ -317,7 +320,7 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
 
   /**
    * Remove a single domain ID from all session domain ID caches
-   * 
+   *
    * @param domainId
    */
   private void removeDomainFromIDCache( String domainId ) {
@@ -379,6 +382,19 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
     final String domainKey = generateDomainIdCacheKeyForSession( session );
     Set<String> domainIds = (Set<String>) cacheManager.getFromRegionCache( CACHE_REGION, domainKey );
     if ( domainIds != null ) {
+      boolean dirtyCache = false;
+
+      for ( String domain : domainIds ) {
+        if ( delegate instanceof IAclAwarePentahoMetadataDomainRepositoryImporter && !( (IAclAwarePentahoMetadataDomainRepositoryImporter) delegate ).hasAccessFor( domain ) ) {
+          domainIds.remove( domain );
+          removeDomainFromIDCache( domain );
+          dirtyCache = true;
+        }
+      }
+
+      if ( dirtyCache ) {
+        cacheManager.putInRegionCache( CACHE_REGION, domainKey, new HashSet<String>( domainIds ) );
+      }
       // We've previously cached domainIds available for this session
       return domainIds;
     }
@@ -407,9 +423,56 @@ public class SessionCachingMetadataDomainRepository implements IMetadataDomainRe
   public Map<String, InputStream> getDomainFilesData( final String domainId ) {
     if ( delegate instanceof org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter ) {
       return ( (org.pentaho.platform.plugin.services.metadata.IPentahoMetadataDomainRepositoryExporter) delegate )
-          .getDomainFilesData( domainId );
+        .getDomainFilesData( domainId );
     } else {
       throw new UnsupportedOperationException( "Exporting is not supported by this Metadata Domain Repository" );
+    }
+  }
+
+  @Override
+  public void storeDomain( InputStream inputStream, String domainId, boolean overwrite, RepositoryFileAcl acl )
+    throws DomainIdNullException, DomainAlreadyExistsException, DomainStorageException {
+    if ( delegate instanceof IAclAwarePentahoMetadataDomainRepositoryImporter ) {
+      ( (IAclAwarePentahoMetadataDomainRepositoryImporter) delegate ).storeDomain( inputStream, domainId, overwrite, acl );
+    }
+  }
+
+  @Override
+  public void setAclFor( String domainId, RepositoryFileAcl acl ) {
+    if ( delegate instanceof IAclAwarePentahoMetadataDomainRepositoryImporter ) {
+      ( (IAclAwarePentahoMetadataDomainRepositoryImporter) delegate ).setAclFor( domainId, acl );
+    }
+  }
+
+  @Override
+  public RepositoryFileAcl getAclFor( String domainId ) {
+    if ( delegate instanceof IAclAwarePentahoMetadataDomainRepositoryImporter ) {
+      return ( (IAclAwarePentahoMetadataDomainRepositoryImporter) delegate ).getAclFor( domainId );
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public boolean hasAccessFor( String domainId ) {
+    return !( delegate instanceof IAclAwarePentahoMetadataDomainRepositoryImporter )
+      || ( (IAclAwarePentahoMetadataDomainRepositoryImporter) delegate ).hasAccessFor( domainId );
+  }
+
+  @Override
+  public void storeDomain( InputStream inputStream, String domainId, boolean overwrite ) throws DomainIdNullException,
+    DomainAlreadyExistsException, DomainStorageException {
+    if ( delegate instanceof IPentahoMetadataDomainRepositoryImporter ) {
+      ( (IAclAwarePentahoMetadataDomainRepositoryImporter) delegate ).storeDomain( inputStream, domainId, overwrite );
+    }
+  }
+
+  @Override
+  public void addLocalizationFile( String domainId, String locale, InputStream inputStream, boolean overwrite )
+    throws DomainStorageException {
+    if ( delegate instanceof IPentahoMetadataDomainRepositoryImporter ) {
+      ( (IAclAwarePentahoMetadataDomainRepositoryImporter) delegate ).addLocalizationFile( domainId, locale,
+          inputStream, overwrite );
     }
   }
 }

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/JaxbList.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/JaxbList.java
@@ -19,10 +19,15 @@ package org.pentaho.platform.web.http.api.resources;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAccessType;
+
 import java.util.List;
 
 @XmlRootElement( name = "List" )
+@XmlAccessorType( XmlAccessType.FIELD )
 public class JaxbList<T> {
+  @XmlElement( name = "Item" )
   protected List<T> list;
 
   public JaxbList() {
@@ -32,8 +37,11 @@ public class JaxbList<T> {
     this.list = list;
   }
 
-  @XmlElement( name = "Item" )
   public List<T> getList() {
     return list;
+  }
+
+  public void setList( List<T> list ) {
+    this.list = list;
   }
 }

--- a/extensions/test-src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperTest.java
@@ -32,22 +32,31 @@ import org.pentaho.platform.api.engine.IUserRoleListService;
 import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.api.util.IPasswordService;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.platform.engine.core.system.SystemSettings;
 import org.pentaho.platform.plugin.services.cache.CacheManager;
+import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
+import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
 import org.pentaho.platform.util.Base64PasswordService;
+import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.pentaho.test.platform.plugin.UserRoleMapperTest.TestUserRoleListService;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.StringContains.containsString;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -59,12 +68,15 @@ import static org.pentaho.platform.repository2.unified.UnifiedRepositoryTestUtil
 @SuppressWarnings( "nls" )
 public class MondrianCatalogHelperTest {
 
+  private static final String CATALOG_NAME = "SteelWheels";
+
   // ~ Instance fields
   // =================================================================================================
 
   private static MicroPlatform booter;
   private ICacheManager cacheMgr;
   private static IUnifiedRepository repo;
+  private MondrianCatalogHelper helper;
 
   @BeforeClass
   public static void setUpClass() throws Exception {
@@ -74,7 +86,7 @@ public class MondrianCatalogHelperTest {
     booter.define( IPasswordService.class, Base64PasswordService.class, Scope.GLOBAL );
     booter.define( IDatabaseConnection.class, DatabaseConnection.class, Scope.GLOBAL );
     booter.define( IDatabaseDialectService.class, DatabaseDialectService.class, Scope.GLOBAL );
-    booter.define( IMondrianCatalogService.class, MondrianCatalogHelper.class, Scope.GLOBAL );
+    booter.define( IAclAwareMondrianCatalogService.class, MondrianCatalogHelper.class, Scope.GLOBAL );
     booter.define( ICacheManager.class, CacheManager.class, Scope.GLOBAL );
     booter.define( IUserRoleListService.class, TestUserRoleListService.class, Scope.GLOBAL );
     booter.defineInstance( IUnifiedRepository.class, repo );
@@ -91,6 +103,8 @@ public class MondrianCatalogHelperTest {
     // Clear up the cache
     cacheMgr = PentahoSystem.getCacheManager( null );
     cacheMgr.clearRegionCache( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION );
+
+    helper = (MondrianCatalogHelper) PentahoSystem.get( IAclAwareMondrianCatalogService.class );
   }
 
   @After
@@ -98,12 +112,44 @@ public class MondrianCatalogHelperTest {
     reset( repo );
   }
 
+
+  private void initMondrianCatalogsCache() {
+    initMondrianCatalogsCache( new HashMap<String, MondrianCatalog>(  ) );
+  }
+
+  private void initMondrianCatalogsCache(Map<String, MondrianCatalog> map) {
+    cacheMgr.addCacheRegion( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION );
+    cacheMgr.putInRegionCache( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION, LocaleHelper.getLocale().toString(), map );
+  }
+
+
+  private MondrianCatalog createTestCatalog() {
+    MondrianSchema schema = new MondrianSchema( CATALOG_NAME, null );
+    return  new MondrianCatalog( CATALOG_NAME, "Provider=mondrian;DataSource=SampleData;",
+        "solution:test/charts/steelwheels.mondrian.xml", schema );
+  }
+
+
+  @Test(expected = MondrianCatalogServiceException.class)
+  public void addCatalog_WhenAlreadyExists() throws Exception {
+    MondrianCatalog cat = createTestCatalog();
+    initMondrianCatalogsCache( Collections.singletonMap( CATALOG_NAME, cat ) );
+
+    helper = spy( helper );
+
+    IPentahoSession session = mock( IPentahoSession.class );
+    doNothing().when( helper ).init( session );
+
+    helper.addCatalog( new ByteArrayInputStream( new byte[0] ), cat, false, null, session );
+  }
+
+
   @Test
   public void testAddCatalog() throws Exception {
     final String mondrianFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "mondrian";
     stubGetFolder( repo, mondrianFolderPath );
     stubGetChildren( repo, mondrianFolderPath ); // return no children
-    final String steelWheelsFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + "SteelWheels";
+    final String steelWheelsFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + CATALOG_NAME;
     stubGetFileDoesNotExist( repo, steelWheelsFolderPath );
     stubCreateFolder( repo, steelWheelsFolderPath );
     final String metadataPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "metadata";
@@ -114,16 +160,18 @@ public class MondrianCatalogHelperTest {
     stubGetChildren( repo, olapFolderPath ); // return no children
 
     IPentahoSession session = new StandaloneSession( "admin" );
-    MondrianCatalogHelper helper = (MondrianCatalogHelper) PentahoSystem.get( IMondrianCatalogService.class );
 
-    MondrianSchema schema = new MondrianSchema( "SteelWheels", null );
-    MondrianCatalog cat =
-        new MondrianCatalog( "SteelWheels", "Provider=mondrian;DataSource=SampleData;",
-            "solution:test/charts/steelwheels.mondrian.xml", schema );
+    MondrianCatalog cat = createTestCatalog();
     File file = new File( "test-src/solution/test/charts/steelwheels.mondrian.xml" );
     String mondrianSchema = IOUtils.toString( new FileInputStream( file ) );
     session.setAttribute( "MONDRIAN_SCHEMA_XML_CONTENT", mondrianSchema );
-    helper.addCatalog( cat, false, session );
+
+    MondrianCatalogHelper helperSpy = spy( helper );
+    IAclNodeHelper aclNodeHelper = mock( IAclNodeHelper.class );
+    doNothing().when( aclNodeHelper ).setAclFor( any( RepositoryFile.class ), any( RepositoryFileAcl.class ) );
+    doReturn( aclNodeHelper ).when( helperSpy ).getAclHelper();
+
+    helperSpy.addCatalog( cat, false, session );
 
     verify( repo ).createFile(
         eq( makeIdObject( steelWheelsFolderPath ) ),
@@ -138,8 +186,39 @@ public class MondrianCatalogHelperTest {
   }
 
   @Test
-  public void testImportSchema() throws Exception {
+  public void addCatalog_WithAcl() throws Exception {
+    initMondrianCatalogsCache();
 
+    MondrianCatalogHelper helperSpy = spy( helper );
+
+    IPentahoSession session = mock( IPentahoSession.class );
+    doNothing().when( helperSpy ).init( session );
+
+    doReturn( Collections.<MondrianCatalog>emptyList()).when( helperSpy ).getCatalogs( session );
+    doReturn( null ).when( helperSpy ).makeSchema( anyString() );
+
+    MondrianCatalog cat = createTestCatalog();
+    RepositoryFileAcl acl = mock( RepositoryFileAcl.class );
+
+    IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
+    doNothing().when( aclHelper ).setAclFor( any( RepositoryFile.class ), eq( acl ) );
+    doReturn( aclHelper ).when( helperSpy ).getAclHelper();
+    doReturn( null ).when( helperSpy ).makeSchema( CATALOG_NAME );
+    doReturn( true ).when( helperSpy ).catalogExists( any( MondrianCatalog.class ), eq( session ) );
+
+    MondrianCatalogRepositoryHelper repositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
+    doReturn( repositoryHelper ).when( helperSpy ).getMondrianCatalogRepositoryHelper();
+
+    helperSpy.addCatalog( new ByteArrayInputStream( new byte[0] ), cat, true, acl, session );
+    verify( aclHelper, times( 1 ) ).setAclFor( any( RepositoryFile.class ), eq( acl ) );
+
+    doNothing().when( aclHelper ).setAclFor( any( RepositoryFile.class ), any( RepositoryFileAcl.class ) );
+    helperSpy.addCatalog( new ByteArrayInputStream( new byte[0] ), cat, true, null, session );
+    verify( aclHelper, times( 2 ) ).setAclFor( any( RepositoryFile.class ), any( RepositoryFileAcl.class ) );
+  }
+
+  @Test
+  public void testImportSchema() throws Exception {
     String TMP_FILE_PATH = File.separatorChar + "test" + File.separatorChar + "analysis" + File.separatorChar;
     String uploadDir = PentahoSystem.getApplicationContext().getSolutionPath( TMP_FILE_PATH );
     File mondrianFile = new File( uploadDir + File.separatorChar + "SampleData.mondrian.xml" );
@@ -160,15 +239,13 @@ public class MondrianCatalogHelperTest {
     stubGetFolder( repo, olapFolderPath );
     stubGetChildren( repo, olapFolderPath ); // return no children
 
-    MondrianCatalogHelper helper = (MondrianCatalogHelper) PentahoSystem.get( IMondrianCatalogService.class );
     helper.importSchema( mondrianFile, "SampleData", "" );
 
-    verify( repo ).createFile(
-        eq( makeIdObject( sampleDataFolderPath ) ),
-        argThat( isLikeFile( makeFileObject( metadataPath ) ) ),
-        argThat( hasData( pathPropertyPair( "/catalog/definition", "mondrian:/" + "SampleData" ), pathPropertyPair(
-            "/catalog/datasourceInfo", "Provider=mondrian;DataSource=SampleData" ) ) ), anyString()
-    );
+    verify( repo ).createFile( eq( makeIdObject( sampleDataFolderPath ) ),
+        argThat( isLikeFile( makeFileObject( metadataPath ) ) ), argThat(
+            hasData( pathPropertyPair( "/catalog/definition", "mondrian:/" + "SampleData" ),
+                pathPropertyPair( "/catalog/datasourceInfo", "Provider=mondrian;DataSource=SampleData" ) ) ),
+        anyString() );
     verify( repo ).createFile( eq( makeIdObject( sampleDataFolderPath ) ),
         argThat( isLikeFile( makeFileObject( sampleDataFolderPath + RepositoryFile.SEPARATOR + "schema.xml" ) ) ),
         any( IRepositoryFileData.class ), anyString() );
@@ -210,10 +287,20 @@ public class MondrianCatalogHelperTest {
     stubGetData( repo, steelWheelsSchemaPath, mondrianSchema1 );
 
     IPentahoSession session = new StandaloneSession( "admin" );
-    MondrianCatalogHelper helper = (MondrianCatalogHelper) PentahoSystem.get( IMondrianCatalogService.class );
 
-    List<MondrianCatalog> cats = helper.listCatalogs( session, false );
-    Assert.assertEquals( 2, cats.size() );
+    helper = spy( helper );
+
+    IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
+    when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
+    doReturn( aclHelper ).when( helper ).getAclHelper();
+
+    MondrianCatalog[] testCatalogs = new MondrianCatalog[] { spy( createTestCatalog() ), spy( createTestCatalog() ) };
+    doReturn( true ).when( testCatalogs[ 0 ] ).isJndi();
+    doReturn( false ).when( testCatalogs[ 1 ] ).isJndi();
+    doReturn( asList( testCatalogs ) ).when( helper ).getCatalogs( session );
+
+    List<MondrianCatalog> cats = helper.listCatalogs( session, true );
+    assertEquals( 1, cats.size() );
   }
 
   @Test
@@ -229,20 +316,69 @@ public class MondrianCatalogHelperTest {
     final String steelWheelsMetadataPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "metadata";
     final String steelWheelsSchemaPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "schema.xml";
     stubGetFile( repo, steelWheelsMetadataPath );
-    stubGetData( repo, steelWheelsMetadataPath, "catalog", pathPropertyPair( "/catalog/definition",
-        "mondrian:/SteelWheels" ), pathPropertyPair( "/catalog/datasourceInfo",
-        "Provider=mondrian;DataSource=SteelWheels;" ) );
+    stubGetData( repo, steelWheelsMetadataPath, "catalog",
+        pathPropertyPair( "/catalog/definition", "mondrian:/SteelWheels" ),
+        pathPropertyPair( "/catalog/datasourceInfo", "Provider=mondrian;DataSource=SteelWheels;" ) );
     stubGetFile( repo, steelWheelsSchemaPath );
     stubGetData( repo, steelWheelsSchemaPath, mondrianSchema1 );
 
     stubGetFolder( repo, steelWheelsFolderPath );
 
     IPentahoSession session = new StandaloneSession( "admin" );
-    MondrianCatalogHelper helper = (MondrianCatalogHelper) PentahoSystem.get( IMondrianCatalogService.class );
+
+    helper = spy( helper );
+    IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
+    when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
+    doReturn( aclHelper ).when( helper ).getAclHelper();
+
+    MondrianCatalogRepositoryHelper repositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
+    doReturn( repositoryHelper ).when( helper ).getMondrianCatalogRepositoryHelper();
 
     helper.removeCatalog( "mondrian:/SteelWheels", session );
 
     verify( repo ).deleteFile( eq( makeIdObject( steelWheelsFolderPath ) ), eq( true ), anyString() );
+  }
+
+  @Test
+  public void removeCatalog_WithAcl() throws Exception {
+    IPentahoSession session = mock( IPentahoSession.class );
+
+    helper = spy( helper );
+    doReturn( createTestCatalog() ).when( helper ).getCatalog( eq( CATALOG_NAME ), eq( session ) );
+    doNothing().when( helper ).reInit( eq( session ) );
+
+    MondrianCatalogRepositoryHelper repositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
+    doReturn( repositoryHelper ).when( helper ).getMondrianCatalogRepositoryHelper();
+
+    IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
+    when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
+    doReturn( aclHelper ).when( helper ).getAclHelper();
+
+    RepositoryFile file = mock( RepositoryFile.class );
+    when( file.getId() ).thenReturn( "1" );
+    when( repo.getFile( "/etc/mondrian/" + CATALOG_NAME ) ).thenReturn( file );
+
+    helper.removeCatalog( CATALOG_NAME, session );
+
+    verify( aclHelper ).removeAclFor( any( RepositoryFile.class ) );
+  }
+
+  @Test(expected = MondrianCatalogServiceException.class)
+  public void removeCatalog_WhenProhibited() throws Exception {
+    IPentahoSession session = mock( IPentahoSession.class );
+
+    helper = spy( helper );
+    doReturn( createTestCatalog() ).when( helper ).getCatalog( eq( CATALOG_NAME ), eq( session ) );
+    doNothing().when( helper ).reInit( eq( session ) );
+
+    MondrianCatalogRepositoryHelper repositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
+    doReturn( repositoryHelper ).when( helper ).getMondrianCatalogRepositoryHelper();
+
+    IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
+    when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( false );
+    doReturn( aclHelper ).when( helper ).getAclHelper();
+
+    helper.removeCatalog( CATALOG_NAME, session );
   }
 
   @Test
@@ -253,7 +389,6 @@ public class MondrianCatalogHelperTest {
         "DynamicSchemaProcessor=org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogHelperTest$DynamicDSPTest";
     final String SCHEMA_MOCK = "Test Schema Mock " + replaceTemplate;
 
-    MondrianCatalogHelper helper = (MondrianCatalogHelper) PentahoSystem.get( IMondrianCatalogService.class );
     MondrianCatalogHelper helperSpy = spy( helper );
     IPentahoSession session = new StandaloneSession( "admin" );
     String schema = helperSpy.applyDSP( session, DATA_SOURCE_INFO_WITH_DSP, SCHEMA_MOCK );
@@ -269,7 +404,6 @@ public class MondrianCatalogHelperTest {
     final String DATA_SOURCE_INFO_WITHOUT_DSP = "DataSource=TestDataSource";
     final String SCHEMA_MOCK = "Test Schema Mock " + replaceTemplate;
 
-    MondrianCatalogHelper helper = (MondrianCatalogHelper) PentahoSystem.get( IMondrianCatalogService.class );
     MondrianCatalogHelper helperSpy = spy( helper );
     doReturn( SCHEMA_MOCK ).when( helperSpy ).docAtUrlToString( anyString(), any( IPentahoSession.class ) );
 
@@ -279,6 +413,26 @@ public class MondrianCatalogHelperTest {
     verify( helperSpy ).docAtUrlToString( anyString(), any( IPentahoSession.class ) );
     assertFalse( schema.contains( "REPLACE_TOKEN" ) );
 
+  }
+
+  @Test
+  public void testGetCatalog() throws Exception {
+    String catalogName = "SteelWheels";
+
+    MondrianCatalog cat = mock( MondrianCatalog.class );
+    doReturn( catalogName ).when( cat ).getName();
+    IPentahoSession session = mock( IPentahoSession.class );
+
+    MondrianCatalogHelper helperSpy = spy( helper );
+    doReturn( true ).when( helperSpy ).hasAccess( eq( cat ), any( RepositoryFilePermission.class ) );
+    doNothing().when( helperSpy ).init( session );
+    doReturn( cat ).when( helperSpy ).getCatalogFromCache( anyString(), eq( session ) );
+        
+    assertEquals( helperSpy.getCatalog( catalogName, session ).getName(), catalogName );
+    verify( helperSpy ).hasAccess( eq( cat ), any( RepositoryFilePermission.class ) );
+
+    doReturn( false ).when( helperSpy ).hasAccess( eq( cat ), any( RepositoryFilePermission.class ) );
+    assertNull( helperSpy.getCatalog( catalogName, session ) );
   }
 
   public static class DynamicDSPTest implements DynamicSchemaProcessor {
@@ -300,45 +454,5 @@ public class MondrianCatalogHelperTest {
 
     String result = helperMock.generateInMemoryDatasourcesXml( unifiedRepositoryMock );
     assertNull( result, null );
-  }
-
-  // The next block of 3 tests is for MONDRIAN-2229 issue
-  @Test
-  public void testGenerateInMemoryDatasourcesXml_DataSourceNameProviderUsingLegacyDbName() throws Exception {
-    String result = prepareResultForMondrian2229Tests( true );
-    assertThat( result, containsString( "<DataSourceName>Provider=Mondrian</DataSourceName>" ) );
-  }
-
-  @Test
-  public void testGenerateInMemoryDatasourcesXml_DataSourceNameProviderNotUsingLegacyDbName() throws Exception {
-    String result = prepareResultForMondrian2229Tests( false );
-    assertThat( result, containsString( "<DataSourceName>Pentaho Mondrian</DataSourceName>" ) );
-  }
-
-  @Test
-  public void testGenerateInMemoryDatasourcesXml_DataSourceInfoProvider() throws Exception {
-    String result = prepareResultForMondrian2229Tests( true );
-    assertThat( result, containsString( "<DataSourceInfo>Provider=Mondrian</DataSourceInfo>" ) );
-  }
-
-  private String prepareResultForMondrian2229Tests( boolean isUseLegacyDbName ) {
-    MondrianCatalogHelper helper = new MondrianCatalogHelper( isUseLegacyDbName );
-    MondrianCatalogHelper helperSpy = spy( helper );
-
-    IUnifiedRepository unifiedRepositoryMock = mock( IUnifiedRepository.class );
-    RepositoryFile repositoryFileMock = mock( RepositoryFile.class );
-
-    when( unifiedRepositoryMock.getFile( any( String.class ) ) ).thenReturn( repositoryFileMock );
-
-    String contextPathStub = "Stub";
-    doReturn( contextPathStub ).when( helperSpy ).contextPathFromRequestContextHolder();
-
-    doNothing().when( helperSpy )
-        .appendCatalogsSection( any( IUnifiedRepository.class ), anyString(), any( RepositoryFile.class ),
-            any( StringBuffer.class ) );
-
-    String result = helperSpy.generateInMemoryDatasourcesXml( unifiedRepositoryMock );
-
-    return result;
   }
 }

--- a/extensions/test-src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper_Mondrian_2229_Test.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelper_Mondrian_2229_Test.java
@@ -1,0 +1,55 @@
+package org.pentaho.platform.plugin.action.mondrian.catalog;
+
+import org.junit.Test;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+
+/**
+ * Thee tests related to MONDRIAN-2229 issue
+ */
+public class MondrianCatalogHelper_Mondrian_2229_Test {
+
+  @Test
+  public void testGenerateInMemoryDatasourcesXml_DataSourceNameProviderUsingLegacyDbName() throws Exception {
+    String result = prepareResultForMondrian2229Tests( true );
+    assertThat( result, containsString( "<DataSourceName>Provider=Mondrian</DataSourceName>" ) );
+  }
+
+  @Test
+  public void testGenerateInMemoryDatasourcesXml_DataSourceNameProviderNotUsingLegacyDbName() throws Exception {
+    String result = prepareResultForMondrian2229Tests( false );
+    assertThat( result, containsString( "<DataSourceName>Pentaho Mondrian</DataSourceName>" ) );
+  }
+
+  @Test
+  public void testGenerateInMemoryDatasourcesXml_DataSourceInfoProvider() throws Exception {
+    String result = prepareResultForMondrian2229Tests( true );
+    assertThat( result, containsString( "<DataSourceInfo>Provider=Mondrian</DataSourceInfo>" ) );
+  }
+
+  private String prepareResultForMondrian2229Tests( boolean isUseLegacyDbName ) {
+    MondrianCatalogHelper helper = new MondrianCatalogHelper( isUseLegacyDbName );
+    MondrianCatalogHelper helperSpy = spy( helper );
+
+    IUnifiedRepository unifiedRepositoryMock = mock( IUnifiedRepository.class );
+    RepositoryFile repositoryFileMock = mock( RepositoryFile.class );
+
+    when( unifiedRepositoryMock.getFile( any( String.class ) ) ).thenReturn( repositoryFileMock );
+
+    String contextPathStub = "Stub";
+    doReturn( contextPathStub ).when( helperSpy ).contextPathFromRequestContextHolder();
+
+    doNothing().when( helperSpy )
+      .appendCatalogsSection( any( IUnifiedRepository.class ), anyString(), any( RepositoryFile.class ),
+        any( StringBuffer.class ) );
+
+    return helperSpy.generateInMemoryDatasourcesXml( unifiedRepositoryMock );
+  }
+}

--- a/extensions/test-src/org/pentaho/test/platform/plugin/UserRoleMapperTest.java
+++ b/extensions/test-src/org/pentaho/test/platform/plugin/UserRoleMapperTest.java
@@ -29,7 +29,9 @@ import org.pentaho.platform.api.engine.ISolutionEngine;
 import org.pentaho.platform.api.engine.IUserRoleListService;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.boot.PlatformInitializationException;
@@ -58,10 +60,13 @@ import org.springframework.security.userdetails.UsernameNotFoundException;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+
+import static org.mockito.Mockito.*;
 
 @SuppressWarnings( "nls" )
 public class UserRoleMapperTest {
@@ -70,10 +75,14 @@ public class UserRoleMapperTest {
 
   @Before
   public void init0() {
+    IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
+    when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
+    MondrianCatalogHelper catalogService = new MondrianCatalogHelper( aclHelper );
+
     microPlatform = new MicroPlatform( "test-src/solution" );
     microPlatform.define( ISolutionEngine.class, SolutionEngine.class );
     microPlatform.define( IUnifiedRepository.class, FileSystemBackedUnifiedRepository.class, Scope.GLOBAL );
-    microPlatform.define( IMondrianCatalogService.class, MondrianCatalogHelper.class, Scope.GLOBAL );
+    microPlatform.defineInstance( IMondrianCatalogService.class, catalogService );
     microPlatform.define( "connection-SQL", SQLConnection.class );
     microPlatform.define( "connection-MDX", MDXConnection.class );
     microPlatform.define( IDBDatasourceService.class, JndiDatasourceService.class, Scope.GLOBAL );
@@ -88,9 +97,8 @@ public class UserRoleMapperTest {
       Assert.fail();
     }
 
-    MondrianCatalogHelper catalogService = (MondrianCatalogHelper) PentahoSystem.get( IMondrianCatalogService.class );
     catalogService.setDataSourcesConfig( "file:"
-        + PentahoSystem.getApplicationContext().getSolutionPath( "test/analysis/test-datasources.xml" ) );
+      + PentahoSystem.getApplicationContext().getSolutionPath( "test/analysis/test-datasources.xml" ) );
 
     // JNDI
     System.setProperty( "java.naming.factory.initial", "org.osjava.sj.SimpleContextFactory" );

--- a/repository/src/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfsFileObject.java
+++ b/repository/src/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfsFileObject.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
@@ -36,27 +37,32 @@ import org.apache.commons.vfs.FileSystemException;
 import org.apache.commons.vfs.FileType;
 import org.apache.commons.vfs.NameScope;
 import org.apache.commons.vfs.operations.FileOperations;
+import org.pentaho.platform.api.engine.ISystemConfig;
 import org.pentaho.platform.api.repository2.unified.Converter;
 import org.pentaho.platform.api.repository2.unified.IRepositoryContentConverterHandler;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.api.repository2.unified.UnifiedRepositoryException;
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
+import org.pentaho.platform.repository2.unified.jcr.JcrAclNodeHelper;
 
 public class SolutionRepositoryVfsFileObject implements FileObject {
 
   private String fileRef;
 
-  private static final IUnifiedRepository REPOSITORY = PentahoSystem.get( IUnifiedRepository.class, null );
+  private static final IUnifiedRepository repository = PentahoSystem.get( IUnifiedRepository.class, null );
 
   private FileContent content = null;
 
-  private boolean fileInitialized;
-
   private RepositoryFile repositoryFile = null;
-  
+
   private IRepositoryContentConverterHandler converterHandler;
+
+  private IAclNodeHelper aclHelper;
 
   public SolutionRepositoryVfsFileObject( final String fileRef ) {
     super();
@@ -64,12 +70,12 @@ public class SolutionRepositoryVfsFileObject implements FileObject {
   }
 
   public IUnifiedRepository getRepository() {
-    return REPOSITORY;
+    return repository;
   }
 
   public IRepositoryContentConverterHandler getConverterHandler() {
-    if(converterHandler == null) {
-      converterHandler = PentahoSystem.get( IRepositoryContentConverterHandler.class);
+    if ( converterHandler == null ) {
+      converterHandler = PentahoSystem.get( IRepositoryContentConverterHandler.class );
     }
     return converterHandler;
   }
@@ -100,20 +106,23 @@ public class SolutionRepositoryVfsFileObject implements FileObject {
   }
 
   private void initFile() {
-    if ( !fileInitialized ) {
-      // decode URL before 'get'
-      String fileUrl = fileRef;
+    // decode URL before 'get'
+    String fileUrl = fileRef;
 
-      try{
-        fileUrl = URLDecoder.decode( fileUrl, Charset.defaultCharset().name() );
-      }
-      catch ( UnsupportedEncodingException e ){
-        fileUrl = fileRef;
-      }
+    try {
+      fileUrl = URLDecoder.decode( fileUrl, Charset.defaultCharset().name() );
+    } catch ( UnsupportedEncodingException e ) {
+      fileUrl = fileRef;
+    }
 
-      repositoryFile = REPOSITORY.getFile( fileUrl );
+    String dsPath = fileUrl;
+    if ( fileUrl.matches( "^(/etc/mondrian/)(.*)(/schema.xml)" ) ) {
+      dsPath = fileUrl.substring( 0, fileUrl.indexOf( "/schema.xml" ) );
+    }
 
-      fileInitialized = true;
+    repositoryFile = getRepository().getFile( fileUrl );
+    if ( !getAclHelper().canAccess( getRepository().getFile( dsPath ),  EnumSet.of( RepositoryFilePermission.READ) ) ) {
+      repositoryFile = null;
     }
   }
 
@@ -155,7 +164,7 @@ public class SolutionRepositoryVfsFileObject implements FileObject {
 
     List<FileObject> fileList = new ArrayList<FileObject>();
     if ( exists() ) {
-      for ( RepositoryFile child : REPOSITORY.getChildren( repositoryFile.getId() ) ) {
+      for ( RepositoryFile child : getRepository().getChildren( repositoryFile.getId() ) ) {
         SolutionRepositoryVfsFileObject fileInfo = new SolutionRepositoryVfsFileObject( child.getPath() );
         fileList.add( fileInfo );
       }
@@ -257,16 +266,24 @@ public class SolutionRepositoryVfsFileObject implements FileObject {
       String extension = FilenameUtils.getExtension( repositoryFile.getPath() );
       // Try to get the converter for the extension. If there is not converter available then we will
       //assume simple type and will get the data that way
-      if(getConverterHandler() != null) {
+      if ( getConverterHandler() != null ) {
         Converter converter = getConverterHandler().getConverter( extension );
-        if(converter != null) {
+        if ( converter != null ) {
           inputStream = converter.convert( repositoryFile.getId() );
         }
       }
-      if(inputStream == null) {
-        inputStream = REPOSITORY.getDataForRead( repositoryFile.getId(), SimpleRepositoryFileData.class ).getStream();
+      if ( inputStream == null ) {
+        inputStream = getRepository().getDataForRead( repositoryFile.getId(), SimpleRepositoryFileData.class ).getStream();
       }
     }
     return inputStream;
   }
+
+  protected synchronized IAclNodeHelper getAclHelper() {
+    if ( aclHelper == null ) {
+      aclHelper = new JcrAclNodeHelper( getRepository() );
+    }
+    return aclHelper;
+  }
+
 }

--- a/repository/src/org/pentaho/platform/repository2/messages/messages.properties
+++ b/repository/src/org/pentaho/platform/repository2/messages/messages.properties
@@ -100,3 +100,6 @@ DefaultDeleteHelper.ERROR_0001_PATH_NOT_FOUND=cannot determine original parent f
 DefaultDeleteHelper.ERROR_0002_NOT_CLEAN=this should have been cleaned up on undelete or permanent delete
 JcrRepositoryFileDao.ERROR_0006_ACCESS_DENIED_DELETE=Access denied while deleting file with id [ {0} ]
 DefaultUnifiedRepository.ERROR_0001_ACCESS_DENIED_UPDATE_ACL=Access denied while updating permissions on file with id [ {0} ]
+AclNodeHelper.ERROR_0001_ROOT_FOLDER_NOT_AVAILABLE=Root folder {0} not available. Using default {1} instead
+AclNodeHelper.WARN_0001_REMOVE_ACL_NODE=Removing the ACL node:
+AclNodeHelper.WARN_0002_REMOVE_ACL_STORE=Removing the ACL store: {0}

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
@@ -1,0 +1,203 @@
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAce;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.api.repository2.unified.data.node.DataNode;
+import org.pentaho.platform.api.repository2.unified.data.node.DataNodeRef;
+import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFileData;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.repository.messages.Messages;
+import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
+import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
+import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+/**
+ * @author Andrey Khayrutdinov
+ * @author Nick Baker
+ */
+public class JcrAclNodeHelper implements IAclNodeHelper {
+  private static final Log logger = LogFactory.getLog( JcrAclNodeHelper.class );
+
+  private static final String IS_ACL_NODE = "IS_ACL_NODE";
+  private static final String TARGET = "TARGET";
+
+  private final IUnifiedRepository unifiedRepository;
+
+  public JcrAclNodeHelper( IUnifiedRepository unifiedRepository) {
+    this.unifiedRepository = unifiedRepository;
+  }
+
+  private boolean hasAclNode( final RepositoryFile file ) {
+    return getAclNode( file ) != null;
+  }
+
+  private RepositoryFile getAclNode( final RepositoryFile file ) {
+    try {
+      return SecurityHelper.getInstance().runAsSystem( new Callable<RepositoryFile>() {
+        @Override public RepositoryFile call() throws Exception {
+
+          List<RepositoryFile> referrers = unifiedRepository.getReferrers( file.getId() );
+
+          // Loop through nodes referring to the target file, return the first one designated as an ACL node
+          int i = referrers.size();
+          while ( i-- > 0 ) {
+            RepositoryFile referrer = referrers.get( i );
+            NodeRepositoryFileData dataForRead =
+                unifiedRepository.getDataForRead( referrer.getId(), NodeRepositoryFileData.class );
+            if ( dataForRead != null && dataForRead.getNode().hasProperty( IS_ACL_NODE ) ) {
+              return referrer;
+            }
+          }
+
+          // No ACL node found
+          return null;
+        }
+      } );
+    } catch ( Exception e ) {
+      logger.error( "Error retrieving ACL Node", e );
+      return null;
+    }
+
+  }
+
+  @Override public boolean canAccess( final RepositoryFile repositoryFile,
+                                      final EnumSet<RepositoryFilePermission> permissions ) {
+
+    // First check to see if there is an ACL node, this call is done as "system"
+    boolean hasAclNode = hasAclNode( repositoryFile );
+
+    // If no ACL node is present, it's a public resource
+    if ( !hasAclNode ) {
+      return true;
+    }
+
+    // Obtain a reference to ACL node as "system", guaranteed access
+    final RepositoryFile aclNode = getAclNode( repositoryFile );
+
+    // Check to see if user has READ access to file, this will throw and exception if not.
+    try {
+      unifiedRepository.getFileById( aclNode.getId() );
+    } catch ( Exception e ) {
+      logger.warn( "Error checking access for file", e );
+      return false;
+    }
+
+    // if read passed, check the other permissions
+    return unifiedRepository.hasAccess( aclNode.getPath(), permissions );
+
+  }
+
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override public RepositoryFileAcl getAclFor( final RepositoryFile repositoryFile ) {
+
+    boolean hasAclNode = hasAclNode( repositoryFile );
+    if ( !hasAclNode ) {
+      return null;
+    }
+
+    RepositoryFileAcl acl;
+    try {
+      acl = unifiedRepository.getAcl( getAclNode( repositoryFile ).getId() );
+    } catch ( Exception e ) {
+      return null;
+    }
+
+    RepositoryFileAcl.Builder aclBuilder = new RepositoryFileAcl.Builder( acl.getId(), acl.getOwner().getName(),
+        RepositoryFileSid.Type.ROLE );
+    aclBuilder.aces( acl.getAces() );
+
+    //add the Administrator role
+    if( canAdminister() ) {
+      String adminRoleName =
+          PentahoSystem.get( String.class, "singleTenantAdminAuthorityName", PentahoSessionHolder.getSession() );
+
+      RepositoryFileAce adminGroup = new RepositoryFileAce( new RepositoryFileSid( adminRoleName,
+          RepositoryFileSid.Type.ROLE ), RepositoryFilePermission.ALL );
+      aclBuilder.ace( adminGroup );
+    }
+
+    return aclBuilder.build();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override public void setAclFor( final RepositoryFile fileToAddAclFor, final RepositoryFileAcl acl ) {
+
+    try {
+      SecurityHelper.getInstance().runAsSystem( new Callable<Void>() {
+        @Override public Void call() throws Exception {
+          RepositoryFile aclNode = getAclNode( fileToAddAclFor );
+
+          if ( acl == null ) {
+            if ( aclNode != null ) {
+              unifiedRepository.deleteFile( aclNode.getId(), true,
+                  Messages.getInstance().getString( "AclNodeHelper.WARN_0001_REMOVE_ACL_NODE", aclNode.getPath() ) );
+            }
+            // ignore if no ACL node is present.
+          } else {
+            if ( aclNode == null ) {
+              // Create ACL Node with reference to given file.
+              aclNode = createAclNode( fileToAddAclFor );
+            }
+            // Update ACL on file.
+            RepositoryFileAcl existing = unifiedRepository.getAcl( aclNode.getId() );
+            RepositoryFileAcl updated =
+                new RepositoryFileAcl.Builder( existing )
+                    .aces( acl.getAces() )
+                    .build();
+            unifiedRepository.updateAcl( updated );
+          }
+          return null;
+        }
+      } );
+    } catch ( Exception e ) {
+      logger.error( "Error setting ACL on node: " + fileToAddAclFor.getPath(), e );
+    }
+  }
+
+  private RepositoryFile createAclNode( RepositoryFile fileToAddAclFor ) {
+
+    DataNode dataNode = new DataNode( "acl node" );
+    DataNodeRef dataNodeRef = new DataNodeRef( fileToAddAclFor.getId() );
+    dataNode.setProperty( TARGET, dataNodeRef );
+    dataNode.setProperty( IS_ACL_NODE, true );
+    NodeRepositoryFileData nodeRepositoryFileData = new NodeRepositoryFileData( dataNode );
+
+    return unifiedRepository.createFile(
+        unifiedRepository.getFile( "/" ).getId(),
+        new RepositoryFile.Builder( UUID.randomUUID().toString() ).aclNode( true ).build(),
+        nodeRepositoryFileData, ""
+    );
+
+  }
+
+  @Override public void removeAclFor( RepositoryFile file ) {
+    setAclFor( file, null );
+  }
+
+  private boolean canAdminister() {
+    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
+    return policy.isAllowed( RepositoryReadAction.NAME ) && policy.isAllowed( RepositoryCreateAction.NAME )
+        && ( policy.isAllowed( AdministerSecurityAction.NAME ) );
+  }
+
+}

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/PentahoJcrConstants.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/PentahoJcrConstants.java
@@ -103,6 +103,8 @@ public class PentahoJcrConstants extends JcrConstants {
 
   private static String PHO_ACL_MANAGEMENT_PRIVILEGE = "aclManagement"; //$NON-NLS-1$
 
+  private static String PHO_ACLNODE = "aclNode";
+
   /**
    * Same abstraction as {@code Locale.ROOT}.
    */
@@ -232,5 +234,7 @@ public class PentahoJcrConstants extends JcrConstants {
   public String getPHO_ACLMANAGEMENT_PRIVILEGE() {
     return resolveName( PHO_NS, PHO_ACL_MANAGEMENT_PRIVILEGE );
   }
+
+  public String getPHO_ACLNODE() { return resolveName( PHO_NS, PHO_ACLNODE ); }
 
 }

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/RepositoryFileProxy.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/RepositoryFileProxy.java
@@ -52,10 +52,11 @@ public class RepositoryFileProxy extends RepositoryFile {
   private String name;
   private String versionId;
   private Date createdDate;
+  private Boolean aclNode;
 
   public RepositoryFileProxy( final Node node, final JcrTemplate template, IPentahoLocale pentahoLocale ) {
     super( null, null, false, false, false, null, null, null, null, false, null, null, null, null, null, null, null,
-        null, -1, null, null );
+        null, -1, null, null, false );
     this.node = node;
     this.pentahoLocale = pentahoLocale;
     try {
@@ -572,6 +573,26 @@ public class RepositoryFileProxy extends RepositoryFile {
       } );
     }
     return versioned;
+  }
+
+  @Override
+  public boolean isAclNode() {
+    if ( aclNode == null ) {
+      this.executeOperation( new SessionOperation() {
+        @Override
+        public void execute( Session session ) {
+          try {
+            if ( node.hasProperty( getPentahoJcrConstants().getPHO_ACLNODE() ) ) {
+              aclNode = node.getProperty( getPentahoJcrConstants().getPHO_ACLNODE() ).getBoolean();
+            }
+          } catch ( RepositoryException e ) {
+            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+          }
+        }
+      } );
+    }
+    // exclude NPE
+    return aclNode == null ? false : aclNode;
   }
 
   @Override

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/sejcr/ntdproviders/HierarchyNodeNtdProvider.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/sejcr/ntdproviders/HierarchyNodeNtdProvider.java
@@ -54,6 +54,7 @@ public class HierarchyNodeNtdProvider implements NodeTypeDefinitionProvider {
     t.getNodeDefinitionTemplates().add( getMetadataNode( ntMgr ) );
     t.getNodeDefinitionTemplates().add( getLocaleNode( ntMgr ) );
     t.getPropertyDefinitionTemplates().add( getHiddenProperty( ntMgr, vFac ) );
+    t.getPropertyDefinitionTemplates().add( getAclNodeProperty( ntMgr, vFac ) );
     return t;
   }
 
@@ -63,6 +64,17 @@ public class HierarchyNodeNtdProvider implements NodeTypeDefinitionProvider {
     t.setName( PHO + "hidden" ); //$NON-NLS-1$
     t.setRequiredType( PropertyType.BOOLEAN );
     t.setDefaultValues( new Value[] { vFac.createValue( false ) } );
+    t.setOnParentVersion( OnParentVersionAction.COPY );
+    t.setMultiple( false );
+    return t;
+  }
+
+  private PropertyDefinitionTemplate getAclNodeProperty( final NodeTypeManager ntMgr, final ValueFactory vFac )
+      throws RepositoryException {
+    PropertyDefinitionTemplate t = ntMgr.createPropertyDefinitionTemplate();
+    t.setName( PHO + "aclNode" ); //$NON-NLS-1$
+    t.setRequiredType( PropertyType.BOOLEAN );
+    t.setDefaultValues( new Value[]{ vFac.createValue( false ) } );
     t.setOnParentVersion( OnParentVersionAction.COPY );
     t.setMultiple( false );
     return t;

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAdapter.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAdapter.java
@@ -86,6 +86,9 @@ public class RepositoryFileAdapter extends XmlAdapter<RepositoryFileDto, Reposit
     if ( include( "hidden", memberSet, exclude ) ) {
       f.hidden = v.isHidden();
     }
+    if ( include( "aclNode", memberSet, exclude ) ) {
+      f.aclNode = v.isAclNode();
+    }
     if ( include( "createDate", memberSet, exclude ) ) {
       f.createdDate = v.getCreatedDate();
     }
@@ -220,7 +223,7 @@ public class RepositoryFileAdapter extends XmlAdapter<RepositoryFileDto, Reposit
       .folder( v.folder ).fileSize( v.fileSize ).lastModificationDate( v.lastModifiedDate ).locale( v.locale )
       .lockDate( v.lockDate ).locked( v.locked ).lockMessage( v.lockMessage ).lockOwner( v.lockOwner )
       .title( v.title ).versioned( v.versioned ).versionId( v.versionId ).originalParentFolderPath(
-        v.originalParentFolderPath ).deletedDate( v.deletedDate ).hidden( v.hidden ).build();
+        v.originalParentFolderPath ).deletedDate( v.deletedDate ).hidden( v.hidden ).aclNode( v.aclNode ).build();
   }
 
   private static DefaultUnifiedRepositoryWebService getRepoWs() {

--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileDto.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileDto.java
@@ -55,6 +55,8 @@ public class RepositoryFileDto implements Serializable {
 
   boolean hidden;
 
+  boolean aclNode;
+
   boolean versioned;
 
   String versionId;
@@ -175,6 +177,14 @@ public class RepositoryFileDto implements Serializable {
 
   public void setHidden( boolean hidden ) {
     this.hidden = hidden;
+  }
+
+  public boolean isAclNode() {
+    return aclNode;
+  }
+
+  public void setAclNode( boolean aclNode ) {
+    this.aclNode = aclNode;
   }
 
   public boolean isVersioned() {
@@ -304,11 +314,12 @@ public class RepositoryFileDto implements Serializable {
   public String toString() {
     return "RepositoryFileDto [id=" + id + ", name=" + name + ", path=" + path + ", folder=" + folder + ", size="
         + fileSize + ", createdDate=" + createdDate + ", creatorId=" + creatorId + ", deletedDate=" + deletedDate
-        + ", description=" + description + ", hidden=" + hidden + ", lastModifiedDate=" + lastModifiedDate
-        + ", locale=" + locale + ", lockDate=" + lockDate + ", lockMessage=" + lockMessage + ", lockOwner=" + lockOwner
-        + ", locked=" + locked + ", originalParentFolderPath=" + originalParentFolderPath + ", owner=" + owner
-        + ", ownerType=" + ownerType + ", title=" + title + ", localePropertiesMapEntries="
-        + localePropertiesMapEntries + ", versionId=" + versionId + ", versioned=" + versioned + ", hasAcl=" + (repositoryFileAclDto != null) + "]";
+        + ", description=" + description + ", hidden=" + hidden + ", aclNode=" + aclNode + ", lastModifiedDate="
+        + lastModifiedDate + ", locale=" + locale + ", lockDate=" + lockDate + ", lockMessage=" + lockMessage
+        + ", lockOwner=" + lockOwner + ", locked=" + locked + ", originalParentFolderPath=" + originalParentFolderPath
+        + ", owner=" + owner + ", ownerType=" + ownerType + ", title=" + title + ", localePropertiesMapEntries="
+        + localePropertiesMapEntries + ", versionId=" + versionId + ", versioned=" + versioned + ", hasAcl="
+        + ( repositoryFileAclDto != null ) + "]";
   }
 
 }

--- a/repository/test-src/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfsFileObjectTest.java
+++ b/repository/test-src/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfsFileObjectTest.java
@@ -1,0 +1,49 @@
+package org.pentaho.platform.repository.solution.filebased;
+
+import org.junit.Test;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+
+import java.util.EnumSet;
+
+import static org.mockito.Mockito.*;
+
+public class SolutionRepositoryVfsFileObjectTest {
+
+
+  @Test
+  public void initFileTest() throws Exception {
+
+    String fileRef = "/etc/mondrian/SteelWheels/schema.xml";
+    SolutionRepositoryVfsFileObject fileObject = new SolutionRepositoryVfsFileObject( fileRef );
+    SolutionRepositoryVfsFileObject fileObjectSpy = spy( fileObject );
+
+    IAclNodeHelper aclNodeHelper = mock( IAclNodeHelper.class );
+    doReturn( aclNodeHelper ).when( fileObjectSpy ).getAclHelper();
+
+    RepositoryFile file = mock( RepositoryFile.class );
+    doReturn( true ).when( aclNodeHelper ).canAccess( file, EnumSet.of( RepositoryFilePermission.READ ) );
+
+
+    IUnifiedRepository repository = mock( IUnifiedRepository.class );
+    doReturn( file ).when( repository ).getFile( fileRef );
+    doReturn( repository ).when( fileObjectSpy ).getRepository();
+
+    fileObjectSpy.getName();
+    verify( repository, times( 1 ) ).getFile( anyString() );
+
+    fileRef = "/etca/mondriana/SteelWheels/schema.xml";
+
+    fileObject = new SolutionRepositoryVfsFileObject( fileRef );
+    fileObjectSpy = spy( fileObject );
+
+    doReturn( aclNodeHelper ).when( fileObjectSpy ).getAclHelper();
+    doReturn( false ).when( aclNodeHelper ).canAccess( file, EnumSet.of( RepositoryFilePermission.READ ) );
+    doReturn( repository ).when( fileObjectSpy ).getRepository();
+
+    fileObjectSpy.getName();
+    verify( repository, times( 2 ) ).getFile( anyString() );
+  }
+}

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperTest.java
@@ -1,0 +1,276 @@
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAce;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.engine.core.system.TenantUtils;
+import org.pentaho.platform.repository2.ClientRepositoryPaths;
+import org.pentaho.platform.repository2.unified.DefaultUnifiedRepositoryBase;
+import org.pentaho.platform.repository2.unified.ServerRepositoryPaths;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.jcr.PathNotFoundException;
+import javax.jcr.ReferentialIntegrityException;
+import java.util.EnumSet;
+
+import static org.junit.Assert.*;
+
+@RunWith( SpringJUnit4ClassRunner.class )
+@ContextConfiguration( locations = { "classpath:/repository.spring.xml",
+    "classpath:/repository-test-override.spring.xml" } )
+public class JcrAclNodeHelperTest extends DefaultUnifiedRepositoryBase {
+
+  private JcrAclNodeHelper helper;
+  private ITenant defaultTenant;
+  private RepositoryFile targetFile;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+
+    createUsers();
+    ensurePublicExists();
+    loginAsRepositoryAdmin();
+    targetFile = createSampleFile( "/public", "test.txt", "test", true, 1 );
+    RepositoryFileAcl acl = repo.getAcl( targetFile.getId() );
+    RepositoryFileAcl newAcl = new RepositoryFileAcl.Builder( acl ).entriesInheriting( false )
+        .clearAces()
+            .entriesInheriting( false )
+        .ace( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE, EnumSet.of( RepositoryFilePermission.READ ) )
+        .build();
+    repo.updateAcl( newAcl );
+
+    helper = new JcrAclNodeHelper( repo );
+    logout();
+  }
+
+  private void createUsers() {
+    loginAsSysTenantAdmin();
+
+    defaultTenant = tenantManager.createTenant( systemTenant, TenantUtils.getDefaultTenant(), tenantAdminRoleName,
+        tenantAuthenticatedRoleName, ANONYMOUS_ROLE_NAME );
+
+    createUser( defaultTenant, singleTenantAdminUserName, PASSWORD, tenantAdminRoleName );
+    createUser( defaultTenant, USERNAME_SUZY, PASSWORD, tenantAuthenticatedRoleName );
+    createUser( defaultTenant, USERNAME_TIFFANY, PASSWORD, tenantAuthenticatedRoleName );
+
+    logout();
+  }
+
+  private void ensurePublicExists() {
+    ensureFolderExists( ClientRepositoryPaths.getPublicFolderPath() );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    loginAsSysTenantAdmin();
+
+    ITenant defaultTenant = tenantManager.getTenant( "/" + ServerRepositoryPaths.getPentahoRootFolderName() + "/"
+        + TenantUtils.getDefaultTenant() );
+    if ( defaultTenant != null ) {
+      cleanupUserAndRoles( defaultTenant );
+    }
+
+    super.tearDown();
+  }
+  
+
+
+  @Test
+  public void visibleForEveryOne() {
+    loginAsRepositoryAdmin();
+    assertTrue( helper.canAccess( targetFile, EnumSet.of( RepositoryFilePermission.READ ) ) );
+  }
+
+
+  @Test
+  public void suzycanAccess() {
+    makeDsPrivate();
+    loginAsSuzy();
+    assertTrue( helper.canAccess( targetFile, EnumSet.of( RepositoryFilePermission.READ ) ) );
+  }
+
+  @Test
+  public void tiffanyHasNoAccess() {
+    makeDsPrivate();
+
+    loginAsTiffany();
+    assertFalse( helper.canAccess( targetFile, EnumSet.of( RepositoryFilePermission.READ ) ) );
+  }
+
+
+  @Test
+  public void publish() {
+    makeDsPrivate();
+    helper.removeAclFor( targetFile );
+
+    loginAsTiffany();
+    assertTrue( helper.canAccess( targetFile, EnumSet.of( RepositoryFilePermission.READ ) ) );
+  }
+
+  @Test
+  public void aclIsReplaced() throws InterruptedException {
+    loginAsRepositoryAdmin();
+    RepositoryFileAcl acl = createAclFor( USERNAME_TIFFANY );
+    helper.setAclFor( targetFile, acl );
+
+    loginAsTiffany();
+    assertTrue( helper.canAccess( targetFile, EnumSet.of( RepositoryFilePermission.READ ) ) );
+
+    loginAsSuzy();
+    assertFalse( helper.canAccess( targetFile, EnumSet.of( RepositoryFilePermission.READ ) ) );
+
+    loginAsRepositoryAdmin();
+    acl = createAclFor( USERNAME_SUZY );
+    helper.setAclFor( targetFile, acl );
+
+    loginAsSuzy();
+
+    // This is failing most of the time in this integration test. ACL is set properly yet Suzy can still see ACL node.
+    // If execution is paused long enough, it does work properly.
+    assertTrue( helper.canAccess( targetFile, EnumSet.of( RepositoryFilePermission.READ ) ) );
+  }
+
+
+  @Test
+  public void aclNodeIsCreated() {
+    makeDsPrivate();
+
+    loginAsRepositoryAdmin();
+    assertTrue( "No ACL node was created", !repo.getReferrers( targetFile.getId() ).isEmpty() );
+  }
+
+  @Test
+  public void aclNodeIsRemoved() {
+    makeDsPrivate();
+
+    loginAsRepositoryAdmin();
+    helper.setAclFor( targetFile, null );
+    assertTrue( "Referrers should be null after ACL delete", repo.getReferrers( targetFile.getId() ).isEmpty() );
+  }
+
+  @Test
+  public void cannotDeleteTargetWithAclNode() {
+    makeDsPrivate();
+
+    loginAsRepositoryAdmin();
+    try {
+      repo.deleteFile( targetFile.getId(), true, "I cannot be killed" );
+      fail("Should have thrown Referential Integrity Exception");
+    } catch( Exception e ){
+      assertTrue( repo.getFile( targetFile.getPath() ) != null );
+    }
+
+  }
+
+  @Test
+  public void canDeleteTargetIfAclNodeRemoved() {
+    makeDsPrivate();
+
+    loginAsRepositoryAdmin();
+    helper.setAclFor( targetFile, null );
+    repo.deleteFile( targetFile.getId(), true, "I can be killed" );
+
+    Throwable pathNotFound = null;
+    try {
+      repo.getFile( targetFile.getPath() );
+    } catch ( Throwable e ) {
+      while ( e != null ) {
+        if (e instanceof PathNotFoundException) {
+          pathNotFound = e;
+          e = null;
+        } else {
+          e = e.getCause();
+        }
+      }
+    }
+    assertNotNull( pathNotFound );
+  }
+
+  @Test
+  public void administratorRoleIsAdded() {
+    makeDsPrivate();
+    loginAsSuzy();
+
+    RepositoryFileAcl aclReturned = helper.getAclFor( targetFile );
+    boolean adminPresent = false;
+
+    for( RepositoryFileAce ace : aclReturned.getAces() ){
+      if( ace.getSid().getName() == tenantAdminRoleName ) {
+        adminPresent = true;
+        break;
+      }
+    }
+
+    assertFalse( adminPresent );
+
+    loginAsRepositoryAdmin();
+
+    aclReturned = helper.getAclFor( targetFile );
+    adminPresent = false;
+
+    for( RepositoryFileAce ace : aclReturned.getAces() ){
+      if( ace.getSid().getName() == tenantAdminRoleName ) {
+        adminPresent = true;
+        break;
+      }
+    }
+
+    assertTrue( adminPresent );
+  }
+
+  private void makeDsPrivate() {
+    loginAsRepositoryAdmin();
+    RepositoryFileAcl acl = createAclFor( USERNAME_SUZY );
+    helper.setAclFor( targetFile, acl );
+    logout();
+  }
+
+  private static RepositoryFileAcl createAclFor( String user ) {
+    RepositoryFileSid userSid = new RepositoryFileSid( user, RepositoryFileSid.Type.USER );
+    return new RepositoryFileAcl.Builder( user )
+        .ace( userSid, EnumSet.of( RepositoryFilePermission.ALL ) )
+        .entriesInheriting( false )
+        .build();
+  }
+
+
+  private RepositoryFile ensureFolderExists( String folderName ) {
+    loginAsRepositoryAdmin();
+    try {
+      RepositoryFile folder = repo.getFile( folderName );
+      if ( folder == null ) {
+        folder = repo.createFolder( repo.getFile( "/" ).getId(), new RepositoryFile.Builder( folderName ).
+            folder( true ).build(), "" );
+
+      }
+
+      RepositoryFileAcl acl = repo.getAcl( folder.getId() );
+      RepositoryFileAcl newAcl = new RepositoryFileAcl.Builder( acl ).entriesInheriting( true )
+          .ace( AUTHENTICATED_ROLE_NAME, RepositoryFileSid.Type.ROLE, EnumSet.of( RepositoryFilePermission.ALL ) )
+          .build();
+      repo.updateAcl( newAcl );
+
+      return folder;
+    } finally {
+      logout();
+    }
+  }
+
+  private void loginAsSuzy() {
+    login( USERNAME_SUZY, defaultTenant, new String[] { tenantAuthenticatedRoleName } );
+  }
+
+  private void loginAsTiffany() {
+    login( USERNAME_TIFFANY, defaultTenant, new String[] { tenantAuthenticatedRoleName } );
+  }
+}

--- a/repository/test-src/org/pentaho/test/platform/repository2/unified/MockUnifiedRepository.java
+++ b/repository/test-src/org/pentaho/test/platform/repository2/unified/MockUnifiedRepository.java
@@ -181,7 +181,7 @@ public class MockUnifiedRepository implements IUnifiedRepository {
                                      final boolean showHidden ) {
     FileRecord r = root.getFileRecord( path );
     RepositoryFile rootFile = r.getFile();
-    if ( !showHidden && rootFile.isHidden() ) {
+    if ( (!showHidden && rootFile.isHidden()) || rootFile.isAclNode() ) {
       return null;
     }
     List<RepositoryFileTree> children;
@@ -1404,7 +1404,7 @@ public class MockUnifiedRepository implements IUnifiedRepository {
     }
     FileRecord fileRecord = idManager.getFileById( folder.getId() );
     fileRecord.setFile( new RepositoryFile.Builder( folder ).hidden( folder.isHidden() ).title( findTitle( folder ) )
-        .description( findDesc( folder ) ).build() );
+        .description( findDesc( folder ) ).aclNode( folder.isAclNode() ).build() );
     if ( folder.isVersioned() ) {
       versionManager.createVersion( fileRecord.getFile().getId(), currentUserProvider.getUser(), versionMessage,
           new Date() );

--- a/user-console/source/org/pentaho/mantle/client/RepositoryFileUtils.java
+++ b/user-console/source/org/pentaho/mantle/client/RepositoryFileUtils.java
@@ -82,6 +82,7 @@ public class RepositoryFileUtils {
     repositoryFile.setDescription( file.getDescription() );
     repositoryFile.setFolder( file.isFolder() );
     repositoryFile.setHidden( file.isHidden() );
+    repositoryFile.setAclNode( false );
     repositoryFile.setId( file.getId() );
     repositoryFile.setLastModifiedDate( file.getLastModifiedDate() );
     repositoryFile.setLocale( file.getLocale() );


### PR DESCRIPTION
 - Added support for ACL file nodes, repository stored non-visible files connected to the file applying acl to it. It uses the referrer mechanism from jcr
 - Changed import handlers to allow acl information to be assigned to a metadata or mondrian data source
 - Added filter for mondrian data sources accessed via Vfs checking acl information
 - Added metadata and mondrian acl checks for every data source operation
 - Updated unit tests accordingly and added new ones to test the added functionalities

This work was developed in the ds-provision branch