### PR TITLE
BISERVER-12194 -- Unable to remove sample JDBC connection through PUC

### DIFF
--- a/repository/src/org/pentaho/platform/repository/JcrBackedDatasourceMgmtService.java
+++ b/repository/src/org/pentaho/platform/repository/JcrBackedDatasourceMgmtService.java
@@ -138,11 +138,15 @@ public class JcrBackedDatasourceMgmtService implements IDatasourceMgmtService {
             "DatasourceMgmtService.ERROR_0002_UNABLE_TO_DELETE_DATASOURCE", "", "" ) ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$       
       }
     } catch ( UnifiedRepositoryException ure ) {
-      throw new DatasourceMgmtServiceException(
+      try{
+        repository.deleteFile( file.getId(), null );
+      }catch ( UnifiedRepositoryException ure1 ) {
+        throw new DatasourceMgmtServiceException(
           Messages
               .getInstance()
               .getErrorString(
-                  "DatasourceMgmtService.ERROR_0002_UNABLE_TO_DELETE_DATASOURCE", file.getName(), ure.getLocalizedMessage() ), ure ); //$NON-NLS-1$
+                  "DatasourceMgmtService.ERROR_0002_UNABLE_TO_DELETE_DATASOURCE", file.getName(), ure1.getLocalizedMessage() ), ure1 ); //$NON-NLS-1$
+      }
     }
   }
 


### PR DESCRIPTION
What was done:
1) on fail with connection permanent removing -- move it to trash folder

So this fix is to return 5.0.x behavior which was asked by customers