### PR TITLE
PDI-13385 - [Regression] Pan and Kitchen could not run transformations a...

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAdapter.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAdapter.java
@@ -96,17 +96,6 @@ public class RepositoryFileAdapter extends XmlAdapter<RepositoryFileDto, Reposit
     if ( include( "creatorId", memberSet, exclude ) ) {
       f.creatorId = v.getCreatorId();
     }
-
-    if ( include( "owner", memberSet, exclude ) ) {
-      Serializable id = v.getId();
-      if( id != null ) {
-        RepositoryFileAclDto acl = getRepoWs().getAcl( "" + id );
-        if ( acl != null ) {
-          f.owner = acl.getOwner();
-        }
-      }
-    }
-
     if ( include( "fileSize", memberSet, exclude ) ) {
       f.fileSize = v.getFileSize();
     }
@@ -167,6 +156,16 @@ public class RepositoryFileAdapter extends XmlAdapter<RepositoryFileDto, Reposit
           }
         } catch ( Exception e ) {
           e.printStackTrace();
+        }
+      }
+
+      if ( include( "owner", memberSet, exclude ) ) {
+        Serializable id = v.getId();
+        if( id != null ) {
+          RepositoryFileAclDto acl = getRepoWs().getAcl( "" + id );
+          if ( acl != null ) {
+            f.owner = acl.getOwner();
+          }
         }
       }
     }


### PR DESCRIPTION
...nd jobs from DI server repository

What was done:
1) moved the call of getting owner to include ACL check. Currently that
call causes Kettle to fail when dealing with DI repository as it tries to
initialize web service endpoint on Spoon side which should not be done.