### PR TITLE
Backport of BISERVER-11537 - Folder Name in PUC different than name attribute used in index.xml after import utility (5.0)

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/importer/LocaleImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/LocaleImportHandler.java
@@ -26,6 +26,13 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.PropertyResourceBundle;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -48,6 +55,11 @@ public class LocaleImportHandler extends RepositoryFileImportFileHandler impleme
 
   private static final String LOCALE_EXT = ".locale";
   private static final String OLD_LOCALE_EXT = ".properties";
+  private static final String XML_LOCALE_EXT = ".xml";
+  
+  private static final String VARIABLE_SYMBOL_FROM_INDEX = "%";
+  private static final String TITLE_PROPERTY_NAME = "name";
+  private static final String DESC_PROPERTY_NAME = "description";
 
   private List<String> artifacts; //spring injected file extensions
 
@@ -61,9 +73,11 @@ public class LocaleImportHandler extends RepositoryFileImportFileHandler impleme
 
   public void importFile(IPlatformImportBundle bundle) throws PlatformImportException {
     RepositoryFileImportBundle localeBundle = (RepositoryFileImportBundle) bundle;
-    RepositoryFile localeParent = getLocaleParent(localeBundle);
 
-    Properties localeProperties = buildLocaleProperties(localeBundle);
+    Properties localePropertiesFromIndex = loadPropertiesByXml( localeBundle );
+    RepositoryFile localeParent = getLocaleParent( localeBundle, localePropertiesFromIndex );
+    
+    Properties localeProperties = buildLocaleProperties( localeBundle, localePropertiesFromIndex );
   
     if (localeParent != null && unifiedRepository != null && localeBundle.getFile() != null) {
       //If the parent file (content) got skipped because it existed then we will not import the locale information
@@ -82,42 +96,48 @@ public class LocaleImportHandler extends RepositoryFileImportFileHandler impleme
    * @param locale
    * @return
    */
-  private Properties buildLocaleProperties(RepositoryFileImportBundle locale) {
+  private Properties buildLocaleProperties( RepositoryFileImportBundle locale, Properties localePropertiesFromIndex ) {
     Properties localeProperties = new Properties();
     PropertyResourceBundle rb = null;  
     String comment = locale.getComment();
     String fileTitle = locale.getName();
 
-    try {      
-        byte[] bytes = IOUtils.toByteArray(locale.getInputStream());
-        java.io.InputStream bundleInputStream = new ByteArrayInputStream(bytes);
-        rb = new PropertyResourceBundle(bundleInputStream);
-      } catch (Exception returnEmptyIfError) {     
-          getLogger().error(returnEmptyIfError.getMessage());
-          return localeProperties;
-      }
+    if ( !localePropertiesFromIndex.isEmpty() ) {
+    	// for old style index.xml as locale
+    	comment = localePropertiesFromIndex.getProperty( DESC_PROPERTY_NAME );
+    	fileTitle = localePropertiesFromIndex.getProperty( TITLE_PROPERTY_NAME );
+    } else {
+    	try {
+    		byte[] bytes = IOUtils.toByteArray( locale.getInputStream() );
+    		java.io.InputStream bundleInputStream = new ByteArrayInputStream( bytes );
+    		rb = new PropertyResourceBundle( bundleInputStream );
+    	} catch ( Exception returnEmptyIfError ) {
+    		getLogger().error( returnEmptyIfError.getMessage() );
+    		return localeProperties;
+    	} 
 
-    if(rb != null){
-      //this is the 4.8 style - name and description
-      // First try file desc. If no file desc, try for a directory desc, else try fallback
-      comment = rb.containsKey("description") ? rb.getString("description"):
-          rb.containsKey(FILE_DESCRIPTION)? rb.getString(FILE_DESCRIPTION):
-              rb.containsKey(DIRECTORY_DESCRIPTION) ? rb.getString(DIRECTORY_DESCRIPTION):
-                  comment;
+	if ( rb != null ) {
+		// this is the 4.8 style - name and description
+		// First try file desc. If no file desc, try for a directory desc, else try fallback
+		comment =
+				rb.containsKey( DESC_PROPERTY_NAME ) ? rb.getString( DESC_PROPERTY_NAME ) : rb
+						.containsKey( FILE_DESCRIPTION ) ? rb.getString( FILE_DESCRIPTION ) : rb
+								.containsKey( DIRECTORY_DESCRIPTION ) ? rb.getString( DIRECTORY_DESCRIPTION ) : comment;
 
-      // First try name. If no name, try title. If no title, try for a directory name, else use filename.
-      fileTitle = rb.containsKey("name") ? rb.getString("name"):
-          rb.containsKey("title") ? rb.getString("title"):
-              rb.containsKey(FILE_TITLE) ? rb.getString(FILE_TITLE) :
-                  rb.containsKey(DIRECTORY_NAME) ? rb.getString(DIRECTORY_NAME) :
-                      fileTitle;
+		// First try name. If no name, try title. If no title, try for a directory name, else use filename.
+		fileTitle =
+				rb.containsKey( TITLE_PROPERTY_NAME ) ? rb.getString( TITLE_PROPERTY_NAME ) : rb.containsKey( "title" )
+						? rb.getString( "title" ) : rb.containsKey( FILE_TITLE ) ? rb.getString( FILE_TITLE ) : rb
+								.containsKey( DIRECTORY_NAME ) ? rb.getString( DIRECTORY_NAME ) : fileTitle;
+								 
+	}
 
     }
 
     //this is the new .locale Jcr property names 
-    localeProperties.setProperty(FILE_DESCRIPTION, comment != null ? comment : "");
-    localeProperties.setProperty(FILE_TITLE, fileTitle != null ? fileTitle : "");
-
+    localeProperties.setProperty( FILE_DESCRIPTION, comment != null ? comment : StringUtils.EMPTY );
+    localeProperties.setProperty( FILE_TITLE, fileTitle != null ? fileTitle : StringUtils.EMPTY );
+    
     return localeProperties;
   }
 
@@ -141,7 +161,7 @@ public class LocaleImportHandler extends RepositoryFileImportFileHandler impleme
     return localeCode;
   }
 
-  private RepositoryFile getLocaleParent( RepositoryFileImportBundle locale ) {
+  private RepositoryFile getLocaleParent( RepositoryFileImportBundle locale, Properties localePropertiesFromIndex ) {
     if ( unifiedRepository == null ) {
       return null;
     }
@@ -153,31 +173,36 @@ public class LocaleImportHandler extends RepositoryFileImportFileHandler impleme
     }
     RepositoryFile localeFolder = unifiedRepository.getFile( locale.getPath() );
 
-    if ( isLocaleFolder( localeFileName ) ) {
+    if ( isLocaleFolder( localeFileName, localePropertiesFromIndex ) ) {
       localeParent = localeFolder;
-    } else {
+    } else if ( localeFolder != null ) {
       List<RepositoryFile> localeFolderChildren = unifiedRepository.getChildren( localeFolder.getId() );
       for ( RepositoryFile localeChild : localeFolderChildren ) {
 
         String localeChildName = extractFileName( localeChild.getName() );
         String localeChildExtension = extractExtension( localeChild.getName() );
 
-        // [BISERVER-10444] locale is not being applied to correct file extension (report1.prpt.locale vs. report1.xaction.locale)
-        boolean localeFileNameAlsoContainsFileExtension = checkIfLocaleFileNameAlsoContainsAFileExtension(localeFileName);
-        
-        if( localeFileNameAlsoContainsFileExtension ){
-          //FilenameUtils.getBaseName() returns name of file or empty string if none exists (NPE safe)
-          //FilenameUtils.getExtension() returns extension of file or empty string if none exists (NPE safe)
+        // [BISERVER-10444] locale is not being applied to correct file extension (report1.prpt.locale vs.
+        // report1.xaction.locale)
+        boolean localeFileNameAlsoContainsFileExtension =
+        		checkIfLocaleFileNameAlsoContainsAFileExtension( localeFileName );
+ 	
+        if ( localeFileNameAlsoContainsFileExtension ) {
+          // FilenameUtils.getBaseName() returns name of file or empty string if none exists (NPE safe)
+          // FilenameUtils.getExtension() returns extension of file or empty string if none exists (NPE safe)
           String localeFileExtension = FilenameUtils.getExtension( FilenameUtils.getBaseName( localeFileName ) );
-          String localeFileNameWithoutExtensions = FilenameUtils.getBaseName( FilenameUtils.getBaseName( localeFileName ) );
+          String localeFileNameWithoutExtensions =
+        		  FilenameUtils.getBaseName( FilenameUtils.getBaseName( localeFileName ) );
           
-          if ( localeFileNameWithoutExtensions.equals( localeChildName ) 
-              && localeFileExtension.equalsIgnoreCase( localeChildExtension ) && artifacts.contains( localeChildExtension ) ) {
+          if ( localeFileNameWithoutExtensions.equals( localeChildName )
+        		  && localeFileExtension.equalsIgnoreCase( localeChildExtension )
+        		  && artifacts.contains( localeChildExtension ) ) {
             localeParent = localeChild;
             break;
           }
           
-        } else if ( extractFileName( localeFileName ).equals( localeChildName ) && artifacts.contains( localeChildExtension ) ) {
+        } else if ( extractFileName( localeFileName ).equals( localeChildName )
+        		&& artifacts.contains( localeChildExtension ) ) {
           localeParent = localeChild;
           break;
         }
@@ -186,9 +211,10 @@ public class LocaleImportHandler extends RepositoryFileImportFileHandler impleme
     return localeParent;
   }
 
-  private boolean isLocaleFolder(String localeFileName) {
+  private boolean isLocaleFolder( String localeFileName, Properties localePropertiesFromIndex ) {
     return (localeFileName.startsWith(LOCALE_FOLDER) && localeFileName.endsWith(LOCALE_EXT))
-        || (localeFileName.startsWith(LOCALE_FOLDER) && localeFileName.endsWith(OLD_LOCALE_EXT));
+    		|| ( localeFileName.startsWith( LOCALE_FOLDER ) && localeFileName.endsWith( OLD_LOCALE_EXT ) )
+    		|| ( localeFileName.equals( LOCALE_FOLDER + XML_LOCALE_EXT ) && !localePropertiesFromIndex.isEmpty() );
   }
 
   private String extractExtension(String name) {
@@ -207,14 +233,42 @@ public class LocaleImportHandler extends RepositoryFileImportFileHandler impleme
     return name.substring(0, idx);
   }
   
-  private boolean checkIfLocaleFileNameAlsoContainsAFileExtension( String locale ){
-    
-    //ex: report1.prpt.locale    
-    if( !StringUtils.isEmpty( locale ) ){
-      //FilenameUtils.getBaseName() returns name of file or empty string if none exists (NPE safe)
-      //FilenameUtils.getExtension() returns extension of file or empty string if none exists (NPE safe)
-      return !StringUtils.isEmpty( FilenameUtils.getExtension( FilenameUtils.getBaseName( locale ) ) );
+  private boolean checkIfLocaleFileNameAlsoContainsAFileExtension( String locale ) {
+	  // ex: report1.prpt.locale
+	  if ( StringUtils.isNotEmpty( locale ) ) {
+		  // FilenameUtils.getBaseName() returns name of file or empty string if none exists (NPE safe)
+		  // FilenameUtils.getExtension() returns extension of file or empty string if none exists (NPE safe)
+		  return StringUtils.isNotEmpty( FilenameUtils.getExtension( FilenameUtils.getBaseName( locale ) ) );
     }
     return false;
   }  
+
+  private Properties loadPropertiesByXml( RepositoryFileImportBundle localeBundle ) {
+	final Properties properties = new Properties();
+	String fileTitle = localeBundle.getName();
+
+	if ( ( LOCALE_FOLDER + XML_LOCALE_EXT ).equals( fileTitle ) ) {
+		DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+		DocumentBuilder builder = null;
+		try {
+			builder = builderFactory.newDocumentBuilder();
+			Document document = builder.parse( localeBundle.getInputStream() );
+			XPath xPath = XPathFactory.newInstance().newXPath();
+
+			String name = xPath.compile( "/index/name" ).evaluate( document );
+			String desc = xPath.compile( "/index/description" ).evaluate( document );
+
+			if ( StringUtils.isNotBlank( name ) && !name.equals( VARIABLE_SYMBOL_FROM_INDEX + TITLE_PROPERTY_NAME ) ) {
+				properties.put( TITLE_PROPERTY_NAME, name );
+			}
+			if ( StringUtils.isNotBlank( desc ) && !desc.equals( VARIABLE_SYMBOL_FROM_INDEX + DESC_PROPERTY_NAME ) ) {
+				properties.put( DESC_PROPERTY_NAME, desc );
+			}
+		} catch ( Exception e ) {
+			getLogger().error( e.getMessage() );
+		}
+	}
+	return properties;
+	}
+
 }

--- a/extensions/test-src/org/pentaho/platform/plugin/services/importer/LocaleImportHandlerTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/importer/LocaleImportHandlerTest.java
@@ -19,22 +19,47 @@
 
 package org.pentaho.platform.plugin.services.importer;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.jmock.Mockery;
 import org.junit.Before;
 import org.junit.Test;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.plugin.services.importexport.Log4JRepositoryImportLogger;
 import org.pentaho.platform.plugin.services.importexport.RepositoryFileBundle;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+
 
 public class LocaleImportHandlerTest {
 
+	private static final String DEFAULT_ENCODING = "UTF-8";
+	
 	PentahoPlatformImporter importer;
+	LocaleFilesProcessor localeFilesProcessor;
 
 	@Before
 	public void setUp() throws Exception {
@@ -60,11 +85,17 @@ public class LocaleImportHandlerTest {
 		List<String> hiddenExtensionsList = new ArrayList<String>();
     hiddenExtensionsList.add(".xml");
     hiddenExtensionsList.add(".png");
+    
+    	
 
 		LocaleImportHandler localeImportHandler = new LocaleImportHandler(allowedArtifacts, approvedExtensionsList, hiddenExtensionsList);
+		LocaleImportHandler spylocaleImportHandler = spy( localeImportHandler );
+		Log log = mock( Log.class );
+		doReturn( log ).when( spylocaleImportHandler ).getLogger();
 
 		Map<String, IPlatformImportHandler> handlers = new HashMap<String, IPlatformImportHandler>();
 		handlers.put("text/locale", localeImportHandler);
+		
 
 		Map<String, String> mimes = new HashMap<String, String>();
 		mimes.put("locale", "text/locale");
@@ -85,7 +116,110 @@ public class LocaleImportHandlerTest {
 
 		LocaleFilesProcessor localeFilesProcessor = new LocaleFilesProcessor();
 		localeFilesProcessor.isLocaleFile(repoFileBundle, "/", localeContent.toString().getBytes());
+		
+		assertTrue( processIsLocalFile( "test.properties", localeContent ) );
+		assertFalse( processIsLocalFile( "test.bla", localeContent ) );
+	
+		localeContent = new StringBuffer( "bla bla" );
+		assertFalse( processIsLocalFile( "test.properties", localeContent ) );
 
 		localeFilesProcessor.processLocaleFiles(importer);
+	}
+	
+	@Test
+	public void testValidImportIndexLocaleFile() {
+		String localeContent =
+				"<index><name>My name</name><description>My descript</description><icon>samples.png</icon><visible>true</visible><display-type>icons</display-type></index>";
+		RepositoryFileImportBundle importBundle = createBundle( localeContent, "index.xml" );
+
+		IUnifiedRepository unifiedRepository = initLocaleHandler( importBundle );
+
+		try {
+			importer.importFile( importBundle );
+
+			verify( unifiedRepository, times( 1 ) ).getFile( anyString() );
+			verify( unifiedRepository, never() ).getChildren( anyInt() );
+			verify( unifiedRepository, times( 1 ) ).setLocalePropertiesForFile( any( RepositoryFile.class ), anyString(),
+					any( Properties.class ) );
+		} catch ( PlatformImportException e ) {
+			fail( e.getMessage() );
+		}
+
+	}
+ 
+	@Test
+	public void testInValidImportIndexLocaleFile() {
+		String localeContent =
+				"<index><name>%name</name><description>%description</description><icon>samples.png</icon><visible>true</visible><display-type>icons</display-type></index>";
+		RepositoryFileImportBundle importBundle = createBundle( localeContent, "index.xml" );
+ 
+		IUnifiedRepository unifiedRepository = initLocaleHandler( importBundle );
+ 
+		try {
+			importer.importFile( importBundle );
+ 
+			verify( unifiedRepository, times( 1 ) ).getFile( anyString() );
+			verify( unifiedRepository, times( 1 ) ).getChildren( anyInt() );
+			verify( unifiedRepository, never() ).setLocalePropertiesForFile( any( RepositoryFile.class ), anyString(),
+					any( Properties.class ) );
+		} catch ( PlatformImportException e ) {
+			fail( e.getMessage() );
+		}
+ 
+	}
+ 
+	@Test
+	public void testImportNotLocaleFile() {
+		String localeContent = "<index></display-type></index>";
+		RepositoryFileImportBundle importBundle = createBundle( localeContent, "test.xml" );
+ 
+		IUnifiedRepository unifiedRepository = initLocaleHandler( importBundle );
+ 
+		try {
+			importer.importFile( importBundle );
+ 
+			verify( unifiedRepository, times( 1 ) ).getFile( anyString() );
+			verify( unifiedRepository, times( 1 ) ).getChildren( anyInt() );
+			verify( unifiedRepository, never() ).setLocalePropertiesForFile( any( RepositoryFile.class ), anyString(),
+					any( Properties.class ) );
+		} catch ( PlatformImportException e ) {
+			fail( e.getMessage() );
+		}
+ 
+	}
+ 
+	private IUnifiedRepository initLocaleHandler( RepositoryFileImportBundle importBundle ) {
+		IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+		when( unifiedRepository.getFile( importBundle.getPath() ) ).thenReturn( importBundle.getFile() );
+		
+		return unifiedRepository;
+	}
+ 
+	private RepositoryFileImportBundle createBundle( String localeContent, String fileName ) {
+		InputStream in = new ByteArrayInputStream( localeContent.getBytes() );
+ 
+		RepositoryFile repoFile = new RepositoryFile.Builder( fileName ).build();
+ 
+		RepositoryFileImportBundle.Builder bundleBuilder = new RepositoryFileImportBundle.Builder();
+		bundleBuilder.path( "/pentaho-solutions/my-test/" + fileName );
+		bundleBuilder.mime( "text/locale" );
+		bundleBuilder.input( in );
+		bundleBuilder.charSet( DEFAULT_ENCODING );
+		bundleBuilder.overwriteFile( true );
+		bundleBuilder.applyAclSettings( true );
+		bundleBuilder.overwriteAclSettings( true );
+		bundleBuilder.retainOwnership( false );
+		bundleBuilder.name( fileName );
+		bundleBuilder.file( repoFile );
+ 
+		RepositoryFileImportBundle importBundle = bundleBuilder.build();
+		return importBundle;
+	}
+	
+	private boolean processIsLocalFile( String fileName, StringBuffer localeContent ) throws Exception {
+	     RepositoryFile file = new RepositoryFile.Builder( fileName ).build();
+	     RepositoryFileBundle repoFileBundle =
+	    		 new RepositoryFileBundle( file, null, StringUtils.EMPTY, null, DEFAULT_ENCODING, null );
+	     return localeFilesProcessor.isLocaleFile( repoFileBundle, "/", localeContent.toString().getBytes() );
 	}
 }


### PR DESCRIPTION

Bug fixed in two modules: pentaho-platform and pentaho-platform-migrator.
See pull request pentaho/pentaho-platform-migrator#249