### PR TITLE
[BISERVER-12360] Importing or uploading an Analyzer report triggers

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/RepositoryImportResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/RepositoryImportResource.java
@@ -17,17 +17,8 @@
 
 package org.pentaho.platform.web.http.api.resources;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import com.sun.jersey.core.header.FormDataContentDisposition;
+import com.sun.jersey.multipart.FormDataParam;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.codehaus.enunciate.Facet;
@@ -36,7 +27,6 @@ import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
-import org.pentaho.platform.plugin.action.olap.IOlapService;
 import org.pentaho.platform.plugin.services.importer.IPlatformImportBundle;
 import org.pentaho.platform.plugin.services.importer.IPlatformImportMimeResolver;
 import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
@@ -48,8 +38,15 @@ import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
 
-import com.sun.jersey.core.header.FormDataContentDisposition;
-import com.sun.jersey.multipart.FormDataParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 
 @Path ( "/repo/files/import" )
 public class RepositoryImportResource {
@@ -86,7 +83,6 @@ public class RepositoryImportResource {
                                 @FormDataParam ( "retainOwnership" ) String retainOwnership, @FormDataParam ( "charSet" ) String pCharSet,
                                 @FormDataParam ( "logLevel" ) String logLevel, @FormDataParam ( "fileUpload" ) FormDataContentDisposition fileInfo,
                                 @FormDataParam ( "fileNameOverride" ) String fileNameOverride ) {
-    
     IRepositoryImportLogger importLogger = null;
     ByteArrayOutputStream importLoggerStream = new ByteArrayOutputStream();
     boolean logJobStarted = false;
@@ -145,12 +141,6 @@ public class RepositoryImportResource {
           PentahoSystem.get( IMondrianCatalogService.class, "IMondrianCatalogService", PentahoSessionHolder
               .getSession() );
       mondrianCatalogService.reInit( PentahoSessionHolder.getSession() );
-
-      // Flush the IOlapService
-      IOlapService olapService =
-          PentahoSystem.get( IOlapService.class, "IOlapService", PentahoSessionHolder.getSession() ); //$NON-NLS-1$
-      olapService.flushAll( PentahoSessionHolder.getSession() );
-
     } catch ( PentahoAccessControlException e ) {
       return Response.serverError().entity( e.toString() ).build();
     } catch ( Exception e ) {
@@ -160,7 +150,7 @@ public class RepositoryImportResource {
         importLogger.endJob();
       }
     }
-    String responseBody = null;
+    String responseBody;
     try {
       responseBody = importLoggerStream.toString( charSet );
     } catch ( UnsupportedEncodingException e ) {
@@ -179,5 +169,4 @@ public class RepositoryImportResource {
       throw new PentahoAccessControlException( "Access Denied" );
     }
   }
-  
 }

--- a/extensions/test-src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperTest.java
@@ -17,10 +17,16 @@
 
 package org.pentaho.platform.plugin.action.mondrian.catalog;
 
+import mondrian.olap.CacheControl;
+import mondrian.olap.Connection;
+import mondrian.olap.Schema;
 import mondrian.olap.Util.PropertyList;
 import mondrian.spi.DynamicSchemaProcessor;
 import org.apache.commons.io.IOUtils;
 import org.junit.*;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.olap4j.OlapConnection;
 import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.database.service.DatabaseDialectService;
@@ -38,6 +44,7 @@ import org.pentaho.platform.api.util.IPasswordService;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.platform.engine.core.system.SystemSettings;
+import org.pentaho.platform.plugin.action.olap.IOlapService;
 import org.pentaho.platform.plugin.services.cache.CacheManager;
 import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
@@ -47,9 +54,7 @@ import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.pentaho.test.platform.plugin.UserRoleMapperTest.TestUserRoleListService;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
+import java.io.*;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -75,12 +80,33 @@ public class MondrianCatalogHelperTest {
 
   private static MicroPlatform booter;
   private ICacheManager cacheMgr;
-  private static IUnifiedRepository repo;
+
   private MondrianCatalogHelper helper;
 
-  @BeforeClass
-  public static void setUpClass() throws Exception {
-    repo = mock( IUnifiedRepository.class );
+  @Mock private IUnifiedRepository repo;
+
+  @Mock private  IOlapService olapService;
+
+  @Mock private CacheControl mondrianCacheControl;
+
+  @Mock private Schema mondrianSchema;
+
+  @Mock private OlapConnection olapConn;
+
+  @Mock private Connection rolapConn;
+
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks( this );
+
+    when( olapService.getConnection( any( String.class ), any( IPentahoSession.class ) ) )
+      .thenReturn( olapConn );
+    when( rolapConn.getSchema() ).thenReturn( mondrianSchema );
+    when( rolapConn.getCacheControl( any( PrintWriter.class ) ) )
+      .thenReturn( mondrianCacheControl );
+    when( olapConn.unwrap( Connection.class ) )
+      .thenReturn( rolapConn );
 
     booter = new MicroPlatform( "test-src/solution" );
     booter.define( IPasswordService.class, Base64PasswordService.class, Scope.GLOBAL );
@@ -90,34 +116,30 @@ public class MondrianCatalogHelperTest {
     booter.define( ICacheManager.class, CacheManager.class, Scope.GLOBAL );
     booter.define( IUserRoleListService.class, TestUserRoleListService.class, Scope.GLOBAL );
     booter.defineInstance( IUnifiedRepository.class, repo );
+    booter.defineInstance( IOlapService.class, olapService );
     booter.setSettingsProvider( new SystemSettings() );
     booter.start();
+
+    cacheMgr = PentahoSystem.getCacheManager( null );
+    helper = (MondrianCatalogHelper) PentahoSystem.get( IAclAwareMondrianCatalogService.class );
   }
 
   @AfterClass
   public static void tearDownClass() throws Exception {
   }
 
-  @Before
-  public void setUp() throws Exception {
-    // Clear up the cache
-    cacheMgr = PentahoSystem.getCacheManager( null );
-    cacheMgr.clearRegionCache( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION );
-
-    helper = (MondrianCatalogHelper) PentahoSystem.get( IAclAwareMondrianCatalogService.class );
-  }
-
   @After
   public void tearDown() throws Exception {
     reset( repo );
+    cacheMgr.clearRegionCache( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION );
+    booter.stop();
   }
-
 
   private void initMondrianCatalogsCache() {
     initMondrianCatalogsCache( new HashMap<String, MondrianCatalog>(  ) );
   }
 
-  private void initMondrianCatalogsCache(Map<String, MondrianCatalog> map) {
+  private void initMondrianCatalogsCache( Map<String, MondrianCatalog> map ) {
     cacheMgr.addCacheRegion( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION );
     cacheMgr.putInRegionCache( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION, LocaleHelper.getLocale().toString(), map );
   }
@@ -130,7 +152,7 @@ public class MondrianCatalogHelperTest {
   }
 
 
-  @Test(expected = MondrianCatalogServiceException.class)
+  @Test( expected = MondrianCatalogServiceException.class )
   public void addCatalog_WhenAlreadyExists() throws Exception {
     MondrianCatalog cat = createTestCatalog();
     initMondrianCatalogsCache( Collections.singletonMap( CATALOG_NAME, cat ) );
@@ -140,7 +162,7 @@ public class MondrianCatalogHelperTest {
     IPentahoSession session = mock( IPentahoSession.class );
     doNothing().when( helper ).init( session );
 
-    helper.addCatalog( new ByteArrayInputStream( new byte[0] ), cat, false, null, session );
+    helper.addCatalog( new ByteArrayInputStream( new byte[ 0 ] ), cat, false, null, session );
   }
 
 
@@ -183,6 +205,11 @@ public class MondrianCatalogHelperTest {
     verify( repo ).createFile( eq( makeIdObject( steelWheelsFolderPath ) ),
         argThat( isLikeFile( makeFileObject( steelWheelsFolderPath + RepositoryFile.SEPARATOR + "schema.xml" ) ) ),
         any( IRepositoryFileData.class ), anyString() );
+
+
+    // cache should be cleared for this schema only
+    verify( olapService, times( 1 ) ).getConnection( CATALOG_NAME, session );
+    verify( mondrianCacheControl, times( 1 ) ).flushSchema( this.mondrianSchema );
   }
 
   @Test
@@ -194,7 +221,7 @@ public class MondrianCatalogHelperTest {
     IPentahoSession session = mock( IPentahoSession.class );
     doNothing().when( helperSpy ).init( session );
 
-    doReturn( Collections.<MondrianCatalog>emptyList()).when( helperSpy ).getCatalogs( session );
+    doReturn( Collections.<MondrianCatalog>emptyList() ).when( helperSpy ).getCatalogs( session );
     doReturn( null ).when( helperSpy ).makeSchema( anyString() );
 
     MondrianCatalog cat = createTestCatalog();
@@ -249,6 +276,10 @@ public class MondrianCatalogHelperTest {
     verify( repo ).createFile( eq( makeIdObject( sampleDataFolderPath ) ),
         argThat( isLikeFile( makeFileObject( sampleDataFolderPath + RepositoryFile.SEPARATOR + "schema.xml" ) ) ),
         any( IRepositoryFileData.class ), anyString() );
+
+    // cache should be cleared for this schema only
+    verify( olapService, times( 1 ) ).getConnection( "SampleData",  null );
+    verify( mondrianCacheControl, times( 1 ) ).flushSchema( mondrianSchema );
   }
 
   @Test
@@ -301,6 +332,8 @@ public class MondrianCatalogHelperTest {
 
     List<MondrianCatalog> cats = helper.listCatalogs( session, true );
     assertEquals( 1, cats.size() );
+
+    verify( mondrianCacheControl, never() ).flushSchema( mondrianSchema );
   }
 
   @Test
@@ -363,7 +396,7 @@ public class MondrianCatalogHelperTest {
     verify( aclHelper ).removeAclFor( any( RepositoryFile.class ) );
   }
 
-  @Test(expected = MondrianCatalogServiceException.class)
+  @Test( expected = MondrianCatalogServiceException.class )
   public void removeCatalog_WhenProhibited() throws Exception {
     IPentahoSession session = mock( IPentahoSession.class );
 
@@ -427,7 +460,7 @@ public class MondrianCatalogHelperTest {
     doReturn( true ).when( helperSpy ).hasAccess( eq( cat ), any( RepositoryFilePermission.class ) );
     doNothing().when( helperSpy ).init( session );
     doReturn( cat ).when( helperSpy ).getCatalogFromCache( anyString(), eq( session ) );
-        
+
     assertEquals( helperSpy.getCatalog( catalogName, session ).getName(), catalogName );
     verify( helperSpy ).hasAccess( eq( cat ), any( RepositoryFilePermission.class ) );
 


### PR DESCRIPTION
Mondrian schema cache to be cleared for all cubes on Server

Formerly cache clearing used an unnecessarily conservative strategy,
flushing all Mondrian catalog during any import action that caused a
reInit of the Mondrian catalog.  This may have been done in part
because the PentahoSystem cache (MONDRIAN_CATALOG_CACHE_REGION) needs
to be flushed in its entirety when changes are made, and the Mondrian
cache was being flushed at the same time.

This change separates Mondrian cache flushing from the
MondrianCatalogHelper.reInit() process, and confines cache flushing to
just the relevant catalog being added.  This eliminates cache flush
during analyzer report imports, for example, when the import does not
actually bring in a schema.  Cache clearing during .removeCatalog was
deliberately left off, since Mondrian will reclaim memory independently, 
and avoiding the flush speeds the UI experience.

@lucboudreau 