### PR TITLE
[SP-1683] - Regression PRD-5353 - Hide Parameter UI System Parameter on ...

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/drilldown-profile.xml
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/drilldown-profile.xml
@@ -58,7 +58,7 @@
     <drilldown-profile name="remote-sugar-no-parameter" class="org.pentaho.reporting.engine.classic.extensions.drilldown.SugarFormulaLinkCustomizer"
                        bundle-name="org.pentaho.reporting.engine.classic.extensions.drilldown.drilldown-profile"
                        expert="false" hidden="false" deprecated="false" preferred="false">
-      <attribute name="formula"><![CDATA[IF(ISCONTENTLINK(["::entries"]); CONTENTLINK(["::entries"]);OPENINMANTLETAB(["::path"] & "api/repos/" & ["::pentaho-path"] & "/content?" &["::parameter"]; IFNA(["::TabName"]; FALSE()); IFNA(["::TabActive"]; FALSE())))]]></attribute>
+      <attribute name="formula"><![CDATA[IF(ISCONTENTLINK(["::entries"]); CONTENTLINK(["::entries"]);OPENINMANTLETAB(["::path"] & "api/repos/" & ["::pentaho-path"] & "/viewer?showParameters=false&" &["::parameter"]; IFNA(["::TabName"]; FALSE()); IFNA(["::TabActive"]; FALSE())))]]></attribute>
       <attribute name="extension">prpt</attribute>
     </drilldown-profile>
     <drilldown-profile name="local-sugar"
@@ -72,7 +72,7 @@
                        class="org.pentaho.reporting.engine.classic.extensions.drilldown.SugarFormulaLinkCustomizer"
                        bundle-name="org.pentaho.reporting.engine.classic.extensions.drilldown.drilldown-profile"
                        expert="false" hidden="false" deprecated="false" preferred="false">
-      <attribute name="formula"><![CDATA[IF(ISCONTENTLINK(["::entries"]); CONTENTLINK(["::entries"]);OPENINMANTLETAB(ENV("pentahoBaseURL") & "api/repos/" & ["::pentaho-path"] & "/content?" & ["::parameter"]; IFNA(["::TabName"]; FALSE()); IFNA(["::TabActive"]; FALSE())))]]></attribute>
+      <attribute name="formula"><![CDATA[IF(ISCONTENTLINK(["::entries"]); CONTENTLINK(["::entries"]);OPENINMANTLETAB(ENV("pentahoBaseURL") & "api/repos/" & ["::pentaho-path"] & "/viewer?showParameters=false&" & ["::parameter"]; IFNA(["::TabName"]; FALSE()); IFNA(["::TabActive"]; FALSE())))]]></attribute>
       <attribute name="extension">prpt</attribute>
     </drilldown-profile>
     <drilldown-profile name="remote-sugar-prpti" class="org.pentaho.reporting.engine.classic.extensions.drilldown.SugarFormulaLinkCustomizer"


### PR DESCRIPTION
...Drilldown function downloads a PRPT report instead of hiding the parameter UI of the target report (5.3 Suite) - switched from "content" to "viewer?showParameters=false" URL

@tmorgner review it please. It is a backport of PRD-5353. The fix contains the following PRs:
https://github.com/pentaho/pentaho-reporting/pull/583
https://github.com/pentaho/pentaho-platform/pull/2237
https://github.com/pentaho/pentaho-platform-ee/pull/688