### PR TITLE
[BACKLOG-2452] - Added support for WADL extensibility via external file ...

### DIFF
--- a/api/src/org/pentaho/platform/api/util/IWadlDocumentResource.java
+++ b/api/src/org/pentaho/platform/api/util/IWadlDocumentResource.java
@@ -1,0 +1,49 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Exposes a SpringResource Interface to access wadl extension files
+ */
+public interface IWadlDocumentResource {
+
+  /**
+   * Gets the InputStream of the referenced SpringResource
+   *
+   * @return InputStream with the file that SpringResource points
+   * @throws IOException
+   */
+  InputStream getResourceAsStream() throws IOException;
+
+  /**
+   * Identifies if the resource we are fetching is from a plugin or not
+   *
+   * @return true if the resource is being retrieved from a plugin
+   */
+  boolean isFromPlugin();
+
+  /**
+   * Gets the pluginId where the SpringResource is being retrieved
+   *
+   * @return String with the pluginId
+   */
+  String getPluginId();
+}

--- a/assembly/package-res/biserver/pentaho-solutions/system/pentahoObjects.spring.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentahoObjects.spring.xml
@@ -320,4 +320,9 @@ not directly from the PentahoObjectFactory. -->
     </constructor-arg>
   </bean>
 
+  <bean class="org.pentaho.platform.web.servlet.DefaultSpringWadlResourceDocument">
+    <constructor-arg value="classpath:META-INF/wadl/wadlResource.xml"/>
+    <pen:publish as-type="INTERFACES"/>
+  </bean>
+
 </beans>

--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/web.xml
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/web.xml
@@ -383,6 +383,10 @@
     <servlet-name>jaxrsEndpoint-spring</servlet-name>
     <description>JAX-RS endpoint</description>
     <servlet-class>org.pentaho.platform.web.servlet.JAXRSServlet</servlet-class>
+    <init-param>
+      <param-name>com.sun.jersey.config.property.WadlGeneratorConfig</param-name>
+      <param-value>org.pentaho.platform.web.servlet.PentahoWadlGeneratorConfig</param-value>
+    </init-param>
   </servlet>
 
   <servlet>

--- a/build-utils/src/org/pentaho/wadl/PentahoResourceDoclet.java
+++ b/build-utils/src/org/pentaho/wadl/PentahoResourceDoclet.java
@@ -58,7 +58,7 @@ public class PentahoResourceDoclet extends ResourceDoclet {
         .append( MessageFormat.format( DEPRECATED_TAG, isDeprecated( methodDoc.annotations() ) ) )
         .append( MessageFormat.format( DOCUMENTATION_TAG, documentation ) );
 
-    System.out.println(); return comment.toString();
+    return comment.toString();
   }
 
   public static boolean start( RootDoc root ) {

--- a/extensions/build.xml
+++ b/extensions/build.xml
@@ -65,4 +65,25 @@
       <arg value="${jmeter.dir}/out.csv" />
     </java>
   </target>
+
+  <target name="compile.post" depends="subfloor.compile.post" >
+    <antcall target="wadl-javadoc"/>
+  </target>
+
+  <property name="wadl.path" value="${basedir}/wadlExtension.xml" />
+
+  <target name="wadl-javadoc" depends="javadoc.init">
+    <javadoc sourcepath="${basedir}/src" access="public" source="6" postProcessGeneratedJavadocs="false" packagenames="*">
+      <classpath id="wadl-lib">
+        <fileset dir="${lib.dir}">
+          <include name="*.jar" />
+        </fileset>
+      </classpath>
+      <doclet name="org.pentaho.wadl.PentahoResourceDoclet" pathref="wadl-lib" >
+        <param name="-output" value="${wadl.path}"/>
+      </doclet>
+    </javadoc>
+
+    <move file="${wadl.path}" todir="${bin.dir}/classes/META-INF/wadl"/>
+  </target>
 </project>

--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -68,7 +68,7 @@
 
     <!--  external lib/xml dependencies -->
     <dependency org="jaxen" name="jaxen" rev="1.1.1" transitive="false"/>
-    <dependency org="xerces" name="xercesImpl" rev="2.9.1">
+    <dependency org="xerces" name="xercesImpl" rev="2.9.1" >
       <exclude org="xml-apis" name="xml-apis"/>
     </dependency>
     <dependency org="xerces" name="xercesImpl" rev="2.9.1" conf="test->default">
@@ -130,7 +130,7 @@
     <dependency org="com.sun.jersey" name="jersey-core" rev="1.16" transitive="false"/>
     <dependency org="com.sun.jersey" name="jersey-json" rev="1.16" transitive="false"/>
     <dependency org="com.sun.jersey" name="jersey-client" rev="1.16" transitive="false"/>
-    <dependency org="com.sun.jersey" name="jersey-server" rev="1.16" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-server" rev="1.16" transitive="false" />
     <dependency org="com.sun.jersey" name="jersey-servlet" rev="1.16" transitive="false"/>
 
     <!-- END JAX-WS (Service extension) dependencies -->
@@ -318,6 +318,8 @@
                 changing="true"/>
     <dependency org="${ivy.artifact.group}" name="pentaho-platform-scheduler" rev="${project.revision}" changing="true"
                 conf="default->default"/>
+    <dependency org="${ivy.artifact.group}" name="pentaho-platform-build-utils" rev="${project.revision}"
+                changing="true"/>
 
     <!--  runtime dependencies -->
     <dependency org="annogen" name="annogen" rev="0.1.0" conf="runtime->default"/>
@@ -385,6 +387,8 @@
       <exclude org="avalon-framework" name="avalon-framework"/>
       <exclude org="log4j" name="log4j"/>
     </dependency>
+
+    <dependency org="com.sun.jersey.contribs" name="wadl-resourcedoc-doclet" rev="1.19" transitive="false" />
 
     <dependency org="com.google.guava" name="guava" rev="17.0" conf="test->default"/>
 

--- a/extensions/src/org/pentaho/platform/web/servlet/DefaultSpringWadlResourceDocument.java
+++ b/extensions/src/org/pentaho/platform/web/servlet/DefaultSpringWadlResourceDocument.java
@@ -1,0 +1,100 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.servlet;
+
+import org.pentaho.platform.api.util.IWadlDocumentResource;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.pluginmgr.PluginClassLoader;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+
+
+public class DefaultSpringWadlResourceDocument implements IWadlDocumentResource {
+  ClassPathResource springResource;
+  String pluginId = "";
+  boolean isPlugin = false;
+
+  private static String WADL_NAME = "META-INF/wadl/wadlExtension.xml";
+
+  public DefaultSpringWadlResourceDocument( Resource resource ) {
+    this.springResource = (ClassPathResource) resource;
+
+    //identify if is plugin
+    if ( springResource.getClassLoader() instanceof PluginClassLoader ) {
+      isPlugin = true;
+      pluginId = ( (PluginClassLoader) springResource.getClassLoader() ).getPluginDir().getName();
+    }
+  }
+
+  @Override
+  public InputStream getResourceAsStream() throws IOException {
+    Enumeration<URL> urls;
+
+    urls = springResource.getClassLoader().getResources( WADL_NAME );
+
+    InputStream is = null;
+    URL url = null;
+
+    String systemPath = getSystemPath();
+
+    while ( urls.hasMoreElements() ) {
+      url = urls.nextElement();
+      if ( !isPlugin ) {
+        break;
+      } else {
+        String urlString = url.getPath();
+        if ( urlString.contains( systemPath + "/" + pluginId ) ) {
+          break;
+        }
+      }
+    }
+
+    if ( url != null ) {
+      try {
+        is = getInputStream( url );
+      } catch ( IOException e ) {
+        e.printStackTrace();
+      }
+    }
+
+    return is;
+  }
+
+  protected String getSystemPath() {
+    return PentahoSystem.getApplicationContext().getSolutionPath( "system" );
+  }
+
+  protected InputStream getInputStream( URL url ) throws IOException {
+    return url.openConnection().getInputStream();
+  }
+
+  @Override
+  public boolean isFromPlugin() {
+    return isPlugin;
+  }
+
+  @Override
+  public String getPluginId() {
+    return pluginId;
+  }
+}

--- a/extensions/src/org/pentaho/platform/web/servlet/PentahoWadlGeneratorConfig.java
+++ b/extensions/src/org/pentaho/platform/web/servlet/PentahoWadlGeneratorConfig.java
@@ -1,0 +1,137 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.servlet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.pentaho.platform.api.engine.IPluginManager;
+import org.pentaho.platform.api.util.IWadlDocumentResource;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+
+import com.sun.jersey.api.wadl.config.WadlGeneratorConfig;
+import com.sun.jersey.api.wadl.config.WadlGeneratorDescription;
+import com.sun.jersey.server.wadl.generators.resourcedoc.WadlGeneratorResourceDocSupport;
+
+/**
+ * The wadl configurator class that extends in run time the wadl pointing to a file that adds pre-computed information
+ */
+public class PentahoWadlGeneratorConfig extends WadlGeneratorConfig {
+
+  @Override
+  public List<WadlGeneratorDescription> configure() {
+    String originalRequest = getOriginalRequest();
+
+    Pattern pluginPattern = Pattern.compile( ".*\\/plugin\\/([^/]+)\\/api\\/application.wadl" );
+    Matcher pluginMatcher = pluginPattern.matcher( originalRequest );
+
+    String plugin = null;
+    if ( pluginMatcher.matches() ) {
+      plugin = pluginMatcher.group( 1 );
+    }
+
+    WadlGeneratorConfigDescriptionBuilder builder = getBuilder( plugin );
+
+    if ( builder != null ) {
+      return builder.descriptions();
+    } else {
+      return new ArrayList<WadlGeneratorDescription>();
+    }
+  }
+
+  /**
+   * Gets the original request used to obtain the wadl.
+   * The wadl request is for plugins is changed so we need to retrieve its original form to be able to get the plugin
+   * and point to the right wadl extension file.
+   *
+   * @return String with the original url request
+   */
+  protected String getOriginalRequest() {
+    JAXRSPluginServlet jaxrsPluginServlet = getJAXRSPluginServlet();
+    String originalRequest = "";
+    if ( jaxrsPluginServlet != null ) {
+      originalRequest = (String) jaxrsPluginServlet.requestThread.get();
+    }
+    if ( originalRequest == null || originalRequest.isEmpty() ) {
+      return "/api/application.wadl"; // global api isn't filled
+    }
+    return originalRequest;
+  }
+
+  /**
+   * Gets the WadlGeneratorConfigDescriptionBuilder that is used to extend the wadl.
+   * It was a property pointing to the InputStream of the file
+   *
+   * @param plugin String with the plugin that is requesting the wadl extension
+   * @return WadlGeneratorConfigDescriptionBuilder that is used to extend the wadl.
+   */
+  protected WadlGeneratorConfigDescriptionBuilder getBuilder( String plugin ) {
+    List<IWadlDocumentResource> resourceReferences = getWadlDocumentResources();
+
+    InputStream is = null;
+    try {
+      for ( IWadlDocumentResource wadlDocumentResource : resourceReferences ) {
+        if ( plugin == null && !wadlDocumentResource.isFromPlugin() ) {
+          is = wadlDocumentResource.getResourceAsStream();
+          break;
+        } else if ( wadlDocumentResource.isFromPlugin() && wadlDocumentResource.getPluginId().equals( plugin ) ) {
+          is = wadlDocumentResource.getResourceAsStream();
+          break;
+        }
+      }
+    } catch ( IOException e ) {
+      e.printStackTrace();
+    }
+
+    if ( is != null ) {
+      return generator( WadlGeneratorResourceDocSupport.class ).prop( "resourceDocStream", is );
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets the JAXRSPluginServlet for api that stores the the original request for the wadl
+   *
+   * @return JAXRSPluginServlet with the stored original request
+   */
+  protected JAXRSPluginServlet getJAXRSPluginServlet() {
+    IPluginManager pluginManager = PentahoSystem.get( IPluginManager.class );
+    JAXRSPluginServlet jaxrsPluginServlet;
+
+    try {
+      jaxrsPluginServlet = (JAXRSPluginServlet) pluginManager.getBean( "api" );
+    } catch ( Exception e ) {
+      return null;
+    }
+    return jaxrsPluginServlet;
+  }
+
+  /**
+   * Returns the list of the wadl extension declared beans
+   *
+   * @return List<IWadlDocumentResource> with the declared beans
+   */
+  protected List<IWadlDocumentResource> getWadlDocumentResources() {
+    return PentahoSystem.getAll( IWadlDocumentResource.class );
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/web/servlet/DefaultSpringWadlResourceDocumentTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/servlet/DefaultSpringWadlResourceDocumentTest.java
@@ -1,0 +1,103 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.servlet;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mortbay.jetty.webapp.WebAppClassLoader;
+import org.pentaho.platform.plugin.services.pluginmgr.PluginClassLoader;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class DefaultSpringWadlResourceDocumentTest {
+  DefaultSpringWadlResourceDocument wadlResourceDocumentPlugin, wadlResourceDocumentPluginSpy,
+      wadlResourceDocumentWebapp, wadlResourceDocumentWebappSpy;
+  ClassPathResource classPathResourcePlugin, classPathResourceWebapp;
+  PluginClassLoader pluginClassLoader;
+  WebAppClassLoader webAppClassLoader;
+
+  String pluginName = "reporting";
+  private static String WADL_NAME = "META-INF/wadl/wadlExtension.xml";
+
+  @Before
+  public void setUp() throws Exception {
+    File plugin = mock( File.class );
+    doReturn( pluginName ).when( plugin ).getName();
+    pluginClassLoader = mock( PluginClassLoader.class );
+    doReturn( plugin ).when( pluginClassLoader ).getPluginDir();
+    classPathResourcePlugin = new ClassPathResource( pluginName, pluginClassLoader );
+    wadlResourceDocumentPlugin = new DefaultSpringWadlResourceDocument( classPathResourcePlugin );
+    wadlResourceDocumentPluginSpy = spy( wadlResourceDocumentPlugin );
+
+    webAppClassLoader = mock( WebAppClassLoader.class );
+    classPathResourceWebapp = new ClassPathResource( pluginName, webAppClassLoader );
+    wadlResourceDocumentWebapp = new DefaultSpringWadlResourceDocument( classPathResourceWebapp );
+    wadlResourceDocumentWebappSpy = spy( wadlResourceDocumentWebapp );
+  }
+
+  @Test
+  public void testConstructor() throws Exception {
+    assertTrue( wadlResourceDocumentPlugin.isFromPlugin() );
+    assertEquals( wadlResourceDocumentPlugin.getPluginId(), pluginName );
+
+    assertFalse( wadlResourceDocumentWebapp.isFromPlugin() );
+    assertEquals( wadlResourceDocumentWebapp.getPluginId(), "" );
+  }
+
+  @Test
+  public void testGetResourceAsStream() throws Exception {
+    URL urlReporting = new URL( "file:system/reporting/wadlExtension.xml" ),
+        urlMyPlugin = new URL( "file:system/myplugin/wadlExtension.xml" );
+
+    Set<URL> urls = new HashSet<URL>();
+    urls.add( urlReporting );
+    urls.add( urlMyPlugin );
+
+    Enumeration<URL> urlsEnumeration = java.util.Collections.enumeration( urls );
+    doReturn( urlsEnumeration ).when( pluginClassLoader ).getResources( WADL_NAME );
+    doReturn( "system" ).when( wadlResourceDocumentPluginSpy ).getSystemPath();
+    doReturn( mock( InputStream.class ) ).when( wadlResourceDocumentPluginSpy ).getInputStream( urlReporting );
+
+    assertNotNull( wadlResourceDocumentPluginSpy.getResourceAsStream() );
+
+    urlsEnumeration = java.util.Collections.enumeration( urls );
+    doReturn( urlsEnumeration ).when( webAppClassLoader ).getResources( WADL_NAME );
+    doReturn( "system" ).when( wadlResourceDocumentWebappSpy ).getSystemPath();
+    doReturn( mock( InputStream.class ) ).when( wadlResourceDocumentWebappSpy ).getInputStream( urlReporting );
+    doReturn( mock( InputStream.class ) ).when( wadlResourceDocumentWebappSpy ).getInputStream( urlMyPlugin );
+
+    assertNotNull( wadlResourceDocumentWebappSpy.getResourceAsStream() );
+
+    urls = new HashSet<URL>();
+    urls.add( urlMyPlugin );
+    urlsEnumeration = java.util.Collections.enumeration( urls );
+    doReturn( urlsEnumeration ).when( pluginClassLoader ).getResources( WADL_NAME );
+    assertNull( wadlResourceDocumentPluginSpy.getResourceAsStream() );
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/web/servlet/PentahoWadlGeneratorConfigTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/servlet/PentahoWadlGeneratorConfigTest.java
@@ -1,0 +1,132 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.servlet;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sun.jersey.api.wadl.config.WadlGeneratorConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.util.IWadlDocumentResource;
+
+import com.sun.jersey.api.wadl.config.WadlGeneratorDescription;
+
+public class PentahoWadlGeneratorConfigTest {
+
+  PentahoWadlGeneratorConfig spyConfig;
+
+  @Before
+  public void setUp() {
+    spyConfig = spy( new PentahoWadlGeneratorConfig() );
+  }
+
+  @Test
+  public void testConfigure() throws Exception {
+    List<WadlGeneratorDescription> result;
+
+    doReturn( null ).when( spyConfig ).getBuilder( null );
+
+    String originalRequest = "/api/application.wadl";
+    doReturn( originalRequest ).when( spyConfig ).getOriginalRequest();
+    result = spyConfig.configure();
+    verify( spyConfig, times( 1 ) ).getBuilder( null );
+    verify( spyConfig, times( 1 ) ).getOriginalRequest();
+    assertTrue( result.size() == 0 );
+
+    originalRequest = "/asdffsadasdfdsaf/adsafds.wadl";
+    doReturn( originalRequest ).when( spyConfig ).getOriginalRequest();
+    result = spyConfig.configure();
+    verify( spyConfig, times( 2 ) ).getBuilder( null );
+    verify( spyConfig, times( 2 ) ).getOriginalRequest();
+    assertTrue( result.size() == 0 );
+
+    originalRequest = "/plugin/reporting/api/application.wadl";
+    doReturn( originalRequest ).when( spyConfig ).getOriginalRequest();
+    result = spyConfig.configure();
+    verify( spyConfig, times( 1 ) ).getBuilder( "reporting" );
+    verify( spyConfig, times( 3 ) ).getOriginalRequest();
+    assertTrue( result.size() == 0 );
+
+    List<WadlGeneratorConfig> wadlGeneratorConfigList = new ArrayList<WadlGeneratorConfig>();
+    wadlGeneratorConfigList.add( mock( WadlGeneratorConfig.class ) );
+
+    WadlGeneratorConfig.WadlGeneratorConfigDescriptionBuilder builder = mock(
+        WadlGeneratorConfig.WadlGeneratorConfigDescriptionBuilder.class );
+    doReturn( builder ).when( spyConfig ).getBuilder( null );
+    doReturn( builder ).when( spyConfig ).getBuilder( "reporting" );
+    doReturn( wadlGeneratorConfigList ).when( builder ).descriptions();
+
+    originalRequest = "/api/application.wadl";
+    doReturn( originalRequest ).when( spyConfig ).getOriginalRequest();
+    result = spyConfig.configure();
+    verify( spyConfig, times( 3 ) ).getBuilder( null );
+    verify( spyConfig, times( 4 ) ).getOriginalRequest();
+    assertTrue( result.size() == 1 );
+
+    originalRequest = "/asdffsadasdfdsaf/adsafds.wadl";
+    doReturn( originalRequest ).when( spyConfig ).getOriginalRequest();
+    result = spyConfig.configure();
+    verify( spyConfig, times( 4 ) ).getBuilder( null );
+    verify( spyConfig, times( 5 ) ).getOriginalRequest();
+    assertTrue( result.size() == 1 );
+
+    originalRequest = "/plugin/reporting/api/application.wadl";
+    doReturn( originalRequest ).when( spyConfig ).getOriginalRequest();
+    result = spyConfig.configure();
+    verify( spyConfig, times( 2 ) ).getBuilder( "reporting" );
+    verify( spyConfig, times( 6 ) ).getOriginalRequest();
+    assertTrue( result.size() == 1 );
+  }
+
+  @Test
+  public void testGetBuilder() throws Exception {
+    List<IWadlDocumentResource> list = new ArrayList<IWadlDocumentResource>();
+    IWadlDocumentResource documentResource1 = mock( IWadlDocumentResource.class ),
+        documentResource2 = mock( IWadlDocumentResource.class ),
+        documentResource3 = mock( IWadlDocumentResource.class );
+    list.add( documentResource1 );
+    list.add( documentResource2 );
+    list.add( documentResource3 );
+
+    doReturn( false ).when( documentResource1 ).isFromPlugin();
+    doReturn( true ).when( documentResource2 ).isFromPlugin();
+    doReturn( true ).when( documentResource3 ).isFromPlugin();
+    doReturn( "" ).when( documentResource1 ).getPluginId();
+    doReturn( "reporting" ).when( documentResource2 ).getPluginId();
+    doReturn( "data-access" ).when( documentResource3 ).getPluginId();
+    doReturn( mock( InputStream.class ) ).when( documentResource1 ).getResourceAsStream();
+    doReturn( mock( InputStream.class ) ).when( documentResource2 ).getResourceAsStream();
+    doThrow( new IOException() ).when( documentResource3 ).getResourceAsStream();
+    doReturn( list ).when( spyConfig ).getWadlDocumentResources();
+
+    assertNotNull( spyConfig.getBuilder( null ) );
+    assertNotNull( spyConfig.getBuilder( "reporting" ) );
+    assertNull( spyConfig.getBuilder( "data-access" ) );
+
+    doThrow( new IOException() ).when( documentResource1 ).getResourceAsStream();
+    assertNull( spyConfig.getBuilder( null ) );
+  }
+}


### PR DESCRIPTION
...generated in build time

 - Updated builds to build this new project and generate a new WADL file
 - WADL is generated via PentahoResourceDoclet
 - In run time, the WADL is patched with the content of the file using WadlGeneratorConfig referenced in web.xml and file is retrieved via SprintResource, where each plugin that wants to expose a WADL file just needs to add a bean with that reference
 - Unit tests created for every new class added

@pentaho-nbaker please review