### PR TITLE
[BACKLOG-2467] - Implement a standard method for registering Javascript plugin objects

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/filters/PentahoWebContextFilter.java
+++ b/extensions/src/org/pentaho/platform/web/http/filters/PentahoWebContextFilter.java
@@ -70,7 +70,7 @@ public class PentahoWebContextFilter implements Filter {
   private static final String CONTEXT = "context"; //$NON-NLS-1$
   private static final String GLOBAL = "global"; //$NON-NLS-1$
   private static final byte[] REQUIRE_JS_CFG_START =
-      "var requireCfg = {waitSeconds: 30, paths: {}, shim: {}};\n".getBytes(); //$NON-NLS-1$
+      "var requireCfg = {waitSeconds: 30, paths: {}, shim: {}, map: {\"*\": {}}, bundles: {}, config: {service: {}}, packages: []};\n".getBytes(); //$NON-NLS-1$
   private static final String REQUIRE_JS = "requirejs"; //$NON-NLS-1$
   // Changed to not do so much work for every request
   private static final ThreadLocal<byte[]> THREAD_LOCAL_CONTEXT_PATH = new ThreadLocal<byte[]>();


### PR DESCRIPTION
* Adds common Require-JS properties to the `requireCfg` object.
* Also includes an `requireCfg.config.service` object, for easier configuration of the proposed Common-UI's AMD plugin (whose AMD module id is `service`).

See associated pull-request https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/361.

@pentaho-nbaker please review.