### PR TITLE
[BACKLOG-3379] REGRESSION: PUC paste functionality is disabled

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/JAXBContextResolver.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/JAXBContextResolver.java
@@ -19,6 +19,7 @@ package org.pentaho.platform.web.http.api.resources;
 
 import com.sun.jersey.api.json.JSONConfiguration;
 import com.sun.jersey.api.json.JSONJAXBContext;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,7 @@ import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
@@ -44,6 +46,7 @@ public class JAXBContextResolver implements ContextResolver<JAXBContext> {
     types.add( Setting.class );
     arrays.add( "list" );
     arrays.add( "values" );
+    arrays.add( "setting" );
     JSONConfiguration config =
         JSONConfiguration.mapped().rootUnwrapping( true ).arrays( arrays.toArray( new String[] {} ) ).build();
     context = new JSONJAXBContext( config, types.toArray( new Class[] {} ) );


### PR DESCRIPTION
This issue appeared after https://github.com/pentaho/pentaho-platform/commit/95b4b631a4ca772e2a6c05cf444e1abf169aee1a

Details:
Function "updateFolderPermissionButtons" from browser.folderButtons.js file expects array of permissions from REST (http://localhost:8080/pentaho/api/repo/files/%3Apublic/canAccessMap?permissions=1). But if result list contains single item JAXB converts it to json as object but not the array.
For example, {"setting":{"name":"1","value":"true"}}

For fixing it I added name of XmlRootElement entity Settings.java. Now response looks like: {"setting":[{"name":"1","value":"true"}]}

Now the same behavior exists for REST /plugin-manager/settings/{settingName}.
Example response: {"Item":{"@type":"setting","name":"common-ui","value":"true"}}
It's not a problem if client of REST expects response both types: object and array. But if we can always receive array we should add "arrays.add( "Item" );" like my fix.

@rmansoor review please
