### PR TITLE
[BACKLOG-3421] - Help Documentation Page is not rendering correctly i…

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/docs/InformationMap.jsp
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/docs/InformationMap.jsp
@@ -1,6 +1,4 @@
-<%@
-        page language="java"
-             import="org.pentaho.platform.web.jsp.messages.Messages"%>
+<%@ page language="java" import="org.pentaho.platform.web.jsp.messages.Messages" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!DOCTYPE HTML>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>


### PR DESCRIPTION
…n French, German and Japanese.

Porting this EE fix to CE, having the JSP flag could remove future localization issues related UTF-8 encoding.