### PR TITLE
[BISERVER-12550] "Close other tabs" hangs when multiple analyzer repo…

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
@@ -623,13 +623,16 @@ public class MantleTabPanel extends org.pentaho.gwt.widgets.client.tabs.PentahoT
   }
 
   public void closeOtherTabs( PentahoTab exceptThisTab ) {
-    // remove from 0 -> me
-    while ( exceptThisTab != getTab( 0 ) ) {
-      closeTab( getTab( 0 ), true );
+    int tabCount = getTabCount();
+    List<PentahoTab> tabs = new ArrayList<PentahoTab>( tabCount - 1 );
+    for ( int i = 0; i < tabCount; i++ ) {
+      PentahoTab tabItem = getTab( i );
+      if ( exceptThisTab != tabItem ) {
+        tabs.add( tabItem );
+      }
     }
-    // remove from END -> me
-    while ( exceptThisTab != getTab( getTabCount() - 1 ) ) {
-      closeTab( getTab( getTabCount() - 1 ), true );
+    for ( PentahoTab tab : tabs ) {
+      closeTab( tab, true );
     }
     selectTab( exceptThisTab );
   }


### PR DESCRIPTION
…rts are open on the PUC

Reason: infinite loop for closing tabs. When we try to close new Analyzer report, it generates confirmation dialog box for closing without saving report.

What was done:
changed loop.

@rmansoor review please 