### PR TITLE
[BACKLOG-3264] Update the platform code to use jackrabbit 2.10.0 and …

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -78,7 +78,7 @@
 
     <dependency org="dom4j" name="dom4j" rev="1.6.1" transitive="false"/>
     <dependency org="wsdl4j" name="wsdl4j" rev="1.6.2" transitive="false"/>
-    <dependency org="javax.jcr" name="jcr" rev="1.0" transitive="false"/>
+    <dependency org="javax.jcr" name="jcr" rev="2.0" transitive="false"/>
     <dependency org="org.apache.geronimo.specs" name="geronimo-stax-api_1.0_spec" rev="1.0" transitive="false"/>
     <dependency org="org.springframework.security" name="spring-security-core" rev="2.0.5.RELEASE" transitive="false"/>
     <dependency org="org.springframework.ldap" name="spring-ldap-core" rev="1.3.0.RELEASE" transitive="false"/>

--- a/repository/ivy.xml
+++ b/repository/ivy.xml
@@ -66,7 +66,12 @@
 		<dependency org="cglib"             name="cglib"        rev="2.2"    transitive="false"/>
 
 		<!-- begin JCR/Jackrabbit -->
-		<dependency org="org.apache.jackrabbit"    	name="jackrabbit-core"            rev="2.4.5" />
+		<dependency org="org.apache.jackrabbit"    	name="jackrabbit-core"            rev="2.10.0" />
+
+    	<dependency org="org.apache.jackrabbit" name="jackrabbit-data" rev="2.10.0" transitive="false">
+      		<artifact name="jackrabbit-data" type="jar"/>
+    	</dependency>
+
 	    <dependency org="org.springframework"      	name="se-jcr"                     rev="0.9" transitive="false" />
 	    <dependency org="javax.jcr"        			name="jcr"                        rev="2.0"        transitive="false"/>
 	    <dependency org="javax.transaction"        	name="jta"                        rev="1.1"        transitive="false"/>

--- a/repository/src/org/apache/jackrabbit/core/security/authorization/acl/CachingPentahoEntryCollector.java
+++ b/repository/src/org/apache/jackrabbit/core/security/authorization/acl/CachingPentahoEntryCollector.java
@@ -156,14 +156,14 @@ public class CachingPentahoEntryCollector extends PentahoEntryCollector {
    * @see EntryCollector#getEntries(org.apache.jackrabbit.core.NodeImpl)
    */
   @Override
-  protected Entries getEntries( NodeImpl node ) throws RepositoryException {
+  protected PentahoEntries getEntries( NodeImpl node ) throws RepositoryException {
     NodeId nodeId = node.getNodeId();
     Entries entries = getCache().get( nodeId );
     if ( entries == null ) {
       // fetch entries and update the cache
       entries = updateCache( node );
     }
-    return entries;
+    return entries instanceof PentahoEntries ? ( PentahoEntries ) entries : new PentahoEntries( entries );
   }
 
   /**

--- a/repository/src/org/apache/jackrabbit/core/security/authorization/acl/PentahoACLProvider.java
+++ b/repository/src/org/apache/jackrabbit/core/security/authorization/acl/PentahoACLProvider.java
@@ -75,7 +75,7 @@ public class PentahoACLProvider extends ACLProvider {
     }
     super.init( systemSession, conf );
     // original initRootACL should run during super.init call above
-    updateRootAcl( (SessionImpl) systemSession, new ACLEditor( session, this ) );
+    updateRootAcl( (SessionImpl) systemSession, new ACLEditor( session, this, false /* allowUnknownPrincipals */ ) );
     this.initialized = true;
     registerEntryCollectorWithObservationManager( systemSession );
   }

--- a/repository/src/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntry.java
+++ b/repository/src/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntry.java
@@ -1,0 +1,292 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.jackrabbit.core.security.authorization.acl;
+
+import org.apache.jackrabbit.api.JackrabbitWorkspace;
+import org.apache.jackrabbit.api.security.principal.PrincipalManager;
+import org.apache.jackrabbit.core.NodeImpl;
+import org.apache.jackrabbit.core.SessionImpl;
+import org.apache.jackrabbit.core.id.NodeId;
+import org.apache.jackrabbit.core.security.authorization.AccessControlConstants;
+import org.apache.jackrabbit.core.security.authorization.GlobPattern;
+import org.apache.jackrabbit.core.security.authorization.PrivilegeBits;
+import org.apache.jackrabbit.core.security.authorization.PrivilegeManagerImpl;
+import org.apache.jackrabbit.core.value.InternalValue;
+import org.apache.jackrabbit.spi.Name;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import java.security.Principal;
+import java.security.acl.Group;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Copy-and-paste of {@code org.apache.jackrabbit.core.security.authorization.acl.Entry} in Jackrabbit 2.10.0.
+ * This class is in {@code org.apache.jackrabbit.core.security.authorization.acl} package due to the scope of
+ * collaborating classes.
+ *
+ * <p/>
+ * <p/>
+ * <p> Changes to original: </p> <ul> <li>{@code Entry} has a single private constructor, we changed the
+ * scope to public {@code null} {@code nextId}.</li>
+ * <p/>
+ * </ul>
+ */
+public class PentahoEntry implements AccessControlConstants {
+
+  private static final Logger log = LoggerFactory.getLogger( ACLTemplate.class );
+
+  private final String principalName;
+  private final boolean isGroupEntry;
+  private final PrivilegeBits privilegeBits;
+  private final boolean isAllow;
+  private final NodeId id;
+  private final GlobPattern pattern;
+  private final boolean hasRestrictions;
+
+  /**
+   * https://issues.apache.org/jira/browse/JCR-3882
+   *
+   * We can't use 'pattern.equals( other.pattern )' for the time being, this is a
+   * workaround while the above issue does not get pushed into a stable jackrabbit release
+   */
+
+  private final String path;
+  private final String restriction;
+
+  /**
+   * end workaround
+   */
+
+
+
+  private int hashCode;
+
+  public PentahoEntry(NodeId id, String principalName, boolean isGroupEntry,
+      PrivilegeBits privilegeBits, boolean allow, String path, Value globValue) throws RepositoryException {
+
+    this.principalName = principalName;
+    this.isGroupEntry = isGroupEntry;
+    this.privilegeBits = privilegeBits;
+    this.isAllow = allow;
+    this.id = id;
+    this.pattern = calculatePattern(path, globValue);
+    this.hasRestrictions = (globValue != null);
+
+    /**
+     * https://issues.apache.org/jira/browse/JCR-3882
+     *
+     * We can't use 'pattern.equals( other.pattern )' for the time being, this is a
+     * workaround while the above issue does not get pushed into a stable jackrabbit release
+     */
+
+    this.path = path;
+    this.restriction = globValue != null ? globValue.getString() : null;
+
+    /**
+     * end workaround
+     */
+  }
+
+  public PentahoEntry(NodeId id, String principalName, boolean isGroupEntry,
+      PrivilegeBits privilegeBits, boolean allow, String path, Map<Name, Value> restrictions ) throws RepositoryException {
+
+    this.principalName = principalName;
+    this.isGroupEntry = isGroupEntry;
+    this.privilegeBits = privilegeBits;
+    this.isAllow = allow;
+    this.id = id;
+    this.pattern = calculatePattern( path, ( restrictions != null ? restrictions.get( P_GLOB ) : null ) );
+    this.hasRestrictions = ( restrictions != null && restrictions.get( P_GLOB ) != null );
+
+    /**
+     * https://issues.apache.org/jira/browse/JCR-3882
+     *
+     * We can't use 'pattern.equals( other.pattern )' for the time being, this is a
+     * workaround while the above issue does not get pushed into a stable jackrabbit release
+     */
+
+    this.path = path;
+    this.restriction = restrictions != null && restrictions.get( P_GLOB ) != null ?
+        restrictions.get( P_GLOB ).getString() : null;
+
+    /**
+     * end workaround
+     */
+  }
+
+  static List<PentahoEntry> readEntries(NodeImpl aclNode, String path) throws RepositoryException {
+    if (aclNode == null || !NT_REP_ACL.equals(aclNode.getPrimaryNodeTypeName())) {
+      throw new IllegalArgumentException("Node must be of type 'rep:ACL'");
+    }
+    SessionImpl sImpl = (SessionImpl) aclNode.getSession();
+    PrincipalManager principalMgr = sImpl.getPrincipalManager();
+    PrivilegeManagerImpl privilegeMgr = (PrivilegeManagerImpl) ((JackrabbitWorkspace) sImpl.getWorkspace()).getPrivilegeManager();
+
+    NodeId nodeId = aclNode.getParentId();
+
+    List<PentahoEntry> entries = new ArrayList<PentahoEntry>();
+    // load the entries:
+    NodeIterator itr = aclNode.getNodes();
+    while (itr.hasNext()) {
+      NodeImpl aceNode = (NodeImpl) itr.nextNode();
+      try {
+        String principalName = aceNode.getProperty(P_PRINCIPAL_NAME).getString();
+        boolean isGroupEntry = false;
+        Principal princ = principalMgr.getPrincipal(principalName);
+        if (princ != null) {
+          isGroupEntry = (princ instanceof Group );
+        }
+
+        InternalValue[] privValues = aceNode.getProperty(P_PRIVILEGES).internalGetValues();
+        Name[] privNames = new Name[privValues.length];
+        for (int i = 0; i < privValues.length; i++) {
+          privNames[i] = privValues[i].getName();
+        }
+
+        Value globValue = null;
+        if (aceNode.hasProperty(P_GLOB)) {
+          globValue = aceNode.getProperty(P_GLOB).getValue();
+        }
+
+        boolean isAllow = NT_REP_GRANT_ACE.equals(aceNode.getPrimaryNodeTypeName());
+        PentahoEntry ace = new PentahoEntry(nodeId, principalName, isGroupEntry, privilegeMgr.getBits(privNames),
+            isAllow, path, globValue);
+        entries.add(ace);
+      } catch (RepositoryException e) {
+        log.debug("Failed to build ACE from content. {}", e.getMessage());
+      }
+    }
+
+    return entries;
+  }
+
+  private static GlobPattern calculatePattern(String path, Value globValue) throws RepositoryException {
+    if (path == null) {
+      return null;
+    } else {
+      if (globValue == null) {
+        return GlobPattern.create(path);
+      } else {
+        return GlobPattern.create(path, globValue.getString());
+      }
+    }
+  }
+
+  /**
+   * @param nodeId
+   * @return <code>true</code> if this entry is defined on the node
+   * at <code>nodeId</code>
+   */
+  boolean isLocal(NodeId nodeId) {
+    return id != null && id.equals(nodeId);
+  }
+
+  /**
+   *
+   * @param jcrPath
+   * @return
+   */
+  boolean matches(String jcrPath) {
+    return pattern != null && pattern.matches(jcrPath);
+  }
+
+  PrivilegeBits getPrivilegeBits() {
+    return privilegeBits;
+  }
+
+  boolean isAllow() {
+    return isAllow;
+  }
+
+  String getPrincipalName() {
+    return principalName;
+  }
+
+  boolean isGroupEntry() {
+    return isGroupEntry;
+  }
+
+  boolean hasRestrictions() {
+    return hasRestrictions;
+  }
+
+  //-------------------------------------------------------------< Object >---
+  /**
+   * @see Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    if (hashCode == -1) {
+      int h = 17;
+      h = 37 * h + principalName.hashCode();
+      h = 37 * h + privilegeBits.hashCode();
+      h = 37 * h + Boolean.valueOf(isAllow).hashCode();
+      h = 37 * h + pattern.hashCode();
+      hashCode = h;
+    }
+    return hashCode;
+  }
+
+  /**
+   * @see Object#equals(Object)
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj instanceof PentahoEntry) {
+      PentahoEntry other = (PentahoEntry) obj;
+
+      return principalName.equals( other.principalName ) &&
+          privilegeBits.equals( other.privilegeBits ) &&
+          isAllow == other.isAllow &&
+
+
+          /* pattern.equals( other.pattern ) */
+
+          /**
+           * https://issues.apache.org/jira/browse/JCR-3882
+           *
+           * We can't use 'pattern.equals( other.pattern )' for the time being, this is a
+           * workaround while the above issue does not get pushed into a stable jackrabbit release
+           */
+
+          (
+
+            path.equals( other.path ) &&
+                ( (restriction == null) ? other.restriction == null : restriction.equals(other.restriction) )
+
+          )
+
+          /**
+           * end workaround
+           */
+
+
+          ;
+
+    }
+    return false;
+  }
+}

--- a/repository/src/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntryFilter.java
+++ b/repository/src/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntryFilter.java
@@ -1,0 +1,5 @@
+package org.apache.jackrabbit.core.security.authorization.acl;
+
+public interface PentahoEntryFilter extends EntryFilter {
+
+}

--- a/repository/src/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntryFilterImpl.java
+++ b/repository/src/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntryFilterImpl.java
@@ -1,0 +1,136 @@
+package org.apache.jackrabbit.core.security.authorization.acl;
+
+import org.apache.jackrabbit.core.SessionImpl;
+import org.apache.jackrabbit.core.id.ItemId;
+import org.apache.jackrabbit.spi.Path;
+import org.apache.jackrabbit.spi.commons.conversion.PathResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Copy-and-paste of {@code org.apache.jackrabbit.core.security.authorization.acl} in Jackrabbit 2.10.0.
+ * This class is in {@code org.apache.jackrabbit.core.security.authorization.acl} package due to the scope of
+ * collaborating classes.
+ *
+ * <p/>
+ * <p/>
+ * <p> Changes to original: </p> <ul> <li>{@code Entry} has a single private constructor, we changed the
+ * scope to public {@code null} {@code nextId}.</li>
+ * <p/>
+ * </ul>
+ */
+public class PentahoEntryFilterImpl extends EntryFilterImpl implements PentahoEntryFilter {
+
+  /**
+   * logger instance
+   */
+  private static final Logger log = LoggerFactory.getLogger(PentahoEntryFilterImpl.class);
+
+  private final Collection<String> principalNames;
+  private final PathProvider pathProvider;
+
+  private String itemPath;
+
+  PentahoEntryFilterImpl(Collection<String> principalNames, final ItemId id, final SessionImpl sessionImpl) {
+    super( principalNames , id , sessionImpl );
+    this.principalNames = principalNames;
+    this.pathProvider = new PathProvider() {
+      public String getPath() throws RepositoryException {
+        Path p = sessionImpl.getHierarchyManager().getPath(id);
+        return sessionImpl.getJCRPath(p);
+      }
+    };
+  }
+
+  PentahoEntryFilterImpl(Collection<String> principalNames, final Path absPath, final PathResolver pathResolver) {
+    super( principalNames, absPath, pathResolver  );
+    this.principalNames = principalNames;
+    this.pathProvider = new PathProvider() {
+      public String getPath() throws RepositoryException {
+        return pathResolver.getJCRPath(absPath);
+      }
+    };
+  }
+
+  /**
+   * Separately collect the entries defined for the user and group
+   * principals.
+   *
+   * @param entries
+   * @param resultLists
+   * @see EntryFilter#filterEntries(java.util.List, java.util.List[])
+   */
+  @Override
+  public void filterEntries( List entries, List... resultLists ) {
+    if ( resultLists.length == 2 ) {
+      List<PentahoEntry> userAces = resultLists[0];
+      List<PentahoEntry> groupAces = resultLists[1];
+
+      int uInsertIndex = userAces.size();
+      int gInsertIndex = groupAces.size();
+
+      // first collect aces present on the given aclNode.
+      for ( PentahoEntry ace : ( List<PentahoEntry> ) entries ) {
+        // only process ace if 'principalName' is contained in the given set
+        if ( matches( ace ) ) {
+          // add it to the proper list (e.g. separated by principals)
+          /**
+           * NOTE: access control entries must be collected in reverse
+           * order in order to assert proper evaluation.
+           */
+          if ( ace.isGroupEntry() ) {
+            groupAces.add( gInsertIndex, ace );
+          } else {
+            userAces.add( uInsertIndex, ace );
+          }
+        }
+      }
+    } else {
+      log.warn( "Filtering aborted. Expected 2 result lists." );
+    }
+  }
+
+  private boolean matches( PentahoEntry entry ) {
+    if ( principalNames == null || principalNames.contains( entry.getPrincipalName() ) ) {
+      if ( !entry.hasRestrictions() ) {
+        // short cut: there is no glob-restriction -> the entry matches
+        // because it is either defined on the node or inherited.
+        return true;
+      } else {
+        // there is a glob-restriction: check if the target path matches
+        // this entry.
+        try {
+          return entry.matches(getPath());
+        } catch (RepositoryException e) {
+          log.error("Cannot determine ACE match.", e);
+        }
+      }
+    }
+
+    // doesn't match this filter -> ignore
+    return false;
+  }
+
+  String getPath() throws RepositoryException {
+    if (itemPath == null) {
+      itemPath = pathProvider.getPath();
+    }
+    return itemPath;
+  }
+
+  //--------------------------------------------------------------------------
+  /**
+   * Interface for lazy calculation of the JCR path used for evaluation of ACE
+   * matching in case of entries defining restriction(s).
+   */
+  private interface PathProvider {
+
+    String getPath() throws RepositoryException;
+
+  }
+
+}


### PR DESCRIPTION
…resolve resulting errors

- created new class PentahoEntry that mimics org.apache.jackrabbit.core.security.authorization.acl.Entry but exposes private constructors
- created new inner class PentahoEntries that extends jackrabbit's inner class Entries, but serves a list of PentahoEntry objects
- created new class PentahoEntryFilterImpl that extends jackrabbit's EntryFilterImpl, but works for PentahoEntry objects
- PentahoCompiledPermissionsImpl now checks the object ( instanceof PentahoEntry or instanceof Entry )
- PentahoEntryCollector kept the same ace gathering logic, mapping the ( now deprecated ) List<AccessControlEntry> to List<PentahoEntry>