### PR TITLE
[CLEANUP] - fixing circular dependency between pentaho-karaf-assembly…

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -221,7 +221,7 @@
     <dependency org="org.quartz-scheduler" name="quartz-oracle" rev="1.7.2" />
 
 
-    <dependency org="pentaho" name="pdi-osgi-bridge" rev="${project.revision}" />
+    <dependency org="pentaho" name="pdi-osgi-bridge-core" rev="${project.revision}" />
     <dependency org="pentaho" name="pentaho-osgi-utils-api" rev="${project.revision}" />
 
     <!-- Platform plugins -->


### PR DESCRIPTION
… and pdi-osgi-bridge.

pdi-osgi-bridge assembly pulled in pentaho-karaf-assembly and pentaho-karaf-assembly (in the standard feature file) pulls in pdi-osgi-bridge-activators. This was the source of the circular dependency and is potentially fixed by splitting out the assembly from the core of the bridge.

@lgrill-pentaho _NOTE: It is still required (by the build) to build the pdi-osgi-bridge core and activator FIRST, then pentaho-karaf-assembly, and LAST the pdi-osgi-bridge assembly._