### PR TITLE
[TEST] - Fixing platform unit tests

### DIFF
--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDaoTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDaoTest.java
@@ -2,13 +2,18 @@ package org.pentaho.platform.repository2.unified.jcr;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Date;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.platform.api.mt.ITenant;
 import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.IRepositoryVersionManager;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.VersionSummary;
 import org.pentaho.platform.api.repository2.unified.data.sample.SampleRepositoryFileData;
@@ -17,10 +22,18 @@ import org.pentaho.platform.repository2.unified.DefaultUnifiedRepositoryBase;
 
 public class JcrRepositoryFileDaoTest extends DefaultUnifiedRepositoryBase {
 
+  @Before
+  public void beforeTest() {
+    IRepositoryVersionManager mockRepositoryVersionManager = mock( IRepositoryVersionManager.class );
+    when( mockRepositoryVersionManager.isVersioningEnabled( anyString() ) ).thenReturn( true );
+    when( mockRepositoryVersionManager.isVersionCommentEnabled( anyString() ) ).thenReturn( false );
+    JcrRepositoryFileUtils.setRepositoryVersionManager( mockRepositoryVersionManager );
+  }
+
   @Test
   //Running within defined date
   public void testUpdateFile1() throws Exception {
-    
+
     RepositoryFile newFile = createFile( "JcrRepositoryFileDaoTest1.test" );
     IRepositoryFileData dataMock = new SampleRepositoryFileData( "", true, 0 );
 


### PR DESCRIPTION
Future-develop was merged with master and code line conflicts require updating unit tests to run.
These tests were failing because repositoryVersionManager was null, these tests existed in master
before the merge and had no knowledge of this class. Mocking out repositoryVersionManager resolves this issue.