### PR TITLE
BISERVER-12646  Cannot run program javadoc.exe: The filename or extension is too long

### DIFF
--- a/extensions/build.xml
+++ b/extensions/build.xml
@@ -86,7 +86,7 @@
     <if>
       <istrue value="${ant.version.atleast.1.9.2}"/>
       <then>
-        <javadoc sourcepath="${basedir}/src" access="public" postprocessgeneratedjavadocs="false" source="6" packagenames="*">
+        <javadoc sourcepath="${basedir}/src" access="public" postprocessgeneratedjavadocs="false" source="6" packagenames="*" useexternalfile="yes">
           <classpath refid="wadl-lib" />
           <doclet name="org.pentaho.wadl.PentahoResourceDoclet" pathref="wadl-lib" >
             <param name="-output" value="${wadl.path}"/>


### PR DESCRIPTION
«Many problems with running javadoc stem from command lines that have become too long - even though the error message doesn't give the slightest hint this may be the problem. If you encounter problems with the task, try to set the useexternalfile attribute to true first.»
Full text at the page https://ant.apache.org/manual/Tasks/javadoc.html 