### PR TITLE
Revert "SP-1948 - Backport of BISERVER-12579 - Non-admin User Unable …

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/jackrabbit/repository.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/jackrabbit/repository.xml
@@ -342,8 +342,6 @@ value="{0}/etc/pdi;org.pentaho.repository.read;jcr:read,jcr:readAccessControl;tr
 value="{0}/etc/pdi;org.pentaho.repository.create;jcr:read,jcr:readAccessControl,jcr:write,jcr:modifyAccessControl,jcr:lockManagement,jcr:versionManagement,jcr:nodeTypeManagement;true;false;false" />
         <param name="magicAceDefinition4"
 value="{0}/etc;org.pentaho.security.publish;jcr:read,jcr:readAccessControl,jcr:write,jcr:modifyAccessControl,jcr:lockManagement,jcr:versionManagement,jcr:nodeTypeManagement;true;true;false" />
-        <param name="magicAceDefinition5"
-value="{0}/etc/pdi/databases;org.pentaho.platform.dataaccess.datasource.security.manage;jcr:read,jcr:readAccessControl,jcr:write,jcr:modifyAccessControl,jcr:lockManagement,jcr:versionManagement,jcr:nodeTypeManagement;true;true;true" />
       </AccessControlProvider>
     </WorkspaceSecurity>
 


### PR DESCRIPTION
@rmansoor 
Please review.

Reverts pentaho/pentaho-platform#2356

Marc Batchelor's comment on SP-1948:
Changing repository.xml cannot be done on an SP for several reasons:
This is a file we expect many of our customers to change. It is backed up and restored as part of the Upgrade Utility as well, so it cannot be fixed / changed in a point release either.
Changing repository.xml will have no effect unless you blow away the repository folder under jackrabbit. This is because the file gets exploded into several other files in that folder.
AFAIK, this change wouldn't take effect unless they started with a completely clean repository.
So - this SP CANNOT be done. Please back out the change, and close this ticket as "Won't Fix".

Goes with https://github.com/pentaho/data-access/pull/643 and https://github.com/pentaho/pentaho-platform-ee/pull/735