### PR TITLE
[BACKLOG-4343] - Pentaho Fails to start with a space in the path dire…

### DIFF
--- a/extensions/src/org/pentaho/platform/osgi/SystemPackageExtrapolator.java
+++ b/extensions/src/org/pentaho/platform/osgi/SystemPackageExtrapolator.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLDecoder;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Properties;
@@ -36,7 +37,7 @@ public class SystemPackageExtrapolator {
       URL[] urLs = ( (URLClassLoader) classLoader ).getURLs();
       for ( URL url : urLs ) {
         try {
-          String fileName = url.getFile();
+          String fileName = URLDecoder.decode(url.getFile());
           File file = new File( fileName );
           if ( !file.exists() || file.isDirectory() ) {
             continue;


### PR DESCRIPTION
…ctory that Pentaho is installed in

File names are coming through with the space encoded and can't be mapped back to an actual file.