### PR TITLE
[BACKLOG-4343] - Pentaho Fails to start with a space in the path dire…

### DIFF
--- a/assembly/package-res/biserver/start-pentaho-debug.bat
+++ b/assembly/package-res/biserver/start-pentaho-debug.bat
@@ -10,9 +10,9 @@ call set-pentaho-env.bat "%~dp0jre"
 
 cd tomcat\bin
 set CATALINA_HOME=%~dp0tomcat
-SET DI_HOME=%~dp0pentaho-solutions\system\kettle
+SET DI_HOME="%~dp0pentaho-solutions\system\kettle"
 
-set CATALINA_OPTS=-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8044 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=%DI_HOME%
+set CATALINA_OPTS=-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8044 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=\"%DI_HOME%\"
 
 rem Make sure we set the appropriate variable so Tomcat can start (e.g. JAVA_HOME iff. _PENTAHO_JAVA_HOME points to a JDK)
 if not exist "%_PENTAHO_JAVA_HOME%\bin\jdb.exe" goto noJdk

--- a/assembly/package-res/biserver/start-pentaho-debug.sh
+++ b/assembly/package-res/biserver/start-pentaho-debug.sh
@@ -19,7 +19,7 @@ setPentahoEnv "$DIR/jre"
 ## The plugin loading system for kettle needs this set to know   ##
 ## where to load the plugins from                                ##
 ### =========================================================== ###
-DI_HOME=$DIR/pentaho-solutions/system/kettle
+DI_HOME="$DIR"/pentaho-solutions/system/kettle
 
 if [ -f "$DIR/promptuser.sh" ]; then
   sh "$DIR/promptuser.sh"
@@ -27,7 +27,7 @@ if [ -f "$DIR/promptuser.sh" ]; then
 fi
 if [ "$?" = 0 ]; then
   cd "$DIR/tomcat/bin"
-  CATALINA_OPTS="-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8044 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=$DI_HOME"
+  CATALINA_OPTS="-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8044 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=\"$DI_HOME\""
   export CATALINA_OPTS
   JAVA_HOME=$_PENTAHO_JAVA_HOME
   sh startup.sh

--- a/assembly/package-res/biserver/start-pentaho.bat
+++ b/assembly/package-res/biserver/start-pentaho.bat
@@ -12,13 +12,13 @@ cd tomcat\bin
 set CATALINA_HOME=%~dp0tomcat
 
 SET BITS=64
-SET DI_HOME=%~dp0pentaho-solutions\system\kettle
+SET DI_HOME="%~dp0pentaho-solutions\system\kettle"
 
 for /f %%a in ('echo %PROCESSOR_ARCHITECTURE% ^| "%SystemRoot%\system32\find" /c "64"') do if not "%%a"=="1" SET BITS=32
 IF "%BITS%" == "64" (
-  set CATALINA_OPTS=-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=%DI_HOME%
+  set CATALINA_OPTS=-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=\"%DI_HOME%\"
 ) ELSE (
-  set CATALINA_OPTS=-Xms256m -Xmx768m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=%DI_HOME%
+  set CATALINA_OPTS=-Xms256m -Xmx768m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=\"%DI_HOME%\"
 )
 
 rem Make sure we set the appropriate variable so Tomcat can start (e.g. JAVA_HOME iff. _PENTAHO_JAVA_HOME points to a JDK)

--- a/assembly/package-res/biserver/start-pentaho.sh
+++ b/assembly/package-res/biserver/start-pentaho.sh
@@ -19,7 +19,7 @@ setPentahoEnv "$DIR/jre"
 ## The plugin loading system for kettle needs this set to know   ##
 ## where to load the plugins from                                ##
 ### =========================================================== ###
-DI_HOME=$DIR/pentaho-solutions/system/kettle
+DI_HOME="$DIR"/pentaho-solutions/system/kettle
 
 errCode=0
 if [ -f "$DIR/promptuser.sh" ]; then
@@ -29,7 +29,7 @@ if [ -f "$DIR/promptuser.sh" ]; then
 fi
 if [ "$errCode" = 0 ]; then
   cd "$DIR/tomcat/bin"
-  CATALINA_OPTS="-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=$DI_HOME"
+  CATALINA_OPTS="-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=\"$DI_HOME\""
   export CATALINA_OPTS
   JAVA_HOME=$_PENTAHO_JAVA_HOME
   sh startup.sh


### PR DESCRIPTION
…ctory that Pentaho is installed in

Updating the start-pentaho scripts to allow spaces in the installation path.