### PR TITLE
[BACKLOG-4343] - Pentaho Fails to start with a space in the path dire…

### DIFF
--- a/assembly/package-res/biserver/start-pentaho-debug.sh
+++ b/assembly/package-res/biserver/start-pentaho-debug.sh
@@ -19,7 +19,7 @@ setPentahoEnv "$DIR/jre"
 ## The plugin loading system for kettle needs this set to know   ##
 ## where to load the plugins from                                ##
 ### =========================================================== ###
-DI_HOME=$DIR/pentaho-solutions/system/kettle
+DI_HOME="$DIR"/pentaho-solutions/system/kettle
 
 if [ -f "$DIR/promptuser.sh" ]; then
   sh "$DIR/promptuser.sh"
@@ -27,7 +27,7 @@ if [ -f "$DIR/promptuser.sh" ]; then
 fi
 if [ "$?" = 0 ]; then
   cd "$DIR/tomcat/bin"
-  CATALINA_OPTS="-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8044 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=$DI_HOME"
+  CATALINA_OPTS="-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8044 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=\"$DI_HOME\""
   export CATALINA_OPTS
   JAVA_HOME=$_PENTAHO_JAVA_HOME
   sh startup.sh

--- a/assembly/package-res/biserver/start-pentaho.sh
+++ b/assembly/package-res/biserver/start-pentaho.sh
@@ -19,7 +19,7 @@ setPentahoEnv "$DIR/jre"
 ## The plugin loading system for kettle needs this set to know   ##
 ## where to load the plugins from                                ##
 ### =========================================================== ###
-DI_HOME=$DIR/pentaho-solutions/system/kettle
+DI_HOME="$DIR"/pentaho-solutions/system/kettle
 
 errCode=0
 if [ -f "$DIR/promptuser.sh" ]; then
@@ -29,7 +29,7 @@ if [ -f "$DIR/promptuser.sh" ]; then
 fi
 if [ "$errCode" = 0 ]; then
   cd "$DIR/tomcat/bin"
-  CATALINA_OPTS="-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=$DI_HOME"
+  CATALINA_OPTS="-Xms1024m -Xmx2048m -XX:MaxPermSize=256m -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -DDI_HOME=\"$DI_HOME\""
   export CATALINA_OPTS
   JAVA_HOME=$_PENTAHO_JAVA_HOME
   sh startup.sh


### PR DESCRIPTION
…ctory that Pentaho is installed in

Updating the start-pentaho scripts for linux to allow spaces in the installation path.