### PR TITLE
[BACKLOG-4549] - Retrieve list of all runtime roles associated to a user

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
@@ -44,11 +44,7 @@ public class UserRoleListService {
   private Comparator<String> userComparator;
 
   public String doGetRolesForUser( String user ) throws Exception {
-    if ( canAdminister() ) {
       return getRolesForUser( user );
-    } else {
-      throw new UnauthorizedException();
-    }
   }
 
   public String doGetUsersInRole( String role ) throws Exception {

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/UserRoleListServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/UserRoleListServiceTest.java
@@ -50,17 +50,9 @@ public class UserRoleListServiceTest {
 
   @Test
   public void testDoGetRolesForUser() throws Exception {
-    doReturn( true ).when( userRoleListService ).canAdminister();
     doReturn( "admin, guest" ).when( userRoleListService ).getRolesForUser( "Administrator" );
     String roles = userRoleListService.doGetRolesForUser( "Administrator" );
     assertTrue( roles.length() > 0 );
-
-    try {
-      doReturn( false ).when( userRoleListService ).canAdminister();
-      userRoleListService.doGetRolesForUser( "unauthorized" );
-    } catch ( Exception e ) {
-      assertTrue( e instanceof UserRoleListService.UnauthorizedException );
-    }
   }
 
   @Test


### PR DESCRIPTION
Removed canAdminister call from function and its associated test. The Jira case has this endpoint listed as not admin only.