### PR TITLE
[BACKLOG-4709] - Small changes in platform to improve performance

### DIFF
--- a/core/src/org/pentaho/platform/engine/core/system/objfac/AbstractSpringPentahoObjectFactory.java
+++ b/core/src/org/pentaho/platform/engine/core/system/objfac/AbstractSpringPentahoObjectFactory.java
@@ -191,10 +191,12 @@ public abstract class AbstractSpringPentahoObjectFactory implements IPentahoObje
   private <T> T
   retreiveObject( Class<T> interfaceClass, String key, IPentahoSession session, Map<String, String> props )
       throws ObjectFactoryException {
-    // cannot access logger here since this object factory provides the logger
-    logger
+    if ( logger.isDebugEnabled() ) {
+      // cannot access logger here since this object factory provides the logger
+      logger
         .debug( "Attempting to get an instance of [" + interfaceClass.getSimpleName() + "] while in session [" + session
-            + "]" ); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+          + "]" ); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+    }
 
     // Set the Thread Context Classloader to that of the classloader who loaded this class.
     ClassLoader originalClassLoader = null;
@@ -204,7 +206,7 @@ public abstract class AbstractSpringPentahoObjectFactory implements IPentahoObje
       originalClassLoader = Thread.currentThread().getContextClassLoader();
       Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
 
-      if ( session != null && session instanceof StandaloneSession ) {
+      if ( session instanceof StandaloneSession ) {
         // first ask Spring for the object, if it is session scoped it will fail
         // since Spring doesn't know about StandaloneSessions
 
@@ -254,9 +256,11 @@ public abstract class AbstractSpringPentahoObjectFactory implements IPentahoObje
         Thread.currentThread().setContextClassLoader( originalClassLoader );
       }
     }
-    
-    logger
+
+    if ( logger.isDebugEnabled() ) {
+      logger
         .debug( " Got an instance of [" + interfaceClass.getSimpleName() + "]: " + object ); //$NON-NLS-1$ //$NON-NLS-2$
+    }
 
     if ( object instanceof IPentahoInitializer ) {
       ( (IPentahoInitializer) object ).init( session );
@@ -266,12 +270,14 @@ public abstract class AbstractSpringPentahoObjectFactory implements IPentahoObje
 
   protected <T> List<T> retreiveObjects( Class<T> type, final IPentahoSession session, Map<String, String> properties )
       throws ObjectFactoryException {
-    // cannot access logger here since this object factory provides the logger
-    logger.debug( "Attempting to get an instance of [" + type.getSimpleName() + "] while in session [" + session
+    if ( logger.isDebugEnabled() ) {
+      // cannot access logger here since this object factory provides the logger
+      logger.debug( "Attempting to get an instance of [" + type.getSimpleName() + "] while in session [" + session
         + "]" ); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+    }
 
     T object = retrieveViaSpring( type );
-    if ( object != null ) {
+    if ( object != null && logger.isDebugEnabled() ) {
       logger.debug( " Got an instance of [" + type.getSimpleName() + "]: " + object ); //$NON-NLS-1$ //$NON-NLS-2$
     }
 

--- a/core/src/org/pentaho/platform/engine/services/audit/AuditConnection.java
+++ b/core/src/org/pentaho/platform/engine/services/audit/AuditConnection.java
@@ -172,9 +172,8 @@ public class AuditConnection {
 
   public Connection getAuditConnection() throws SQLException {
     SQLException sqlEx = null;
-    int[] sleepTime = { 0, 200, 500, 2000 };
-    for ( int i = 0; i <= 3; i++ ) {
-      waitFor( sleepTime[i] );
+    int[] sleepTime = { 200, 500, 2000 };
+    for ( int aSleepTime : sleepTime ) {
       try {
         Connection con = getConnection();
         try {
@@ -186,9 +185,10 @@ public class AuditConnection {
       } catch ( SQLException ex ) {
         sqlEx = ex;
         AuditConnection.logger.warn( Messages.getInstance().getErrorString(
-            "AuditConnection.WARN_0001_CONNECTION_ATTEMPT_FAILED", "" //$NON-NLS-1$ //$NON-NLS-2$
-                + sleepTime[i] ) );
+          "AuditConnection.WARN_0001_CONNECTION_ATTEMPT_FAILED", "" //$NON-NLS-1$ //$NON-NLS-2$
+            + aSleepTime ) );
       }
+      waitFor( aSleepTime );
     }
     throw new SQLException( Messages.getInstance().getErrorString( "AUDSQLENT.ERROR_0001_INVALID_CONNECTION" ), sqlEx ); //$NON-NLS-1$
   }

--- a/core/test-src/org/pentaho/platform/engine/security/event/OrderedApplicationEventMulticasterTest.java
+++ b/core/test-src/org/pentaho/platform/engine/security/event/OrderedApplicationEventMulticasterTest.java
@@ -1,0 +1,169 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security.event;
+
+import org.junit.Test;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.Ordered;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class OrderedApplicationEventMulticasterTest {
+
+  @Test
+  public void multicastEvent_DirectOrderOfListeners() throws Exception {
+    List<ApplicationListener> collector = collector();
+    List<ApplicationListener> listeners = new ArrayList<>();
+    for ( int i = 0; i < 5; i++ ) {
+      listeners.add( new OrderedStubListener( i, collector ) );
+    }
+
+    runTest( listeners, collector );
+  }
+
+  @Test
+  public void multicastEvent_ReverseOrderOfListeners() throws Exception {
+    List<ApplicationListener> collector = collector();
+    List<ApplicationListener> listeners = new ArrayList<>();
+    for ( int i = 0; i < 5; i++ ) {
+      listeners.add( new OrderedStubListener( -i, collector ) );
+    }
+
+    runTest( listeners, collector );
+  }
+
+  @Test
+  public void multicastEvent_RandomOrderOfListeners() throws Exception {
+    List<ApplicationListener> collector = collector();
+    List<ApplicationListener> listeners = new ArrayList<>();
+    for ( int i = 0; i < 5; i++ ) {
+      listeners.add( new OrderedStubListener( i, collector ) );
+    }
+    Collections.shuffle( listeners );
+
+    runTest( listeners, collector );
+  }
+
+
+  @Test
+  public void multicastEvent_RandomOrderOfDifferentListeners() throws Exception {
+    List<ApplicationListener> collector = collector();
+    List<ApplicationListener> listeners = new ArrayList<>();
+    for ( int i = 0; i < 5; i++ ) {
+      listeners.add( new OrderedStubListener( i, collector ) );
+    }
+    for ( int i = 0; i < 5; i++ ) {
+      listeners.add( new StubListener( collector ) );
+    }
+    Collections.shuffle( listeners );
+
+    runTest( listeners, collector );
+  }
+
+
+  private void runTest( Collection<ApplicationListener> listeners, List<ApplicationListener> collector ) {
+    TestMulticaster multicaster = new TestMulticaster();
+    multicaster.setApplicationListeners( listeners );
+
+    multicaster.multicastEvent( mock( ApplicationEvent.class ) );
+    assertCalledInOrder( collector );
+  }
+
+  private List<ApplicationListener> collector() {
+    return Collections.synchronizedList( new ArrayList<ApplicationListener>() );
+  }
+
+  private void assertCalledInOrder( List<ApplicationListener> list ) {
+    if ( list.size() > 1 ) {
+      ApplicationListener previous = list.get( 0 );
+      for ( int i = 1; i < list.size(); i++ ) {
+        ApplicationListener current = list.get( i );
+        if ( previous instanceof Ordered ) {
+          if ( current instanceof Ordered ) {
+            int prevOrder = ( (Ordered) previous ).getOrder();
+            int curOrder = ( (Ordered) current ).getOrder();
+            assertTrue( "Previous=" + prevOrder + "\tCurrent=" + curOrder, prevOrder <= curOrder );
+          }
+        } else {
+          if ( current instanceof Ordered ) {
+            fail( "Ordered listeners should always precede non-ordered" );
+          }
+        }
+        previous = current;
+      }
+    }
+  }
+
+  private static class TestMulticaster extends OrderedApplicationEventMulticaster {
+    private Collection<ApplicationListener> applicationListeners;
+
+    public void setApplicationListeners( Collection<ApplicationListener> applicationListeners ) {
+      this.applicationListeners = applicationListeners;
+    }
+
+    @Override
+    public Collection<ApplicationListener> getApplicationListeners() {
+      return applicationListeners;
+    }
+  }
+
+  private static class OrderedStubListener implements ApplicationListener, Ordered {
+    private final int order;
+    private final List<ApplicationListener> invoked;
+
+    public OrderedStubListener( int order, List<ApplicationListener> invoked ) {
+      this.order = order;
+      this.invoked = invoked;
+    }
+
+    @Override
+    public void onApplicationEvent( ApplicationEvent applicationEvent ) {
+      invoked.add( this );
+    }
+
+    @Override
+    public int getOrder() {
+      return order;
+    }
+  }
+
+  private static class StubListener implements ApplicationListener {
+    private final List<ApplicationListener> invoked;
+
+    public StubListener( List<ApplicationListener> invoked ) {
+      this.invoked = invoked;
+    }
+
+    @Override
+    public void onApplicationEvent( ApplicationEvent applicationEvent ) {
+      invoked.add( this );
+    }
+  }
+}

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/DefaultPermissionConversionHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/DefaultPermissionConversionHelper.java
@@ -105,7 +105,7 @@ public class DefaultPermissionConversionHelper implements IPermissionConversionH
       // convert it to match the Privilege.JCR_* string constants
       String extendedPrivilegeName = privilege.getName();
       String privilegeName = privilege.getName();
-      int colonIndex = privilegeName.indexOf( ":" ); //$NON-NLS-1$
+      int colonIndex = privilegeName.indexOf( ':' ); //$NON-NLS-1$
       if ( colonIndex > -1 ) {
         String namespaceUri = session.getNamespaceURI( privilegeName.substring( 0, colonIndex ) );
         extendedPrivilegeName = "{" + namespaceUri + "}" + privilegeName.substring( colonIndex + 1 ); //$NON-NLS-1$ //$NON-NLS-2$

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileAclUtils.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileAclUtils.java
@@ -45,6 +45,7 @@ import javax.jcr.security.Privilege;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -139,14 +140,13 @@ public class JcrRepositoryFileAclUtils {
    */
   public static Privilege[] expandPrivileges( final Privilege[] privileges, final boolean expandNonStandardOnly ) {
     // find all aggregate privileges and expand
-    Set<Privilege> expandedPrivileges = new HashSet<Privilege>();
-    expandedPrivileges.addAll( Arrays.asList( privileges ) );
+    Set<Privilege> expandedPrivileges = new HashSet<Privilege>( Arrays.asList( privileges ) );
     while ( true ) {
       boolean foundAggregatePrivilege = false;
-      Set<Privilege> iterable = new HashSet<Privilege>( expandedPrivileges );
+      List<Privilege> iterable = new ArrayList<Privilege>( expandedPrivileges );
       for ( Privilege privilege : iterable ) {
         // expand impl custom privileges (e.g. rep:write) but keep aggregates like jcr:write intact
-        if ( !expandNonStandardOnly || expandNonStandardOnly && !privilege.getName().startsWith( "jcr:" ) ) { //$NON-NLS-1$
+        if ( !expandNonStandardOnly || !privilege.getName().startsWith( "jcr:" ) ) { //$NON-NLS-1$
           if ( privilege.isAggregate() ) {
             expandedPrivileges.remove( privilege );
             expandedPrivileges.addAll( Arrays.asList( privilege.getAggregatePrivileges() ) );

--- a/repository/src/org/pentaho/platform/security/policy/rolebased/RoleAuthorizationPolicy.java
+++ b/repository/src/org/pentaho/platform/security/policy/rolebased/RoleAuthorizationPolicy.java
@@ -85,12 +85,12 @@ public class RoleAuthorizationPolicy implements IAuthorizationPolicy {
   }
 
   protected List<String> getRuntimeRoleNames() {
-    List<String> runtimeRoles = new ArrayList<String>();
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     Assert.state( authentication != null );
     GrantedAuthority[] authorities = authentication.getAuthorities();
-    for ( int i = 0; i < authorities.length; i++ ) {
-      runtimeRoles.add( authorities[i].getAuthority() );
+    List<String> runtimeRoles = new ArrayList<String>( authorities.length );
+    for ( GrantedAuthority authority : authorities ) {
+      runtimeRoles.add( authority.getAuthority() );
     }
     return runtimeRoles;
   }


### PR DESCRIPTION
- UserSettingService
   - replace keySet() + get() combination with entrySet()
   - remove useless object instantiation
   - remove useless explicit map.remove()
- AbstractSpringPentahoObjectFactory
   - add logger.isDebugEnabled()
   - remove useless non-null validation
- OrderedApplicationEventMulticaster
   - replace ArrayList with array for faster sorting
   - extract stateless Comparator to a final field to avoid useless instantiation
   - replace new Integer.compareTo() with Integer.compare()
   - add tests
- RoleAuthorizationPolicy
   - create ArrayLists of exact size
- JcrRepositoryFileAclUtils
   - iterate through List, not Set
- DefaultPermissionConversionHelper
   - replace indexOf(":") with indexOf(':') as it is more effective
- AuditConnection
   - change the order: first try to obtain a connection and only then sleep

@pentaho-nbaker, @rmansoor, @e-cuellar, @mdamour1976, review it please.
I didn't add any additional tests for ```UserSettingService```, because it is already almost fully covered