### PR TITLE
[BACKLOG-4284] - after getting to the prompts when scheduling an xact…

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/ActionSequenceParameterUiContentGenerator.java
+++ b/extensions/src/org/pentaho/platform/web/http/ActionSequenceParameterUiContentGenerator.java
@@ -89,10 +89,6 @@ public class ActionSequenceParameterUiContentGenerator extends SimpleContentGene
 
   @SuppressWarnings ( "unchecked" )
   private IParameterProvider getRequestParameters() {
-    if ( this.requestParameters != null ) {
-      return this.requestParameters;
-    }
-
     if ( this.parameterProviders == null ) {
       return new SimpleParameterProvider();
     }
@@ -110,9 +106,6 @@ public class ActionSequenceParameterUiContentGenerator extends SimpleContentGene
 
   @SuppressWarnings ( "unchecked" )
   public IParameterProvider getPathParameters() {
-    if ( this.pathParameters != null ) {
-      return this.pathParameters;
-    }
 
     IParameterProvider pathParams = this.parameterProviders.get( "path" ); //$NON-NLS-1$
     SimpleParameterSetter parameters = new SimpleParameterSetter();


### PR DESCRIPTION
…ion the user continues to get the same prompts regardless of which xaction is being scheduled

Similar to other issues recently discovered where request & path params being cached in member variables was causing stale responses from service requests, we have to remove this.