### PR TITLE
[BISERVER-12642] - Inconsistent synchronization leading to deadlock b…

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
@@ -52,6 +52,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -412,19 +413,20 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     logger.debug( "getDomainIds()" );
     reloadDomainsIfNeeded();
 
+    Collection<String> domains;
     lock.readLock().lock();
     try {
-      Collection<String> domains = metadataMapping.getDomainIds();
-      Set<String> domainIds = new HashSet<String>( domains.size() );
-      for ( String domain : domains ) {
-        if ( hasAccessFor( domain ) ) {
-          domainIds.add( domain );
-        }
-      }
-      return domainIds;
+      domains = new ArrayList<String>( metadataMapping.getDomainIds() );
     } finally {
       lock.readLock().unlock();
     }
+    Set<String> domainIds = new HashSet<String>( domains.size() );
+    for ( String domain : domains ) {
+      if ( hasAccessFor( domain ) ) {
+        domainIds.add( domain );
+      }
+    }
+    return domainIds;
   }
 
   /**

--- a/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
@@ -289,11 +289,12 @@ public class PentahoMetadataDomainRepositoryTest extends TestCase {
     domainRepositorySpy.removeDomain( STEEL_WHEELS );
     domainRepositorySpy.removeDomain( SAMPLE_DOMAIN_ID );
 
+    doReturn( true ).when( aclNodeHelper ).canAccess( any( RepositoryFile.class ), eq( EnumSet.of(
+      RepositoryFilePermission.READ ) ) );
+
     final MockDomain originalDomain = new MockDomain( SAMPLE_DOMAIN_ID );
     domainRepositorySpy.storeDomain( originalDomain, false );
 
-    doReturn( true ).when( aclNodeHelper ).canAccess( any( RepositoryFile.class ), eq( EnumSet.of(
-        RepositoryFilePermission.READ ) ) );
     final Domain testDomain1 = domainRepositorySpy.getDomain( SAMPLE_DOMAIN_ID );
 
     assertNotNull( testDomain1 );
@@ -433,9 +434,9 @@ public class PentahoMetadataDomainRepositoryTest extends TestCase {
     domainRepositorySpy.removeDomain( STEEL_WHEELS );
     domainRepositorySpy.removeDomain( SAMPLE_DOMAIN_ID );
 
-    domainRepositorySpy.storeDomain( new MockDomain( SAMPLE_DOMAIN_ID ), true );
     doReturn( true ).when( aclNodeHelper ).canAccess( any( RepositoryFile.class ),
-        eq( EnumSet.of( RepositoryFilePermission.READ ) ) );
+      eq( EnumSet.of( RepositoryFilePermission.READ ) ) );
+    domainRepositorySpy.storeDomain( new MockDomain( SAMPLE_DOMAIN_ID ), true );
     final Set<String> domainIds1 = domainRepositorySpy.getDomainIds();
 
     assertNotNull( domainIds1 );


### PR DESCRIPTION
…etween JCR and PentahoMetadataDomainRepository

- release read lock as soon as possible to prevent deadlocks
- fix PentahoMetadataDomainRepositoryTest

@pentaho-nbaker, @mbatchelor, @pamval, review it please.
This is a corrected fix instead of https://github.com/pentaho/pentaho-platform/pull/2434. The previous was vulnerable against a deadlock