### PR TITLE
[SP-1988] - Backport of BISERVER-12642 - Inconsistent synchronization leading to deadlock between JCR and PentahoMetadataDomainRepository (5.4 Suite)

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
@@ -51,6 +51,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -61,6 +62,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Handles the storage and retrieval of Pentaho Metada Domain objects in a repository. It does this by using a
@@ -81,7 +83,7 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
   private static final Messages messages = Messages.getInstance();
 
   private static final Map<IUnifiedRepository, PentahoMetadataInformationMap> metaMapStore =
-      new HashMap<IUnifiedRepository, PentahoMetadataInformationMap>();
+    new HashMap<IUnifiedRepository, PentahoMetadataInformationMap>();
 
   // The type of repository file (domain, locale)
   private static final String PROPERTY_NAME_TYPE = "file-type";
@@ -104,6 +106,9 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
   // The default mime-type for locale files
   private static final String LOCALE_MIME_TYPE = "text/plain";
 
+  // caching immutable object
+  private static final EnumSet<RepositoryFilePermission> READ = EnumSet.of( RepositoryFilePermission.READ );
+
   // The repository used to store / retrieve objects
   private IUnifiedRepository repository;
 
@@ -121,11 +126,13 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
 
   private IAclNodeHelper aclHelper;
 
+  private final ReentrantReadWriteLock lock;
+  private boolean needToReload;
+
   /**
    * Creates an instance of this class providing the {@link IUnifiedRepository} repository backend.
    *
-   * @param repository
-   *          the {@link IUnifiedRepository} in which data will be stored / retrieved
+   * @param repository the {@link IUnifiedRepository} in which data will be stored / retrieved
    */
   public PentahoMetadataDomainRepository( final IUnifiedRepository repository ) {
     this( repository, null, null, null );
@@ -134,20 +141,17 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
   /**
    * Helper constructor used for setting other objects in this class
    *
-   * @param repository
-   *          the {@link IUnifiedRepository} in which data will be stored / retrieved
-   * @param repositoryUtils
-   *          utility class for working inside the repository </br>(NOTE: {@code null} is acceptable and will create a
-   *          default instance)
-   * @param xmiParser
-   *          the parser class for serializing / de-serializing Domain objects </br>(NOTE: {@code null} is acceptable
-   *          and will create a default instance)
-   * @param localizationUtil
-   *          the object used to add locale bundles into a Pentaho Metadata Domain object </br>(NOTE: {@code null} is
-   *          acceptable and will create a default instance)
+   * @param repository       the {@link IUnifiedRepository} in which data will be stored / retrieved
+   * @param repositoryUtils  utility class for working inside the repository </br>(NOTE: {@code null} is acceptable and
+   *                         will create a default instance)
+   * @param xmiParser        the parser class for serializing / de-serializing Domain objects </br>(NOTE: {@code null}
+   *                         is acceptable and will create a default instance)
+   * @param localizationUtil the object used to add locale bundles into a Pentaho Metadata Domain object </br>(NOTE:
+   *                         {@code null} is acceptable and will create a default instance)
    */
   protected PentahoMetadataDomainRepository( final IUnifiedRepository repository,
-      final RepositoryUtils repositoryUtils, final XmiParser xmiParser, final LocalizationUtil localizationUtil ) {
+                                             final RepositoryUtils repositoryUtils, final XmiParser xmiParser,
+                                             final LocalizationUtil localizationUtil ) {
     if ( null == repository ) {
       throw new IllegalArgumentException();
     }
@@ -156,29 +160,29 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     setRepositoryUtils( repositoryUtils );
     setLocalizationUtil( localizationUtil );
     setXmiParser( xmiParser );
+    this.lock = new ReentrantReadWriteLock();
+    this.needToReload = true;
   }
 
   /**
    * Store a domain to the repository. The domain should persist between JVM restarts.
    *
-   * @param domain
-   *          domain object to store
-   * @param overwrite
-   *          if true, overwrite existing domain
-   * @throws DomainIdNullException
-   *           if domain id is null or empty
-   * @throws DomainAlreadyExistsException
-   *           if a domain with the same Domain ID already exists in the repository and {@code overwrite == false}
-   * @throws DomainStorageException
-   *           if there is a problem storing the domain
+   * @param domain    domain object to store
+   * @param overwrite if true, overwrite existing domain
+   * @throws DomainIdNullException        if domain id is null or empty
+   * @throws DomainAlreadyExistsException if a domain with the same Domain ID already exists in the repository and
+   *                                      {@code overwrite == false}
+   * @throws DomainStorageException       if there is a problem storing the domain
    */
   @Override
   public void storeDomain( final Domain domain, final boolean overwrite ) throws DomainIdNullException,
-      DomainAlreadyExistsException, DomainStorageException {
-    logger.debug( "storeDomain(domain(id=" + ( domain != null ? domain.getId() : "" ) + ", " + overwrite + ")" );
+    DomainAlreadyExistsException, DomainStorageException {
+    if ( logger.isDebugEnabled() ) {
+      logger.debug( "storeDomain(domain(id=" + ( domain != null ? domain.getId() : "" ) + ", " + overwrite + ")" );
+    }
     if ( null == domain || StringUtils.isEmpty( domain.getId() ) ) {
       throw new DomainIdNullException( messages
-          .getErrorString( "PentahoMetadataDomainRepository.ERROR_0001_DOMAIN_ID_NULL" ) );
+        .getErrorString( "PentahoMetadataDomainRepository.ERROR_0001_DOMAIN_ID_NULL" ) );
     }
 
     String xmi = "";
@@ -195,8 +199,8 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
       throw dae;
     } catch ( Exception e ) {
       final String errorMessage =
-          messages.getErrorString( "PentahoMetadataDomainRepository.ERROR_0003_ERROR_STORING_DOMAIN", domain.getId(), e
-              .getLocalizedMessage() );
+        messages.getErrorString( "PentahoMetadataDomainRepository.ERROR_0003_ERROR_STORING_DOMAIN", domain.getId(), e
+          .getLocalizedMessage() );
       logger.error( errorMessage, e );
       throw new DomainStorageException( xmi + errorMessage, e );
     }
@@ -211,13 +215,13 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
    */
   @Override
   public void storeDomain( final InputStream inputStream, final String domainId, final boolean overwrite )
-      throws DomainIdNullException, DomainAlreadyExistsException, DomainStorageException {
+    throws DomainIdNullException, DomainAlreadyExistsException, DomainStorageException {
     storeDomain( inputStream, domainId, overwrite, null );
   }
 
   @Override
   public void storeDomain( InputStream inputStream, String domainId, boolean overwrite, RepositoryFileAcl acl )
-      throws DomainIdNullException, DomainAlreadyExistsException, DomainStorageException {
+    throws DomainIdNullException, DomainAlreadyExistsException, DomainStorageException {
     if ( logger.isDebugEnabled() ) {
       logger.debug( String.format( "storeDomain(inputStream, %s, %s, %s)", domainId, overwrite, acl ) );
     }
@@ -226,35 +230,40 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     }
     if ( StringUtils.isEmpty( domainId ) ) {
       throw new DomainIdNullException( messages
-          .getErrorString( "PentahoMetadataDomainRepository.ERROR_0001_DOMAIN_ID_NULL" ) );
+        .getErrorString( "PentahoMetadataDomainRepository.ERROR_0001_DOMAIN_ID_NULL" ) );
     }
 
     // Check to see if the domain already exists
     final RepositoryFile domainFile = getMetadataRepositoryFile( domainId );
     if ( !overwrite && domainFile != null ) {
       final String errorString =
-          messages.getErrorString( "PentahoMetadataDomainRepository.ERROR_0002_DOMAIN_ALREADY_EXISTS", domainId );
+        messages.getErrorString( "PentahoMetadataDomainRepository.ERROR_0002_DOMAIN_ALREADY_EXISTS", domainId );
       logger.error( errorString );
       throw new DomainAlreadyExistsException( errorString );
     }
 
     // Check if this is valid xml
-    InputStream inputStream2 = null;
-    String xmi = null;
+    InputStream inputStream2;
+    String xmi;
     try {
       // try to see if the xmi can be parsed (ie, check if it's valid xmi)
       // first, convert our input stream to a string
-      BufferedReader reader = new BufferedReader( new InputStreamReader( inputStream, DEFAULT_ENCODING ) );
       StringBuilder stringBuilder = new StringBuilder();
-      while ( ( xmi = reader.readLine() ) != null ) {
-        stringBuilder.append( xmi );
+      BufferedReader reader = new BufferedReader( new InputStreamReader( inputStream, DEFAULT_ENCODING ) );
+      try {
+        while ( ( xmi = reader.readLine() ) != null ) {
+          stringBuilder.append( xmi );
+        }
+      } finally {
+        inputStream.close();
       }
-      inputStream.close();
       xmi = stringBuilder.toString();
       // now, try to see if the xmi can be parsed (ie, check if it's valid xmi)
-      Domain domain = xmiParser.parseXmi( new java.io.ByteArrayInputStream( xmi.getBytes( DEFAULT_ENCODING ) ) );
+      byte[] xmiBytes = xmi.getBytes( DEFAULT_ENCODING );
+      inputStream2 = new java.io.ByteArrayInputStream( xmiBytes );
+      xmiParser.parseXmi( inputStream2 );
       // xmi is valid. Create a new inputstream for the actual import action.
-      inputStream2 = new java.io.ByteArrayInputStream( xmi.getBytes( DEFAULT_ENCODING ) );
+      inputStream2.reset();
     } catch ( Exception ex ) {
       logger.error( ex.getMessage() );
       // throw new
@@ -266,7 +275,7 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     }
 
     final SimpleRepositoryFileData data =
-        new SimpleRepositoryFileData( inputStream2, DEFAULT_ENCODING, DOMAIN_MIME_TYPE );
+      new SimpleRepositoryFileData( inputStream2, DEFAULT_ENCODING, DOMAIN_MIME_TYPE );
     final RepositoryFile newDomainFile;
     if ( domainFile == null ) {
       newDomainFile = createUniqueFile( domainId, null, data );
@@ -299,7 +308,17 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
 
   @Override
   public boolean hasAccessFor( String domainId ) {
-    return getAclHelper().canAccess( getMetadataRepositoryFile( domainId ), EnumSet.of( RepositoryFilePermission.READ ) );
+    return getAclHelper().canAccess( getMetadataRepositoryFile( domainId ), READ );
+  }
+
+  /**
+   * This method can be called to avoid useless obtaining of repository file if the file has already been loaded
+   *
+   * @param repositoryFile repository file
+   * @return delegates the call to <code>getAclHelper().canAccess()</code>
+   */
+  private boolean hasAccessFor( RepositoryFile repositoryFile ) {
+    return getAclHelper().canAccess( repositoryFile, READ );
   }
 
   /*
@@ -307,11 +326,15 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
    * file and multiple .properties files.
    */
   public Map<String, InputStream> getDomainFilesData( final String domainId ) {
-    Map<String, InputStream> values = new HashMap<String, InputStream>();
     Set<RepositoryFile> metadataFiles;
-    synchronized ( metadataMapping ) {
+    lock.readLock().lock();
+    try {
       metadataFiles = metadataMapping.getFiles( domainId );
+    } finally {
+      lock.readLock().unlock();
     }
+
+    Map<String, InputStream> values = new HashMap<String, InputStream>( metadataFiles.size() );
     for ( RepositoryFile repoFile : metadataFiles ) {
       RepositoryFileInputStream is;
       try {
@@ -320,7 +343,7 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
         return null; // This pretty much ensures an exception will be thrown later and passed to the client
       }
       String fileName = repoFile.getName().endsWith( ".properties" ) ? repoFile.getName()
-          : domainId + ( domainId.endsWith( ".xmi" ) ? "" : ".xmi" );
+        : domainId + ( domainId.endsWith( ".xmi" ) ? "" : ".xmi" );
       values.put( fileName, is );
     }
     return values;
@@ -330,13 +353,15 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
    * retrieve a domain from the repo. This does lazy loading of the repo, so it calls reloadDomains() if not already
    * loaded.
    *
-   * @param domainId
-   *          domain to get from the repository
+   * @param domainId domain to get from the repository
    * @return domain object
    */
   @Override
   public Domain getDomain( final String domainId ) {
-    logger.debug( "getDomain(" + domainId + ")" );
+    if ( logger.isDebugEnabled() ) {
+      logger.debug( "getDomain(" + domainId + ")" );
+    }
+
     if ( StringUtils.isEmpty( domainId ) ) {
       throw new IllegalArgumentException( messages.getErrorString(
         "PentahoMetadataDomainRepository.ERROR_0004_DOMAIN_ID_INVALID", domainId ) );
@@ -346,7 +371,7 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
       // Load the domain file
       final RepositoryFile file = getMetadataRepositoryFile( domainId );
       if ( file != null ) {
-        if ( hasAccessFor( domainId ) ) {
+        if ( hasAccessFor( file ) ) {
           SimpleRepositoryFileData data = repository.getDataForRead( file.getId(), SimpleRepositoryFileData.class );
           if ( data != null ) {
             domain = xmiParser.parseXmi( data.getStream() );
@@ -357,18 +382,18 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
             logger.debug( "loaded I18N bundles" );
           } else {
             throw new UnifiedRepositoryException( messages.getErrorString(
-                "PentahoMetadataDomainRepository.ERROR_0005_ERROR_RETRIEVING_DOMAIN", domainId, "data not found" ) );
+              "PentahoMetadataDomainRepository.ERROR_0005_ERROR_RETRIEVING_DOMAIN", domainId, "data not found" ) );
           }
         } else {
           throw new PentahoAccessControlException( messages.getErrorString(
-              "PentahoMetadataDomainRepository.ERROR_0005_ERROR_RETRIEVING_DOMAIN", domainId, "access denied" ) );
+            "PentahoMetadataDomainRepository.ERROR_0005_ERROR_RETRIEVING_DOMAIN", domainId, "access denied" ) );
         }
       }
     } catch ( Exception e ) {
       if ( !( e instanceof UnifiedRepositoryException || e instanceof PentahoAccessControlException ) ) {
         throw new UnifiedRepositoryException( messages.getErrorString(
-            "PentahoMetadataDomainRepository.ERROR_0005_ERROR_RETRIEVING_DOMAIN",
-            domainId, e.getLocalizedMessage() ), e );
+          "PentahoMetadataDomainRepository.ERROR_0005_ERROR_RETRIEVING_DOMAIN",
+          domainId, e.getLocalizedMessage() ), e );
       }
     }
 
@@ -384,17 +409,22 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
   @Override
   public Set<String> getDomainIds() {
     logger.debug( "getDomainIds()" );
-    internalReloadDomains();
-    final Set<String> domainIds = new HashSet<String>();
-    synchronized ( metadataMapping ) {
-      Collection<String> domains = metadataMapping.getDomainIds();
-      for ( String domain : domains ) {
-        if ( hasAccessFor( domain ) ) {
-          domainIds.add( domain );
-        }
-      }
-      return domainIds;
+    reloadDomainsIfNeeded();
+
+    Collection<String> domains;
+    lock.readLock().lock();
+    try {
+      domains = new ArrayList<String>( metadataMapping.getDomainIds() );
+    } finally {
+      lock.readLock().unlock();
     }
+    Set<String> domainIds = new HashSet<String>( domains.size() );
+    for ( String domain : domains ) {
+      if ( hasAccessFor( domain ) ) {
+        domainIds.add( domain );
+      }
+    }
+    return domainIds;
   }
 
   /**
@@ -404,17 +434,23 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
    */
   @Override
   public void removeDomain( final String domainId ) {
-    logger.debug( "removeDomain(" + domainId + ")" );
+    if ( logger.isDebugEnabled() ) {
+      logger.debug( "removeDomain(" + domainId + ")" );
+    }
+
     if ( StringUtils.isEmpty( domainId ) ) {
       throw new IllegalArgumentException( messages.getErrorString(
-          "PentahoMetadataDomainRepository.ERROR_0004_DOMAIN_ID_INVALID", domainId ) );
+        "PentahoMetadataDomainRepository.ERROR_0004_DOMAIN_ID_INVALID", domainId ) );
     }
 
     // Get the metadata domain file
     Set<RepositoryFile> domainFiles;
-    synchronized ( metadataMapping ) {
+    lock.writeLock().lock();
+    try {
       domainFiles = metadataMapping.getFiles( domainId );
       metadataMapping.deleteDomain( domainId );
+    } finally {
+      lock.writeLock().lock();
     }
 
     // it no node exists, nothing would happen
@@ -441,15 +477,18 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
    */
   @Override
   public void removeModel( final String domainId, final String modelId ) throws DomainIdNullException,
-      DomainStorageException {
-    logger.debug( "removeModel(" + domainId + ", " + modelId + ")" );
+    DomainStorageException {
+    if ( logger.isDebugEnabled() ) {
+      logger.debug( "removeModel(" + domainId + ", " + modelId + ")" );
+    }
+
     if ( StringUtils.isEmpty( domainId ) ) {
       throw new IllegalArgumentException( messages.getErrorString(
-          "PentahoMetadataDomainRepository.ERROR_0004_DOMAIN_ID_INVALID", domainId ) );
+        "PentahoMetadataDomainRepository.ERROR_0004_DOMAIN_ID_INVALID", domainId ) );
     }
     if ( StringUtils.isEmpty( modelId ) ) {
       throw new IllegalArgumentException( messages
-          .getErrorString( "PentahoMetadataDomainRepository.ERROR_0006_MODEL_ID_INVALID" ) );
+        .getErrorString( "PentahoMetadataDomainRepository.ERROR_0006_MODEL_ID_INVALID" ) );
     }
 
     // Get the domain and remove the model
@@ -491,19 +530,24 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
    * Performs the process of reloading the domain information from the repository
    */
   private void internalReloadDomains() {
-    synchronized ( metadataMapping ) {
+    lock.writeLock().lock();
+    try {
       metadataMapping.reset();
 
       // Reload the metadata about the metadata (that was fun to say)
       final List<RepositoryFile> children = repository.getChildren( getMetadataDir().getId(), "*" );
-      logger.trace( "\tFound " + children.size() + " files in the repository" );
+      if ( logger.isTraceEnabled() ) {
+        logger.trace( "\tFound " + children.size() + " files in the repository" );
+      }
       for ( final RepositoryFile child : children ) {
-        if ( getAclHelper().canAccess( child, EnumSet.of( RepositoryFilePermission.READ ) ) ) {
+        if ( getAclHelper().canAccess( child, READ ) ) {
           // Get the metadata for this file
           final Map<String, Serializable> fileMetadata = repository.getFileMetadata( child.getId() );
           if ( fileMetadata == null || StringUtils.isEmpty( (String) fileMetadata.get( PROPERTY_NAME_DOMAIN_ID ) ) ) {
-            logger.warn( messages.getString( "PentahoMetadataDomainRepository.WARN_0001_FILE_WITHOUT_METADATA", child
+            if ( logger.isWarnEnabled() ) {
+              logger.warn( messages.getString( "PentahoMetadataDomainRepository.WARN_0001_FILE_WITHOUT_METADATA", child
                 .getName() ) );
+            }
             continue;
           }
           final String domainId = (String) fileMetadata.get( PROPERTY_NAME_DOMAIN_ID );
@@ -521,6 +565,10 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
           }
         }
       }
+
+      needToReload = false;
+    } finally {
+      lock.writeLock().unlock();
     }
   }
 
@@ -551,15 +599,12 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
   /**
    * Adds a set of properties as a locale properties file for the specified Domain ID
    *
-   * @param domainId
-   *          the domain ID for which this properties file will be added
-   * @param locale
-   *          the locale for which this properties file will be added
-   * @param properties
-   *          the properties to be added
+   * @param domainId   the domain ID for which this properties file will be added
+   * @param locale     the locale for which this properties file will be added
+   * @param properties the properties to be added
    */
   public void addLocalizationFile( final String domainId, final String locale, final Properties properties )
-      throws DomainStorageException {
+    throws DomainStorageException {
     // This is safe since ByteArray streams don't have to be closed
     if ( null != properties ) {
       try {
@@ -568,41 +613,45 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
         addLocalizationFile( domainId, locale, new ByteArrayInputStream( out.toString().getBytes() ), true );
       } catch ( IOException e ) {
         throw new DomainStorageException( messages.getErrorString(
-            "PentahoMetadataDomainRepository.ERROR_0008_ERROR_IN_REPOSITORY", e.getLocalizedMessage() ), e );
+          "PentahoMetadataDomainRepository.ERROR_0008_ERROR_IN_REPOSITORY", e.getLocalizedMessage() ), e );
       }
     }
   }
 
   @Override
   public void addLocalizationFile( final String domainId, final String locale, final InputStream inputStream,
-      final boolean overwrite ) throws DomainStorageException {
-    logger.debug( "addLocalizationFile(" + domainId + ", " + locale + ", inputStream)" );
+                                   final boolean overwrite ) throws DomainStorageException {
+    if ( logger.isDebugEnabled() ) {
+      logger.debug( "addLocalizationFile(" + domainId + ", " + locale + ", inputStream)" );
+    }
     if ( null != inputStream ) {
       if ( StringUtils.isEmpty( domainId ) || StringUtils.isEmpty( locale ) ) {
         throw new IllegalArgumentException( messages.getErrorString(
-            "PentahoMetadataDomainRepository.ERROR_0004_DOMAIN_ID_INVALID", domainId ) );
+          "PentahoMetadataDomainRepository.ERROR_0004_DOMAIN_ID_INVALID", domainId ) );
       }
 
-      synchronized ( metadataMapping ) {
+      lock.writeLock().lock();
+      try {
         // Check for duplicates
         final RepositoryFile localeFile = metadataMapping.getLocaleFile( domainId, locale );
         if ( !overwrite && localeFile != null ) {
           throw new DomainStorageException( messages.getErrorString(
-              "PentahoMetadataDomainRepository.ERROR_0009_LOCALE_ALREADY_EXISTS", domainId, locale ), null );
+            "PentahoMetadataDomainRepository.ERROR_0009_LOCALE_ALREADY_EXISTS", domainId, locale ), null );
         }
 
         final SimpleRepositoryFileData data =
-            new SimpleRepositoryFileData( inputStream, DEFAULT_ENCODING, LOCALE_MIME_TYPE );
+          new SimpleRepositoryFileData( inputStream, DEFAULT_ENCODING, LOCALE_MIME_TYPE );
         if ( localeFile == null ) {
           final RepositoryFile newLocaleFile = createUniqueFile( domainId, locale, data );
           metadataMapping.addLocale( domainId, locale, newLocaleFile );
         } else {
           repository.updateFile( localeFile, data, null );
         }
+        // This invalidates any cached information
+        flushDomains();
+      } finally {
+        lock.writeLock().unlock();
       }
-
-      // This invalidates any cached information
-      flushDomains();
     }
   }
 
@@ -617,7 +666,9 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
       for ( final String locale : localeFiles.keySet() ) {
         final RepositoryFile localeFile = localeFiles.get( locale );
         final Properties properties = loadProperties( localeFile );
-        logger.trace( "\tLoading properties [" + domain + " : " + locale + "]" );
+        if ( logger.isTraceEnabled() ) {
+          logger.trace( "\tLoading properties [" + domain + " : " + locale + "]" );
+        }
         localizationUtil.importLocalizedProperties( domain, properties, locale );
       }
     }
@@ -627,39 +678,38 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     try {
       Properties properties = null;
       final SimpleRepositoryFileData bundleData =
-          repository.getDataForRead( bundle.getId(), SimpleRepositoryFileData.class );
+        repository.getDataForRead( bundle.getId(), SimpleRepositoryFileData.class );
       if ( bundleData != null ) {
         properties = new Properties();
         properties.load( bundleData.getStream() );
       } else {
-        logger.warn( "Could not load properties from repository file: " + bundle.getName() );
+        if ( logger.isWarnEnabled() ) {
+          logger.warn( "Could not load properties from repository file: " + bundle.getName() );
+        }
       }
       return properties;
     } catch ( IOException e ) {
       throw new UnifiedRepositoryException( messages.getErrorString(
-          "PentahoMetadataDomainRepository.ERROR_0008_ERROR_IN_REPOSITORY", e.getLocalizedMessage() ), e );
+        "PentahoMetadataDomainRepository.ERROR_0008_ERROR_IN_REPOSITORY", e.getLocalizedMessage() ), e );
     }
   }
 
   /**
    * Creates a new repository file (with the supplied data) and applies the proper metadata to this file.
    *
-   * @param domainId
-   *          the Domain id associated with this file
-   * @param locale
-   *          the locale associated with this file (or null for a domain file)
-   * @param data
-   *          the data to put in the file
+   * @param domainId the Domain id associated with this file
+   * @param locale   the locale associated with this file (or null for a domain file)
+   * @param data     the data to put in the file
    * @return the repository file created
    */
   protected RepositoryFile createUniqueFile( final String domainId, final String locale,
-      final SimpleRepositoryFileData data ) {
+                                             final SimpleRepositoryFileData data ) {
     // Generate a "unique" filename
     final String filename = UUID.randomUUID().toString();
 
     // Create the new file
     final RepositoryFile file =
-        repository.createFile( getMetadataDir().getId(), new RepositoryFile.Builder( filename ).build(), data, null );
+      repository.createFile( getMetadataDir().getId(), new RepositoryFile.Builder( filename ).build(), data, null );
 
     // Add metadata to the file
     final Map<String, Serializable> metadataMap = new HashMap<String, Serializable>();
@@ -714,8 +764,8 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     try {
       final Map<String, Serializable> fileMetadata = repository.getFileMetadata( file.getId() );
       return "[type=" + fileMetadata.get( PROPERTY_NAME_TYPE ) + " : domain="
-          + fileMetadata.get( PROPERTY_NAME_DOMAIN_ID ) + " : locale=" + fileMetadata.get( PROPERTY_NAME_LOCALE )
-          + " : filename=" + file.getName() + "]";
+        + fileMetadata.get( PROPERTY_NAME_DOMAIN_ID ) + " : locale=" + fileMetadata.get( PROPERTY_NAME_LOCALE )
+        + " : filename=" + file.getName() + "]";
     } catch ( Throwable ignore ) {
       //ignore
     }
@@ -726,19 +776,45 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
    * Accesses the metadata mapping (with 1 retry) to find the metadata file for the specified domainId
    */
   protected RepositoryFile getMetadataRepositoryFile( final String domainId ) {
-    RepositoryFile domainFile = metadataMapping.getDomainFile( domainId );
-    if ( null == domainFile ) {
-      reloadDomains();
+    lock.readLock().lock();
+    RepositoryFile domainFile;
+    try {
       domainFile = metadataMapping.getDomainFile( domainId );
+    } finally {
+      lock.readLock().unlock();
     }
+
+    if ( domainFile == null ) {
+      lock.writeLock().lock();
+      try {
+        domainFile = metadataMapping.getDomainFile( domainId );
+        if ( domainFile == null ) {
+          reloadDomainsIfNeeded();
+          domainFile = metadataMapping.getDomainFile( domainId );
+        }
+      } finally {
+        lock.writeLock().unlock();
+      }
+    }
+
     return domainFile;
+  }
+
+  private void reloadDomainsIfNeeded() {
+    lock.writeLock().lock();
+    try {
+      if ( needToReload ) {
+        internalReloadDomains();
+      }
+    } finally {
+      lock.writeLock().unlock();
+    }
   }
 
   /**
    * Returns the MatadataInformationMap for the specified IUnifiedRepository
    *
-   * @param repository
-   *          the repository for which a map is specified
+   * @param repository the repository for which a map is specified
    * @return the MatadataInformationMap for the repository
    */
   private static synchronized PentahoMetadataInformationMap getMetadataMapping( final IUnifiedRepository repository ) {

--- a/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryConcurrencyTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryConcurrencyTest.java
@@ -1,0 +1,464 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.plugin.services.metadata;
+
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.pentaho.metadata.model.Domain;
+import org.pentaho.metadata.util.XmiParser;
+import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
+import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
+import org.pentaho.test.platform.repository2.unified.EmptyUnifiedRepository;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class PentahoMetadataDomainRepositoryConcurrencyTest {
+
+  private static final String METADATA_DIR_ID = "metadataDirId";
+
+  private DomainsStubRepository repository;
+  private IAclNodeHelper aclNodeHelper;
+  private PentahoMetadataDomainRepository domainRepository;
+
+  @SuppressWarnings( "unchecked" )
+  @Before
+  public void setUp() throws Exception {
+    repository = new DomainsStubRepository();
+    repository = spy( repository );
+    RepositoryFile metadataDir = new RepositoryFile.Builder( METADATA_DIR_ID, "metadataDir" ).folder( true ).build();
+    doReturn( metadataDir ).when( repository ).getFile( PentahoMetadataDomainRepositoryInfo.getMetadataFolderPath() );
+
+    aclNodeHelper = mock( IAclNodeHelper.class );
+    when( aclNodeHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
+
+    domainRepository = new PentahoMetadataDomainRepository( repository );
+    domainRepository = spy( domainRepository );
+    doReturn( aclNodeHelper ).when( domainRepository ).getAclHelper();
+  }
+
+  @SuppressWarnings( "unchecked" )
+  @After
+  public void cleanUp() throws Exception {
+    Map<IUnifiedRepository, ?> metaMapStore =
+      (Map<IUnifiedRepository, ?>) FieldUtils
+        .readStaticField( PentahoMetadataDomainRepository.class, "metaMapStore", true );
+    if ( metaMapStore != null ) {
+      metaMapStore.remove( repository );
+    }
+
+    repository = null;
+    aclNodeHelper = null;
+    domainRepository = null;
+  }
+
+
+  @Test
+  public void getMetadataRepositoryFile_TenReaders() throws Exception {
+    final int amountOfReaders = 10;
+    final int cycles = 30;
+    final int amountOfDomains = amountOfReaders - 1;
+
+    createRepositoryFiles( amountOfDomains );
+
+    List<FilesLookuper> readers = new ArrayList<FilesLookuper>( amountOfReaders );
+    for ( int i = 0; i < amountOfDomains; i++ ) {
+      readers.add( new FilesLookuper( domainRepository, generateDomainId( i ), cycles, true ) );
+    }
+    readers.add( new FilesLookuper( domainRepository, "non-existing domain", cycles, false ) );
+    // randomizing the order of readers
+    Collections.shuffle( readers );
+
+    runTest( readers );
+  }
+
+
+  @Test
+  public void getDomainIds_TenReaders() throws Exception {
+    final int amountOfReaders = 10;
+    final int cycles = 30;
+
+    createRepositoryFiles( amountOfReaders );
+    Set<String> ids = new HashSet<String>( amountOfReaders );
+    for ( int i = 0; i < amountOfReaders; i++ ) {
+      ids.add( generateDomainId( i ) );
+    }
+    ids = Collections.unmodifiableSet( ids );
+
+    List<IdsLookuper> readers = new ArrayList<IdsLookuper>( amountOfReaders );
+    for ( int i = 0; i < amountOfReaders; i++ ) {
+      readers.add( new IdsLookuper( domainRepository, ids, cycles ) );
+    }
+
+    runTest( readers );
+  }
+
+
+  @Test
+  public void addDomain_getDomain_Simultaneously() throws Exception {
+    final int readersAmount = 10;
+    final int cycles = 30;
+    final int addersAmount = 20;
+
+    createRepositoryFiles( readersAmount );
+    doAnswer( new Answer() {
+      @Override public Object answer( InvocationOnMock invocation ) throws Throwable {
+        String domainId = (String) invocation.getArguments()[ 0 ];
+        repository.createFile( null, createRepositoryFile( domainId ), null, null );
+        repository.setFileMetadata( domainId, generateMetadataFor( domainId ) );
+        return null;
+      }
+    } ).when( domainRepository ).createUniqueFile( anyString(), anyString(), any( SimpleRepositoryFileData.class ) );
+
+    domainRepository.setXmiParser( mockXmiParser() );
+
+    List<Callable<String>> actors = new ArrayList<Callable<String>>( readersAmount + addersAmount * 2 );
+    for ( int i = 0; i < readersAmount; i++ ) {
+      actors.add( new FilesLookuper( domainRepository, generateDomainId( i ), cycles, true ) );
+    }
+    for ( int i = 0; i < addersAmount; i++ ) {
+      int index = i + readersAmount;
+      String domainId = generateDomainId( index );
+      AtomicBoolean condition = new AtomicBoolean( true );
+      AtomicBoolean addedFlag = new AtomicBoolean( false );
+      actors.add( new DomainAdder( domainRepository, domainId, condition, addedFlag ) );
+      actors.add( new DomainLookuper( domainRepository, domainId, condition, addedFlag ) );
+    }
+
+    Collections.shuffle( actors );
+    runTest( actors );
+  }
+
+  private XmiParser mockXmiParser() throws Exception {
+    XmiParser parser = mock( XmiParser.class );
+    when( parser.generateXmi( any( Domain.class ) ) ).thenReturn( "" );
+    when( parser.parseXmi( any( InputStream.class ) ) ).thenAnswer( new Answer<Domain>() {
+      @Override public Domain answer( InvocationOnMock invocation ) throws Throwable {
+        return new Domain();
+      }
+    } );
+    return parser;
+  }
+
+
+  private void runTest( final List<? extends Callable<String>> actors ) throws Exception {
+    List<String> errors = new ArrayList<String>();
+    ExecutorService executorService = Executors.newFixedThreadPool( actors.size() );
+    try {
+      CompletionService<String> completionService = new ExecutorCompletionService<String>( executorService );
+      for ( Callable<String> reader : actors ) {
+        completionService.submit( reader );
+      }
+
+      for ( int i = 0; i < actors.size(); i++ ) {
+        Future<String> take = completionService.take();
+        String result;
+        try {
+          result = take.get();
+        } catch ( ExecutionException e ) {
+          result = "Execution exception: " + e.getMessage();
+        }
+        if ( result != null ) {
+          errors.add( result );
+        }
+      }
+    } finally {
+      executorService.shutdown();
+    }
+
+    if ( !errors.isEmpty() ) {
+      StringBuilder builder = new StringBuilder();
+      builder.append( "The following errors occurred: \n" );
+      for ( String error : errors ) {
+        builder.append( error ).append( '\n' );
+      }
+      fail( builder.toString() );
+    }
+  }
+
+
+  private void createRepositoryFiles( int amountOfDomains ) {
+    for ( int i = 0; i < amountOfDomains; i++ ) {
+      RepositoryFile file = createRepositoryFile( generateDomainId( i ) );
+      repository.createFile( null, file, null, null );
+
+      Map<String, Serializable> metadata = generateMetadataFor( file.getId() );
+      repository.setFileMetadata( file.getId(), metadata );
+    }
+  }
+
+  private Map<String, Serializable> generateMetadataFor( Serializable id ) {
+    Map<String, Serializable> metadata = new HashMap<String, Serializable>();
+    metadata.put( "file-type", "domain" );
+    metadata.put( "domain-id", id );
+    return metadata;
+  }
+
+  private static String generateDomainId( int index ) {
+    return "domain_" + index;
+  }
+
+  private static RepositoryFile createRepositoryFile( String id ) {
+    return new RepositoryFile.Builder( id, id ).build();
+  }
+
+
+  private static class FilesLookuper implements Callable<String> {
+    private final PentahoMetadataDomainRepository domainRepository;
+    private final String domainId;
+    private final int cycles;
+    private final boolean expectNotNull;
+
+    public FilesLookuper( PentahoMetadataDomainRepository domainRepository, String domainId, int cycles,
+                          boolean expectNotNull ) {
+      this.domainRepository = domainRepository;
+      this.domainId = domainId;
+      this.cycles = cycles;
+      this.expectNotNull = expectNotNull;
+    }
+
+    @Override
+    public String call() throws Exception {
+      for ( int i = 0; i < cycles; i++ ) {
+        RepositoryFile file = domainRepository.getMetadataRepositoryFile( domainId );
+        if ( expectNotNull ) {
+          if ( file == null ) {
+            return String.format( "Expected to obtain existing domain: [%s]", domainId );
+          }
+        } else {
+          if ( file != null ) {
+            return String.format( "Expected to obtain null for non-existing domain: [%s]", domainId );
+          }
+        }
+      }
+      return null;
+    }
+  }
+
+
+  private static class IdsLookuper implements Callable<String> {
+    private final PentahoMetadataDomainRepository domainRepository;
+    private final Set<String> expectedIds;
+    private final int cycles;
+
+    public IdsLookuper( PentahoMetadataDomainRepository domainRepository, Set<String> expectedIds, int cycles ) {
+      this.domainRepository = domainRepository;
+      this.expectedIds = expectedIds;
+      this.cycles = cycles;
+    }
+
+    @Override
+    public String call() throws Exception {
+      for ( int i = 0; i < cycles; i++ ) {
+        Set<String> domainIds = domainRepository.getDomainIds();
+        if ( domainIds.size() != expectedIds.size() ) {
+          return error( domainIds );
+        } else {
+          Set<String> tmp = new HashSet<String>( expectedIds );
+          tmp.removeAll( domainIds );
+          if ( !tmp.isEmpty() ) {
+            return error( domainIds );
+          }
+        }
+      }
+      return null;
+    }
+
+    private String error( Set<String> domainIds ) {
+      return String.format( "Expected to obtain [%s], but got [%s]", expectedIds, domainIds );
+    }
+  }
+
+
+  private static class DomainLookuper implements Callable<String> {
+    private final PentahoMetadataDomainRepository domainRepository;
+    private final String domainId;
+    private final AtomicBoolean continueCondition;
+    private final AtomicBoolean addedFlag;
+
+    public DomainLookuper( PentahoMetadataDomainRepository domainRepository, String domainId,
+                           AtomicBoolean continueCondition, AtomicBoolean addedFlag ) {
+      this.domainRepository = domainRepository;
+      this.domainId = domainId;
+      this.continueCondition = continueCondition;
+      this.addedFlag = addedFlag;
+    }
+
+    @Override
+    public String call() throws Exception {
+      while ( continueCondition.get() ) {
+        if ( addedFlag.get() ) {
+          Domain domain = domainRepository.getDomain( domainId );
+          if ( domain == null ) {
+            return String.format( "Expected to obtain [%s], but got null", domainId );
+          }
+        } else {
+          Domain domain = domainRepository.getDomain( domainId );
+          if ( domain != null ) {
+            // the reason we are doing such tricky hack is that the flag is not set inside
+            // a transaction with storing domain, in other words, it is possible that domain has been already stored,
+            // but the flag is not yet set
+            // it is a drawback of testing approach and it is hardly can occur in real application
+            Thread.sleep( 200 );
+            if ( !addedFlag.get() ) {
+              return String.format( "Expected not to find domain [%s], but got it", domainId );
+            }
+          }
+        }
+      }
+      return null;
+    }
+  }
+
+  private static class DomainAdder implements Callable<String> {
+    private final PentahoMetadataDomainRepository domainRepository;
+    private final String domainId;
+    private final AtomicBoolean continueCondition;
+    private final AtomicBoolean addedFlag;
+
+    public DomainAdder( PentahoMetadataDomainRepository domainRepository, String domainId,
+                        AtomicBoolean continueCondition, AtomicBoolean addedFlag ) {
+      this.domainRepository = domainRepository;
+      this.domainId = domainId;
+      this.continueCondition = continueCondition;
+      this.addedFlag = addedFlag;
+    }
+
+    @Override
+    public String call() throws Exception {
+      try {
+        // sleep for a while to give lookupers a possibility to get nulls
+        Thread.sleep( 2000 + new Random().nextInt( 500 ) );
+        Domain domain = new Domain();
+        domain.setId( domainId );
+        domainRepository.storeDomain( domain, false );
+        addedFlag.set( true );
+      } finally {
+        continueCondition.set( false );
+      }
+      return null;
+    }
+  }
+
+
+  private static class DomainsStubRepository extends EmptyUnifiedRepository {
+    private final List<RepositoryFile> files;
+    private final Map<Serializable, Map<String, Serializable>> metadatas;
+
+    public DomainsStubRepository() {
+      this.files = new ArrayList<RepositoryFile>();
+      this.metadatas = new HashMap<Serializable, Map<String, Serializable>>();
+    }
+
+    @Override
+    public List<RepositoryFile> getChildren( Serializable folderId ) {
+      return getChildren( folderId, null );
+    }
+
+    @Override
+    public List<RepositoryFile> getChildren( Serializable folderId, String filter ) {
+      return getChildren( folderId, null, null );
+    }
+
+    @Override
+    public List<RepositoryFile> getChildren( Serializable folderId, String filter,
+                                             Boolean showHiddenFiles ) {
+      return getChildren( (RepositoryRequest) null );
+    }
+
+    @Override
+    public synchronized List<RepositoryFile> getChildren( RepositoryRequest repositoryRequest ) {
+      emulateJcrDelay();
+      return new ArrayList<RepositoryFile>( files );
+    }
+
+
+    @Override
+    public RepositoryFile createFile( Serializable parentFolderId, RepositoryFile file,
+                                      IRepositoryFileData data, String versionMessage ) {
+      return this.createFile( parentFolderId, file, data, null, versionMessage );
+    }
+
+    @Override
+    public synchronized RepositoryFile createFile( Serializable parentFolderId, RepositoryFile file,
+                                                   IRepositoryFileData data, RepositoryFileAcl acl,
+                                                   String versionMessage ) {
+      emulateJcrDelay();
+      files.add( file );
+      return file;
+    }
+
+    @Override
+    public synchronized Map<String, Serializable> getFileMetadata( Serializable fileId ) {
+      return metadatas.get( fileId );
+    }
+
+    @Override
+    public synchronized void setFileMetadata( Serializable fileId, Map<String, Serializable> metadataMap ) {
+      metadatas.put( fileId, metadataMap );
+    }
+
+
+    @Override
+    public synchronized <T extends IRepositoryFileData> T getDataForRead( Serializable fileId, Class<T> dataClass ) {
+      return (T) new SimpleRepositoryFileData( new ByteArrayInputStream( new byte[ 0 ] ), "utf-8", null );
+    }
+
+    private void emulateJcrDelay() {
+      try {
+        Thread.sleep( new Random().nextInt( 10 ) );
+      } catch ( Exception e ) {
+        throw new RuntimeException( e );
+      }
+    }
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
@@ -38,7 +38,6 @@ import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
-import org.pentaho.platform.api.repository2.unified.UnifiedRepositoryException;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.repository2.unified.RepositoryUtils;
 import org.pentaho.platform.repository2.unified.fs.FileSystemBackedUnifiedRepository;
@@ -280,11 +279,12 @@ public class PentahoMetadataDomainRepositoryTest extends TestCase {
     domainRepositorySpy.removeDomain( STEEL_WHEELS );
     domainRepositorySpy.removeDomain( SAMPLE_DOMAIN_ID );
 
+    doReturn( true ).when( aclNodeHelper ).canAccess( any( RepositoryFile.class ), eq( EnumSet.of(
+      RepositoryFilePermission.READ ) ) );
+
     final MockDomain originalDomain = new MockDomain( SAMPLE_DOMAIN_ID );
     domainRepositorySpy.storeDomain( originalDomain, false );
 
-    doReturn( true ).when( aclNodeHelper ).canAccess( any( RepositoryFile.class ), eq ( EnumSet.of(
-        RepositoryFilePermission.READ ) ) );
     final Domain testDomain1 = domainRepositorySpy.getDomain( SAMPLE_DOMAIN_ID );
 
     assertNotNull( testDomain1 );
@@ -424,9 +424,9 @@ public class PentahoMetadataDomainRepositoryTest extends TestCase {
     domainRepositorySpy.removeDomain( STEEL_WHEELS );
     domainRepositorySpy.removeDomain( SAMPLE_DOMAIN_ID );
 
-    domainRepositorySpy.storeDomain( new MockDomain( SAMPLE_DOMAIN_ID ), true );
     doReturn( true ).when( aclNodeHelper ).canAccess( any( RepositoryFile.class ),
-        eq( EnumSet.of( RepositoryFilePermission.READ ) ) );
+      eq( EnumSet.of( RepositoryFilePermission.READ ) ) );
+    domainRepositorySpy.storeDomain( new MockDomain( SAMPLE_DOMAIN_ID ), true );
     final Set<String> domainIds1 = domainRepositorySpy.getDomainIds();
 
     assertNotNull( domainIds1 );


### PR DESCRIPTION
- cherry picked from commit 93b5ecd
  - add a test revealing a vulnerability in getMetadataRepositoryFile()
  - fix the issue
- cherry picked from commit 00c98b5
  - apply formatting and improve the code by explicitly setting collections' sizes, checking log level, removing useless assignments, etc
- cherry picked from commit 09f727c
  - prevent getDomainIds() and getMetadataRepositoryFile() from reloading domains on each call
  - add a test case with reading and storing domains
- cherry picked from commit 491ee25
  - release read lock as soon as possible to prevent deadlocks
  - fix PentahoMetadataDomainRepositoryTest

@pentaho-nbaker, @rmansoor, @e-cuellar, @mdamour1976, review it please.
This is a backport of https://github.com/pentaho/pentaho-platform/pull/2413 and https://github.com/pentaho/pentaho-platform/pull/2435