### PR TITLE
Revert "Revert "[BACKLOG-4548] - Create public REST interfaces for Re…

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
@@ -21,6 +21,8 @@ import com.sun.jersey.api.NotFoundException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.codehaus.enunciate.Facet;
+import org.codehaus.enunciate.jaxrs.ResponseCode;
+import org.codehaus.enunciate.jaxrs.StatusCodes;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
@@ -36,15 +38,18 @@ import org.pentaho.platform.security.policy.rolebased.RoleBindingStruct;
 import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
+import org.pentaho.platform.web.http.api.resources.services.UserRoleDaoService;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -66,6 +71,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
 
   private IRoleAuthorizationPolicyRoleBindingDao roleBindingDao = null;
   private ITenantManager tenantManager = null;
+  private final UserRoleDaoService userRoleDaoService;
   private ArrayList<String> systemRoles;
   private String adminRole;
 
@@ -76,12 +82,16 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
   public UserRoleDaoResource() {
     this( PentahoSystem.get( IRoleAuthorizationPolicyRoleBindingDao.class ), PentahoSystem.get( ITenantManager.class ),
         PentahoSystem.get( ArrayList.class, "singleTenantSystemAuthorities", PentahoSessionHolder.getSession() ),
-        PentahoSystem.get( String.class, "singleTenantAdminAuthorityName", PentahoSessionHolder.getSession() ) );
+        PentahoSystem.get( String.class, "singleTenantAdminAuthorityName", PentahoSessionHolder.getSession() ), new UserRoleDaoService() );
   }
 
   public UserRoleDaoResource( final IRoleAuthorizationPolicyRoleBindingDao roleBindingDao,
                               final ITenantManager tenantMgr, final ArrayList<String> systemRoles, final String adminRole ) {
+    this( roleBindingDao, tenantMgr, systemRoles, adminRole, new UserRoleDaoService() );
+  }
 
+  public UserRoleDaoResource( final IRoleAuthorizationPolicyRoleBindingDao roleBindingDao,
+                              final ITenantManager tenantMgr, final ArrayList<String> systemRoles, final String adminRole, UserRoleDaoService  service ) {
     if ( roleBindingDao == null ) {
       throw new IllegalArgumentException();
     }
@@ -90,30 +100,41 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
     this.tenantManager = tenantMgr;
     this.systemRoles = systemRoles;
     this.adminRole = adminRole;
-
+    this.userRoleDaoService = service;
   }
 
   /**
-   * Returns the list of users in the platform's repository
+   * Returns the list of users in the platform's repository.
    *
-   * @return list of users in the platform
-   * @throws Exception
+   * <p><b>Example Request:</b><br />
+   * GET pentaho/api/userroledao/users
+   * </p>
+   *
+   * @return list of users in the
+   *
+   * <p><b>Example Response:</b>
+   * <pre function="syntax.xml">
+   *  <userList>
+   *    <users>suzy</users>
+   *    <users>pat</users>
+   *    <users>tiffany</users>
+   *    <users>admin</users>
+   *  </userList>
+   * </pre>
    */
   @GET
   @Path ( "/users" )
   @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
-  @Facet( name = "Unsupported" )
-  public UserListWrapper getUsers() throws Exception {
-    if ( canAdminister() ) {
-      try {
-        IUserRoleDao roleDao =
-            PentahoSystem.get( IUserRoleDao.class, "userRoleDaoProxy", PentahoSessionHolder.getSession() );
-        return new UserListWrapper( roleDao.getUsers() );
-      } catch ( Throwable t ) {
-        throw new WebApplicationException( t );
-      }
-    } else {
-      throw new WebApplicationException( new Throwable() );
+  @StatusCodes( {
+      @ResponseCode ( code = 200, condition = "Successfully returned the list of users" ),
+      @ResponseCode ( code = 500, condition = "An error occurred in the platform while trying to access the list of users." )
+  } )
+  public UserListWrapper getUsers() throws WebApplicationException {
+    try {
+      return userRoleDaoService.getUsers();
+    } catch ( Exception e ) {
+      logger.warn( e.getMessage(), e );
+      throw new WebApplicationException( Response.Status.INTERNAL_SERVER_ERROR );
     }
   }
 

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/services/UserRoleDaoService.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/services/UserRoleDaoService.java
@@ -1,0 +1,31 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources.services;
+
+import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.web.http.api.resources.UserListWrapper;
+
+public class UserRoleDaoService {
+    public UserListWrapper getUsers() throws Exception {
+        IUserRoleDao roleDao =
+                PentahoSystem.get( IUserRoleDao.class, "userRoleDaoProxy", PentahoSessionHolder.getSession() );
+        return new UserListWrapper( roleDao.getUsers() );
+    }
+}

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
@@ -1,0 +1,72 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
+import org.pentaho.platform.api.mt.ITenantManager;
+import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
+import org.pentaho.platform.web.http.api.resources.services.UserRoleDaoService;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UserRoleDaoResourceTest {
+    private UserRoleDaoResource userRoleResource;
+
+    //Mocks
+    private IRoleAuthorizationPolicyRoleBindingDao roleBindingDao;
+    private ITenantManager tenantManager;
+    private ArrayList<String> systemRoles;
+    private String adminRole;
+    private UserRoleDaoService userRoleService;
+
+    @Before
+    public void setUp() throws Exception {
+        roleBindingDao = mock( IRoleAuthorizationPolicyRoleBindingDao.class );
+        tenantManager = mock( ITenantManager.class );
+        systemRoles = new ArrayList<String>();
+        adminRole = "MockSession";
+        userRoleService = mock( UserRoleDaoService.class );
+        userRoleResource = new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, userRoleService );
+    }
+
+    @Test
+    public void testGetUsers() throws Exception {
+        UserListWrapper userListWrapper = new UserListWrapper( new ArrayList<IPentahoUser>() );
+        when( userRoleService.getUsers() ).thenReturn( userListWrapper );
+
+        assertEquals( userListWrapper, userRoleResource.getUsers() );
+    }
+
+    @Test
+    public void testGetUsersError() throws Exception {
+        try {
+            when( userRoleService.getUsers() ).thenThrow( new Exception() );
+        } catch( WebApplicationException e ) {
+            assertEquals( Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), e.getResponse().getStatus() );
+        }
+    }
+}

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/UserRoleDaoServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/UserRoleDaoServiceTest.java
@@ -1,0 +1,61 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources.services;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
+import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.web.http.api.resources.UserListWrapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UserRoleDaoServiceTest {
+    private UserRoleDaoService userRoleService;
+    @Before
+    public void setUp() throws Exception {
+        PentahoSystem.init();
+        userRoleService = new UserRoleDaoService();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        PentahoSystem.clearObjectFactory();
+        PentahoSystem.shutdown();
+    }
+
+
+    @Test
+    public void testGetUsers() throws Exception {
+        List<IPentahoUser> userList = new ArrayList<IPentahoUser>();
+        IUserRoleDao roleDao = mock( IUserRoleDao.class );
+        when( roleDao.getUsers() ).thenReturn( userList );
+        PentahoSystem.registerObject(roleDao);
+
+        UserListWrapper wrapUserList = new UserListWrapper( userList );
+
+        assertEquals( wrapUserList.getUsers(), userRoleService.getUsers().getUsers() );
+    }
+}


### PR DESCRIPTION
Reverts pentaho/pentaho-platform#2416, The DAO object is supposed to be productized, any modification or users or roles should live in the DAO object. Undoing the original REVERT that pulled this work out of the DAO. @pentaho-nbaker Please take a look at the constructor I've built to account for a DAO Service object to correspond to the Resource object.