### PR TITLE
[PDI-13736] - Regression: PDI Server Startup Time with invalid databa…

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
@@ -136,6 +136,7 @@
 	  <test-while-idle>false</test-while-idle>
 	  <test-on-borrow>true</test-on-borrow>
 	  <test-on-return>false</test-on-return>
+	  <pre-populate-pool>false</pre-populate-pool>
    </dbcp-defaults>
    <file-upload-defaults>
    		<relative-path>/system/metadata/csvfiles/</relative-path>

--- a/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelper.java
+++ b/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelper.java
@@ -45,6 +45,7 @@ import org.pentaho.database.service.IDatabaseDialectService;
 import org.pentaho.platform.api.data.DBDatasourceServiceException;
 import org.pentaho.platform.api.data.IDBDatasourceService;
 import org.pentaho.platform.api.engine.ICacheManager;
+import org.pentaho.platform.api.engine.ILogger;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.services.messages.Messages;
@@ -277,8 +278,15 @@ public class PooledDatasourceHelper {
           + maxIdleConnection + "max idle" + "with " + waitTime + "wait time"//$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
           + " idle connections." ); //$NON-NLS-1$
 
-      for ( int i = 0; i < maxIdleConnection; ++i ) {
-        pool.addObject();
+      String prePopulatePoolStr = PentahoSystem.getSystemSetting( "dbcp-defaults/pre-populate-pool", null );
+      if ( Boolean.parseBoolean( prePopulatePoolStr ) ) {
+        for ( int i = 0; i < maxIdleConnection; ++i ) {
+          pool.addObject();
+        }
+        if ( Logger.getLogLevel() <= ILogger.DEBUG ) {
+          Logger.debug( PooledDatasourceHelper.class,
+            "Pool has been pre-populated with " + maxIdleConnection + " connections" );
+        }
       }
       Logger.debug( PooledDatasourceHelper.class, "Pool now has " + pool.getNumActive() + " active/"
           + pool.getNumIdle() + " idle connections." ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$


### PR DESCRIPTION
…se connections

- do not pre-populate the pool with idle connections unless the property 'dbcp-defaults/pre-populate-pool' is set to 'true'

@mbatchelor, @pentaho-nbaker, review it please. This change turns off pool's pre-populating unless deliberately allowed
/cc @pamval 