### PR TITLE
[SP-2051] - Backport of BISERVER-12637 - Jackrabbit's ds_repos_datastore table can grow out of control causing performance issues (5.4 Suite)

### DIFF
--- a/core/test-res/solution/system/logs/audit/PentahoAuditLog.log
+++ b/core/test-res/solution/system/logs/audit/PentahoAuditLog.log
@@ -88,3 +88,163 @@
 2013/01/17 23:25:52	Global startup actions	system session	testsolution/testpath/test.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system session	instance_start	25229c3e-6127-11e2-bd08-60334b14b37d			0.0
 2013/01/17 23:25:53	Global startup actions	system session	testsolution/testpath/test.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system session	instance_start	2540365f-6127-11e2-bd08-60334b14b37d			0.0
 2013/01/17 23:25:53	Global startup actions	system session	testsolution/testpath/test.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system session	instance_start	25565670-6127-11e2-bd08-60334b14b37d			0.0
+2015/08/20 11:05:33	234234	2342342342	234234234	String	actor	messageType	messageName	messageTxtValue	2324323.23	23.0
+2015/08/20 11:05:33	2342342	242423	23423423	objType	actor	messageType	messageName	messageTxtValue		23.0
+2015/08/20 11:05:33	2342342	242423	23423423	objType	actor	messageType	messageName		2324323.23	0.0
+2015/08/20 11:05:33	2342342	242423	23423423	objType	actor	messageType	messageName	messageTxtValue		0.0
+2015/08/20 11:05:34	234234	2342342342	234234234	String	actor	messageType	messageName	messageTxtValue	2324323.23	23.0
+2015/08/20 11:05:34					!BaseTest.DEBUG_JUNIT_SESSION!	Type	This is a message	Values		34.0
+2015/08/20 11:05:34	334234	342323		String	admin	Type	This is a message	Values		34.0
+2015/08/20 11:05:34		342323	ViewAction	String	admin	Type	This is a message	Values		34.0
+2015/08/20 11:05:34	334234		ViewAction	String	admin	Type	This is a message	Values		34.0
+2015/08/20 11:05:35	simple output test	system	isOutputParameterTest.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	87501a97-4744-11e5-ba39-080027007436			0.0
+2015/08/20 11:05:35	simple output test	87501a97-4744-11e5-ba39-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:35	simple output test	87501a97-4744-11e5-ba39-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.0
+2015/08/20 11:05:35	simple output test	system	isOutputParameterTest.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	87501a97-4744-11e5-ba39-080027007436			0.009999999776482582
+2015/08/20 11:05:36	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	87d29111-4744-11e5-b2ea-080027007436			0.0
+2015/08/20 11:05:36	empty action sequence test	87d29111-4744-11e5-b2ea-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:36	empty action sequence test	87d29111-4744-11e5-b2ea-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	deprecated	org.pentaho.plugin.core.ContentOutputComponent	org.pentaho.platform.plugin.action.deprecated.ContentOutputComponent		0.0
+2015/08/20 11:05:36	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	87d29111-4744-11e5-b2ea-080027007436			0.03099999949336052
+2015/08/20 11:05:37	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	88586203-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	empty action sequence test	88586203-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	88586203-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	88586203-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.004999999888241291
+2015/08/20 11:05:37	empty action sequence test	88586203-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.006000000052154064
+2015/08/20 11:05:37	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	88586203-4744-11e5-8d65-080027007436			0.07400000095367432
+2015/08/20 11:05:37	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	88677d34-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	empty action sequence test	88677d34-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	88677d34-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.TestPojo1	system	component_execution_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	88677d34-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.TestPojo1	system	component_execution_end	end			0.004000000189989805
+2015/08/20 11:05:37	empty action sequence test	88677d34-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.004999999888241291
+2015/08/20 11:05:37	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	88677d34-4744-11e5-8d65-080027007436			0.017999999225139618
+2015/08/20 11:05:37	empty action sequence test	system	pojo1b.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	886b4dc5-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	empty action sequence test	886b4dc5-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	886b4dc5-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	886b4dc5-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.004999999888241291
+2015/08/20 11:05:37	empty action sequence test	886b4dc5-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.004999999888241291
+2015/08/20 11:05:37	empty action sequence test	system	pojo1b.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	886b4dc5-4744-11e5-8d65-080027007436			0.013000000268220901
+2015/08/20 11:05:37	empty action sequence test	system	pojo4.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	886e5b06-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	empty action sequence test	886e5b06-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	886e5b06-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	886e5b06-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.0010000000474974513
+2015/08/20 11:05:37	empty action sequence test	886e5b06-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.0020000000949949026
+2015/08/20 11:05:37	empty action sequence test	system	pojo4.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	886e5b06-4744-11e5-8d65-080027007436			0.008999999612569809
+2015/08/20 11:05:37	empty action sequence test	system	pojo5.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	88707de7-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	empty action sequence test	88707de7-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	88707de7-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	88707de7-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.0020000000949949026
+2015/08/20 11:05:37	empty action sequence test	88707de7-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.003000000026077032
+2015/08/20 11:05:37	empty action sequence test	system	pojo5.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	88707de7-4744-11e5-8d65-080027007436			0.013000000268220901
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	88736418-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	invalid class setting test	88736418-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	88736418-4744-11e5-8d65-080027007436			0.019999999552965164
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	88775bb9-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	invalid class setting test	88775bb9-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	88775bb9-4744-11e5-8d65-080027007436			0.009999999776482582
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	8879ccba-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	invalid class setting test	8879ccba-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	invalid class setting test	8879ccba-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:05:37	invalid class setting test	8879ccba-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_failed	execution			0.0020000000949949026
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	8879ccba-4744-11e5-8d65-080027007436			0.00800000037997961
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	887bc88b-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	invalid class setting test	887bc88b-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	invalid class setting test	887bc88b-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:05:37	invalid class setting test	887bc88b-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.0010000000474974513
+2015/08/20 11:05:37	invalid class setting test	887bc88b-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.0020000000949949026
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	887bc88b-4744-11e5-8d65-080027007436			0.00800000037997961
+2015/08/20 11:05:37	empty action sequence test	system	test1.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	887e127d-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	empty action sequence test	887e127d-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	887e127d-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:05:37	empty action sequence test	887e127d-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.0020000000949949026
+2015/08/20 11:05:37	empty action sequence test	887e127d-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.003000000026077032
+2015/08/20 11:05:37	empty action sequence test	system	test1.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	887e127d-4744-11e5-8d65-080027007436			0.014999999664723873
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	8880f8ae-4744-11e5-8d65-080027007436			0.0
+2015/08/20 11:05:37	invalid class setting test	8880f8ae-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:37	invalid class setting test	8880f8ae-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:05:37	invalid class setting test	8880f8ae-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_failed	failed	Base.ERROR_0002 - Component execution failed		0.0
+2015/08/20 11:05:37	invalid class setting test	8880f8ae-4744-11e5-8d65-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_failed	execution			0.0010000000474974513
+2015/08/20 11:05:37	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	8880f8ae-4744-11e5-8d65-080027007436			0.00800000037997961
+2015/08/20 11:05:38	empty action sequence test	system	test1.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	89006265-4744-11e5-aad3-080027007436			0.0
+2015/08/20 11:05:38	empty action sequence test	89006265-4744-11e5-aad3-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:05:38	empty action sequence test	89006265-4744-11e5-aad3-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.0
+2015/08/20 11:05:38	empty action sequence test	system	test1.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	89006265-4744-11e5-aad3-080027007436			0.013000000268220901
+2015/08/20 11:10:05	234234	2342342342	234234234	String	actor	messageType	messageName	messageTxtValue	2324323.23	23.0
+2015/08/20 11:10:05	2342342	242423	23423423	objType	actor	messageType	messageName	messageTxtValue		23.0
+2015/08/20 11:10:05	2342342	242423	23423423	objType	actor	messageType	messageName		2324323.23	0.0
+2015/08/20 11:10:05	2342342	242423	23423423	objType	actor	messageType	messageName	messageTxtValue		0.0
+2015/08/20 11:10:05	234234	2342342342	234234234	String	actor	messageType	messageName	messageTxtValue	2324323.23	23.0
+2015/08/20 11:10:06					!BaseTest.DEBUG_JUNIT_SESSION!	Type	This is a message	Values		34.0
+2015/08/20 11:10:06	334234	342323		String	admin	Type	This is a message	Values		34.0
+2015/08/20 11:10:06		342323	ViewAction	String	admin	Type	This is a message	Values		34.0
+2015/08/20 11:10:06	334234		ViewAction	String	admin	Type	This is a message	Values		34.0
+2015/08/20 11:10:07	simple output test	system	isOutputParameterTest.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	294ff74a-4745-11e5-9337-080027007436			0.0
+2015/08/20 11:10:07	simple output test	294ff74a-4745-11e5-9337-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:07	simple output test	294ff74a-4745-11e5-9337-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.0
+2015/08/20 11:10:07	simple output test	system	isOutputParameterTest.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	294ff74a-4745-11e5-9337-080027007436			0.009999999776482582
+2015/08/20 11:10:08	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	29d5ef8d-4745-11e5-ad9d-080027007436			0.0
+2015/08/20 11:10:08	empty action sequence test	29d5ef8d-4745-11e5-ad9d-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:08	empty action sequence test	29d5ef8d-4745-11e5-ad9d-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	deprecated	org.pentaho.plugin.core.ContentOutputComponent	org.pentaho.platform.plugin.action.deprecated.ContentOutputComponent		0.0
+2015/08/20 11:10:08	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	29d5ef8d-4745-11e5-ad9d-080027007436			0.03099999949336052
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a5c368e-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	invalid class setting test	2a5c368e-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	invalid class setting test	2a5c368e-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:10:09	invalid class setting test	2a5c368e-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_failed	failed	Base.ERROR_0002 - Component execution failed		0.0
+2015/08/20 11:10:09	invalid class setting test	2a5c368e-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_failed	execution			0.004000000189989805
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	2a5c368e-4745-11e5-a8fa-080027007436			0.0729999989271164
+2015/08/20 11:10:09	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a6b51bf-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	empty action sequence test	2a6b51bf-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a6b51bf-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.TestPojo1	system	component_execution_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a6b51bf-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.TestPojo1	system	component_execution_end	end			0.006000000052154064
+2015/08/20 11:10:09	empty action sequence test	2a6b51bf-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.007000000216066837
+2015/08/20 11:10:09	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	2a6b51bf-4745-11e5-a8fa-080027007436			0.019999999552965164
+2015/08/20 11:10:09	empty action sequence test	system	pojo1b.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a6f7070-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	empty action sequence test	2a6f7070-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a6f7070-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a6f7070-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.004000000189989805
+2015/08/20 11:10:09	empty action sequence test	2a6f7070-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.004000000189989805
+2015/08/20 11:10:09	empty action sequence test	system	pojo1b.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	2a6f7070-4745-11e5-a8fa-080027007436			0.012000000104308128
+2015/08/20 11:10:09	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a7256a1-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	empty action sequence test	2a7256a1-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a7256a1-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a7256a1-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.004000000189989805
+2015/08/20 11:10:09	empty action sequence test	2a7256a1-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.004999999888241291
+2015/08/20 11:10:09	empty action sequence test	system	test1a.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	2a7256a1-4745-11e5-a8fa-080027007436			0.017000000923871994
+2015/08/20 11:10:09	empty action sequence test	system	pojo4.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a75d912-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	empty action sequence test	2a75d912-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a75d912-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a75d912-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.0020000000949949026
+2015/08/20 11:10:09	empty action sequence test	2a75d912-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.0020000000949949026
+2015/08/20 11:10:09	empty action sequence test	system	pojo4.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	2a75d912-4745-11e5-a8fa-080027007436			0.008999999612569809
+2015/08/20 11:10:09	empty action sequence test	system	pojo5.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a77fbf3-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	empty action sequence test	2a77fbf3-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a77fbf3-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a77fbf3-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.0020000000949949026
+2015/08/20 11:10:09	empty action sequence test	2a77fbf3-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.0020000000949949026
+2015/08/20 11:10:09	empty action sequence test	system	pojo5.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	2a77fbf3-4745-11e5-a8fa-080027007436			0.020999999716877937
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a7c1aa4-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	invalid class setting test	2a7c1aa4-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	2a7c1aa4-4745-11e5-a8fa-080027007436			0.006000000052154064
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a7dc855-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	invalid class setting test	2a7dc855-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	2a7dc855-4745-11e5-a8fa-080027007436			0.009999999776482582
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a801246-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	invalid class setting test	2a801246-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	invalid class setting test	2a801246-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:10:09	invalid class setting test	2a801246-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_failed	execution			0.0010000000474974513
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_failed	2a801246-4745-11e5-a8fa-080027007436			0.00800000037997961
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a823527-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	invalid class setting test	2a823527-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	invalid class setting test	2a823527-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:10:09	invalid class setting test	2a823527-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.0020000000949949026
+2015/08/20 11:10:09	invalid class setting test	2a823527-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.0020000000949949026
+2015/08/20 11:10:09	invalid class setting test	system	test	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	2a823527-4745-11e5-a8fa-080027007436			0.00800000037997961
+2015/08/20 11:10:09	empty action sequence test	system	test1.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2a845809-4745-11e5-a8fa-080027007436			0.0
+2015/08/20 11:10:09	empty action sequence test	2a845809-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a845809-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_start	start			0.0
+2015/08/20 11:10:09	empty action sequence test	2a845809-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.solution.PojoComponent	system	component_execution_end	end			0.0020000000949949026
+2015/08/20 11:10:09	empty action sequence test	2a845809-4745-11e5-a8fa-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.004000000189989805
+2015/08/20 11:10:09	empty action sequence test	system	test1.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	2a845809-4745-11e5-a8fa-080027007436			0.013000000268220901
+2015/08/20 11:10:10	empty action sequence test	system	test1.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_start	2b05488b-4745-11e5-9b63-080027007436			0.0
+2015/08/20 11:10:10	empty action sequence test	2b05488b-4745-11e5-9b63-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_start	start			0.0
+2015/08/20 11:10:10	empty action sequence test	2b05488b-4745-11e5-9b63-080027007436		org.pentaho.platform.engine.services.runtime.RuntimeContext	system	action_sequence_end	end			0.0
+2015/08/20 11:10:10	empty action sequence test	system	test1.xaction	org.pentaho.platform.engine.services.solution.SolutionEngine	system	instance_end	2b05488b-4745-11e5-9b63-080027007436			0.012000000104308128

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/RepositoryCleaner.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/RepositoryCleaner.java
@@ -1,0 +1,78 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jackrabbit.api.management.DataStoreGarbageCollector;
+import org.apache.jackrabbit.core.RepositoryImpl;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+
+/**
+ * This class provides a static method {@linkplain #gc()} for running JCR's GC routine.
+ *
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCleaner {
+
+  private static final Log logger = LogFactory.getLog( RepositoryCleaner.class );
+
+  public static synchronized void gc() {
+    Repository jcrRepository = PentahoSystem.get( Repository.class, "jcrRepository", null );
+    if ( jcrRepository == null ) {
+      logger.error( "Cannot obtain JCR repository. Exiting" );
+      return;
+    }
+
+    if ( !( jcrRepository instanceof RepositoryImpl ) ) {
+      logger.error(
+        String.format( "Expected RepositoryImpl, but got: [%s]. Exiting", jcrRepository.getClass().getName() ) );
+      return;
+    }
+
+    RepositoryImpl repository = (RepositoryImpl) jcrRepository;
+    try {
+      logger.info( "Creating garbage collector" );
+      // JCR's documentation recommends not to use RepositoryImpl.createDataStoreGarbageCollector() and
+      // instead invoke RepositoryManager.createDataStoreGarbageCollector()
+      // (see it here: http://wiki.apache.org/jackrabbit/DataStore#Data_Store_Garbage_Collection)
+
+      // However, the example from the wiki cannot be applied directly, because
+      // RepositoryFactoryImpl accepts only TransientRepository's instances that were created by itself;
+      // it creates such instance in "not started" state, and when the instance tries to start, it fails,
+      // because Pentaho's JCR repository is already running.
+
+      DataStoreGarbageCollector gc = repository.createDataStoreGarbageCollector();
+      try {
+        logger.debug( "Starting marking stage" );
+        gc.mark();
+        logger.debug( "Starting sweeping stage" );
+        int deleted = gc.sweep();
+        logger.info( String.format( "Garbage collecting completed. %d items were deleted", deleted ) );
+      } finally {
+        gc.close();
+      }
+    } catch ( RepositoryException e ) {
+      logger.error( "Error during garbage collecting", e );
+    }
+  }
+}

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/RepositoryCleanerTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/RepositoryCleanerTest.java
@@ -1,0 +1,58 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.apache.jackrabbit.core.RepositoryImpl;
+import org.apache.jackrabbit.core.data.GarbageCollector;
+import org.junit.Test;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
+
+import javax.jcr.Repository;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCleanerTest {
+
+  @Test
+  public void gc() throws Exception {
+    GarbageCollector collector = mock( GarbageCollector.class );
+
+    RepositoryImpl repository = mock( RepositoryImpl.class );
+    when( repository.createDataStoreGarbageCollector() ).thenReturn( collector );
+
+    MicroPlatform mp = new MicroPlatform();
+    mp.defineInstance( Repository.class, repository );
+    mp.defineInstance( "jcrRepository", repository );
+    mp.start();
+
+    try {
+      RepositoryCleaner.gc();
+    } finally {
+      mp.stop();
+    }
+
+    verify( collector, times( 1 ) ).mark();
+    verify( collector, times( 1 ) ).sweep();
+    verify( collector, times( 1 ) ).close();
+  }
+
+}

--- a/scheduler/ivy.xml
+++ b/scheduler/ivy.xml
@@ -22,10 +22,12 @@
     <dependency org="junit" name="junit" rev="4.4" conf="test->default" />
     <dependency org="org.jmock" name="jmock-junit4" rev="2.5.1" conf="test->default" />
     	<dependency org="org.jmock" name="jmock-legacy" rev="2.5.1" conf="test->default" />
+    <dependency org="org.mockito" name="mockito-all"  rev="1.8.5" conf="test->default"/>
 
     <!--  internal dependencies -->
     <dependency org="${ivy.artifact.group}" name="pentaho-platform-api"  rev="${project.revision}" changing="true" conf="default->default" />
     <dependency org="${ivy.artifact.group}" name="pentaho-platform-core" rev="${project.revision}" changing="true" conf="default->default" />
+    <dependency org="${ivy.artifact.group}" name="pentaho-platform-repository" rev="${project.revision}" changing="true" conf="default->default" />
     <dependency org="pentaho" name="pentaho-versionchecker" rev="${dependency.pentaho-versionchecker.revision}" changing="true" />
    	<dependency org="javax.mail" name="mail" rev="1.4.1" transitive="false" />
         

--- a/scheduler/src/org/pentaho/platform/scheduler2/gc/RepositoryCleanerSystemListener.java
+++ b/scheduler/src/org/pentaho/platform/scheduler2/gc/RepositoryCleanerSystemListener.java
@@ -1,0 +1,222 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.scheduler2.gc;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.IPentahoSystemListener;
+import org.pentaho.platform.api.scheduler2.ComplexJobTrigger;
+import org.pentaho.platform.api.scheduler2.IJobFilter;
+import org.pentaho.platform.api.scheduler2.IScheduler;
+import org.pentaho.platform.api.scheduler2.Job;
+import org.pentaho.platform.api.scheduler2.JobTrigger;
+import org.pentaho.platform.api.scheduler2.SchedulerException;
+import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This is a 5.4-only class. To use it, update <tt>systemListeners.xml</tt> by adding the following section:
+ * <pre>
+  &lt;bean id="repositoryCleanerSystemListener"
+        class="org.pentaho.platform.scheduler2.gc.RepositoryCleanerSystemListener"&gt;
+    &lt;property name="gcEnabled" value="true"/&gt;
+    &lt;property name="execute" value="now"/&gt;
+  &lt;/bean&gt;
+ * </pre>
+ * <tt>gcEnabled</tt> is a non-mandatory parameter, <tt>true</tt> by default. Use it to turn off the listener without
+ * removing its description from the XML-file
+ * <tt>execute</tt> is a parameter, that describes a time pattern of GC procedure. Supported values are:
+ * <ul>
+ *   <li><tt>now</tt> - for one time execution</li>
+ *   <li><tt>weekly</tt> - for every Monday execution</li>
+ *   <li><tt>monthly</tt> - for every first day of month execution</li>
+ * </ul>
+ * Note, that periodic executions will be planned to start at 0:00. If an execution was not started at that time,
+ * e.g. the server was shut down, then it will be started as soon as the scheduler is restored.
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCleanerSystemListener implements IPentahoSystemListener, IJobFilter {
+
+  private final Log logger = LogFactory.getLog( RepositoryCleanerSystemListener.class );
+
+  enum Frequency {
+    NOW( "now" ) {
+      @Override public JobTrigger createTrigger() {
+        return new SimpleJobTrigger( new Date(),
+          new Date( Long.MAX_VALUE ), 0, 1 );
+      }
+    },
+
+    WEEKLY( "weekly" ) {
+      @Override public JobTrigger createTrigger() {
+        // execute each first day of week at 0 hours
+        return new ComplexJobTrigger( null, null, null, ComplexJobTrigger.SUNDAY, 0 );
+      }
+    },
+
+    MONTHLY( "monthly" ) {
+      @Override public JobTrigger createTrigger() {
+        // execute each first day of month at 0 hours
+        return new ComplexJobTrigger( null, null, 1, null, 0 );
+      }
+    };
+
+    private final String value;
+
+    Frequency( String value ) {
+      this.value = value;
+    }
+
+    public abstract JobTrigger createTrigger();
+
+    public static Frequency fromString( String name ) {
+      for ( Frequency frequency : values() ) {
+        if ( frequency.value.equalsIgnoreCase( name ) ) {
+          return frequency;
+        }
+      }
+      return null;
+    }
+
+    String getValue() {
+      return value;
+    }
+  }
+
+  private boolean gcEnabled = true;
+  private String execute;
+
+  @Override
+  public boolean startup( IPentahoSession session ) {
+    IScheduler scheduler = PentahoSystem.get( IScheduler.class, "IScheduler2", session );
+    if ( scheduler == null ) {
+      logger.error( "Cannot obtain an instance of IScheduler2" );
+      return false;
+    }
+
+    try {
+      List<Job> jobs = scheduler.getJobs( this );
+      if ( gcEnabled ) {
+        if ( jobs.isEmpty() ) {
+          return scheduleJob( scheduler );
+        } else {
+          return rescheduleIfNecessary( scheduler, jobs );
+        }
+      } else {
+        if ( !jobs.isEmpty() ) {
+          return unscheduleJob( scheduler, jobs );
+        }
+      }
+    } catch ( SchedulerException e ) {
+      logger.error( "Scheduler error", e );
+    }
+    return false;
+  }
+
+  private JobTrigger findJobTrigger() {
+    if ( StringUtil.isEmpty( execute ) ) {
+      logger.error( "\"execute\" property is not specified!" );
+      return null;
+    }
+
+    Frequency frequency = Frequency.fromString( execute );
+    if ( frequency == null ) {
+      logger.error( "Unknown value for property \"execute\": " + execute );
+      return null;
+    }
+
+    return frequency.createTrigger();
+  }
+
+  private boolean scheduleJob( IScheduler scheduler ) throws SchedulerException {
+    JobTrigger trigger = findJobTrigger();
+    if ( trigger != null ) {
+      logger.info( "Creating new job with trigger: " + trigger );
+      scheduler.createJob( RepositoryGcJob.JOB_NAME, RepositoryGcJob.class, null, trigger );
+      return true;
+    }
+    return false;
+  }
+
+  private boolean rescheduleIfNecessary( IScheduler scheduler, List<Job> jobs ) throws SchedulerException {
+    JobTrigger trigger = findJobTrigger();
+    if ( trigger == null ) {
+      return false;
+    }
+
+    List<Job> matched = new ArrayList<Job>( jobs.size() );
+    for ( Job job : jobs ) {
+      JobTrigger tr = job.getJobTrigger();
+      // unfortunately, JobTrigger does not override equals
+      if ( trigger.getClass() != tr.getClass() ) {
+        logger.info( "Removing job with id: " + job.getJobId() );
+        scheduler.removeJob( job.getJobId() );
+      } else {
+        matched.add( job );
+      }
+    }
+
+    if ( matched.isEmpty() ) {
+      logger.info( "Need to re-schedule job" );
+      scheduleJob( scheduler );
+    }
+    return true;
+  }
+
+  private boolean unscheduleJob( IScheduler scheduler, List<Job> jobs ) throws SchedulerException {
+    for ( Job job : jobs ) {
+      logger.info( "Removing job with id: " + job.getJobId() );
+      scheduler.removeJob( job.getJobId() );
+    }
+    return true;
+  }
+
+
+  @Override
+  public void shutdown() {
+    // nothing to do
+  }
+
+  @Override
+  public boolean accept( Job job ) {
+    return RepositoryGcJob.JOB_NAME.equals( job.getJobName() );
+  }
+
+
+  public boolean isGcEnabled() {
+    return gcEnabled;
+  }
+
+  public void setGcEnabled( boolean gcEnabled ) {
+    this.gcEnabled = gcEnabled;
+  }
+
+  public String getExecute() {
+    return execute;
+  }
+
+  public void setExecute( String execute ) {
+    this.execute = execute;
+  }
+}

--- a/scheduler/src/org/pentaho/platform/scheduler2/gc/RepositoryGcJob.java
+++ b/scheduler/src/org/pentaho/platform/scheduler2/gc/RepositoryGcJob.java
@@ -1,0 +1,39 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.scheduler2.gc;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.action.IAction;
+import org.pentaho.platform.repository2.unified.jcr.RepositoryCleaner;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryGcJob implements IAction {
+  public static final String JOB_NAME = "RepositoryGcJob";
+
+  private static final Log logger = LogFactory.getLog( RepositoryGcJob.class );
+
+  @Override
+  public void execute() throws Exception {
+    logger.info( "Starting repository GC" );
+    RepositoryCleaner.gc();
+    logger.info( "Repository GC has been finished" );
+  }
+}

--- a/scheduler/test-src/org/pentaho/platform/scheduler2/gc/RepositoryCleanerSystemListenerTest.java
+++ b/scheduler/test-src/org/pentaho/platform/scheduler2/gc/RepositoryCleanerSystemListenerTest.java
@@ -1,0 +1,191 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.scheduler2.gc;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.scheduler2.CronJobTrigger;
+import org.pentaho.platform.api.scheduler2.IJobFilter;
+import org.pentaho.platform.api.scheduler2.IJobTrigger;
+import org.pentaho.platform.api.scheduler2.IScheduler;
+import org.pentaho.platform.api.scheduler2.Job;
+import org.pentaho.platform.api.scheduler2.SchedulerException;
+import org.pentaho.platform.scheduler2.gc.RepositoryCleanerSystemListener.Frequency;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCleanerSystemListenerTest {
+
+  private MicroPlatform mp;
+  private IScheduler scheduler;
+  private RepositoryCleanerSystemListener listener;
+
+  @Before
+  public void setUp() throws Exception {
+    scheduler = mock( IScheduler.class );
+    listener = new RepositoryCleanerSystemListener();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if ( mp != null ) {
+      mp.stop();
+      mp = null;
+    }
+    scheduler = null;
+    listener = null;
+  }
+
+
+  @Test
+  public void gcEnabledIsTrue_executeIsNull_ByDefault() {
+    assertTrue( listener.isGcEnabled() );
+    assertNull( listener.getExecute() );
+  }
+
+  @Test
+  public void stops_IfSchedulerIsNotDefined() {
+    assertFalse( listener.startup( null ) );
+  }
+
+
+  private void prepareMp() throws Exception {
+    mp = new MicroPlatform();
+    mp.defineInstance( IScheduler.class, scheduler );
+    mp.start();
+  }
+
+  private void verifyJobRemoved( String jobId ) throws SchedulerException {
+    verify( scheduler ).removeJob( jobId );
+  }
+
+  private void verifyJobCreated( Frequency frequency ) throws SchedulerException {
+    verify( scheduler ).createJob( eq( RepositoryGcJob.JOB_NAME ), eq( RepositoryGcJob.class ), anyMap(),
+      isA( frequency.createTrigger().getClass() ) );
+  }
+
+
+  private void verifyJobHaveNotCreated() throws SchedulerException {
+    verify( scheduler, never() )
+      .createJob( eq( RepositoryGcJob.JOB_NAME ), eq( RepositoryGcJob.class ), anyMap(), any( IJobTrigger.class ) );
+  }
+
+
+  @Test
+  public void removesJobs_WhenDisabled() throws Exception {
+    final String jobId = "jobId";
+    Job job = new Job();
+    job.setJobId( jobId );
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.singletonList( job ) );
+
+    prepareMp();
+
+    listener.setGcEnabled( false );
+
+    assertTrue( listener.startup( null ) );
+    verifyJobRemoved( jobId );
+  }
+
+  @Test
+  public void schedulesJob_Now() throws Exception {
+    testSchedulesJob( Frequency.NOW );
+  }
+
+  @Test
+  public void schedulesJob_Weekly() throws Exception {
+    testSchedulesJob( Frequency.WEEKLY );
+  }
+
+  @Test
+  public void schedulesJob_Monthly() throws Exception {
+    testSchedulesJob( Frequency.MONTHLY );
+  }
+
+
+  private void testSchedulesJob( Frequency frequency ) throws Exception {
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.<Job>emptyList() );
+    prepareMp();
+    listener.setExecute( frequency.getValue() );
+
+    assertTrue( listener.startup( null ) );
+    verifyJobCreated( frequency );
+  }
+
+  @Test
+  public void schedulesJob_Unknown() throws Exception {
+    testSchedulesJob_IncorrectExecute( "unknown" );
+  }
+
+  @Test
+  public void schedulesJob_Null() throws Exception {
+    testSchedulesJob_IncorrectExecute( null );
+  }
+
+  private void testSchedulesJob_IncorrectExecute( String execute ) throws Exception {
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.<Job>emptyList() );
+    prepareMp();
+    listener.setExecute( execute );
+
+    assertFalse( listener.startup( null ) );
+    verifyJobHaveNotCreated();
+  }
+
+
+  @Test
+  public void reschedulesJob_IfFoundDifferent() throws Exception {
+    final String oldJobId = "oldJobId";
+    Job oldJob = new Job();
+    oldJob.setJobTrigger( new CronJobTrigger() );
+    oldJob.setJobId( oldJobId );
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.singletonList( oldJob ) );
+
+    prepareMp();
+
+    listener.setExecute( Frequency.NOW.getValue() );
+
+    assertTrue( listener.startup( null ) );
+    verifyJobRemoved( oldJobId );
+    verifyJobCreated( Frequency.NOW );
+  }
+
+  @Test
+  public void doesNotRescheduleJob_IfFoundSame() throws Exception {
+    final String oldJobId = "oldJobId";
+    Job oldJob = new Job();
+    oldJob.setJobTrigger( Frequency.WEEKLY.createTrigger() );
+    oldJob.setJobId( oldJobId );
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.singletonList( oldJob ) );
+
+    prepareMp();
+
+    listener.setExecute( Frequency.WEEKLY.getValue() );
+
+    assertTrue( listener.startup( null ) );
+    verify( scheduler, never() ).removeJob( oldJobId );
+    verifyJobHaveNotCreated();
+  }
+}


### PR DESCRIPTION
- this is not a backport!
- create a class inside platform-repository to be a startpoint of running GC
- create a system listener and a job inside pentaho-scheduler to be able to run the GC

@mbatchelor, @pmalves, review it please.
/cc @pamval   