### PR TITLE
[SP-1979] - Backport of PDI-13961 - Spoon firstly tries to conect via JNDI although connection type is JDBC (5.4 Suite)

### DIFF
--- a/api/src/org/pentaho/platform/api/data/IJndiDatasourceService.java
+++ b/api/src/org/pentaho/platform/api/data/IJndiDatasourceService.java
@@ -1,0 +1,27 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.data;
+
+
+/**
+ * This interface defines Pentaho's ExtendedDatasourceService API. You should implement it
+ * if you want to create your own DB data sources management system.
+ *
+ */
+public interface IJndiDatasourceService extends IDBDatasourceService {
+}

--- a/api/src/org/pentaho/platform/api/data/IPooledDatasourceService.java
+++ b/api/src/org/pentaho/platform/api/data/IPooledDatasourceService.java
@@ -1,0 +1,27 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.data;
+
+
+/**
+ * This interface defines Pentaho's ExtendedDatasourceService API. You should implement it
+ * if you want to create your own DB data sources management system.
+ *
+ */
+public interface IPooledDatasourceService extends IDBDatasourceService {
+}

--- a/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/JndiDatasourceService.java
+++ b/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/JndiDatasourceService.java
@@ -20,11 +20,12 @@ package org.pentaho.platform.engine.services.connection.datasource.dbcp;
 
 import org.pentaho.platform.api.data.DBDatasourceServiceException;
 import org.pentaho.platform.api.data.IDBDatasourceService;
+import org.pentaho.platform.api.data.IJndiDatasourceService;
 import org.pentaho.platform.engine.services.messages.Messages;
 
 import javax.sql.DataSource;
 
-public class JndiDatasourceService extends BaseDatasourceService {
+public class JndiDatasourceService extends BaseDatasourceService implements IJndiDatasourceService {
 
   @Override
   protected DataSource retrieve( String dsName ) throws DBDatasourceServiceException {

--- a/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceService.java
+++ b/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceService.java
@@ -20,10 +20,11 @@ package org.pentaho.platform.engine.services.connection.datasource.dbcp;
 
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.platform.api.data.DBDatasourceServiceException;
+import org.pentaho.platform.api.data.IPooledDatasourceService;
 
 import javax.sql.DataSource;
 
-public class PooledDatasourceService extends NonPooledDatasourceService {
+public class PooledDatasourceService extends NonPooledDatasourceService implements IPooledDatasourceService {
 
   @Override
   public String getDSBoundName( final String dsName ) throws DBDatasourceServiceException {

--- a/extensions/src/org/pentaho/platform/plugin/boot/PentahoBoot.java
+++ b/extensions/src/org/pentaho/platform/plugin/boot/PentahoBoot.java
@@ -19,6 +19,8 @@ package org.pentaho.platform.plugin.boot;
 
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.data.IDBDatasourceService;
+import org.pentaho.platform.api.data.IJndiDatasourceService;
+import org.pentaho.platform.api.data.IPooledDatasourceService;
 import org.pentaho.platform.api.engine.IPentahoDefinableObjectFactory;
 import org.pentaho.platform.api.engine.IPentahoDefinableObjectFactory.Scope;
 import org.pentaho.platform.api.engine.IPentahoObjectFactory;
@@ -29,6 +31,7 @@ import org.pentaho.platform.api.engine.IServiceManager;
 import org.pentaho.platform.api.engine.ISolutionEngine;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.engine.core.system.boot.PentahoSystemBoot;
+import org.pentaho.platform.engine.services.connection.datasource.dbcp.JndiDatasourceService;
 import org.pentaho.platform.engine.services.connection.datasource.dbcp.PooledDatasourceSystemListener;
 import org.pentaho.platform.engine.services.connection.datasource.dbcp.PooledOrJndiDatasourceService;
 import org.pentaho.platform.engine.services.solution.SolutionEngine;
@@ -45,6 +48,7 @@ import org.pentaho.platform.plugin.services.pluginmgr.PluginResourceLoader;
 import org.pentaho.platform.plugin.services.pluginmgr.SystemPathXmlPluginProvider;
 import org.pentaho.platform.plugin.services.pluginmgr.servicemgr.DefaultServiceManager;
 import org.pentaho.platform.repository2.unified.fs.FileSystemBackedUnifiedRepository;
+import org.pentaho.reporting.engine.classic.extensions.modules.connections.PooledDatasourceService;
 
 /**
  * This class is designed to help embedded deployments start the Pentaho system
@@ -112,6 +116,8 @@ public class PentahoBoot extends PentahoSystemBoot {
     IPentahoObjectFactory objectFactory = getFactory();
     if ( objectFactory instanceof IPentahoDefinableObjectFactory ) {
       define( IDBDatasourceService.class, PooledOrJndiDatasourceService.class, Scope.LOCAL );
+      define( IPooledDatasourceService.class, PooledDatasourceService.class, Scope.LOCAL );
+      define( IJndiDatasourceService.class, JndiDatasourceService.class, Scope.LOCAL );
     }
     addLifecycleListener( new PooledDatasourceSystemListener() );
   }


### PR DESCRIPTION
- introduce two interfaces for sharing different data source providers
- update PlatformKettleDataSourceProvider to implement ExtendedDSProviderInterface

@pentaho-nbaker, @rmansoor, please review it.
This PR comes together with pentaho/pentaho-kettle#1657 and **should not be merged before it**
/cc @pamval