### PR TITLE
[SP-1988] - Backport of BISERVER-12642 - Inconsistent synchronization leading to deadlock between JCR and PentahoMetadataDomainRepository (5.4 Suite)

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
@@ -450,7 +450,7 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
       domainFiles = metadataMapping.getFiles( domainId );
       metadataMapping.deleteDomain( domainId );
     } finally {
-      lock.writeLock().lock();
+      lock.writeLock().unlock();
     }
 
     // it no node exists, nothing would happen


### PR DESCRIPTION
- Fix for lock during removeDomain() (cherry picked from 95a7a6bfb3d5351d945da04c7f373122d3228c7b)

@rmansoor, @pminutillo, review it please. This is a backport of https://github.com/pminutillo/pentaho-platform/commit/95a7a6bfb3d5351d945da04c7f373122d3228c7b  