### PR TITLE
[SP-2051] - Backport of BISERVER-12637 - Jackrabbit's ds_repos_datastore table can grow out of control causing performance issues (5.4 Suite)

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/repository/RepositoryCleanerSystemListener.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/repository/RepositoryCleanerSystemListener.java
@@ -119,19 +119,19 @@ public class RepositoryCleanerSystemListener implements IPentahoSystemListener, 
       List<Job> jobs = scheduler.getJobs( this );
       if ( gcEnabled ) {
         if ( jobs.isEmpty() ) {
-          return scheduleJob( scheduler );
+          scheduleJob( scheduler );
         } else {
-          return rescheduleIfNecessary( scheduler, jobs );
+          rescheduleIfNecessary( scheduler, jobs );
         }
       } else {
         if ( !jobs.isEmpty() ) {
-          return unscheduleJob( scheduler, jobs );
+          unscheduleJob( scheduler, jobs );
         }
       }
     } catch ( SchedulerException e ) {
       logger.error( "Scheduler error", e );
     }
-    return false;
+    return true;
   }
 
   private JobTrigger findJobTrigger() {
@@ -149,20 +149,18 @@ public class RepositoryCleanerSystemListener implements IPentahoSystemListener, 
     return frequency.createTrigger();
   }
 
-  private boolean scheduleJob( IScheduler scheduler ) throws SchedulerException {
+  private void scheduleJob( IScheduler scheduler ) throws SchedulerException {
     JobTrigger trigger = findJobTrigger();
     if ( trigger != null ) {
       logger.info( "Creating new job with trigger: " + trigger );
       scheduler.createJob( RepositoryGcJob.JOB_NAME, RepositoryGcJob.class, null, trigger );
-      return true;
     }
-    return false;
   }
 
-  private boolean rescheduleIfNecessary( IScheduler scheduler, List<Job> jobs ) throws SchedulerException {
+  private void rescheduleIfNecessary( IScheduler scheduler, List<Job> jobs ) throws SchedulerException {
     JobTrigger trigger = findJobTrigger();
     if ( trigger == null ) {
-      return false;
+      return;
     }
 
     List<Job> matched = new ArrayList<Job>( jobs.size() );
@@ -181,15 +179,13 @@ public class RepositoryCleanerSystemListener implements IPentahoSystemListener, 
       logger.info( "Need to re-schedule job" );
       scheduleJob( scheduler );
     }
-    return true;
   }
 
-  private boolean unscheduleJob( IScheduler scheduler, List<Job> jobs ) throws SchedulerException {
+  private void unscheduleJob( IScheduler scheduler, List<Job> jobs ) throws SchedulerException {
     for ( Job job : jobs ) {
       logger.info( "Removing job with id: " + job.getJobId() );
       scheduler.removeJob( job.getJobId() );
     }
-    return true;
   }
 
 

--- a/extensions/test-src/org/pentaho/platform/plugin/services/repository/RepositoryCleanerSystemListenerTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/repository/RepositoryCleanerSystemListenerTest.java
@@ -96,6 +96,14 @@ public class RepositoryCleanerSystemListenerTest {
 
 
   @Test
+  public void returnsTrue_EvenGetsExceptions() throws Exception {
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenThrow( new SchedulerException( "test exception" ) );
+    prepareMp();
+    assertTrue( "The listener should not return false to let the system continue working", listener.startup( null ) );
+  }
+
+
+  @Test
   public void removesJobs_WhenDisabled() throws Exception {
     final String jobId = "jobId";
     Job job = new Job();
@@ -150,7 +158,7 @@ public class RepositoryCleanerSystemListenerTest {
     prepareMp();
     listener.setExecute( execute );
 
-    assertFalse( listener.startup( null ) );
+    listener.startup( null );
     verifyJobHaveNotCreated();
   }
 


### PR DESCRIPTION
- prohibit returning false except the case when Scheduler has not been found
- add test case

@mbatchelor, @pentaho-nbaker, @rmansoor, review it please.

While preparing an overview for Sandra, I realize I don't like the current behaviour. Now, if something goes wrong, the listener ruins the system as well. However, this is not an essential listener, and the platform can work w/o it.

That's why I made this PR. The only case, when the listener still returns false, is when Scheduler cannot be obtained.