### PR TITLE
[BACKLOG-4922]  Upgrade to vfs2.1.

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -27,7 +27,7 @@
     <dependency org="commons-httpclient" name="commons-httpclient" rev="3.0.1" transitive="false"/>
     <dependency org="commons-logging" name="commons-logging" rev="1.1.1" transitive="false"/>
     <dependency org="commons-lang" name="commons-lang" rev="2.4" transitive="false"/>
-    <dependency org="org.apache.commons" name="commons-vfs2" rev="2.0" transitive="false"/>
+    <dependency org="org.apache.commons" name="commons-vfs2" rev="2.1-20150824" transitive="false"/>
     <dependency org="org.owasp.esapi" name="esapi" rev="2.0.1" transitive="false" />
 
     <dependency org="org.slf4j" name="slf4j-api" rev="1.7.3"/>

--- a/repository/ivy.xml
+++ b/repository/ivy.xml
@@ -26,7 +26,7 @@
 		<dependency org="commons-lang"        name="commons-lang"        rev="2.4"   transitive="false"/>
 		<dependency org="commons-logging"     name="commons-logging"     rev="1.1.1" transitive="false"/>
 		<dependency org="commons-pool"        name="commons-pool"        rev="1.5.7" transitive="false"/>
-    <dependency org="org.apache.commons" name="commons-vfs2" rev="2.0" transitive="false"/>
+    <dependency org="org.apache.commons" name="commons-vfs2" rev="2.1-20150824" transitive="false"/>
 
 		<dependency org="org.aspectj"            name="aspectjrt"          rev="1.6.6"   transitive="false"/>
 		<dependency org="javax.jcr"              name="jcr"                rev="2.0"     transitive="false"/>

--- a/repository/src/org/pentaho/platform/repository/solution/filebased/DecoratedFileContent.java
+++ b/repository/src/org/pentaho/platform/repository/solution/filebased/DecoratedFileContent.java
@@ -19,6 +19,7 @@ import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.RandomAccessContent;
 import org.apache.commons.vfs2.util.RandomAccessMode;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.cert.Certificate;
@@ -105,5 +106,21 @@ public class DecoratedFileContent implements FileContent {
 
   @Override public boolean isOpen() {
     return fileContent.isOpen();
+  }
+
+  @Override public long write( FileContent fileContent ) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public long write( FileObject fileObject ) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public long write( OutputStream outputStream ) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public long write( OutputStream outputStream, int i ) throws IOException {
+    throw new UnsupportedOperationException();
   }
 }

--- a/repository/src/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfsFileContent.java
+++ b/repository/src/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfsFileContent.java
@@ -25,6 +25,7 @@ import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.RandomAccessContent;
 import org.apache.commons.vfs2.util.RandomAccessMode;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.cert.Certificate;
@@ -139,6 +140,22 @@ public class SolutionRepositoryVfsFileContent implements FileContent {
   public boolean isOpen() {
     // not needed for our usage
     return isOpen;
+  }
+
+  @Override public long write( FileContent output ) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public long write( FileObject file ) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public long write( OutputStream output ) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public long write( OutputStream output, int bufferSize ) throws IOException {
+    throw new UnsupportedOperationException();
   }
 
 }

--- a/repository/src/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfsFileObject.java
+++ b/repository/src/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfsFileObject.java
@@ -25,6 +25,7 @@ import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -158,6 +159,10 @@ public class SolutionRepositoryVfsFileObject implements FileObject {
     return null;
   }
 
+  @Override public String getPublicURIString() {
+    throw new UnsupportedOperationException();
+  }
+
   public FileSystem getFileSystem() {
     // not needed for our usage
     return null;
@@ -185,6 +190,18 @@ public class SolutionRepositoryVfsFileObject implements FileObject {
     return null;
   }
 
+  @Override public boolean setExecutable( boolean executable, boolean ownerOnly ) throws FileSystemException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public boolean setReadable( boolean readable, boolean ownerOnly ) throws FileSystemException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public boolean setWritable( boolean writable, boolean ownerOnly ) throws FileSystemException {
+    throw new UnsupportedOperationException();
+  }
+
   public FileObject resolveFile( final String arg0 ) throws FileSystemException {
     // not needed for our usage
     return null;
@@ -207,6 +224,10 @@ public class SolutionRepositoryVfsFileObject implements FileObject {
   public int delete( final FileSelector arg0 ) throws FileSystemException {
     // not needed for our usage
     return 0;
+  }
+
+  @Override public int deleteAll() throws FileSystemException {
+    throw new UnsupportedOperationException();
   }
 
   public void createFolder() throws FileSystemException {
@@ -258,6 +279,18 @@ public class SolutionRepositoryVfsFileObject implements FileObject {
     return ( content != null ) && content.isOpen();
   }
 
+  @Override public boolean isExecutable() throws FileSystemException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public boolean isFile() throws FileSystemException {
+    return getType().equals( FileType.FILE );
+  }
+
+  @Override public boolean isFolder() throws FileSystemException {
+    throw new UnsupportedOperationException();
+  }
+
   public FileOperations getFileOperations() throws FileSystemException {
     // not needed for our usage
     return null;
@@ -301,5 +334,13 @@ public class SolutionRepositoryVfsFileObject implements FileObject {
   @VisibleForTesting
   public static void setTestAclHelper( IAclNodeHelper helper ){
     testAclHelper = helper;
+  }
+
+  @Override public int compareTo( FileObject file ) {
+    return file == null ? 1 : this.getName().getURI().compareTo( file.getName().getURI() );
+  }
+
+  @Override public Iterator<FileObject> iterator() {
+    throw new UnsupportedOperationException();
   }
 }


### PR DESCRIPTION
Required new methods on some classes due to interface changes.
These methods are assumed to be unused.  Most will currently
throw UnsupportedOperationException.

!! Do not merge until we get the official go-ahead for VFS2.1.