### PR TITLE
[BISERVER-12637] - Jackrabbit's ds_repos_datastore table can grow out of control causing performance issues

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/repository/RepositoryCleanerSystemListener.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/repository/RepositoryCleanerSystemListener.java
@@ -1,0 +1,218 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.plugin.services.repository;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.IPentahoSystemListener;
+import org.pentaho.platform.api.scheduler2.ComplexJobTrigger;
+import org.pentaho.platform.api.scheduler2.IJobFilter;
+import org.pentaho.platform.api.scheduler2.IScheduler;
+import org.pentaho.platform.api.scheduler2.Job;
+import org.pentaho.platform.api.scheduler2.JobTrigger;
+import org.pentaho.platform.api.scheduler2.SchedulerException;
+import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This is a 5.4-only class. To use it, update <tt>systemListeners.xml</tt> by adding the following section:
+ * <pre>
+  &lt;bean id="repositoryCleanerSystemListener"
+        class="org.pentaho.platform.plugin.services.repository.RepositoryCleanerSystemListener"&gt;
+    &lt;property name="gcEnabled" value="true"/&gt;
+    &lt;property name="execute" value="now"/&gt;
+  &lt;/bean&gt;
+ * </pre>
+ * <tt>gcEnabled</tt> is a non-mandatory parameter, <tt>true</tt> by default. Use it to turn off the listener without
+ * removing its description from the XML-file
+ * <tt>execute</tt> is a parameter, that describes a time pattern of GC procedure. Supported values are:
+ * <ul>
+ *   <li><tt>now</tt> - for one time execution</li>
+ *   <li><tt>weekly</tt> - for every Monday execution</li>
+ *   <li><tt>monthly</tt> - for every first day of month execution</li>
+ * </ul>
+ * Note, that periodic executions will be planned to start at 0:00. If an execution was not started at that time,
+ * e.g. the server was shut down, then it will be started as soon as the scheduler is restored.
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCleanerSystemListener implements IPentahoSystemListener, IJobFilter {
+
+  private final Log logger = LogFactory.getLog( RepositoryCleanerSystemListener.class );
+
+  enum Frequency {
+    NOW( "now" ) {
+      @Override public JobTrigger createTrigger() {
+        return new SimpleJobTrigger( new Date(),
+          new Date( Long.MAX_VALUE ), 0, 1 );
+      }
+    },
+
+    WEEKLY( "weekly" ) {
+      @Override public JobTrigger createTrigger() {
+        // execute each first day of week at 0 hours
+        return new ComplexJobTrigger( null, null, null, ComplexJobTrigger.SUNDAY, 0 );
+      }
+    },
+
+    MONTHLY( "monthly" ) {
+      @Override public JobTrigger createTrigger() {
+        // execute each first day of month at 0 hours
+        return new ComplexJobTrigger( null, null, 1, null, 0 );
+      }
+    };
+
+    private final String value;
+
+    Frequency( String value ) {
+      this.value = value;
+    }
+
+    public abstract JobTrigger createTrigger();
+
+    public static Frequency fromString( String name ) {
+      for ( Frequency frequency : values() ) {
+        if ( frequency.value.equalsIgnoreCase( name ) ) {
+          return frequency;
+        }
+      }
+      return null;
+    }
+
+    String getValue() {
+      return value;
+    }
+  }
+
+  private boolean gcEnabled = true;
+  private String execute;
+
+  @Override
+  public boolean startup( IPentahoSession session ) {
+    IScheduler scheduler = PentahoSystem.get( IScheduler.class, "IScheduler2", session );
+    if ( scheduler == null ) {
+      logger.error( "Cannot obtain an instance of IScheduler2" );
+      return false;
+    }
+
+    try {
+      List<Job> jobs = scheduler.getJobs( this );
+      if ( gcEnabled ) {
+        if ( jobs.isEmpty() ) {
+          scheduleJob( scheduler );
+        } else {
+          rescheduleIfNecessary( scheduler, jobs );
+        }
+      } else {
+        if ( !jobs.isEmpty() ) {
+          unscheduleJob( scheduler, jobs );
+        }
+      }
+    } catch ( SchedulerException e ) {
+      logger.error( "Scheduler error", e );
+    }
+    return true;
+  }
+
+  private JobTrigger findJobTrigger() {
+    if ( StringUtil.isEmpty( execute ) ) {
+      logger.error( "\"execute\" property is not specified!" );
+      return null;
+    }
+
+    Frequency frequency = Frequency.fromString( execute );
+    if ( frequency == null ) {
+      logger.error( "Unknown value for property \"execute\": " + execute );
+      return null;
+    }
+
+    return frequency.createTrigger();
+  }
+
+  private void scheduleJob( IScheduler scheduler ) throws SchedulerException {
+    JobTrigger trigger = findJobTrigger();
+    if ( trigger != null ) {
+      logger.info( "Creating new job with trigger: " + trigger );
+      scheduler.createJob( RepositoryGcJob.JOB_NAME, RepositoryGcJob.class, null, trigger );
+    }
+  }
+
+  private void rescheduleIfNecessary( IScheduler scheduler, List<Job> jobs ) throws SchedulerException {
+    JobTrigger trigger = findJobTrigger();
+    if ( trigger == null ) {
+      return;
+    }
+
+    List<Job> matched = new ArrayList<Job>( jobs.size() );
+    for ( Job job : jobs ) {
+      JobTrigger tr = job.getJobTrigger();
+      // unfortunately, JobTrigger does not override equals
+      if ( trigger.getClass() != tr.getClass() ) {
+        logger.info( "Removing job with id: " + job.getJobId() );
+        scheduler.removeJob( job.getJobId() );
+      } else {
+        matched.add( job );
+      }
+    }
+
+    if ( matched.isEmpty() ) {
+      logger.info( "Need to re-schedule job" );
+      scheduleJob( scheduler );
+    }
+  }
+
+  private void unscheduleJob( IScheduler scheduler, List<Job> jobs ) throws SchedulerException {
+    for ( Job job : jobs ) {
+      logger.info( "Removing job with id: " + job.getJobId() );
+      scheduler.removeJob( job.getJobId() );
+    }
+  }
+
+
+  @Override
+  public void shutdown() {
+    // nothing to do
+  }
+
+  @Override
+  public boolean accept( Job job ) {
+    return RepositoryGcJob.JOB_NAME.equals( job.getJobName() );
+  }
+
+
+  public boolean isGcEnabled() {
+    return gcEnabled;
+  }
+
+  public void setGcEnabled( boolean gcEnabled ) {
+    this.gcEnabled = gcEnabled;
+  }
+
+  public String getExecute() {
+    return execute;
+  }
+
+  public void setExecute( String execute ) {
+    this.execute = execute;
+  }
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/repository/RepositoryGcJob.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/repository/RepositoryGcJob.java
@@ -1,0 +1,39 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.plugin.services.repository;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.action.IAction;
+import org.pentaho.platform.repository2.unified.jcr.RepositoryCleaner;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryGcJob implements IAction {
+  public static final String JOB_NAME = "RepositoryGcJob";
+
+  private static final Log logger = LogFactory.getLog( RepositoryGcJob.class );
+
+  @Override
+  public void execute() throws Exception {
+    logger.info( "Starting repository GC" );
+    RepositoryCleaner.gc();
+    logger.info( "Repository GC has been finished" );
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/plugin/services/repository/RepositoryCleanerSystemListenerTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/repository/RepositoryCleanerSystemListenerTest.java
@@ -1,0 +1,199 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.plugin.services.repository;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.scheduler2.CronJobTrigger;
+import org.pentaho.platform.api.scheduler2.IJobFilter;
+import org.pentaho.platform.api.scheduler2.IJobTrigger;
+import org.pentaho.platform.api.scheduler2.IScheduler;
+import org.pentaho.platform.api.scheduler2.Job;
+import org.pentaho.platform.api.scheduler2.SchedulerException;
+import org.pentaho.platform.plugin.services.repository.RepositoryCleanerSystemListener.Frequency;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCleanerSystemListenerTest {
+
+  private MicroPlatform mp;
+  private IScheduler scheduler;
+  private RepositoryCleanerSystemListener listener;
+
+  @Before
+  public void setUp() throws Exception {
+    scheduler = mock( IScheduler.class );
+    listener = new RepositoryCleanerSystemListener();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if ( mp != null ) {
+      mp.stop();
+      mp = null;
+    }
+    scheduler = null;
+    listener = null;
+  }
+
+
+  @Test
+  public void gcEnabledIsTrue_executeIsNull_ByDefault() {
+    assertTrue( listener.isGcEnabled() );
+    assertNull( listener.getExecute() );
+  }
+
+  @Test
+  public void stops_IfSchedulerIsNotDefined() {
+    assertFalse( listener.startup( null ) );
+  }
+
+
+  private void prepareMp() throws Exception {
+    mp = new MicroPlatform();
+    mp.defineInstance( IScheduler.class, scheduler );
+    mp.start();
+  }
+
+  private void verifyJobRemoved( String jobId ) throws SchedulerException {
+    verify( scheduler ).removeJob( jobId );
+  }
+
+  private void verifyJobCreated( Frequency frequency ) throws SchedulerException {
+    verify( scheduler ).createJob( eq( RepositoryGcJob.JOB_NAME ), eq( RepositoryGcJob.class ), anyMap(),
+      isA( frequency.createTrigger().getClass() ) );
+  }
+
+
+  private void verifyJobHaveNotCreated() throws SchedulerException {
+    verify( scheduler, never() )
+      .createJob( eq( RepositoryGcJob.JOB_NAME ), eq( RepositoryGcJob.class ), anyMap(), any( IJobTrigger.class ) );
+  }
+
+
+  @Test
+  public void returnsTrue_EvenGetsExceptions() throws Exception {
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenThrow( new SchedulerException( "test exception" ) );
+    prepareMp();
+    assertTrue( "The listener should not return false to let the system continue working", listener.startup( null ) );
+  }
+
+
+  @Test
+  public void removesJobs_WhenDisabled() throws Exception {
+    final String jobId = "jobId";
+    Job job = new Job();
+    job.setJobId( jobId );
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.singletonList( job ) );
+
+    prepareMp();
+
+    listener.setGcEnabled( false );
+
+    assertTrue( listener.startup( null ) );
+    verifyJobRemoved( jobId );
+  }
+
+  @Test
+  public void schedulesJob_Now() throws Exception {
+    testSchedulesJob( Frequency.NOW );
+  }
+
+  @Test
+  public void schedulesJob_Weekly() throws Exception {
+    testSchedulesJob( Frequency.WEEKLY );
+  }
+
+  @Test
+  public void schedulesJob_Monthly() throws Exception {
+    testSchedulesJob( Frequency.MONTHLY );
+  }
+
+
+  private void testSchedulesJob( Frequency frequency ) throws Exception {
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.<Job>emptyList() );
+    prepareMp();
+    listener.setExecute( frequency.getValue() );
+
+    assertTrue( listener.startup( null ) );
+    verifyJobCreated( frequency );
+  }
+
+  @Test
+  public void schedulesJob_Unknown() throws Exception {
+    testSchedulesJob_IncorrectExecute( "unknown" );
+  }
+
+  @Test
+  public void schedulesJob_Null() throws Exception {
+    testSchedulesJob_IncorrectExecute( null );
+  }
+
+  private void testSchedulesJob_IncorrectExecute( String execute ) throws Exception {
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.<Job>emptyList() );
+    prepareMp();
+    listener.setExecute( execute );
+
+    listener.startup( null );
+    verifyJobHaveNotCreated();
+  }
+
+
+  @Test
+  public void reschedulesJob_IfFoundDifferent() throws Exception {
+    final String oldJobId = "oldJobId";
+    Job oldJob = new Job();
+    oldJob.setJobTrigger( new CronJobTrigger() );
+    oldJob.setJobId( oldJobId );
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.singletonList( oldJob ) );
+
+    prepareMp();
+
+    listener.setExecute( Frequency.NOW.getValue() );
+
+    assertTrue( listener.startup( null ) );
+    verifyJobRemoved( oldJobId );
+    verifyJobCreated( Frequency.NOW );
+  }
+
+  @Test
+  public void doesNotRescheduleJob_IfFoundSame() throws Exception {
+    final String oldJobId = "oldJobId";
+    Job oldJob = new Job();
+    oldJob.setJobTrigger( Frequency.WEEKLY.createTrigger() );
+    oldJob.setJobId( oldJobId );
+    when( scheduler.getJobs( any( IJobFilter.class ) ) ).thenReturn( Collections.singletonList( oldJob ) );
+
+    prepareMp();
+
+    listener.setExecute( Frequency.WEEKLY.getValue() );
+
+    assertTrue( listener.startup( null ) );
+    verify( scheduler, never() ).removeJob( oldJobId );
+    verifyJobHaveNotCreated();
+  }
+}

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/RepositoryCleaner.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/RepositoryCleaner.java
@@ -1,0 +1,78 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jackrabbit.api.management.DataStoreGarbageCollector;
+import org.apache.jackrabbit.core.RepositoryImpl;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+
+/**
+ * This class provides a static method {@linkplain #gc()} for running JCR's GC routine.
+ *
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCleaner {
+
+  private static final Log logger = LogFactory.getLog( RepositoryCleaner.class );
+
+  public static synchronized void gc() {
+    Repository jcrRepository = PentahoSystem.get( Repository.class, "jcrRepository", null );
+    if ( jcrRepository == null ) {
+      logger.error( "Cannot obtain JCR repository. Exiting" );
+      return;
+    }
+
+    if ( !( jcrRepository instanceof RepositoryImpl ) ) {
+      logger.error(
+        String.format( "Expected RepositoryImpl, but got: [%s]. Exiting", jcrRepository.getClass().getName() ) );
+      return;
+    }
+
+    RepositoryImpl repository = (RepositoryImpl) jcrRepository;
+    try {
+      logger.info( "Creating garbage collector" );
+      // JCR's documentation recommends not to use RepositoryImpl.createDataStoreGarbageCollector() and
+      // instead invoke RepositoryManager.createDataStoreGarbageCollector()
+      // (see it here: http://wiki.apache.org/jackrabbit/DataStore#Data_Store_Garbage_Collection)
+
+      // However, the example from the wiki cannot be applied directly, because
+      // RepositoryFactoryImpl accepts only TransientRepository's instances that were created by itself;
+      // it creates such instance in "not started" state, and when the instance tries to start, it fails,
+      // because Pentaho's JCR repository is already running.
+
+      DataStoreGarbageCollector gc = repository.createDataStoreGarbageCollector();
+      try {
+        logger.debug( "Starting marking stage" );
+        gc.mark();
+        logger.debug( "Starting sweeping stage" );
+        int deleted = gc.sweep();
+        logger.info( String.format( "Garbage collecting completed. %d items were deleted", deleted ) );
+      } finally {
+        gc.close();
+      }
+    } catch ( RepositoryException e ) {
+      logger.error( "Error during garbage collecting", e );
+    }
+  }
+}

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/RepositoryCleanerTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/RepositoryCleanerTest.java
@@ -1,0 +1,58 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.apache.jackrabbit.core.RepositoryImpl;
+import org.apache.jackrabbit.core.gc.GarbageCollector;
+import org.junit.Test;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
+
+import javax.jcr.Repository;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RepositoryCleanerTest {
+
+  @Test
+  public void gc() throws Exception {
+    GarbageCollector collector = mock( GarbageCollector.class );
+
+    RepositoryImpl repository = mock( RepositoryImpl.class );
+    when( repository.createDataStoreGarbageCollector() ).thenReturn( collector );
+
+    MicroPlatform mp = new MicroPlatform();
+    mp.defineInstance( Repository.class, repository );
+    mp.defineInstance( "jcrRepository", repository );
+    mp.start();
+
+    try {
+      RepositoryCleaner.gc();
+    } finally {
+      mp.stop();
+    }
+
+    verify( collector, times( 1 ) ).mark();
+    verify( collector, times( 1 ) ).sweep();
+    verify( collector, times( 1 ) ).close();
+  }
+
+}


### PR DESCRIPTION
- create a class inside platform-repository to be a startpoint of running GC
- create a system listener and a job inside pentaho-extensions to be able to run the GC
- prohibit Listener returning false except the case when Scheduler has not
  been found
- add tests
(adopted from commits a38048c, 191c608, 299f8b0)

@mbatchelor, @pentaho-nbaker, @rmansoor, review it please.
Since there is no enough time to implement planned solution, it was decided to move changes from 5.4  to have some.