### PR TITLE
[BISERVER-12642] - Inconsistent synchronization leading to deadlock between JCR and PentahoMetadataDomainRepository

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
@@ -446,17 +446,21 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     }
 
     // Get the metadata domain file
+    RepositoryFile domainFile;
     Set<RepositoryFile> domainFiles;
     lock.writeLock().lock();
     try {
       domainFiles = metadataMapping.getFiles( domainId );
+      domainFile = metadataMapping.getDomainFile( domainId );
       metadataMapping.deleteDomain( domainId );
     } finally {
       lock.writeLock().unlock();
     }
 
-    // it no node exists, nothing would happen
-    getAclHelper().removeAclFor( getMetadataRepositoryFile( domainId ) );
+    if ( domainFile != null ) {
+      // it no node exists, nothing would happen
+      getAclHelper().removeAclFor( domainFile );
+    }
 
     for ( final RepositoryFile file : domainFiles ) {
       if ( logger.isTraceEnabled() ) {

--- a/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
@@ -26,17 +26,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import org.pentaho.metadata.model.Domain;
 import org.pentaho.metadata.model.LogicalModel;
 import org.pentaho.metadata.model.concept.types.LocaleType;
@@ -67,6 +56,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+
+import static org.mockito.Mockito.*;
 
 /**
  * Class Description
@@ -282,7 +273,7 @@ public class PentahoMetadataDomainRepositoryTest extends TestCase {
     }
 
     doReturn( false ).when( aclNodeHelper ).canAccess( any( RepositoryFile.class ), eq( EnumSet.of(
-        RepositoryFilePermission.READ ) ) );
+      RepositoryFilePermission.READ ) ) );
     assertNull( domainRepositorySpy.getDomain( "doesn't exist" ) );
     doNothing().when( aclNodeHelper ).removeAclFor( any( RepositoryFile.class ) );
     domainRepositorySpy.removeDomain( "steel-wheels_test" );
@@ -498,6 +489,7 @@ public class PentahoMetadataDomainRepositoryTest extends TestCase {
     assertNull( domainRepositorySpy.getDomain( STEEL_WHEELS ) );
     domainRepositorySpy.removeDomain( STEEL_WHEELS );
     assertEquals( originalFileCount, repository.getChildren( folder.getId() ).size() );
+    verify( domainRepositorySpy.getAclHelper(), never() ).removeAclFor( null );
   }
 
   @Test


### PR DESCRIPTION
- fix a problem with getting NPE when removing a domain
- update test to detect the problem

This PR fixes a problem with getting NPE on each call of ```removeDomain()```. It is easy to see, that firstly the domain is removed from the cache, when the cache is accessed to obtain the domain once again to pass it for AclHelper and apparently the cache returns ```null```.

@mbatchelor, @pentaho-nbaker, @rmansoor, review it please.   