### PR TITLE
[SP-1988] - Backport of BISERVER-12642 - Inconsistent synchronization leading to deadlock between JCR and PentahoMetadataDomainRepository (5.4 Suite)

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
@@ -444,17 +444,21 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     }
 
     // Get the metadata domain file
+    RepositoryFile domainFile;
     Set<RepositoryFile> domainFiles;
     lock.writeLock().lock();
     try {
       domainFiles = metadataMapping.getFiles( domainId );
+      domainFile = metadataMapping.getDomainFile( domainId );
       metadataMapping.deleteDomain( domainId );
     } finally {
       lock.writeLock().unlock();
     }
 
-    // it no node exists, nothing would happen
-    getAclHelper().removeAclFor( getMetadataRepositoryFile( domainId ) );
+    if ( domainFile != null ) {
+      // it no node exists, nothing would happen
+      getAclHelper().removeAclFor( domainFile );
+    }
 
     for ( final RepositoryFile file : domainFiles ) {
       if ( logger.isTraceEnabled() ) {

--- a/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
@@ -488,6 +488,7 @@ public class PentahoMetadataDomainRepositoryTest extends TestCase {
     assertNull( domainRepositorySpy.getDomain( STEEL_WHEELS ) );
     domainRepositorySpy.removeDomain( STEEL_WHEELS );
     assertEquals( originalFileCount, repository.getChildren( folder.getId() ).size() );
+    verify( domainRepositorySpy.getAclHelper(), never() ).removeAclFor( null );
   }
 
   @Test


### PR DESCRIPTION
- fix a problem with getting NPE when removing a domain
- update test to detect the problem
(cherry picked from commit d7b69a40052ef0d8792d737fa92a84f1e7437844)

@mbatchelor, @pentaho-nbaker, @rmansoor, review it please. This is a backport of https://github.com/pentaho/pentaho-platform/pull/2485