### PR TITLE
BACKLOG-3121 -- Save As dialog should not show when using Save [only]…

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/commands/SaveCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/SaveCommand.java
@@ -77,7 +77,6 @@ public class SaveCommand extends AbstractCommand {
       public void onSuccess( RepositoryFileTree tree ) {
 
         retrieveCachedValues( navigatorPerspective.getContentTabPanel().getCurrentFrame() );
-
         if ( isSaveAs || name == null ) {
           String fileDir = "";
           if ( path != null && !StringUtils.isEmpty( path ) ) {
@@ -144,6 +143,7 @@ public class SaveCommand extends AbstractCommand {
                       true );
                     Window.setTitle( Messages.getString( "productName" ) + " - " + name ); //$NON-NLS-1$ //$NON-NLS-2$
                     FileChooserDialog.setIsDirty( Boolean.TRUE );
+                    persistFileInfoInFrame();
                   }
 
                   public void cancelPressed() {


### PR DESCRIPTION
… on a

report that was already saved overwriting an existing report

What was done:
1) added storing file info to tab context if it was overwritten