### PR TITLE
[BACKLOG-4452] - setting the preserveDsw flag on each archive bundle …

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/importer/ArchiveLoader.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/ArchiveLoader.java
@@ -83,6 +83,7 @@ public class ArchiveLoader {
     bundleBuilder.applyAclSettings( true );
     bundleBuilder.overwriteAclSettings( false );
     bundleBuilder.retainOwnership( true );
+    bundleBuilder.preserveDsw( true );
     return bundleBuilder.build();
   }
 


### PR DESCRIPTION
…imported to ensure the same flag is set on the bundles created/imported for contained .xmi files.