### PR TITLE
[BACKLOG-4446] - Handling inline-modeling annotations on backup/restore of mondrian schemas.

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -46,6 +46,7 @@ import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportMa
 import org.pentaho.platform.plugin.services.importexport.exportManifest.Parameters;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetadata;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMondrian;
+import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
 import org.pentaho.platform.repository.RepositoryFilenameUtils;
 import org.pentaho.platform.repository.messages.Messages;
 import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
@@ -142,7 +143,7 @@ public class SolutionImportHandler implements IPlatformImportHandler {
 
         RepositoryFileImportBundle.Builder bundleBuilder =
             new RepositoryFileImportBundle.Builder().charSet( "UTF_8" ).hidden( false ).name( catName ).overwriteFile(
-                true ).mime( "application/vnd.pentaho.mondrian+xml" )
+              true ).mime( "application/vnd.pentaho.mondrian+xml" )
                 .withParam( "parameters", parametersStr.toString() ).withParam( "domain-id", catName ); // TODO: this is
         // definitely
         // named wrong
@@ -153,6 +154,21 @@ public class SolutionImportHandler implements IPlatformImportHandler {
         bundleBuilder.withParam( "EnableXmla", xmlaEnabled );
 
         cachedImports.put( exportManifestMondrian.getFile(), bundleBuilder );
+
+        String annotationsFile = exportManifestMondrian.getAnnotationsFile();
+        if ( annotationsFile != null ) {
+          RepositoryFileImportBundle.Builder annotationsBundle = new RepositoryFileImportBundle.Builder()
+            .path( MondrianCatalogRepositoryHelper.ETC_MONDRIAN_JCR_FOLDER + RepositoryFile.SEPARATOR + catName )
+            .name( "annotations.xml" )
+            .charSet( "UTF_8" )
+            .overwriteFile( true )
+            .mime( "text/xml" )
+            .hidden( false )
+            .overwriteFile( true )
+            .withParam( "domain-id", catName );
+          cachedImports.put( annotationsFile, annotationsBundle );
+
+        }
       }
     }
 

--- a/extensions/src/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestMondrian.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestMondrian.java
@@ -46,6 +46,7 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="catalogName" type="{http://www.w3.org/2001/XMLSchema}string"/>
  *         &lt;element name="xmlaEnabled" type="{http://www.w3.org/2001/XMLSchema}boolean"/>
  *         &lt;element name="parameters" type="{http://www.pentaho.com/schema/}Parameters" minOccurs="0"/>
+ *         &lt;element name="annotationsFile" type="{http://www.w3.org/2001/XMLSchema}string"/>
  *       &lt;/sequence>
  *       &lt;attribute name="file" type="{http://www.w3.org/2001/XMLSchema}string" />
  *     &lt;/restriction>
@@ -56,7 +57,7 @@ import javax.xml.bind.annotation.XmlType;
  * 
  */
 @XmlAccessorType( XmlAccessType.FIELD )
-@XmlType( name = "ExportManifestMondrian", propOrder = { "catalogName", "xmlaEnabled", "parameters" } )
+@XmlType( name = "ExportManifestMondrian", propOrder = { "catalogName", "xmlaEnabled", "parameters", "annotationsFile" } )
 public class ExportManifestMondrian {
 
   @XmlElement( required = true )
@@ -66,6 +67,8 @@ public class ExportManifestMondrian {
   protected org.pentaho.platform.plugin.services.importexport.exportManifest.Parameters parameters;
   @XmlAttribute( name = "file" )
   protected String file;
+  @XmlElement( required = false )
+  protected String annotationsFile;
 
   /**
    * Gets the value of the catalogName property.
@@ -148,4 +151,20 @@ public class ExportManifestMondrian {
     this.file = value;
   }
 
+  /**
+   * Gets the value of the annotationsFile property.
+   * @return possible object is {@link String }
+   */
+  public String getAnnotationsFile() {
+    return annotationsFile;
+  }
+
+  /**
+   * Sets the value of the annotationsFile property
+   * @param annotationsFile
+   *          allowed object is {@link String }
+   */
+  public void setAnnotationsFile( String annotationsFile ) {
+    this.annotationsFile = annotationsFile;
+  }
 }


### PR DESCRIPTION

on export: generate the ExportManifestMondrian with a new, optional element for a reference to the annotations file in the zip for this mondrian schema.

on import: drop the annotations file into the same folder in /etc/mondrian/<catalog-name>/ as the schema.xml file. One caveat, if the annotations file is imported first, the catalog folder is hidden by default. Had to make a change on the addHostedCatalog method of MondrianCatalogRepositoryHelper to set that to not be hidden when the schema file is added. Otherwise, the model will not appear in PUC.