### PR TITLE
[BACKLOG-4445] - Implementation of exporting the metastore as part of backup/restore

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -108,8 +108,6 @@
     <dependency org="pentaho" name="pentaho-osgi-utils-api" rev="${project.revision}" />
     <dependency org="pentaho" name="pentaho-metaverse-api" rev="${project.revision}" changing="true" transitive="true"/>
 
-    <dependency org="pentaho" name="pur-repository-base-plugin" rev="${project.revision}" changing="true" transitive="false" />
-
     <!-- Platform plugins -->
     <dependency org="pentaho-reporting-engine" name="pentaho-reporting-engine-classic-core-platform-plugin-package" rev="${dependency.pentaho-reporting-plugin.revision}" transitive="false" changing="true"  conf="plugin->default" />
     <!-- In progrress D-A-v2

--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -231,6 +231,8 @@
     <dependency org="pentaho-kettle" name="kettle-core" rev="${dependency.kettle.revision}" changing="true"/>
     <dependency org="pentaho-kettle" name="kettle-ui-swt" rev="${dependency.kettle.revision}" changing="true"/>
 
+    <dependency org="pentaho" name="pur-repository-base-plugin" rev="${project.revision}" changing="true" transitive="false" />
+
     <dependency org="org.snmp4j" name="snmp4j" rev="1.9.3d" conf="default->default" transitive="false"/>
     <dependency org="pentaho" name="salesforce-partner" rev="24.0" conf="default->default" transitive="false"/>
     <dependency org="rome" name="rome" rev="1.0" conf="default->default" transitive="false"/>

--- a/extensions/src/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifest.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifest.java
@@ -19,13 +19,13 @@
 package org.pentaho.platform.plugin.services.importexport.exportManifest;
 
 import org.pentaho.database.model.DatabaseConnection;
-import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.plugin.services.importexport.RoleExport;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestDto;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestEntityDto;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetaStore;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetadata;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMondrian;
 import org.pentaho.platform.web.http.api.resources.JobScheduleRequest;
@@ -36,7 +36,6 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.namespace.QName;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.OutputStream;
@@ -62,6 +61,7 @@ public class ExportManifest {
   private List<DatabaseConnection> datasourceList = new ArrayList<DatabaseConnection>();
   private List<UserExport> userExports = new ArrayList<UserExport>();
   private List<RoleExport> roleExports = new ArrayList<RoleExport>();
+  private ExportManifestMetaStore metaStore;
 
   public ExportManifest() {
     this.exportManifestEntities = new HashMap<String, ExportManifestEntity>();
@@ -82,6 +82,7 @@ public class ExportManifest {
     this.datasourceList = exportManifestDto.getExportManifestDatasource();
     this.userExports = exportManifestDto.getExportManifestUser();
     this.roleExports = exportManifestDto.getExportManifestRole();
+    setMetaStore( exportManifestDto.getExportManifestMetaStore() );
   }
 
   /**
@@ -186,6 +187,7 @@ public class ExportManifest {
     rawExportManifest.getExportManifestDatasource().addAll( this.datasourceList );
     rawExportManifest.getExportManifestUser().addAll( this.getUserExports() );
     rawExportManifest.getExportManifestRole().addAll( this.getRoleExports() );
+    rawExportManifest.setExportManifestMetaStore( this.getMetaStore() );
 
     return rawExportManifest;
   }
@@ -278,5 +280,13 @@ public class ExportManifest {
 
   public void addRoleExport( RoleExport roleExport ) {
     this.roleExports.add( roleExport );
+  }
+
+  public void setMetaStore( ExportManifestMetaStore metaStore ) {
+    this.metaStore = metaStore;
+  }
+
+  public ExportManifestMetaStore getMetaStore() {
+    return metaStore;
   }
 }

--- a/extensions/src/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestDto.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestDto.java
@@ -80,7 +80,8 @@ import java.util.List;
  */
 @XmlAccessorType ( XmlAccessType.FIELD )
 @XmlType ( name = "ExportManifestDto", propOrder = { "exportManifestInformation", "exportManifestMondrian",
-    "exportManifestMetadata", "exportManifestSchedule", "exportManifestDatasource", "exportManifestEntity", "exportManifestUser", "exportManifestRole" } )
+  "exportManifestMetadata", "exportManifestSchedule", "exportManifestDatasource", "exportManifestEntity",
+  "exportManifestUser", "exportManifestRole", "exportManifestMetaStore" } )
 public class ExportManifestDto {
 
   @XmlElement ( name = "ExportManifestInformation", required = true )
@@ -99,6 +100,8 @@ public class ExportManifestDto {
   protected List<UserExport> exportManifestUser;
   @XmlElement ( name = "ExportManifestRole" )
   protected List<RoleExport> exportManifestRole;
+  @XmlElement ( name = "ExportManifestMetaStore", required = false)
+  protected ExportManifestMetaStore exportManifestMetaStore;
 
   /**
    * Gets the value of the exportManifestInformation property.
@@ -377,4 +380,20 @@ public class ExportManifestDto {
 
   }
 
+  /**
+   * Gets the metastore, if present
+   * @return possible object is {@link ExportManifestMetaStore}
+   */
+  public ExportManifestMetaStore getExportManifestMetaStore() {
+    return exportManifestMetaStore;
+  }
+
+  /**
+   * sets the metastore
+   * @param exportManifestMetaStore allowed object is {@link ExportManifestMetaStore}
+   */
+  public void setExportManifestMetaStore(
+    ExportManifestMetaStore exportManifestMetaStore ) {
+    this.exportManifestMetaStore = exportManifestMetaStore;
+  }
 }

--- a/extensions/src/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestMetaStore.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestMetaStore.java
@@ -1,0 +1,81 @@
+package org.pentaho.platform.plugin.services.importexport.exportManifest.bindings;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * Definition of the export metadata required for a MetaStore.
+ */
+@XmlAccessorType( XmlAccessType.FIELD )
+@XmlType( name = "ExportManifestMetaStore", propOrder = { "name", "description" } )
+public class ExportManifestMetaStore {
+
+  @XmlAttribute( name = "file" )
+  protected String file;
+
+  @XmlElement( name = "name" )
+  protected String name;
+
+  @XmlElement( name = "description" )
+  protected String description;
+
+  public ExportManifestMetaStore() {
+  }
+
+  public ExportManifestMetaStore( String file, String name, String description ) {
+    this.description = description;
+    this.file = file;
+    this.name = name;
+  }
+
+  /**
+   * Gets the description for the metastore
+   * @return
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Sets the description for the metastore
+   * @param description
+   */
+  public void setDescription( String description ) {
+    this.description = description;
+  }
+
+  /**
+   * Get the file path (zip) that indicates where in the export zip the metastore content is located
+   * @return
+   */
+  public String getFile() {
+    return file;
+  }
+
+  /**
+   * Set the path to where in the export zip the metastore content is located (path to the zipped metastore)
+   * @param file
+   */
+  public void setFile( String file ) {
+    this.file = file;
+  }
+
+  /**
+   * Get the name of the metastore
+   * @return
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Set the name of the metastore
+   * @param name
+   */
+  public void setName( String name ) {
+    this.name = name;
+  }
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/messages/messages.properties
+++ b/extensions/src/org/pentaho/platform/plugin/services/messages/messages.properties
@@ -354,3 +354,4 @@ ERROR.CreatingUser=Could not create user {0}.
 ROLE.Already.Exists=Role {0} already exists, could not create it.
 USER.Already.Exists=User {0} already exists, could not create it.
 ERROR.SettingRolePermissions=Could not set permissions for role {0} during import.
+PentahoPlatformExporter.ERROR.ExportingMetaStore=Error exporting the MetaStore


### PR DESCRIPTION
[BACKLOG-4445] - Implementation of exporting the metastore as part of backup/restore

Overview:
- get the metastore from the pur respoitory
- convert it to an xml metastore
- zip it up
- add that zip to the export zip as metastore.zip
- add a new type in the export manifest to support this.