### PR TITLE
[BACKLOG-4449] -Implement the MetaStore portion of the Import process

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/ImportHandlerMimeTypeDefinitions.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/ImportHandlerMimeTypeDefinitions.xml
@@ -123,6 +123,14 @@
         <extension>prpt</extension>
       </MimeTypeDefinition>
     </MimeTypeDefinitions>
-  </ImportHandler> 
-  
+  </ImportHandler>
+
+  <ImportHandler class="org.pentaho.platform.plugin.services.importer.MetaStoreImportHandler">
+    <MimeTypeDefinitions>
+      <MimeTypeDefinition mimeType="application/vnd.pentaho.metastore">
+        <extension>mzip</extension>
+      </MimeTypeDefinition>
+    </MimeTypeDefinitions>
+  </ImportHandler>
+
 </tns:ImportHandlerMimeTypeDefinitions>

--- a/assembly/package-res/biserver/pentaho-solutions/system/importExport.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/importExport.xml
@@ -196,6 +196,14 @@
 					<property name="defaultAclHandler" ref="defaultAclHandler" />
 				</bean>
 
+				<bean class="org.pentaho.platform.plugin.services.importer.MetaStoreImportHandler">
+					<constructor-arg>
+						<bean factory-bean="MimeTypeListFactory" factory-method="createMimeTypeList" >
+							<constructor-arg value="org.pentaho.platform.plugin.services.importer.MetaStoreImportHandler"/>
+						</bean>
+					</constructor-arg>
+				</bean>
+
 			</util:list>
 		</constructor-arg>
 	</bean>

--- a/extensions/src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java
@@ -68,6 +68,7 @@ public class PentahoPlatformExporter extends ZipExportProcessor {
   public static final String ANALYSIS_PATH_IN_ZIP = DATA_SOURCES_PATH_IN_ZIP + "analysis/";
   public static final String CONNECTIONS_PATH_IN_ZIP = DATA_SOURCES_PATH_IN_ZIP + "connections/";
   public static final String METASTORE = "metastore";
+  public static final String METASTORE_BACKUP_EXT = ".mzip";
 
   private File exportFile;
   protected ZipOutputStream zos;
@@ -338,7 +339,7 @@ public class PentahoPlatformExporter extends ZipExportProcessor {
 
       // now that we have the zipped content of an xml metastore, we need to write that to the export bundle
       FileInputStream zis = new FileInputStream( zippedMetastore );
-      String zipFileLocation = METASTORE + EXPORT_TEMP_FILENAME_EXT;
+      String zipFileLocation = METASTORE + METASTORE_BACKUP_EXT;
       ZipEntry metastoreZipFileZipEntry = new ZipEntry( zipFileLocation );
       zos.putNextEntry( metastoreZipFileZipEntry );
       try {

--- a/extensions/src/org/pentaho/platform/plugin/services/importer/MetaStoreImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/MetaStoreImportHandler.java
@@ -1,0 +1,142 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2013 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.plugin.services.importer;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.metadata.repository.DomainAlreadyExistsException;
+import org.pentaho.metadata.repository.DomainIdNullException;
+import org.pentaho.metadata.repository.DomainStorageException;
+import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
+import org.pentaho.metastore.stores.xml.XmlMetaStore;
+import org.pentaho.metastore.util.MetaStoreUtil;
+import org.pentaho.platform.api.mimetype.IMimeType;
+import org.pentaho.platform.api.repository2.unified.IPlatformImportBundle;
+import org.pentaho.platform.plugin.services.exporter.MetaStoreExportUtil;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.nio.file.Files;
+
+public class MetaStoreImportHandler implements IPlatformImportHandler {
+  private static final Log log = LogFactory.getLog( MetaStoreImportHandler.class );
+
+  private static final String METASTORE = "metastore";
+  private List<IMimeType> mimeTypes;
+  private IMetaStore metastore;
+  protected XmlMetaStore tmpXmlMetaStore;
+
+  public MetaStoreImportHandler() {
+  }
+
+  public MetaStoreImportHandler( List<IMimeType> mimeTypes ) {
+    this.mimeTypes = mimeTypes;
+  }
+
+  @Override
+  public void importFile( IPlatformImportBundle bundle )
+    throws PlatformImportException, DomainIdNullException, DomainAlreadyExistsException, DomainStorageException,
+    IOException {
+
+    InputStream inputStream = bundle.getInputStream();
+    Path path = Files.createTempDirectory( METASTORE );
+    path.toFile().deleteOnExit();
+
+    // get the zipped metastore from the export bundle
+    ZipInputStream zis = new ZipInputStream( inputStream );
+    ZipEntry entry;
+    while ( ( entry = zis.getNextEntry() ) != null ) {
+      try {
+        String filePath = path.toString() + File.separator + entry.getName();
+        if ( entry.isDirectory() ) {
+          File dir = new File( filePath );
+          dir.mkdir();
+        } else {
+          File file = new File( filePath );
+          file.getParentFile().mkdirs();
+          FileOutputStream fos = new FileOutputStream( filePath );
+          IOUtils.copy( zis, fos );
+          IOUtils.closeQuietly( fos );
+        }
+      } finally {
+        zis.closeEntry();
+      }
+    }
+    IOUtils.closeQuietly( zis );
+
+    // get a hold of the metastore to import into
+    IMetaStore metastore = getRepoMetaStore();
+    if ( metastore != null ) {
+      // copy the exported metastore to where it needs to go
+      try {
+        if ( tmpXmlMetaStore == null ) {
+          tmpXmlMetaStore = new XmlMetaStore( path.toString() );
+        }
+        tmpXmlMetaStore.setName( bundle.getName() );
+
+        String desc = bundle.getProperty( "description" ) == null ?
+          null : bundle.getProperty( "description" ).toString();
+
+        tmpXmlMetaStore.setDescription( desc );
+
+        MetaStoreUtil.copy( tmpXmlMetaStore, metastore );
+
+      } catch ( MetaStoreException e ) {
+        log.error( "Could not restore the MetaStore" );
+        log.debug( "Error restoring the MetaStore", e );
+      }
+    }
+
+  }
+
+  public void setMimeTypes( List<IMimeType> mimeTypes ) {
+    this.mimeTypes = mimeTypes;
+  }
+
+  @Override
+  public List<IMimeType> getMimeTypes() {
+    return mimeTypes;
+  }
+
+  protected IMetaStore getRepoMetaStore() {
+    if ( metastore == null ) {
+      try {
+        metastore = MetaStoreExportUtil.connectToRepository( null ).getMetaStore();
+      } catch ( KettleException e ) {
+        // can't get the metastore to import into
+        log.debug( "Can't get the metastore to import into" );
+      }
+    }
+    return metastore;
+  }
+
+  protected void setRepoMetaStore( IMetaStore metastore ) {
+    this.metastore = metastore;
+  }
+
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -44,6 +44,7 @@ import org.pentaho.platform.plugin.services.importexport.RoleExport;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.Parameters;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetaStore;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetadata;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMondrian;
 import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
@@ -71,7 +72,7 @@ public class SolutionImportHandler implements IPlatformImportHandler {
   private static final Log log = LogFactory.getLog( SolutionImportHandler.class );
 
   private static final String sep = ";";
-  private Map<String, RepositoryFileImportBundle.Builder> cachedImports;
+  protected Map<String, RepositoryFileImportBundle.Builder> cachedImports;
   private SolutionFileImportHelper solutionHelper;
   private List<IMimeType> mimeTypes;
 
@@ -171,6 +172,8 @@ public class SolutionImportHandler implements IPlatformImportHandler {
         }
       }
     }
+
+    importMetaStore( manifest );
 
     for ( IRepositoryFileBundle file : importSource.getFiles() ) {
       String fileName = file.getFile().getName();
@@ -302,6 +305,24 @@ public class SolutionImportHandler implements IPlatformImportHandler {
     }
     // Process locale files.
     localeFilesProcessor.processLocaleFiles( importer );
+  }
+
+  protected void importMetaStore( ExportManifest manifest ) {
+    // get the metastore
+    ExportManifestMetaStore manifestMetaStore = manifest.getMetaStore();
+    if ( manifestMetaStore != null ) {
+      // get the zipped metastore from the export bundle
+      RepositoryFileImportBundle.Builder bundleBuilder =
+        new RepositoryFileImportBundle.Builder()
+          .path( manifestMetaStore.getFile() )
+          .name( manifestMetaStore.getName() )
+          .withParam( "description", manifestMetaStore.getDescription() )
+          .charSet( "UTF-8" )
+          .mime( "application/vnd.pentaho.metastore" );
+
+      cachedImports.put( manifestMetaStore.getFile(), bundleBuilder );
+    }
+
   }
 
   /**

--- a/extensions/test-src/org/pentaho/platform/plugin/services/importer/MetaStoreImportHandlerTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/importer/MetaStoreImportHandlerTest.java
@@ -1,0 +1,71 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.plugin.services.importer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.api.IMetaStoreElementType;
+import org.pentaho.metastore.stores.xml.XmlMetaStore;
+import org.pentaho.platform.api.repository2.unified.IPlatformImportBundle;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class MetaStoreImportHandlerTest {
+
+  MetaStoreImportHandler handler;
+  IMetaStore metastore;
+  XmlMetaStore fromMetaStore;
+
+  @Before
+  public void setUp() throws Exception {
+    handler = new MetaStoreImportHandler();
+    metastore = mock( IMetaStore.class );
+    handler.setRepoMetaStore( metastore );
+    String[] namespaces = new String[] { "pentaho", "hitachi" };
+    fromMetaStore = mock( XmlMetaStore.class );
+    when( fromMetaStore.getNamespaces() ).thenReturn( Arrays.asList( namespaces ) );
+  }
+
+  @Test
+  public void testImportFile() throws Exception {
+
+    IPlatformImportBundle bundle = mock( IPlatformImportBundle.class );
+    InputStream ios = mock( InputStream.class );
+    byte[] bytes = new byte[]{};
+    when( ios.read( any( bytes.getClass() ), anyInt(), anyInt() ) ).thenReturn( -1 );
+    when( bundle.getInputStream() ).thenReturn( ios );
+    when( bundle.getName() ).thenReturn( "metastore" );
+    when( bundle.getProperty( "description" ) ).thenReturn( "bundle description" );
+    handler.tmpXmlMetaStore = fromMetaStore;
+
+    handler.importFile( bundle );
+
+    // not going to test all of the internals of the MetaStoreUtil.copy, just enough to make sure it was called.
+    verify( metastore ).createNamespace( "pentaho" );
+    verify( metastore ).createNamespace( "hitachi" );
+
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
@@ -10,6 +10,8 @@ import org.pentaho.platform.api.mt.ITenant;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.services.importexport.RoleExport;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetaStore;
 import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
 
 import java.util.ArrayList;
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -180,7 +183,8 @@ public class SolutionImportHandlerTest {
     importHandler.importRoles( roles, roleToUserMap );
 
     verify( userRoleDao ).createRole( any( ITenant.class ), eq( roleName ), anyString(), any( userStrings.getClass() ) );
-    verify( roleAuthorizationPolicyRoleBindingDao ).setRoleBindings( any( ITenant.class ), eq( roleName ), eq( permissions ) );
+    verify( roleAuthorizationPolicyRoleBindingDao ).setRoleBindings( any( ITenant.class ), eq( roleName ),
+      eq( permissions ) );
   }
 
   @Test
@@ -214,6 +218,31 @@ public class SolutionImportHandlerTest {
     verify( roleAuthorizationPolicyRoleBindingDao ).setRoleBindings( any( ITenant.class ), eq( roleName ), eq(
       permissions ) );
 
+  }
+
+  @Test
+  public void testImportMetaStore() throws Exception {
+    ExportManifest manifest = spy( new ExportManifest() );
+    String path = "/path/to/file.zip";
+    ExportManifestMetaStore manifestMetaStore = new ExportManifestMetaStore( path,
+      "metastore",
+      "description of the metastore" );
+    importHandler.cachedImports = new HashMap<String, RepositoryFileImportBundle.Builder>();
+
+    when( manifest.getMetaStore() ).thenReturn( manifestMetaStore );
+
+    importHandler.importMetaStore( manifest );
+    assertEquals( 1, importHandler.cachedImports.size() );
+    assertTrue( importHandler.cachedImports.get( path ) != null );
+  }
+
+  @Test
+  public void testImportMetaStore_nullMetastoreManifest() throws Exception {
+    ExportManifest manifest = spy( new ExportManifest() );
+
+    importHandler.cachedImports = new HashMap<String, RepositoryFileImportBundle.Builder>();
+    importHandler.importMetaStore( manifest );
+    assertEquals( 0, importHandler.cachedImports.size() );
   }
 
   @After


### PR DESCRIPTION
Added a new import handler for metastore import (supports mime type "application/vnd.pentaho.metastore" and extension is mzip (just a regular zip file however, but different to allow for another handler other than the SolutionImportHandler).

Expects the mzip file to contain the zipped up contents of an XmlMetaStore. This is extracted to a temp location on the fs to allow it to be loaded in as an XmlMetaStore before walking the structure and copying it to the repository meta store.