### PR TITLE
BACKLOG-4822 -- /pentaho/api/userrolelist/allroles API result doesn't…

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
@@ -74,7 +74,22 @@ public class UserRoleListService {
 
   public RoleListWrapper getAllRoles() {
     List<String> roles = getUserRoleListService().getAllRoles();
-    roles.addAll( getExtraRoles() );
+    List<String> extraRoles = getExtraRoles();
+    if ( extraRoles != null ) {
+      if ( systemRoles != null ) {
+        extraRoles.addAll( systemRoles );
+      }
+    }
+    else {
+      extraRoles = systemRoles;
+    }
+    if ( extraRoles != null ) {
+      for ( String ex : extraRoles ) {
+        if( ! roles.contains( ex ) ) {
+          roles.add( ex );
+        }
+      }
+    }
     return new RoleListWrapper( roles );
   }
 


### PR DESCRIPTION
… show

Administrator role

What was done:
1) fixed backlog-4922 and 4821 cause they should be fixed in the same
method and it should not affect app. The check of already included roles
was added