### PR TITLE
Fixes

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/importer/MetaStoreImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/MetaStoreImportHandler.java
@@ -96,6 +96,9 @@ public class MetaStoreImportHandler implements IPlatformImportHandler {
       try {
         if ( tmpXmlMetaStore == null ) {
           tmpXmlMetaStore = new XmlMetaStore( path.toString() );
+        } else {
+          // we are re-using an existing object, make sure the root folder is pointed at the new location on disk
+          tmpXmlMetaStore.setRootFolder( path.toString() + File.separator + METASTORE );
         }
         tmpXmlMetaStore.setName( bundle.getName() );
 

--- a/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -305,21 +305,22 @@ public class SolutionImportHandler implements IPlatformImportHandler {
 
   protected void importMetaStore( ExportManifest manifest, boolean overwrite ) {
     // get the metastore
-    ExportManifestMetaStore manifestMetaStore = manifest.getMetaStore();
-    if ( manifestMetaStore != null ) {
-      // get the zipped metastore from the export bundle
-      RepositoryFileImportBundle.Builder bundleBuilder =
-        new RepositoryFileImportBundle.Builder()
-          .path( manifestMetaStore.getFile() )
-          .name( manifestMetaStore.getName() )
-          .withParam( "description", manifestMetaStore.getDescription() )
-          .charSet( "UTF-8" )
-          .overwriteFile( overwrite )
-          .mime( "application/vnd.pentaho.metastore" );
+    if ( manifest != null ) {
+      ExportManifestMetaStore manifestMetaStore = manifest.getMetaStore();
+      if ( manifestMetaStore != null ) {
+        // get the zipped metastore from the export bundle
+        RepositoryFileImportBundle.Builder bundleBuilder =
+          new RepositoryFileImportBundle.Builder()
+            .path( manifestMetaStore.getFile() )
+            .name( manifestMetaStore.getName() )
+            .withParam( "description", manifestMetaStore.getDescription() )
+            .charSet( "UTF-8" )
+            .overwriteFile( overwrite )
+            .mime( "application/vnd.pentaho.metastore" );
 
-      cachedImports.put( manifestMetaStore.getFile(), bundleBuilder );
+        cachedImports.put( manifestMetaStore.getFile(), bundleBuilder );
+      }
     }
-
   }
 
   /**

--- a/extensions/test-src/org/pentaho/platform/plugin/services/importer/MetaStoreImportHandlerTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/importer/MetaStoreImportHandlerTest.java
@@ -66,6 +66,6 @@ public class MetaStoreImportHandlerTest {
     // not going to test all of the internals of the MetaStoreUtil.copy, just enough to make sure it was called.
     verify( metastore ).createNamespace( "pentaho" );
     verify( metastore ).createNamespace( "hitachi" );
-
+    verify( fromMetaStore ).setRootFolder( anyString() );
   }
 }


### PR DESCRIPTION
Unit test failure fix

Also a fix for a scenario when doing multiple restores (different import files) without restarting the server. basically got a cached set of the metastore xml folder (from the first load).