### PR TITLE
[BACKLOG-4328] - Adding the PentahoBeanScopeProcessor to the plugin manager

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/pluginmgr/DefaultPluginManager.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/pluginmgr/DefaultPluginManager.java
@@ -46,6 +46,7 @@ import org.pentaho.platform.api.engine.perspective.pojo.IPluginPerspective;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.objfac.StandaloneSpringPentahoObjectFactory;
+import org.pentaho.platform.engine.core.system.objfac.spring.PentahoBeanScopeValidatorPostProcessor;
 import org.pentaho.platform.plugin.services.messages.Messages;
 import org.pentaho.platform.plugin.services.pluginmgr.servicemgr.ServiceConfig;
 import org.pentaho.platform.util.logging.Logger;
@@ -454,7 +455,7 @@ public class DefaultPluginManager implements IPluginManager {
         beanFactory.getBeanFactory().setParentBeanFactory( nativeBeanFactory );
       }
     }
-
+    beanFactory.addBeanFactoryPostProcessor( new PentahoBeanScopeValidatorPostProcessor() );
     beanFactoryMap.put( plugin.getId(), beanFactory );
 
     //


### PR DESCRIPTION
This is a same changes we made to the PentahoSystemPluginManager https://github.com/pentaho/pentaho-platform/blob/master/extensions/src/org/pentaho/platform/plugin/services/pluginmgr/PentahoSystemPluginManager.java#L715
