### PR TITLE
[BACKLOG-4452] - removing the hard-coded boolean (true) form the Solu…

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -124,7 +124,7 @@ public class SolutionImportHandler implements IPlatformImportHandler {
       for ( ExportManifestMetadata exportManifestMetadata : metadataList ) {
 
         String domainId = exportManifestMetadata.getDomainId();
-        boolean overWriteInRepository = true;
+        boolean overWriteInRepository = isOverwriteFile();
         RepositoryFileImportBundle.Builder bundleBuilder =
             new RepositoryFileImportBundle.Builder().charSet( "UTF-8" )
               .hidden( false )
@@ -151,7 +151,7 @@ public class SolutionImportHandler implements IPlatformImportHandler {
 
         RepositoryFileImportBundle.Builder bundleBuilder =
             new RepositoryFileImportBundle.Builder().charSet( "UTF_8" ).hidden( false ).name( catName ).overwriteFile(
-              true ).mime( "application/vnd.pentaho.mondrian+xml" )
+              isOverwriteFile() ).mime( "application/vnd.pentaho.mondrian+xml" )
                 .withParam( "parameters", parametersStr.toString() ).withParam( "domain-id", catName ); // TODO: this is
         // definitely
         // named wrong

--- a/extensions/test-src/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
@@ -363,6 +363,7 @@ public class SolutionImportHandlerTest {
     settings.add( new ExportManifestUserSetting( "language", "en_US" ) );
     settings.add( new ExportManifestUserSetting( "showHiddenFiles", "false" ) );
     IUserSettingService userSettingService = mock( IUserSettingService.class );
+    PentahoSystem.registerObject( userSettingService );
 
     importHandler.importGlobalUserSettings( settings );
 
@@ -378,6 +379,7 @@ public class SolutionImportHandlerTest {
     settings.add( new ExportManifestUserSetting( "language", "en_US" ) );
     settings.add( new ExportManifestUserSetting( "showHiddenFiles", "false" ) );
     IUserSettingService userSettingService = mock( IUserSettingService.class );
+    PentahoSystem.registerObject( userSettingService );
     IUserSetting setting = mock( IUserSetting.class );
     when( userSettingService.getGlobalUserSetting( "language", null ) ).thenReturn( null );
     when( userSettingService.getGlobalUserSetting( "showHiddenFiles", null ) ).thenReturn( setting );
@@ -385,7 +387,7 @@ public class SolutionImportHandlerTest {
     importHandler.importGlobalUserSettings( settings );
 
     verify( userSettingService ).setGlobalUserSetting( "language", "en_US" );
-    verify( userSettingService, never() ).setGlobalUserSetting( "showHiddenFiles", anyString() );
+    verify( userSettingService, never() ).setGlobalUserSetting( eq( "showHiddenFiles" ), anyString() );
     verify( userSettingService ).getGlobalUserSetting( "language", null );
     verify( userSettingService ).getGlobalUserSetting( "showHiddenFiles", null );
 


### PR DESCRIPTION
__[BACKLOG-4452]__ - removing the hard-coded boolean (true) form the SolutionImportHandler for mondrian and metadata data sources. they now obey the parent bundle's setting for overwrite.

Also fixed 2 failing unit tests

__Master Commit__
https://github.com/pentaho/pentaho-platform/pull/2568

__DEVCI build success__
http://devci.pentaho.com/job/6.0-snapshot/job/platform-base/144/
