### PR TITLE
[BISERVER-12657] - SpringSecurityPrincipalProvider uses static maps instead of CacheManager

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider.java
@@ -153,6 +153,14 @@ public class SpringSecurityPrincipalProvider implements PrincipalProvider {
     }
 
     cacheManager = PentahoSystem.getCacheManager( null );
+    if ( cacheManager != null ) {
+      if ( !cacheManager.cacheEnabled( USER_CACHE_REGION ) ) {
+        cacheManager.addCacheRegion( USER_CACHE_REGION );
+      }
+      if ( !cacheManager.cacheEnabled( ROLE_CACHE_REGION ) ) {
+        cacheManager.addCacheRegion( ROLE_CACHE_REGION );
+      }
+    }
 
     initialized.set( true );
   }


### PR DESCRIPTION
- add cache regions for roles and users
- update tests

@pentaho-nbaker, @rmansoor, review it please.
Only ```global``` and ```session``` regions are created by default, the rest should be added programmatically.