### PR TITLE
[TEST] - Backport QuartzScheduler's tests from master

### DIFF
--- a/scheduler/ivy.xml
+++ b/scheduler/ivy.xml
@@ -20,6 +20,7 @@
     <dependency org="org.quartz-scheduler" name="quartz" rev="1.7.2"  transitive="false"/>
 
     <dependency org="junit" name="junit" rev="4.4" conf="test->default" />
+    <dependency org="org.mockito" name="mockito-all" rev="1.8.5" conf="test->default"/>
     <dependency org="org.jmock" name="jmock-junit4" rev="2.5.1" conf="test->default" />
     	<dependency org="org.jmock" name="jmock-legacy" rev="2.5.1" conf="test->default" />
 

--- a/scheduler/test-src/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
+++ b/scheduler/test-src/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
@@ -1,0 +1,322 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.scheduler2.quartz;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.pentaho.platform.api.action.IAction;
+import org.pentaho.platform.api.scheduler2.ComplexJobTrigger;
+import org.pentaho.platform.api.scheduler2.IBackgroundExecutionStreamProvider;
+import org.pentaho.platform.api.scheduler2.IJobFilter;
+import org.pentaho.platform.api.scheduler2.IJobTrigger;
+import org.pentaho.platform.api.scheduler2.IScheduler;
+import org.pentaho.platform.api.scheduler2.ISchedulerListener;
+import org.pentaho.platform.api.scheduler2.Job;
+import org.pentaho.platform.api.scheduler2.SchedulerException;
+import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
+import org.pentaho.platform.engine.core.system.boot.PlatformInitializationException;
+import org.quartz.CronTrigger;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerFactory;
+import org.quartz.SimpleTrigger;
+import org.quartz.Trigger;
+
+import java.io.Serializable;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.Assert.*;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings( "nls" )
+public class QuartzSchedulerTest {
+  private static final String CRON_EXPRESSION = "1 0 0 * * ? *";
+  private static final String USER_NAME = "userName";
+  private static final String JOB_NAME = "jobName";
+  private static final String JOB_ID = USER_NAME + "\t" + JOB_NAME + "\t" + System.currentTimeMillis();
+
+  private QuartzScheduler scheduler;
+  private Scheduler quartzScheduler;
+  private final Map<String, Serializable> jobDetails = new HashMap<String, Serializable>();
+
+  @Before
+  public void init() throws SchedulerException, PlatformInitializationException, org.quartz.SchedulerException {
+    final SchedulerFactory schedulerFactory = mock( SchedulerFactory.class );
+    quartzScheduler = mock( Scheduler.class );
+    when( schedulerFactory.getScheduler() ).thenReturn( quartzScheduler );
+    scheduler = spy( new QuartzScheduler( schedulerFactory ) );
+    when( scheduler.getCurrentUser() ).thenReturn( USER_NAME );
+
+    jobDetails.clear();
+    jobDetails.put( QuartzScheduler.RESERVEDMAPKEY_ACTIONCLASS, "RESERVEDMAPKEY_ACTIONCLASS" );
+    jobDetails.put( QuartzScheduler.RESERVEDMAPKEY_STREAMPROVIDER, "RESERVEDMAPKEY_STREAMPROVIDER" );
+    jobDetails.put( QuartzScheduler.RESERVEDMAPKEY_UIPASSPARAM, "RESERVEDMAPKEY_UIPASSPARAM" );
+  }
+
+  @Test
+  public void getQuartzSchedulerTest() throws Exception {
+    assertEquals( quartzScheduler, scheduler.getQuartzScheduler() );
+  }
+
+  @Test
+  public void createJobTest() throws Exception {
+    String actionId = "actionId";
+    ComplexJobTrigger trigger = getComplexJobTrigger();
+    IBackgroundExecutionStreamProvider outputStreamProvider = mock( IBackgroundExecutionStreamProvider.class );
+    final Job job = scheduler.createJob( JOB_NAME, actionId, null, trigger, outputStreamProvider );
+
+    assertNotNull( job );
+    assertEquals( Job.JobState.NORMAL, job.getState() );
+
+    assertTrue( job.getJobParams().containsKey( QuartzScheduler.RESERVEDMAPKEY_ACTIONID ) );
+    assertEquals( actionId, job.getJobParams().get( QuartzScheduler.RESERVEDMAPKEY_ACTIONID ) );
+    assertTrue( job.getJobParams().containsKey( QuartzScheduler.RESERVEDMAPKEY_STREAMPROVIDER ) );
+    assertEquals( outputStreamProvider, job.getJobParams().get( QuartzScheduler.RESERVEDMAPKEY_STREAMPROVIDER ) );
+    assertTrue( job.getJobParams().containsKey( QuartzScheduler.RESERVEDMAPKEY_LINEAGE_ID ) );
+    assertNotNull( job.getJobParams().get( QuartzScheduler.RESERVEDMAPKEY_LINEAGE_ID ) );
+    assertTrue( job.getJobParams().containsKey( QuartzScheduler.RESERVEDMAPKEY_ACTIONUSER ) );
+    assertEquals( USER_NAME, job.getJobParams().get( QuartzScheduler.RESERVEDMAPKEY_ACTIONUSER ) );
+  }
+
+  @Test
+  @Ignore(value = "Ignored unless BACKLOG-5291 is backported" )
+  public void createJobTest_ForUser() throws Exception {
+    String actionId = "actionId";
+    ComplexJobTrigger trigger = getComplexJobTrigger();
+    IBackgroundExecutionStreamProvider outputStreamProvider = mock( IBackgroundExecutionStreamProvider.class );
+    Map<String, Serializable> paramMap = new HashMap<String, Serializable>();
+    paramMap.put( QuartzScheduler.RESERVEDMAPKEY_ACTIONUSER, "ninja" );
+    final Job job = scheduler.createJob( JOB_NAME, paramMap, trigger, outputStreamProvider );
+
+    assertNotNull( job );
+    assertEquals( "ninja", job.getUserName() );
+    assertEquals( Job.JobState.NORMAL, job.getState() );
+  }
+
+  @Test
+  public void createQuartzTriggerComplexTriggerTest() throws Exception {
+    final Trigger quartzTrigger = QuartzScheduler.createQuartzTrigger( getComplexJobTrigger(), getJobKey() );
+
+    assertNotNull( quartzTrigger );
+    assertTrue( quartzTrigger instanceof CronTrigger );
+    assertEquals( SimpleTrigger.MISFIRE_INSTRUCTION_FIRE_NOW, quartzTrigger.getMisfireInstruction() );
+    assertEquals( CRON_EXPRESSION, ( (CronTrigger) quartzTrigger ).getCronExpression() );
+    assertEquals( USER_NAME, quartzTrigger.getGroup() );
+
+  }
+
+  @Test
+  public void createQuartzTriggerSimpleTriggerTest() throws Exception {
+    final Calendar calendar = Calendar.getInstance();
+    Date startTime = calendar.getTime();
+    calendar.add( Calendar.MONTH, 1 );
+    Date endTime = calendar.getTime();
+    int repeatCount = 5;
+    long repeatIntervalSeconds = 10;
+    final SimpleJobTrigger simpleJobTrigger = new SimpleJobTrigger( startTime, endTime, repeatCount,
+      repeatIntervalSeconds );
+    final Trigger quartzTrigger = QuartzScheduler.createQuartzTrigger( simpleJobTrigger, getJobKey() );
+
+    assertNotNull( quartzTrigger );
+    assertTrue( quartzTrigger instanceof SimpleTrigger );
+    assertEquals( SimpleTrigger.MISFIRE_INSTRUCTION_RESCHEDULE_NEXT_WITH_REMAINING_COUNT,
+      quartzTrigger.getMisfireInstruction() );
+    assertEquals( USER_NAME, quartzTrigger.getGroup() );
+
+    SimpleTrigger simpleTrigger = (SimpleTrigger) quartzTrigger;
+    assertEquals( startTime, simpleTrigger.getStartTime() );
+    assertEquals( endTime, simpleTrigger.getEndTime() );
+    assertEquals( repeatCount, simpleTrigger.getRepeatCount() );
+    assertEquals( repeatIntervalSeconds * 1000, simpleTrigger.getRepeatInterval() );
+  }
+
+  @Test( expected = SchedulerException.class )
+  public void createQuartzTriggerNotDefinedTriggerTest() throws Exception {
+    final IJobTrigger trigger = mock( IJobTrigger.class );
+    QuartzScheduler.createQuartzTrigger( trigger, getJobKey() );
+  }
+
+  @Test
+  public void updateJobTest() throws Exception {
+    final JobDetail jobDetail = setJobDataMap( USER_NAME );
+
+    scheduler.updateJob( JOB_ID, new HashMap<String, Serializable>(), getComplexJobTrigger() );
+
+    verify( quartzScheduler, times( 1 ) ).addJob( eq( jobDetail ), eq( true ) );
+    verify( quartzScheduler, times( 1 ) ).rescheduleJob( eq( JOB_ID ), eq( USER_NAME ), any( Trigger.class ) );
+  }
+
+  @Test
+  public void triggerNowTest() throws Exception {
+    final SimpleTrigger simpleTrigger = mock( SimpleTrigger.class );
+    final CronTrigger cronTrigger = mock( CronTrigger.class );
+    when( quartzScheduler.getTriggersOfJob( eq( JOB_ID ), eq( USER_NAME ) ) ).thenReturn( new Trigger[] { simpleTrigger,
+      cronTrigger
+    } );
+
+    scheduler.triggerNow( JOB_ID );
+
+    verify( simpleTrigger, times( 1 ) ).setPreviousFireTime( any( Date.class ) );
+    verify( cronTrigger, times( 1 ) ).setPreviousFireTime( any( Date.class ) );
+    verify( quartzScheduler, times( 1 ) ).rescheduleJob( eq( JOB_ID ), eq( USER_NAME ), eq( simpleTrigger ) );
+    verify( quartzScheduler, times( 1 ) ).rescheduleJob( eq( JOB_ID ), eq( USER_NAME ), eq( cronTrigger ) );
+    verify( quartzScheduler, times( 1 ) ).triggerJob( eq( JOB_ID ), eq( USER_NAME ) );
+  }
+
+  @Test
+  public void getJobTest() throws Exception {
+    final CronTrigger cronTrigger = mock( CronTrigger.class );
+    when( cronTrigger.getCronExpression() ).thenReturn( CRON_EXPRESSION );
+    when( quartzScheduler.getTriggersOfJob( eq( JOB_ID ), eq( USER_NAME ) ) ).thenReturn( new Trigger[] { cronTrigger } );
+    setJobDataMap( USER_NAME );
+
+    final Job job = scheduler.getJob( JOB_ID );
+
+    assertEquals( JOB_ID, job.getJobId() );
+    assertEquals( jobDetails, job.getJobParams() );
+    assertEquals( USER_NAME, job.getUserName() );
+    assertEquals( JOB_NAME, job.getJobName() );
+    assertEquals( Job.JobState.NORMAL, job.getState() );
+  }
+
+  @Test
+  public void getJobsTest() throws Exception {
+    final IJobFilter jobFilter = mock( IJobFilter.class );
+    when( jobFilter.accept( any( Job.class ) ) ).thenReturn( true );
+
+    final String groupName = "groupName";
+    when( quartzScheduler.getJobGroupNames() ).thenReturn( new String[] { groupName } );
+    when( quartzScheduler.getJobNames( eq( groupName ) ) ).thenReturn( new String[] { JOB_ID } );
+    final Trigger trigger = mock( Trigger.class );
+    when( trigger.getPreviousFireTime() ).thenReturn( new Date(  ) );
+    when( trigger.getNextFireTime() ).thenReturn( new Date(  ) );
+    final Trigger trigger2 = mock( Trigger.class );
+    when( trigger2.getGroup() ).thenReturn( "MANUAL_TRIGGER" );
+    when( quartzScheduler.getTriggersOfJob( eq( JOB_ID ), eq( groupName ) ) ).thenReturn( new Trigger[] { trigger, trigger2 } );
+    setJobDataMap( groupName );
+
+    final List<Job> jobs = scheduler.getJobs( jobFilter );
+
+    assertNotNull( jobs );
+    assertEquals( 1, jobs.size() );
+
+    Job job = jobs.get( 0 );
+    assertEquals( groupName, job.getGroupName() );
+    assertEquals( USER_NAME, job.getUserName() );
+    assertEquals( jobDetails, job.getJobParams() );
+    assertEquals( JOB_ID, job.getJobId() );
+    assertEquals( JOB_NAME, job.getJobName() );
+    assertEquals( trigger.getPreviousFireTime(), job.getLastRun() );
+    assertEquals( trigger.getNextFireTime(), job.getNextRun() );
+  }
+
+  private JobDetail setJobDataMap( String groupName ) throws org.quartz.SchedulerException {
+    final JobDetail jobDetail = new JobDetail( JOB_ID, USER_NAME, BlockingQuartzJob.class );
+    jobDetail.setJobDataMap( new JobDataMap( jobDetails ) );
+    when( quartzScheduler.getJobDetail( eq( JOB_ID ), eq( groupName ) ) ).thenReturn( jobDetail );
+    return jobDetail;
+  }
+
+  @Test
+  public void pauseTest() throws Exception {
+    scheduler.pause();
+
+    verify( quartzScheduler, times( 1 ) ).standby();
+  }
+
+  @Test
+  public void pauseJobTest() throws Exception {
+    scheduler.pauseJob( JOB_ID );
+
+    verify( quartzScheduler, times( 1 ) ).pauseJob( eq( JOB_ID ), eq( USER_NAME ) );
+  }
+
+  @Test
+  public void removeJobTest() throws Exception {
+    scheduler.removeJob( JOB_ID );
+
+    verify( quartzScheduler, times( 1 ) ).deleteJob( eq( JOB_ID ), eq( USER_NAME ) );
+  }
+
+  @Test
+  public void startTest() throws Exception {
+    scheduler.start();
+
+    verify( quartzScheduler, times( 1 ) ).start();
+  }
+
+  @Test
+  public void resumeJobTest() throws Exception {
+    scheduler.resumeJob( JOB_ID );
+    verify( quartzScheduler, times( 1 ) ).resumeJob( eq( JOB_ID ), eq( USER_NAME ) );
+  }
+
+  @Test
+  public void getStatusTest() throws Exception {
+    when( quartzScheduler.isInStandbyMode() ).thenReturn( true );
+    assertEquals( IScheduler.SchedulerStatus.PAUSED, scheduler.getStatus() );
+
+    when( quartzScheduler.isInStandbyMode() ).thenReturn( false );
+    when( quartzScheduler.isStarted() ).thenReturn( true );
+    assertEquals( IScheduler.SchedulerStatus.RUNNING, scheduler.getStatus() );
+
+    when( quartzScheduler.isInStandbyMode() ).thenThrow( new org.quartz.SchedulerException() );
+    try {
+      scheduler.getStatus();
+      fail();
+    } catch ( SchedulerException e ) {
+      // it's expected
+    }
+  }
+
+  @Test
+  public void shutdownTest() throws Exception {
+    scheduler.shutdown();
+
+    verify( quartzScheduler, times( 1 ) ).shutdown( eq( true ) );
+  }
+
+  @Test
+  public void fireJobCompletedTest() throws Exception {
+    final IAction actionBean = mock( IAction.class );
+    final String actionUser = "actionUser";
+    final ISchedulerListener schedulerListener = mock( ISchedulerListener.class );
+    scheduler.addListener( schedulerListener );
+    final Map<String, Serializable> params = new HashMap<String, Serializable>();
+    final IBackgroundExecutionStreamProvider streamProvider = mock( IBackgroundExecutionStreamProvider.class );
+    scheduler.fireJobCompleted( actionBean, actionUser, params, streamProvider );
+
+    verify( schedulerListener, times( 1 ) ).jobCompleted( eq( actionBean ), eq( actionUser ), eq( params ), eq( streamProvider ) );
+  }
+
+  private QuartzJobKey getJobKey() throws SchedulerException {
+    return new QuartzJobKey( JOB_NAME, USER_NAME );
+  }
+
+  private ComplexJobTrigger getComplexJobTrigger() {
+    final ComplexJobTrigger trigger = new ComplexJobTrigger();
+    trigger.setSecondRecurrence( 1 );
+    return trigger;
+  }
+}

--- a/scheduler/test-src/org/pentaho/platform/scheduler2/quartz/test/QuartzSchedulerTest.java
+++ b/scheduler/test-src/org/pentaho/platform/scheduler2/quartz/test/QuartzSchedulerTest.java
@@ -24,12 +24,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.pentaho.platform.api.action.IAction;
 import org.pentaho.platform.api.engine.IAuditEntry;
@@ -43,9 +40,6 @@ import org.pentaho.platform.api.scheduler2.recur.ITimeRecurrence;
 import org.pentaho.platform.engine.core.TestAuditEntry;
 import org.pentaho.platform.engine.core.system.boot.PlatformInitializationException;
 import org.pentaho.platform.engine.security.SecurityHelper;
-import org.pentaho.platform.scheduler2.messsages.Messages;
-import org.pentaho.platform.scheduler2.quartz.BlockingQuartzJob;
-import org.pentaho.platform.scheduler2.quartz.QuartzJobKey;
 import org.pentaho.platform.scheduler2.quartz.QuartzScheduler;
 import org.pentaho.platform.scheduler2.quartz.QuartzSchedulerAvailability;
 import org.pentaho.platform.scheduler2.recur.IncrementalRecurrence;
@@ -54,16 +48,10 @@ import org.pentaho.platform.scheduler2.recur.SequentialRecurrence;
 import org.pentaho.platform.scheduler2.ws.test.JaxWsSchedulerServiceTest.TestQuartzScheduler;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.springframework.security.userdetails.UserDetailsService;
-import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
-import org.quartz.Scheduler;
-import org.quartz.Trigger;
 
 @SuppressWarnings( "nls" )
 public class QuartzSchedulerTest {
   private QuartzScheduler scheduler;
-
-  public static final String SESSION_PRINCIPAL = "SECURITY_PRINCIPAL";
 
   private String TEST_USER = "TestUser";
 
@@ -131,23 +119,28 @@ public class QuartzSchedulerTest {
     Assert.assertEquals( calendar.getNextIncludedTime( startTime.getTime() ), startTime.getTime() + 1 );
   }
 
-  @Ignore  
   @Test
   public void runComplexTriggerTest() throws SchedulerException {
     Calendar calendar = Calendar.getInstance();
+    final int testTime = 7; // seconds
 
     int startingMinute = calendar.get( Calendar.MINUTE );
-
-    RecurrenceList recurrenceList = new RecurrenceList( 40, 45 );
-    SequentialRecurrence sequentialRecurrence = new SequentialRecurrence( 40, 45 );
-    IncrementalRecurrence incrementalRecurrence = new IncrementalRecurrence( 40, 5 );
-
-    if ( calendar.get( Calendar.SECOND ) > 30 ) {
-      recurrenceList = new RecurrenceList( 10, 15 );
-      sequentialRecurrence = new SequentialRecurrence( 10, 15 );
-      incrementalRecurrence = new IncrementalRecurrence( 10, 5 );
+    int startingSec = calendar.get( Calendar.SECOND ) + 1;
+    // we can't finish until end of the minute - sleep for this time
+    if ( startingSec > 59 - testTime ) {
+      sleep( 59 - startingSec );
+      startingSec = 0;
       startingMinute++;
+      if ( startingMinute > 59 ) {
+        startingMinute = startingMinute % 60;
+      }
     }
+    int endingSecond = startingSec + 5;
+
+    RecurrenceList recurrenceList = new RecurrenceList( startingSec, endingSecond );
+    SequentialRecurrence sequentialRecurrence = new SequentialRecurrence( startingSec, endingSecond );
+    IncrementalRecurrence incrementalRecurrence = new IncrementalRecurrence( startingSec, 1 );
+
     ComplexJobTrigger jobTrigger = new ComplexJobTrigger();
     jobTrigger.setHourlyRecurrence( (ITimeRecurrence) null );
     jobTrigger.setMinuteRecurrence( startingMinute );
@@ -177,7 +170,7 @@ public class QuartzSchedulerTest {
     //
     // Wait for the jobs to complete, then check that each action executed the correct number of times
     //
-    sleep( 60 );
+    sleep( testTime );
 
     Assert.assertEquals( "Job did not run the correct number of times", 2, TestAction.counter );
     Assert.assertEquals( "Job did not run the correct number of times", 6, TestAction2.counter );
@@ -189,18 +182,18 @@ public class QuartzSchedulerTest {
   public void editJobTest() throws SchedulerException {
     SimpleJobTrigger repeater = new SimpleJobTrigger();
     repeater.setStartTime( new Date() );
-    repeater.setRepeatInterval( 5 );
+    repeater.setRepeatInterval( 2 );
     repeater.setRepeatCount( 20 );
 
     Job job = scheduler.createJob( "testName", TestAction.class, new HashMap<String, Serializable>(), repeater );
 
-    sleep( 12 );
+    sleep( 3 );
 
     Assert.assertTrue( "Job did not run the correct number of times", TestAction.counter >= 2 );
 
     repeater = new SimpleJobTrigger();
     repeater.setStartTime( new Date() );
-    repeater.setRepeatInterval( 20 );
+    repeater.setRepeatInterval( 5 );
     repeater.setRepeatCount( 3 );
 
     int count = TestAction.counter;
@@ -209,14 +202,14 @@ public class QuartzSchedulerTest {
     List<Job> jobs = scheduler.getJobs( null );
     Assert.assertEquals( "Unexpected number of scheduled jobs", 1, jobs.size() );
     SimpleJobTrigger simpleJobTrigger = (SimpleJobTrigger) jobs.get( 0 ).getJobTrigger();
-    Assert.assertEquals( 20, simpleJobTrigger.getRepeatInterval() );
+    Assert.assertEquals( 5, simpleJobTrigger.getRepeatInterval() );
     Assert.assertEquals( 3, simpleJobTrigger.getRepeatCount() );
-    sleep( 5 );
+    sleep( 1 );
     Assert.assertEquals( "Job did not run the correct number of times", count + 1, TestAction.counter );
     count = TestAction.counter;
-    sleep( 10 );
+    sleep( 3 );
     Assert.assertEquals( "Job ran unexpectedly", count, TestAction.counter );
-    sleep( 20 );
+    sleep( 3 );
     Assert.assertTrue( "Job did not run the correct number of times", count < TestAction.counter );
   }
 
@@ -281,10 +274,13 @@ public class QuartzSchedulerTest {
     int counter = TestAction.counter;
     Calendar calendar = Calendar.getInstance();
     int startingMin = calendar.get( Calendar.MINUTE );
-    int startingSec = calendar.get( Calendar.SECOND ) + 10;
+    int startingSec = calendar.get( Calendar.SECOND ) + 1;
     if ( startingSec > 59 ) {
       startingSec = startingSec % 60;
       startingMin++;
+      if ( startingMin > 59 ) {
+        startingMin = startingMin % 60;
+      }
     }
     ComplexJobTrigger complexJobTrigger = new ComplexJobTrigger();
     complexJobTrigger.setHourlyRecurrence( (ITimeRecurrence) null );
@@ -292,11 +288,11 @@ public class QuartzSchedulerTest {
     complexJobTrigger.setSecondRecurrence( startingSec );
     Job job = scheduler.createJob( jobName, TestAction.class, jobParams, complexJobTrigger );
     scheduler.pauseJob( job.getJobId() );
-    sleep( 30 );
+    sleep( 2 );
     Assert.assertEquals( counter, TestAction.counter );
     Assert.assertEquals( 1, scheduler.getJobs( null ).size() );
     scheduler.resumeJob( job.getJobId() );
-    sleep( 30 );
+    sleep( 2 );
     Assert.assertTrue( counter != TestAction.counter );
     scheduler.removeJob( job.getJobId() );
     Assert.assertEquals( 0, scheduler.getJobs( null ).size() );
@@ -305,7 +301,7 @@ public class QuartzSchedulerTest {
   @Test
   public void testPauseAndResumeScheduler() throws SchedulerException {
     Calendar calendar = Calendar.getInstance();
-    int startingSec = calendar.get( Calendar.SECOND ) + 10;
+    int startingSec = calendar.get( Calendar.SECOND ) + 1;
     if ( startingSec > 59 ) {
       startingSec = startingSec % 60;
     }
@@ -318,12 +314,12 @@ public class QuartzSchedulerTest {
 
     scheduler.pause();
     scheduler.createJob( jobName, TestAction.class, jobParams, complexJobTrigger );
-    sleep( 30 );
+    sleep( 3 );
     Assert.assertEquals( "Job executed while scheduler is supposedly paused!", counter, TestAction.counter );
     Assert.assertEquals( "Scheduler is not aware of the dormant job!", 1, scheduler.getJobs( null ).size() );
 
     scheduler.start();
-    sleep( 90 );
+    sleep( 3 );
     Assert.assertTrue( "Job did not execute after scheduler started back up!", counter != TestAction.counter );
   }
 
@@ -339,16 +335,19 @@ public class QuartzSchedulerTest {
     startEndJobTrigger.setMinuteRecurrence( (ITimeRecurrence) null );
     startJobTrigger.setMinuteRecurrence( (ITimeRecurrence) null );
     endJobTrigger.setMinuteRecurrence( (ITimeRecurrence) null );
-    startEndJobTrigger.setSecondRecurrence( new IncrementalRecurrence( 0, 5 ) );
-    startJobTrigger.setSecondRecurrence( new IncrementalRecurrence( 0, 5 ) );
-    endJobTrigger.setSecondRecurrence( new IncrementalRecurrence( 0, 5 ) );
+    startEndJobTrigger.setSecondRecurrence( new IncrementalRecurrence( 0, 1 ) );
+    startJobTrigger.setSecondRecurrence( new IncrementalRecurrence( 0, 1 ) );
+    endJobTrigger.setSecondRecurrence( new IncrementalRecurrence( 0, 1 ) );
 
     Calendar calendar = Calendar.getInstance();
     int startingMin = calendar.get( Calendar.MINUTE );
-    int startingSec = calendar.get( Calendar.SECOND ) + 20;
+    int startingSec = calendar.get( Calendar.SECOND ) + 3;
     if ( startingSec > 59 ) {
       startingSec = startingSec % 60;
       startingMin++;
+      if ( startingMin > 59 ) {
+        startingMin = startingMin % 60;
+      }
     }
     calendar.set( Calendar.MINUTE, startingMin );
     calendar.set( Calendar.SECOND, startingSec );
@@ -356,7 +355,7 @@ public class QuartzSchedulerTest {
     startEndJobTrigger.setStartTime( calendar.getTime() );
     startJobTrigger.setStartTime( calendar.getTime() );
 
-    calendar.add( Calendar.MINUTE, 1 );
+    calendar.add( Calendar.SECOND, 3 );
     startEndJobTrigger.setEndTime( calendar.getTime() );
     endJobTrigger.setEndTime( calendar.getTime() );
 
@@ -364,33 +363,29 @@ public class QuartzSchedulerTest {
     int startCounter = TestAction2.counter;
     int endCounter = TestAction3.counter;
 
-    Job job = scheduler.createJob("startEndJob", TestAction.class, jobParams, startEndJobTrigger);
+    Job job = scheduler.createJob( "startEndJob", TestAction.class, jobParams, startEndJobTrigger );
     Job job2 = scheduler.createJob( "startJob", TestAction2.class, jobParams, startJobTrigger );
     Job job3 = scheduler.createJob( "endJob", TestAction3.class, jobParams, endJobTrigger );
-    try{
+    try {
 
-      sleep( 10 );
+      sleep( 2 );
       Assert.assertEquals( startEndCounter, TestAction.counter );
       Assert.assertEquals( startCounter, TestAction2.counter );
       Assert.assertTrue( endCounter != TestAction3.counter );
       endCounter = TestAction3.counter;
-      sleep( 20 );
+      sleep( 3 );
       Assert.assertTrue( startEndCounter != TestAction.counter );
       Assert.assertTrue( startCounter != TestAction2.counter );
       Assert.assertTrue( endCounter != TestAction3.counter );
-      sleep( 60 );
+      sleep( 3 );
       startEndCounter = TestAction.counter;
       startCounter = TestAction2.counter;
       endCounter = TestAction3.counter;
-      sleep( 30 );
+      sleep( 3 );
       Assert.assertEquals( startEndCounter, TestAction.counter );
       Assert.assertTrue( startCounter != TestAction2.counter );
       Assert.assertEquals( endCounter, TestAction3.counter );
-    }
-    catch( Throwable ex ){
-      TestCase.fail();
-    }
-    finally{
+    } finally {
       scheduler.removeJob( job.getJobId() );
       scheduler.removeJob( job2.getJobId() );
       scheduler.removeJob( job3.getJobId() );
@@ -446,31 +441,14 @@ public class QuartzSchedulerTest {
     if ( startingSec > 59 ) {
       startingSec = startingSec % 60;
       startingMin++;
+      if ( startingMin > 59 ) {
+        startingMin = startingMin % 60;
+      }
     }
     calendar.set( Calendar.MINUTE, startingMin );
     calendar.set( Calendar.SECOND, startingSec );
     SimpleJobTrigger jobTrigger = new SimpleJobTrigger( calendar.getTime(), null, 0, 0 );
     testGetJobsSchduler.createJob( "getJobsTestJob", TestAction.class, jobParams, jobTrigger );
-
-    SimpleJobTrigger jobTrigger2 = new SimpleJobTrigger( calendar.getTime(), null, 0, 0 );
-    String manualGroup = "MANUAL_TRIGGER";
-    QuartzJobKey jobId = new QuartzJobKey( "getJbosTestJob2", manualGroup );
-    Trigger quartzTrigger = QuartzScheduler.createQuartzTrigger( jobTrigger2, jobId );
-    quartzTrigger.setGroup( manualGroup );
-    if ( jobTrigger2.getEndTime() != null ) {
-      quartzTrigger.setEndTime( jobTrigger2.getEndTime() );
-    }
-    JobDetail jobDetail = new JobDetail( jobId.toString(), jobId.getUserName(), BlockingQuartzJob.class );
-    jobParams.put( QuartzScheduler.RESERVEDMAPKEY_ACTIONUSER, jobId.getUserName() );
-    JobDataMap jobDataMap = new JobDataMap( jobParams );
-    jobDetail.setJobDataMap( jobDataMap );
-    try {
-      Scheduler scheduler = testGetJobsSchduler.getQuartzScheduler();
-      scheduler.scheduleJob( jobDetail, quartzTrigger );
-    } catch ( org.quartz.SchedulerException e ) {
-      throw new SchedulerException( Messages.getInstance().getString(
-          "QuartzScheduler.ERROR_0001_FAILED_TO_SCHEDULE_JOB", "getJbosTestJob2" ), e ); //$NON-NLS-1$
-    }
 
     List<Job> jobs = testGetJobsSchduler.getJobs( null );
     Assert.assertEquals( 1, jobs.size() );


### PR DESCRIPTION
- backport tests from scheduler2/quartz and scheduler2/quartz/test
- ignore one test that depends on unbackported changes
- add Mockito 1.8.5 dependency

@pamval, review it please. This PR makes tests in 5.4 and master consistent with an exception for one case, which depends on BACKLOG-5291 - I marked it with ```@Ignore```.

However, since http://jira.pentaho.com/browse/BISERVER-12297 is planned to be backported and it needs the changes from BACKLOG-5291, then it makes sense to leave the marked case now and to uncomment it later.
 