### PR TITLE
[BISERVER-11565] - File upload names fail if the name has double quotes

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -379,11 +379,11 @@
     </dependency>
     <!-- end security test dependencies -->
 
-    <dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-core" rev="1.5"
+    <dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-core" rev="1.16"
                 conf="test->default"/>
-    <dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-grizzly" rev="1.5"
+    <dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-grizzly" rev="1.16"
                 conf="test->default"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.5" conf="test->default"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.16" conf="test->default"/>
 
     <dependency org="org.springframework" name="spring-test" rev="${dependency.spring.framework.revision}" conf="test->default"/>
 

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/RepositoryPublishResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/RepositoryPublishResourceTest.java
@@ -22,12 +22,17 @@ import org.pentaho.platform.plugin.services.importer.PlatformImportException;
 import org.pentaho.platform.web.http.api.resources.services.RepositoryPublishService;
 
 import javax.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Date;
 
-import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static javax.ws.rs.core.Response.Status.*;
 import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
+import static org.pentaho.platform.plugin.services.importer.PlatformImportException.PUBLISH_GENERAL_ERROR;
+import static org.pentaho.platform.plugin.services.importer.PlatformImportException.PUBLISH_USERNAME_PASSWORD_FAIL;
 
 public class RepositoryPublishResourceTest {
 
@@ -47,24 +52,20 @@ public class RepositoryPublishResourceTest {
   @Test
   public void testWriteFile() throws Exception {
     String pathId = "pathId";
-    InputStream fileContents = mock( InputStream.class );
-    Boolean overwriteFile = Boolean.TRUE;
+    InputStream fileContents = emptyStream();
     FormDataContentDisposition mockFormDataContentDisposition = mock( FormDataContentDisposition.class );
 
     doNothing().when( repositoryPublishResource.repositoryPublishService )
-      .writeFile( pathId, fileContents, overwriteFile );
-
-    Response mockResponse = mock( Response.class );
+      .writeFile( pathId, fileContents, true );
 
     String okResponseText = "SUCCESS";
-    doReturn( mockResponse ).when( repositoryPublishResource ).buildPlainTextOkResponse( okResponseText );
 
     Response testResponse =
-      repositoryPublishResource.writeFile( pathId, fileContents, overwriteFile, mockFormDataContentDisposition );
-    assertEquals( mockResponse, testResponse );
+      repositoryPublishResource.writeFile( pathId, fileContents, true, mockFormDataContentDisposition );
+    assertResponse( testResponse, OK, okResponseText );
 
     verify( repositoryPublishResource.repositoryPublishService, times( 1 ) )
-      .writeFile( pathId, fileContents, overwriteFile );
+      .writeFile( pathId, fileContents, true );
     verify( repositoryPublishResource, times( 1 ) ).buildPlainTextOkResponse( okResponseText );
   }
 
@@ -87,7 +88,7 @@ public class RepositoryPublishResourceTest {
 
     Response mockServerErrorResponse = mock( Response.class );
     doReturn( mockServerErrorResponse ).when( repositoryPublishResource )
-      .buildServerErrorResponse( PlatformImportException.PUBLISH_GENERAL_ERROR );
+      .buildServerErrorResponse( PUBLISH_GENERAL_ERROR );
 
     // Test 1
     Exception mockPentahoAccessControlException = mock( PentahoAccessControlException.class );
@@ -123,6 +124,118 @@ public class RepositoryPublishResourceTest {
       PlatformImportException.PUBLISH_USERNAME_PASSWORD_FAIL );
     verify( repositoryPublishResource, times( 1 ) ).buildStatusResponse( PRECONDITION_FAILED, errorStatus );
     verify( repositoryPublishResource, times( 1 ) )
-      .buildServerErrorResponse( PlatformImportException.PUBLISH_GENERAL_ERROR );
+      .buildServerErrorResponse( PUBLISH_GENERAL_ERROR );
+  }
+
+
+  @Test
+  public void writeFileWithEncodedName_Returns200_OnSuccess() throws Exception {
+    final String originalFile = "my-ktr.ktr";
+    final String originalPath = "/public/" + originalFile;
+
+    doReturn( false ).when( repositoryPublishResource ).invalidPath( originalPath );
+
+    Response shouldBeOk = repositoryPublishResource
+      .writeFileWithEncodedName( encode( originalPath ), emptyStream(), true, dummyInfo( originalFile ) );
+
+    assertResponse( shouldBeOk, OK, "SUCCESS" );
+    verify( repositoryPublishResource.repositoryPublishService, times( 1 ) )
+      .publishFile( eq( originalPath ), any( InputStream.class ), eq( true ) );
+  }
+
+  @Test
+  public void writeFileWithEncodedName_Returns422_OnPathWithReservedChars() throws Exception {
+    final String originalFile = "my\nktr.ktr";
+    final String originalPath = "/public/" + originalFile;
+
+    doReturn( true ).when( repositoryPublishResource ).invalidPath( originalPath );
+
+    Response shouldBeUnprocessableEntity = repositoryPublishResource
+      .writeFileWithEncodedName( encode( originalPath ), emptyStream(), true, dummyInfo( originalFile ) );
+
+    assertResponse( shouldBeUnprocessableEntity, 422,
+      "Cannot publish [" + originalPath + "] because it contains reserved character(s)" );
+    verify( repositoryPublishResource.repositoryPublishService, never() )
+      .writeFile( eq( originalPath ), any( InputStream.class ), eq( true ) );
+  }
+
+  @Test
+  public void writeFileWithEncodedName_Returns500_OnUnexpectedError() throws Exception {
+    testWriteFileWithEncodedName_OnError(
+      new RuntimeException( "unexpected" ),
+      INTERNAL_SERVER_ERROR, PUBLISH_GENERAL_ERROR );
+  }
+
+  @Test
+  public void writeFileWithEncodedName_Returns401_OnUnauthorizedAccess() throws Exception {
+    testWriteFileWithEncodedName_OnError(
+      new PentahoAccessControlException( "unauthorized" ),
+      UNAUTHORIZED, PUBLISH_USERNAME_PASSWORD_FAIL );
+  }
+
+  @Test
+  public void writeFileWithEncodedName_Returns412_OnPlatformImportException() throws Exception {
+    final int someCode = 50;
+    testWriteFileWithEncodedName_OnError(
+      new PlatformImportException( "import exception", someCode ),
+      PRECONDITION_FAILED, someCode );
+  }
+
+  private void testWriteFileWithEncodedName_OnError( Exception thrownException, Response.Status expectedStatus,
+                                                     int expectedErrorCode ) throws Exception {
+    final String originalFile = "my-ktr.ktr";
+    final String originalPath = "/public/" + originalFile;
+
+    doReturn( false ).when( repositoryPublishResource ).invalidPath( originalPath );
+    doThrow( thrownException ).when( repositoryPublishResource.repositoryPublishService )
+      .publishFile( eq( originalPath ), any( InputStream.class ), eq( true ) );
+
+    Response response = repositoryPublishResource
+      .writeFileWithEncodedName( encode( originalPath ), emptyStream(), true, dummyInfo( originalFile ) );
+    assertResponse( response, expectedStatus, String.valueOf( expectedErrorCode ) );
+  }
+
+  @Test
+  public void writeFileWithEncodedName_DecodesPathAndName() throws Exception {
+    final String originalFile = "my-\"quoted\".ktr";
+    final String originalPath = "/public/" + originalFile;
+
+    doReturn( false ).when( repositoryPublishResource ).invalidPath( originalPath );
+
+    repositoryPublishResource.writeFileWithEncodedName(
+      encode( originalPath ), emptyStream(), true, dummyInfo( originalFile ) );
+
+    // decodes path
+    verify( repositoryPublishResource.repositoryPublishService, times( 1 ) )
+      .publishFile( eq( originalPath ), any( InputStream.class ), eq( true ) );
+  }
+
+
+  private static String encode( String originalPath ) throws UnsupportedEncodingException {
+    return URLEncoder.encode( originalPath, "UTF-8" );
+  }
+
+  private static InputStream emptyStream() {
+    return new ByteArrayInputStream( new byte[ 0 ] );
+  }
+
+  private static FormDataContentDisposition dummyInfo( String fileName ) throws Exception {
+    return FormDataContentDisposition
+      .name( "name" ).size( 1 ).fileName( encode( fileName ) )
+      .creationDate( new Date( 0 ) )
+      .modificationDate( new Date( 1 ) )
+      .readDate( new Date( 2 ) )
+      .build();
+  }
+
+
+  private static void assertResponse( Response actual, Response.Status expectedStatus, Object expectedEntity ) {
+    assertResponse( actual, expectedStatus.getStatusCode(), expectedEntity );
+  }
+
+  private static void assertResponse( Response actual, int expectedCode, Object expectedEntity ) {
+    assertNotNull( "Response should not be null", actual );
+    assertEquals( expectedCode, actual.getStatus() );
+    assertEquals( expectedEntity, actual.getEntity() );
   }
 }

--- a/extensions/test-src/org/pentaho/test/platform/web/http/api/RepositoryPublishResourceIT.java
+++ b/extensions/test-src/org/pentaho/test/platform/web/http/api/RepositoryPublishResourceIT.java
@@ -1,0 +1,165 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.test.platform.web.http.api;
+
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.sun.jersey.api.json.JSONConfiguration;
+import com.sun.jersey.core.header.FormDataContentDisposition;
+import com.sun.jersey.multipart.FormDataMultiPart;
+import com.sun.jersey.multipart.impl.MultiPartWriter;
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.WebAppDescriptor;
+import com.sun.jersey.test.framework.spi.container.TestContainerException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.repository2.unified.IPlatformImportBundle;
+import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
+import org.pentaho.platform.plugin.services.importexport.TestAuthorizationPolicy;
+import org.pentaho.platform.repository2.unified.DefaultUnifiedRepositoryBase;
+import org.pentaho.platform.web.http.filters.PentahoRequestContextFilter;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.ws.rs.core.MediaType;
+
+import java.io.ByteArrayInputStream;
+import java.net.URLEncoder;
+
+import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.pentaho.test.platform.web.http.api.JerseyTestUtil.assertResponse;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+@RunWith( SpringJUnit4ClassRunner.class )
+@ContextConfiguration( locations = { "classpath:/repository.spring.xml",
+    "classpath:/repository-test-override.spring.xml" } )
+public class RepositoryPublishResourceIT extends JerseyTest implements ApplicationContextAware {
+
+  private final DefaultUnifiedRepositoryBase testBase;
+
+  public RepositoryPublishResourceIT() throws TestContainerException {
+    testBase = new DefaultUnifiedRepositoryBase();
+  }
+
+  @Override
+  public void setApplicationContext( final ApplicationContext applicationContext ) throws BeansException {
+    testBase.setApplicationContext( applicationContext );
+  }
+
+  @BeforeClass
+  public static void init() throws Exception {
+    DefaultUnifiedRepositoryBase.setUpClass();
+  }
+
+  @AfterClass
+  public static void dispose() throws Exception {
+    DefaultUnifiedRepositoryBase.tearDownClass();
+  }
+
+  @Override
+  protected AppDescriptor configure() {
+    ClientConfig config = new DefaultClientConfig();
+    config.getClasses().add( MultiPartWriter.class );
+    config.getFeatures().put( JSONConfiguration.FEATURE_POJO_MAPPING, Boolean.TRUE );
+
+    return new WebAppDescriptor.Builder( "org.pentaho.platform.web.http.api.resources" )
+      .contextPath( "api" )
+      .addFilter( PentahoRequestContextFilter.class, "pentahoRequestContextFilter" )
+      .clientConfig( config )
+      .build();
+  }
+
+  private IPlatformImporter importer;
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    importer = mock( IPlatformImporter.class );
+
+    testBase.setUp();
+    // allow all actions
+    testBase.getMp().defineInstance( IAuthorizationPolicy.class, new TestAuthorizationPolicy() );
+    // let's replace real Importer with a mock here
+    testBase.getMp().defineInstance( IPlatformImporter.class, importer );
+
+    super.setUp();
+
+    // will be a repository admin not to bother setting sufficient rights
+    testBase.loginAsRepositoryAdmin();
+  }
+
+  @Override
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+    testBase.tearDown();
+  }
+
+  @Test
+  public void importsPath_Simple() throws Exception {
+    testImportsSuccessfully( "/public", "my.txt" );
+  }
+
+  @Test
+  public void importsPath_WithQuotes() throws Exception {
+    testImportsSuccessfully( "/public", "my-\"quoted\".txt" );
+  }
+
+  private void testImportsSuccessfully( String path, String filename ) throws Exception {
+    String full = path + '/' + filename;
+    FormDataMultiPart part = new FormDataMultiPart();
+    part.field( "importPath", URLEncoder.encode( full, "UTF-8"  ), MULTIPART_FORM_DATA_TYPE );
+    part.field( "fileUpload", new ByteArrayInputStream( new byte[ 0 ] ), MULTIPART_FORM_DATA_TYPE );
+    part.field( "overwriteFile", "true", MULTIPART_FORM_DATA_TYPE );
+    part.getField( "fileUpload" )
+      .setContentDisposition( FormDataContentDisposition.name( "fileUpload" )
+        .fileName( URLEncoder.encode( filename, "UTF-8" ) )
+        .build() );
+
+    ClientResponse response = resource()
+      .path( "repo/publish/file" )
+      .type( MediaType.MULTIPART_FORM_DATA )
+      .accept( TEXT_PLAIN )
+      .post( ClientResponse.class, part );
+    assertResponse( response, ClientResponse.Status.OK, MediaType.TEXT_PLAIN );
+
+    ArgumentCaptor<IPlatformImportBundle> captor = ArgumentCaptor.forClass( IPlatformImportBundle.class );
+    verify( importer ).importFile( captor.capture() );
+    IPlatformImportBundle bundle = captor.getValue();
+
+    assertEquals( path, bundle.getPath() );
+    assertEquals( filename, bundle.getName() );
+  }
+}


### PR DESCRIPTION
- introduce new endpoint '/repo/publish/file' which expects path to be encoded
- deprecate existing and fix their javadocs
- add tests
- update jersey-related artifacts in test condiguration to 1.16 that is used in compile configuration

@pentaho-nbaker, @mbatchelor, @pamval, review it please.
In addition to the tests (where the actual storing in repository is not checked), I verified the case locally, after building my own platform and my own report-designer. It became possible to publish files with quotes