### PR TITLE
[PPP-3409] - Manage DataSources dialog can't be opened: Error retrieving ACL Node

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
@@ -75,10 +75,10 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
   @Override public boolean canAccess( final RepositoryFile repositoryFile,
                                       final EnumSet<RepositoryFilePermission> permissions ) {
 
-    if(repositoryFile == null) {
+    if ( repositoryFile == null ) {
       return false;
     }
-      
+
     // Obtain a reference to ACL node as "system", guaranteed access
     final RepositoryFile aclNode = getAclNode( repositoryFile );
     
@@ -108,6 +108,10 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
    * {@inheritDoc}
    */
   @Override public RepositoryFileAcl getAclFor( final RepositoryFile repositoryFile ) {
+
+    if ( repositoryFile == null ) {
+      return null;
+    }
 
     // Obtain a reference to ACL node as "system", guaranteed access
     final RepositoryFile aclNode = getAclNode( repositoryFile );

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperIT.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperIT.java
@@ -2,7 +2,6 @@ package org.pentaho.platform.repository2.unified.jcr;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pentaho.platform.api.mt.ITenant;
@@ -19,7 +18,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.jcr.PathNotFoundException;
-import javax.jcr.ReferentialIntegrityException;
 import java.util.EnumSet;
 
 import static org.junit.Assert.*;
@@ -234,6 +232,20 @@ public class JcrAclNodeHelperIT extends DefaultUnifiedRepositoryBase {
 
     assertTrue( adminPresent );
   }
+
+
+  @Test
+  public void getAclFor_Null_ReturnsFalse() throws Exception {
+    loginAsRepositoryAdmin();
+    assertNull( helper.getAclFor( null ) );
+  }
+
+  @Test
+  public void canAccess_Null_ReturnsFalse() throws Exception {
+    loginAsRepositoryAdmin();
+    assertFalse( helper.canAccess( null, EnumSet.of( RepositoryFilePermission.READ ) ) );
+  }
+
 
   private void makeDsPrivate() {
     loginAsRepositoryAdmin();


### PR DESCRIPTION
- add additional check to prevent NPE in getAclNode()
- add tests

@rmansoor, @pentaho-nbaker, review it please.
This is a guarding condition to prevent NPEs