### PR TITLE
[SP-2195] - Backport of BISERVER-12758 - DefaultUnifiedRepository.getFileById() throws exception if none was found (5.4 Suite)

### DIFF
--- a/api/src/org/pentaho/platform/api/repository2/unified/IUnifiedRepository.java
+++ b/api/src/org/pentaho/platform/api/repository2/unified/IUnifiedRepository.java
@@ -140,7 +140,7 @@ public interface IUnifiedRepository {
    *          {@link Serializable} file Id of the file
    * @param locale
    *          {@link IPentahoLocale} which the user wishes to have contained in the map
-   * @return {@link RepositoryFile}
+   * @return file or {@code null} if the file does not exist or access is denied
    */
   RepositoryFile getFileById( final Serializable fileId, final IPentahoLocale locale );
 
@@ -169,7 +169,7 @@ public interface IUnifiedRepository {
    * @param locale
    *          {@link IPentahoLocale} locale to retrieve for {@link RepositoryFile}
    * 
-   * @return {@link RepositoryFile}
+   * @return file or {@code null} if the file does not exist or access is denied
    */
   RepositoryFile getFileById( final Serializable fileId, final boolean loadLocaleMaps, final IPentahoLocale locale );
 

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDaoTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDaoTest.java
@@ -1,10 +1,13 @@
 package org.pentaho.platform.repository2.unified.jcr;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Test;
 import org.pentaho.platform.api.mt.ITenant;
@@ -20,7 +23,7 @@ public class JcrRepositoryFileDaoTest extends DefaultUnifiedRepositoryBase {
   @Test
   //Running within defined date
   public void testUpdateFile1() throws Exception {
-    
+
     RepositoryFile newFile = createFile( "JcrRepositoryFileDaoTest1.test" );
     IRepositoryFileData dataMock = new SampleRepositoryFileData( "", true, 0 );
 
@@ -33,8 +36,8 @@ public class JcrRepositoryFileDaoTest extends DefaultUnifiedRepositoryBase {
     assertEquals( "incorrect version date", lastVersionDate, startDate );
 
   }
-  
-  
+
+
   @Test
   //Running without defined date
   public void testUpdateFile2() throws Exception {
@@ -76,6 +79,24 @@ public class JcrRepositoryFileDaoTest extends DefaultUnifiedRepositoryBase {
 
     return newFile;
 
+  }
+
+
+  @Test
+  public void getFileById_ReturnsNull_WhenDoesNotExist() throws Exception {
+    loginAsRepositoryAdmin();
+    RepositoryFile file = repo.getFileById( UUID.randomUUID().toString() );
+    assertNull( file );
+  }
+
+  @Test
+  public void getFileById_ReturnsFile_WhenExists() throws Exception {
+    RepositoryFile file = createFile( "file-to-be-returned-by-id.test" );
+    assertNotNull( file.getId() );
+
+    loginAsRepositoryAdmin();
+    RepositoryFile found = repo.getFileById( file.getId() );
+    assertEquals( file.getName(), found.getName() );
   }
 
 }


### PR DESCRIPTION
- catch JCR's exception and return null instead
- add test
- add logging on JCR's exception
- update java docs
- fix checkstyle violations for affected classes
(cherry picked from commits 82ccbc0, 9fdc0ff)

@pentaho-nbaker, @rmansoor, review it please. This is a backport of https://github.com/pentaho/pentaho-platform/pull/2654 and https://github.com/pentaho/pentaho-platform/pull/2659  