### PR TITLE
[SP-2195] - Backport of BISERVER-12758 - DefaultUnifiedRepository.getFileById() throws exception if none was found (5.4 Suite)

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
@@ -89,11 +89,8 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
     // Obtain a reference to ACL node as "system", guaranteed access
     final RepositoryFile aclNode = getAclNode( repositoryFile );
 
-    // Check to see if user has READ access to file, this will throw and exception if not.
-    try {
-      unifiedRepository.getFileById( aclNode.getId() );
-    } catch ( Exception e ) {
-      logger.warn( "Error checking access for file", e );
+    // Check to see if user has READ access to file, this will return null if not.
+    if ( unifiedRepository.getFileById( aclNode.getId() ) == null ) {
       return false;
     }
 


### PR DESCRIPTION
- change getFileById() handling due to new behaviour

@pamval, review it please 