### PR TITLE
[BISERVER-12758] - DefaultUnifiedRepository.getFileById() throws exception if none was found

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
@@ -88,13 +88,8 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
       return true;
     }
 
-    // Check to see if user has READ access to file, this will throw and exception if not.
-    try {
-      unifiedRepository.getFileById( aclNode.getId() );
-    } catch ( Exception e ) {
-      if (logger.isWarnEnabled()) {
-        logger.warn( "Error checking access for file", e );
-      }
+    // Check to see if user has READ access to file, this will return null if not.
+    if ( unifiedRepository.getFileById( aclNode.getId() ) == null ) {
       return false;
     }
 


### PR DESCRIPTION
- change getFileById() handling due to new behaviour

@mbatchelor, @pamval, review it please.
In 5.4, ```JcrAclNodeHelperTest``` failed due to this line. However, in master everything passes. This happens because of the changes from BISERVER-12780. Nevertheless, I'm replacing old handling with a correct.

