### PR TITLE
[SP-2196] - Backport of BISERVER-12758 - DefaultUnifiedRepository.getFileById() throws exception if none was found (6.0 Suite)

### DIFF
--- a/api/src/org/pentaho/platform/api/repository2/unified/IUnifiedRepository.java
+++ b/api/src/org/pentaho/platform/api/repository2/unified/IUnifiedRepository.java
@@ -140,7 +140,7 @@ public interface IUnifiedRepository {
    *          {@link Serializable} file Id of the file
    * @param locale
    *          {@link IPentahoLocale} which the user wishes to have contained in the map
-   * @return {@link RepositoryFile}
+   * @return file or {@code null} if the file does not exist or access is denied
    */
   RepositoryFile getFileById( final Serializable fileId, final IPentahoLocale locale );
 
@@ -169,7 +169,7 @@ public interface IUnifiedRepository {
    * @param locale
    *          {@link IPentahoLocale} locale to retrieve for {@link RepositoryFile}
    * 
-   * @return {@link RepositoryFile}
+   * @return file or {@code null} if the file does not exist or access is denied
    */
   RepositoryFile getFileById( final Serializable fileId, final boolean loadLocaleMaps, final IPentahoLocale locale );
 

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
@@ -39,7 +39,7 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
 
   private final IUnifiedRepository unifiedRepository;
 
-  public JcrAclNodeHelper( IUnifiedRepository unifiedRepository) {
+  public JcrAclNodeHelper( IUnifiedRepository unifiedRepository ) {
     this.unifiedRepository = unifiedRepository;
   }
   // Set to protected for test access
@@ -75,26 +75,30 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
   @Override public boolean canAccess( final RepositoryFile repositoryFile,
                                       final EnumSet<RepositoryFilePermission> permissions ) {
 
-    if(repositoryFile == null) {
+    if ( repositoryFile == null ) {
       return false;
     }
-      
+
     // Obtain a reference to ACL node as "system", guaranteed access
     final RepositoryFile aclNode = getAclNode( repositoryFile );
-    
+
     // If no ACL node is present, it's a public resource
     // Removed redundant call to getAclNode via BISERVER-12780
     if ( aclNode == null ) {
       return true;
     }
 
-    // Check to see if user has READ access to file, this will throw and exception if not.
+    boolean notFound;
     try {
-      unifiedRepository.getFileById( aclNode.getId() );
+      // Check to see if user has READ access to file, this will return null if not.
+      notFound = ( unifiedRepository.getFileById( aclNode.getId() ) == null );
     } catch ( Exception e ) {
-      if (logger.isWarnEnabled()) {
+      if ( logger.isWarnEnabled() ) {
         logger.warn( "Error checking access for file", e );
       }
+      notFound = true;
+    }
+    if ( notFound ) {
       return false;
     }
 
@@ -130,9 +134,9 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
     aclBuilder.aces( acl.getAces() );
 
     //add the Administrator role
-    if( canAdminister() ) {
+    if ( canAdminister() ) {
       String adminRoleName =
-          PentahoSystem.get( String.class, "singleTenantAdminAuthorityName", PentahoSessionHolder.getSession() );
+        PentahoSystem.get( String.class, "singleTenantAdminAuthorityName", PentahoSessionHolder.getSession() );
 
       RepositoryFileAce adminGroup = new RepositoryFileAce( new RepositoryFileSid( adminRoleName,
           RepositoryFileSid.Type.ROLE ), RepositoryFilePermission.ALL );


### PR DESCRIPTION
- catch JCR's exception and return null instead
- add logging on JCR's exception
- change getFileById() handling so, that it is able to cope with both exception and null
- add test
- update java docs
- fix checkstyle violations for affected classes
(cherry picked from commits 82ccbc0, 9fdc0ff, 160fcc4)

@pentaho-nbaker, @rmansoor, review it please. This is a backport of https://github.com/pentaho/pentaho-platform/pull/2654, https://github.com/pentaho/pentaho-platform/pull/2659, https://github.com/pentaho/pentaho-platform/pull/2667  