### PR TITLE
[SP-2194] - Backport of PPP-3409 - Manage DataSources dialog can't be opened: Error retrieving ACL Node (6.0 Suite)

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
@@ -113,6 +113,10 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
    */
   @Override public RepositoryFileAcl getAclFor( final RepositoryFile repositoryFile ) {
 
+    if ( repositoryFile == null ) {
+      return null;
+    }
+
     // Obtain a reference to ACL node as "system", guaranteed access
     final RepositoryFile aclNode = getAclNode( repositoryFile );
 

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperTest.java
@@ -235,6 +235,20 @@ public class JcrAclNodeHelperTest extends DefaultUnifiedRepositoryBase {
     assertTrue( adminPresent );
   }
 
+
+  @Test
+  public void getAclFor_Null_ReturnsFalse() throws Exception {
+    loginAsRepositoryAdmin();
+    assertNull( helper.getAclFor( null ) );
+  }
+
+  @Test
+  public void canAccess_Null_ReturnsFalse() throws Exception {
+    loginAsRepositoryAdmin();
+    assertFalse( helper.canAccess( null, EnumSet.of( RepositoryFilePermission.READ ) ) );
+  }
+
+
   private void makeDsPrivate() {
     loginAsRepositoryAdmin();
     RepositoryFileAcl acl = createAclFor( USERNAME_SUZY );


### PR DESCRIPTION
- add additional check to prevent NPE in getAclNode()
- add tests

@pentaho-nbaker, @rmansoor, review it please. This is a backport of https://github.com/pentaho/pentaho-platform/pull/2656  