### PR TITLE
[SP-2193] - Backport of PPP-3409 - Manage DataSources dialog can't be opened: Error retrieving ACL Node (5.4 Suite)

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelper.java
@@ -78,6 +78,10 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
   @Override public boolean canAccess( final RepositoryFile repositoryFile,
                                       final EnumSet<RepositoryFilePermission> permissions ) {
 
+    if ( repositoryFile == null ) {
+      return false;
+    }
+      
     // First check to see if there is an ACL node, this call is done as "system"
     boolean hasAclNode = hasAclNode( repositoryFile );
 
@@ -113,6 +117,10 @@ public class JcrAclNodeHelper implements IAclNodeHelper {
    * {@inheritDoc}
    */
   @Override public RepositoryFileAcl getAclFor( final RepositoryFile repositoryFile ) {
+
+    if ( repositoryFile == null ) {
+      return null;
+    }
 
     boolean hasAclNode = hasAclNode( repositoryFile );
     if ( !hasAclNode ) {

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrAclNodeHelperTest.java
@@ -2,7 +2,6 @@ package org.pentaho.platform.repository2.unified.jcr;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pentaho.platform.api.mt.ITenant;
@@ -19,7 +18,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.jcr.PathNotFoundException;
-import javax.jcr.ReferentialIntegrityException;
 import java.util.EnumSet;
 
 import static org.junit.Assert.*;
@@ -227,6 +225,20 @@ public class JcrAclNodeHelperTest extends DefaultUnifiedRepositoryBase {
 
     assertTrue( adminPresent );
   }
+
+
+  @Test
+  public void getAclFor_Null_ReturnsFalse() throws Exception {
+    loginAsRepositoryAdmin();
+    assertNull( helper.getAclFor( null ) );
+  }
+
+  @Test
+  public void canAccess_Null_ReturnsFalse() throws Exception {
+    loginAsRepositoryAdmin();
+    assertFalse( helper.canAccess( null, EnumSet.of( RepositoryFilePermission.READ ) ) );
+  }
+
 
   private void makeDsPrivate() {
     loginAsRepositoryAdmin();


### PR DESCRIPTION
- add additional checks to prevent NPE in getAclNode()
- add tests
(cherry picked from commits 4078564, 5e6ab46)

@pentaho-nbaker, @rmansoor, review it please. This is a backport of https://github.com/pentaho/pentaho-platform/pull/2397 and https://github.com/pentaho/pentaho-platform/pull/2656