### PR TITLE
[SP-2228] - Backport of BISERVER-12189 - JCR becomes very slow when there are too many home directories > 400 (6.0 Suite)

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
@@ -28,6 +28,15 @@
 	<log-level>DEBUG</log-level>
 
 	<!--
+		This flag indicates whether or not UserDetailsService is called during creation of user's principal.
+
+		If the service is external (e.g. LDAP or JDBC-based auth is used) then such calls can be expensive.
+		On the other hand, if user has been removed within external service, then it becomes impossible to
+		prevent principal creation when the verification is muted
+	-->
+	<verify-user-on-principal-creation>true</verify-user-on-principal-creation>
+
+	<!--
 		The configuration of publishers, system listeners, and session actions has been moved to
 		the systemListeners.xml, adminPlugins.xml, and sessionStartupActions.xml files which 
 		can be found in the "system" folder within your configured pentaho solution directory.

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider.java
@@ -237,8 +237,11 @@ public class SpringSecurityPrincipalProvider implements PrincipalProvider {
 
         // 2. then try the springSecurityUserCache and, failing that, actual
         // back-end user lookup
-        final UserDetails userDetails = internalGetUserDetails( principalName );
-        if ( userDetails != null ) {
+
+        // it may not be necessary to get user's details to emit principal,
+        boolean skipVerification =
+          !"true".equalsIgnoreCase( PentahoSystem.getSystemSetting( "verify-user-on-principal-creation", "true" ) );
+        if ( skipVerification || internalGetUserDetails( principalName ) != null ) {
           final Principal user = new UserPrincipal( principalName );
           if ( cacheManager != null ) {
             cacheManager.putInRegionCache( USER_CACHE_REGION, principalName, user );
@@ -321,7 +324,7 @@ public class SpringSecurityPrincipalProvider implements PrincipalProvider {
 
         final String roleAuthority = role.getAuthority();
         Principal fromCache;
-        if (cacheManager == null) {
+        if ( cacheManager == null ) {
           fromCache = null;
         } else {
           fromCache = (Principal) cacheManager.getFromRegionCache( ROLE_CACHE_REGION, roleAuthority );

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider_Caching_Test.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider_Caching_Test.java
@@ -19,16 +19,13 @@
 package org.pentaho.platform.repository2.unified.jcr.jackrabbit.security;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.platform.api.engine.ICacheManager;
 import org.pentaho.platform.api.mt.ITenant;
 import org.pentaho.platform.api.mt.ITenantedPrincipleNameResolver;
 import org.pentaho.platform.core.mt.Tenant;
 import org.pentaho.platform.engine.core.system.SimpleMapCacheManager;
-import org.pentaho.platform.repository2.unified.jcr.JcrTenantUtils;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.springframework.security.GrantedAuthority;
 import org.springframework.security.userdetails.User;
@@ -37,31 +34,13 @@ import org.springframework.security.userdetails.User;
 import java.security.Principal;
 import java.util.Properties;
 
-import static org.apache.commons.lang.reflect.FieldUtils.readStaticField;
-import static org.apache.commons.lang.reflect.FieldUtils.writeStaticField;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.pentaho.platform.repository2.unified.jcr.jackrabbit.security.SpringSecurityPrincipalProvider.*;
 
-public class SpringSecurityPrincipalProviderTest {
+public class SpringSecurityPrincipalProvider_Caching_Test {
   private static final String USER_PRINCIPLE = "user";
   private static final String ROLE_PRINCIPLE = "role";
-
-  private static Object userNameUtils;
-  private static Object roleNameUtils;
-
-  @BeforeClass
-  public static void saveInternalFields() throws Exception {
-    userNameUtils = readStaticField( JcrTenantUtils.class, "userNameUtils", true );
-    roleNameUtils = readStaticField( JcrTenantUtils.class, "roleNameUtils", true );
-  }
-
-  @AfterClass
-  public static void restoreInternalFields() throws Exception {
-    writeStaticField( JcrTenantUtils.class, "userNameUtils", userNameUtils, true );
-    writeStaticField( JcrTenantUtils.class, "roleNameUtils", roleNameUtils, true );
-  }
-
 
   private SpringSecurityPrincipalProvider provider;
   private MicroPlatform mp;
@@ -75,10 +54,6 @@ public class SpringSecurityPrincipalProviderTest {
 
   @Before
   public void setUp() throws Exception {
-    // cleaning up static fields
-    writeStaticField( JcrTenantUtils.class, "userNameUtils", null, true );
-    writeStaticField( JcrTenantUtils.class, "roleNameUtils", null, true );
-
     userResolver = mock( ITenantedPrincipleNameResolver.class );
     roleResolver = mock( ITenantedPrincipleNameResolver.class );
 

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider_PrincipalCreation_Test.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider_PrincipalCreation_Test.java
@@ -1,0 +1,151 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.repository2.unified.jcr.jackrabbit.security;
+
+import org.apache.jackrabbit.core.config.LoginModuleConfig;
+import org.apache.jackrabbit.core.security.AnonymousPrincipal;
+import org.apache.jackrabbit.core.security.principal.AdminPrincipal;
+import org.apache.jackrabbit.core.security.principal.EveryonePrincipal;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.mt.ITenantedPrincipleNameResolver;
+import org.pentaho.platform.core.mt.Tenant;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.core.system.SimpleSystemSettings;
+import org.pentaho.platform.repository2.unified.jcr.JcrAclMetadataStrategy;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
+import org.springframework.security.userdetails.UserDetails;
+
+import java.security.Principal;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class SpringSecurityPrincipalProvider_PrincipalCreation_Test {
+
+  private static final String ADMIN_ID = "notDefaultAdmin";
+  private static final String ANONYMOUS_ID = "notDefaultAnonymous";
+
+  private static final String USERNAME = "username";
+
+  private SpringSecurityPrincipalProvider provider;
+  private ITenantedPrincipleNameResolver userResolver;
+  private MicroPlatform mp;
+
+  @Before
+  public void setUp() throws Exception {
+    userResolver = mock( ITenantedPrincipleNameResolver.class );
+
+    mp = new MicroPlatform();
+    mp.defineInstance( "tenantedUserNameUtils", userResolver );
+    mp.start();
+
+    Properties properties = new Properties();
+    properties.put( LoginModuleConfig.PARAM_ADMIN_ID, ADMIN_ID );
+    properties.put( LoginModuleConfig.PARAM_ANONYMOUS_ID, ANONYMOUS_ID );
+    provider = new SpringSecurityPrincipalProvider();
+    provider.init( properties );
+    // remove caching to avoid its impact
+    provider.setCacheManager( null );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mp.stop();
+    provider = null;
+    userResolver = null;
+    mp = null;
+  }
+
+
+  @Test
+  public void getPrincipal_Admin() throws Exception {
+    Principal principal = provider.getPrincipal( ADMIN_ID );
+    assertThat( principal, is( instanceOf( AdminPrincipal.class ) ) );
+    assertEquals( ADMIN_ID, principal.getName() );
+  }
+
+  @Test
+  public void getPrincipal_Anonymous() throws Exception {
+    Principal principal = provider.getPrincipal( ANONYMOUS_ID );
+    assertThat( principal, is( instanceOf( AnonymousPrincipal.class ) ) );
+  }
+
+  @Test
+  public void getPrincipal_Everyone() throws Exception {
+    Principal principal = provider.getPrincipal( EveryonePrincipal.getInstance().getName() );
+    assertEquals( principal, EveryonePrincipal.getInstance() );
+  }
+
+  @Test
+  public void getPrincipal_AclMetadataPrincipal() throws Exception {
+    Principal principal =
+      provider.getPrincipal( JcrAclMetadataStrategy.AclMetadataPrincipal.PRINCIPAL_PREFIX
+        + JcrAclMetadataStrategy.AclMetadataPrincipal.SEPARATOR + USERNAME
+        + JcrAclMetadataStrategy.AclMetadataPrincipal.SEPARATOR + USERNAME );
+    assertThat( principal, is( instanceOf( JcrAclMetadataStrategy.AclMetadataPrincipal.class ) ) );
+  }
+
+
+  @Test
+  public void getPrincipal_User_AccessesUserDetailsServiceByDefault() throws Exception {
+    Principal principal = callGetPrincipalForUser( null, mock( UserDetails.class ) );
+    assertEquals( USERNAME, principal.getName() );
+    verify( provider, times( 1 ) ).internalGetUserDetails( USERNAME );
+  }
+
+  @Test
+  public void getPrincipal_User_SkipsAccessingUserDetailsServiceAccordingToProperty() throws Exception {
+    Principal principal = callGetPrincipalForUser( Boolean.FALSE, mock( UserDetails.class ) );
+    assertEquals( USERNAME, principal.getName() );
+    verify( provider, never() ).internalGetUserDetails( USERNAME );
+  }
+
+  @Test
+  public void getPrincipal_User_ReturnsNullIfUserDetailsAreAbsent() throws Exception {
+    Principal principal = callGetPrincipalForUser( Boolean.TRUE, null );
+    assertNull( principal );
+    verify( provider, times( 1 ) ).internalGetUserDetails( USERNAME );
+  }
+
+  private Principal callGetPrincipalForUser( Boolean verifyUser, UserDetails dummyDetails ) throws Exception {
+    when( userResolver.isValid( USERNAME ) ).thenReturn( true );
+    when( userResolver.getTenant( USERNAME ) ).thenReturn( new Tenant( USERNAME, true ) );
+
+    SimpleSystemSettings settings = new SimpleSystemSettings();
+    if ( verifyUser != null ) {
+      settings.addSetting( "verify-user-on-principal-creation", verifyUser.toString() );
+    }
+    PentahoSystem.setSystemSettingsService( settings );
+
+    provider = spy( provider );
+    doReturn( dummyDetails ).when( provider ).internalGetUserDetails( USERNAME );
+
+    return provider.getPrincipal( USERNAME );
+  }
+}


### PR DESCRIPTION
- introduce "verify-user-on-principal-creation" property to indicate whether or not to call USerDetailsService on emitting new principal
- set its default value to true to keep backward-compatibility
- add tests
- fix Checkstyle violations
(cherry picked from commit 6b326c2)

@pentaho-nbaker, @rmansoor, review it please. This is a backport of https://github.com/pentaho/pentaho-platform/pull/2686  