### PR TITLE
[SP-2270] Backport of BISERVER-10705 - PUC gives you an error if you try to upload prptstyle file (5.4 Suite)

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/ImportHandlerMimeTypeDefinitions.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/ImportHandlerMimeTypeDefinitions.xml
@@ -116,6 +116,14 @@
         <extension>prpt</extension>
       </MimeTypeDefinition>
     </MimeTypeDefinitions>
-  </ImportHandler> 
-  
+  </ImportHandler>
+
+  <ImportHandler class="org.pentaho.platform.plugin.services.importer.RepositoryFileImportFileHandler">
+    <MimeTypeDefinitions>
+      <MimeTypeDefinition mimeType="application/vnd.pentaho.prptstyle+xml" hidden="true">
+        <extension>prptstyle</extension>
+      </MimeTypeDefinition>
+    </MimeTypeDefinitions>
+  </ImportHandler>
+
 </tns:ImportHandlerMimeTypeDefinitions>


### PR DESCRIPTION
Cherry-picked (with conflict merge) from https://github.com/pentaho/pentaho-platform/pull/2695

Added prptstyle extension to ImportHandlerMimeTypeDefinitions.xml config file.

@pentaho-nbaker, @dkincade, @rmansoor could you please review?