### PR TITLE
[BACKLOG-5688] - Implement JAXRS and JAXWS endpoints for ServerStatus…

### DIFF
--- a/core/test-src/org/pentaho/test/platform/engine/core/MicroPlatform.java
+++ b/core/test-src/org/pentaho/test/platform/engine/core/MicroPlatform.java
@@ -44,6 +44,10 @@ public class MicroPlatform extends PentahoSystemBoot {
 
   protected RepositoryModule repositoryModule;
 
+  {
+    setUseThreadForStart( false );
+  }
+
   public MicroPlatform() {
     super();
   }

--- a/extensions/src/org/pentaho/platform/web/servlet/GetResource.java
+++ b/extensions/src/org/pentaho/platform/web/servlet/GetResource.java
@@ -23,17 +23,20 @@ import org.pentaho.platform.api.engine.IActionSequenceResource;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.core.system.status.ServerStatusProvider;
 import org.pentaho.platform.engine.services.actionsequence.ActionSequenceResource;
 import org.pentaho.platform.util.StringUtil;
 import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.platform.web.servlet.messages.Messages;
 
 import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintWriter;
 
 public class GetResource extends ServletBase {
   private static final long serialVersionUID = 1L;
@@ -56,6 +59,18 @@ public class GetResource extends ServletBase {
     throws ServletException, IOException {
     // TODO perform any authorization here...
     // TODO support caching
+
+    // check server status
+    if ( request.getParameter( "serverStatus" ) != null ) { //$NON-NLS-1$
+      response.setContentType( "text/plain" ); //$NON-NLS-1$
+      response.setStatus( HttpServletResponse.SC_OK );
+      response.setCharacterEncoding( LocaleHelper.getSystemEncoding() );
+      try ( PrintWriter writer = response.getWriter() ) {
+        writer.write( ServerStatusProvider.getInstance().getStatus().toString() );
+      }
+      return;
+    }
+
     PentahoSystem.systemEntryPoint();
     try {
       IPentahoSession session = getPentahoSession( request );

--- a/extensions/test-src/org/pentaho/test/platform/web/GetResourceIT.java
+++ b/extensions/test-src/org/pentaho/test/platform/web/GetResourceIT.java
@@ -23,11 +23,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.pentaho.platform.api.engine.IServerStatusProvider;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.boot.PlatformInitializationException;
+import org.pentaho.platform.engine.core.system.status.ServerStatusProvider;
+import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.platform.web.servlet.GetResource;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 
@@ -40,6 +43,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
 import java.io.Serializable;
 
 import static junit.framework.Assert.assertEquals;
@@ -176,5 +180,19 @@ public class GetResourceIT {
     verify( response ).setContentType( eq( TEST_MIME_TYPE ) );
     verify( response ).setHeader( eq( CONTENT_DISPOSITION_HEADER ), endsWith( repoFileName ) );
     verify( response ).setContentLength( repoFileLength );
+  }
+
+  @Test
+  public void testServerStatus() throws Exception {
+    when( request.getParameter( "serverStatus" ) ).thenReturn( "" );
+    final PrintWriter writer = mock( PrintWriter.class );
+    when( response.getWriter() ).thenReturn( writer );
+
+    servlet.service( request, response );
+
+    verify( response ).setContentType( "text/plain" );
+    verify( response ).setStatus( HttpServletResponse.SC_OK );
+    verify( response ).setCharacterEncoding( LocaleHelper.getSystemEncoding() );
+    verify( writer ).write( ServerStatusProvider.ServerStatus.STARTED.toString() );
   }
 }


### PR DESCRIPTION
…Provider

- as we cannot change config files, I added serverStatus check to GetResource servlet. We can check the status by checking `/pentaho/GetResource?serverStatus` url.

- set MicroPlatform not use thread for PentahoSystem::init

@rmansoor please review