### PR TITLE
[BISERVER-12317] - Impossible to publish content without read and write permissions

### DIFF
--- a/api/src/org/pentaho/platform/api/engine/IAggregatingAuthorizationAction.java
+++ b/api/src/org/pentaho/platform/api/engine/IAggregatingAuthorizationAction.java
@@ -1,0 +1,36 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+import java.util.List;
+
+/**
+ * This interface defines aggregating actions which should be implicitly endowed with additional privileges.
+ * For example, {@code Publisher} should be possible to create content as publishing includes it.
+ *
+ * @author Andrey Khayrutdinov
+ */
+public interface IAggregatingAuthorizationAction extends IAuthorizationAction {
+
+  /**
+   * Returns names of aggregated actions
+   *
+   * @return names of aggregated actions
+   */
+  List<String> getAggregatedActions();
+}

--- a/assembly/package-res/biserver/pentaho-solutions/system/repository.spring.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/repository.spring.xml
@@ -754,6 +754,11 @@
     <constructor-arg ref="roleAuthorizationPolicyRoleBindingDaoTxn"/>
   </bean>
 
+  <!-- this bean is needed to avoid interceptions on its methods invocations (used in PentahoEntryCollector) -->
+  <bean id="nonTransactedAuthorizationPolicy" class="org.pentaho.platform.security.policy.rolebased.RoleAuthorizationPolicy">
+    <constructor-arg ref="roleAuthorizationPolicyRoleBindingDaoTarget"/>
+  </bean>
+
   <util:map id="immutableRoleBindingMap">
     <entry key-ref="singleTenantAdminAuthorityName">
 	<pen:list class="org.pentaho.platform.api.engine.IAuthorizationAction"/> 

--- a/repository/src/org/pentaho/platform/security/policy/rolebased/ISessionAwareAuthorizationPolicy.java
+++ b/repository/src/org/pentaho/platform/security/policy/rolebased/ISessionAwareAuthorizationPolicy.java
@@ -1,0 +1,21 @@
+package org.pentaho.platform.security.policy.rolebased;
+
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+
+import javax.jcr.Session;
+
+/**
+ * This is a extension interface to decouple {@link org.apache.jackrabbit.core.security.authorization.acl
+ * .PentahoEntryCollector}
+ * @author Andrey Khayrutdinov
+ */
+public interface ISessionAwareAuthorizationPolicy extends IAuthorizationPolicy {
+  /**
+   * Returns {@code true} if the the action should be allowed doing all checks within {@code session}.
+   *
+   * @param actionName name of action (see {@linkplain org.pentaho.platform.api.engine.IAuthorizationAction
+   * IAuthorizationAction})
+   * @return {@code true} if {@code actionName} is allowed
+   */
+  boolean isAllowed( Session session, String actionName );
+}

--- a/repository/src/org/pentaho/platform/security/policy/rolebased/actions/PublishAction.java
+++ b/repository/src/org/pentaho/platform/security/policy/rolebased/actions/PublishAction.java
@@ -13,18 +13,27 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2013 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.security.policy.rolebased.actions;
 
+import org.pentaho.platform.api.engine.IAggregatingAuthorizationAction;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.ResourceBundle;
 
 /**
  * User: nbaker Date: 3/30/13
  */
-public class PublishAction extends AbstractAuthorizationAction {
+public class PublishAction extends AbstractAuthorizationAction implements IAggregatingAuthorizationAction {
   public static final String NAME = "org.pentaho.security.publish";
+
+  private static final List<String> IMPLICIT_PRIVILEGES =
+    Arrays.asList( RepositoryReadAction.NAME, RepositoryCreateAction.NAME );
+
   ResourceBundle resourceBundle;
 
   @Override
@@ -36,5 +45,10 @@ public class PublishAction extends AbstractAuthorizationAction {
   public String getLocalizedDisplayName( String localeString ) {
     resourceBundle = getResourceBundle( localeString );
     return resourceBundle.getString( NAME );
+  }
+
+  @Override
+  public List<String> getAggregatedActions() {
+    return Collections.unmodifiableList( IMPLICIT_PRIVILEGES );
   }
 }

--- a/repository/src/org/pentaho/platform/security/policy/rolebased/ws/DefaultAuthorizationPolicyWebService.java
+++ b/repository/src/org/pentaho/platform/security/policy/rolebased/ws/DefaultAuthorizationPolicyWebService.java
@@ -13,15 +13,17 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2013 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.security.policy.rolebased.ws;
 
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.security.policy.rolebased.ISessionAwareAuthorizationPolicy;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.security.policy.rolebased.messages.Messages;
 
+import javax.jcr.Session;
 import javax.jws.WebService;
 import java.util.List;
 
@@ -34,7 +36,8 @@ import java.util.List;
 @WebService( endpointInterface = "org.pentaho.platform.security.policy.rolebased.ws.IAuthorizationPolicyWebService",
     serviceName = "authorizationPolicy", portName = "authorizationPolicyPort",
     targetNamespace = "http://www.pentaho.org/ws/1.0" )
-public class DefaultAuthorizationPolicyWebService implements IAuthorizationPolicyWebService {
+public class DefaultAuthorizationPolicyWebService implements IAuthorizationPolicyWebService,
+  ISessionAwareAuthorizationPolicy {
 
   // ~ Static fields/initializers
   // ======================================================================================
@@ -75,4 +78,12 @@ public class DefaultAuthorizationPolicyWebService implements IAuthorizationPolic
     return policy.isAllowed( actionName );
   }
 
+  @Override
+  public boolean isAllowed( Session session, String actionName ) {
+    if ( policy instanceof ISessionAwareAuthorizationPolicy ) {
+      return ( (ISessionAwareAuthorizationPolicy) policy ).isAllowed( session, actionName );
+    }
+
+    throw new UnsupportedOperationException( "Not implemented by policy: " + policy.getClass() );
+  }
 }

--- a/repository/test-src/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntryCollector_AggregatingActions_IT.java
+++ b/repository/test-src/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntryCollector_AggregatingActions_IT.java
@@ -1,0 +1,115 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.apache.jackrabbit.core.security.authorization.acl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.engine.IAuthorizationAction;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
+import org.pentaho.platform.security.policy.rolebased.ISessionAwareAuthorizationPolicy;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
+import org.springframework.security.Authentication;
+import org.springframework.security.GrantedAuthority;
+import org.springframework.security.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class PentahoEntryCollector_AggregatingActions_IT {
+
+  private MicroPlatform mp;
+  private PentahoEntryCollector collector;
+
+  @Before
+  public void setUp() {
+    mp = new MicroPlatform();
+
+    collector = mock( PentahoEntryCollector.class );
+    when( collector.getSessionAwarePolicy() ).thenCallRealMethod();
+  }
+
+  @After
+  public void tearDown() {
+    if ( mp.isInitialized() ) {
+      mp.stop();
+    }
+
+    mp = null;
+    collector = null;
+  }
+
+  @Test
+  public void getSessionAwarePolicy_PicksExisting() throws Exception {
+    ISessionAwareAuthorizationPolicy defined = mock( ISessionAwareAuthorizationPolicy.class );
+    mp.defineInstance( "nonTransactedAuthorizationPolicy", defined );
+    mp.start();
+
+    ISessionAwareAuthorizationPolicy picked = collector.getSessionAwarePolicy();
+    assertEquals( defined, picked );
+  }
+
+  @Test
+  public void getSessionAwarePolicy_CreatesAndRegistersAbsent() throws Exception {
+    IAuthorizationAction fakeAction = mock( IAuthorizationAction.class );
+    when( fakeAction.getName() ).thenReturn( "fakeAction" );
+
+    IRoleAuthorizationPolicyRoleBindingDao nonTransactedDao = mock( IRoleAuthorizationPolicyRoleBindingDao.class );
+    when( nonTransactedDao.getBoundLogicalRoleNames( anyListOf( String.class ) ) )
+      .thenReturn( singletonList( "fakeAction" ) );
+
+    mp.defineInstance( IAuthorizationAction.class, fakeAction );
+    mp.defineInstance( "roleAuthorizationPolicyRoleBindingDaoTarget", nonTransactedDao );
+    mp.start();
+
+    ISessionAwareAuthorizationPolicy policy = collector.getSessionAwarePolicy();
+    ISessionAwareAuthorizationPolicy registered = PentahoSystem.get( ISessionAwareAuthorizationPolicy.class,
+      "nonTransactedAuthorizationPolicy", PentahoSessionHolder.getSession() );
+    assertEquals( policy, registered );
+
+    Authentication origAuth = SecurityContextHolder.getContext().getAuthentication();
+    try {
+      Authentication authentication = mock( Authentication.class );
+      // empty array does not matter, fake DAO accepts any input
+      when( authentication.getAuthorities() ).thenReturn( new GrantedAuthority[ 0 ] );
+      SecurityContextHolder.getContext().setAuthentication( authentication );
+
+      List<String> actions = policy.getAllowedActions( null );
+      assertEquals( 1, actions.size() );
+      assertEquals( fakeAction.getName(), actions.get( 0 ) );
+    } finally {
+      SecurityContextHolder.getContext().setAuthentication( origAuth );
+    }
+  }
+
+  @Test( expected = IllegalStateException.class )
+  public void getSessionAwarePolicy_FailsWhenNonTransactedDaoIsAbsent() {
+    collector.getSessionAwarePolicy();
+  }
+}

--- a/repository/test-src/org/pentaho/platform/security/policy/rolebased/RoleAuthorizationPolicy_AggregatingActions_Test.java
+++ b/repository/test-src/org/pentaho/platform/security/policy/rolebased/RoleAuthorizationPolicy_AggregatingActions_Test.java
@@ -1,0 +1,153 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.security.policy.rolebased;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.engine.IAggregatingAuthorizationAction;
+import org.pentaho.platform.api.engine.IAuthorizationAction;
+import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
+import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
+import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
+import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class RoleAuthorizationPolicy_AggregatingActions_Test {
+
+  private RoleAuthorizationPolicy policy;
+
+  @Before
+  public void setUp() {
+    policy = mock( RoleAuthorizationPolicy.class );
+    when( policy.buildActionsMapping( anyListOf( IAuthorizationAction.class ) ) ).thenCallRealMethod();
+  }
+
+
+  @Test
+  public void noActions() {
+    testAggregating(
+      Collections.<IAuthorizationAction>emptyList(),
+      ImmutableListMultimap.<IAggregatingAuthorizationAction, String>builder().build()
+    );
+  }
+
+  @Test
+  public void noAggregatingActions() {
+    testAggregating(
+      asList( new RepositoryCreateAction(), new RepositoryReadAction(), new AdministerSecurityAction() ),
+      ImmutableListMultimap.<IAggregatingAuthorizationAction, String>builder().build()
+    );
+  }
+
+  @Test
+  public void oneLevelAggregation() {
+    ListMultimap<IAggregatingAuthorizationAction, String> map = ArrayListMultimap.create( 1, 3 );
+    map.putAll( new PublishAction(),
+      asList( PublishAction.NAME, RepositoryCreateAction.NAME, RepositoryReadAction.NAME ) );
+
+    testAggregating(
+      asList( new RepositoryReadAction(), new RepositoryCreateAction(), new AdministerSecurityAction() ),
+      map
+    );
+  }
+
+  @Test
+  public void twoLevelAggregation() {
+    // 1 <- 2 <- 3
+    IAggregatingAuthorizationAction action1 = createAggregatingAction( "action1", "action2" );
+    IAggregatingAuthorizationAction action2 = createAggregatingAction( "action2", "action3" );
+    IAggregatingAuthorizationAction action3 = createAggregatingAction( "action3" );
+
+    ListMultimap<IAggregatingAuthorizationAction, String> map = ArrayListMultimap.create( 3, 3 );
+    map.putAll( action1, asList( "action1", "action2", "action3" ) );
+    map.putAll( action2, asList( "action2", "action3" ) );
+    map.put( action3, "action3" );
+
+    testAggregating( singletonList( new RepositoryReadAction() ), map );
+  }
+
+  private void testAggregating( List<? extends IAuthorizationAction> plainActions,
+                                ListMultimap<IAggregatingAuthorizationAction, String> aggregatingActions ) {
+    Map<IAggregatingAuthorizationAction, Collection<String>> aggregatingMap = aggregatingActions.asMap();
+
+    final int expectedSize = plainActions.size() + aggregatingMap.size();
+    List<IAuthorizationAction> all = new ArrayList<>( expectedSize );
+    all.addAll( plainActions );
+    all.addAll( aggregatingMap.keySet() );
+    ListMultimap<String, String> multimap = policy.buildActionsMapping( all );
+
+    assertEquals( expectedSize, multimap.keySet().size() );
+    for ( IAuthorizationAction action : plainActions ) {
+      assertActions( multimap.get( action.getName() ), singletonList( action.getName() ) );
+    }
+    for ( Map.Entry<IAggregatingAuthorizationAction, Collection<String>> entry : aggregatingMap.entrySet() ) {
+      assertActions( multimap.get( entry.getKey().getName() ), entry.getValue() );
+    }
+  }
+
+
+  @Test( expected = IllegalStateException.class )
+  public void circularDependency() {
+    IAggregatingAuthorizationAction action1 = createAggregatingAction( "action1", "action2" );
+    IAggregatingAuthorizationAction action2 = createAggregatingAction( "action2", "action1" );
+    policy.buildActionsMapping( asList( action1, action2, new RepositoryReadAction() ) );
+  }
+
+
+  private static IAggregatingAuthorizationAction createAggregatingAction( String name, String... implicitlyIncluded ) {
+    IAggregatingAuthorizationAction action = mock( IAggregatingAuthorizationAction.class );
+    when( action.getName() ).thenReturn( name );
+
+    if ( implicitlyIncluded == null ) {
+      implicitlyIncluded = new String[ 0 ];
+    }
+    when( action.getAggregatedActions() ).thenReturn( asList( implicitlyIncluded ) );
+    return action;
+  }
+
+
+  private static void assertActions( List<String> actions, Collection<String> expected ) {
+    assertEquals( expected.size(), actions.size() );
+
+    Set<String> set = new HashSet<>( expected );
+    for ( String action : actions ) {
+      assertTrue( action, set.remove( action ) );
+    }
+  }
+}

--- a/repository/test-src/org/pentaho/platform/security/policy/rolebased/ws/DefaultAuthorizationPolicyWebServiceTest.java
+++ b/repository/test-src/org/pentaho/platform/security/policy/rolebased/ws/DefaultAuthorizationPolicyWebServiceTest.java
@@ -1,0 +1,54 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.security.policy.rolebased.ws;
+
+import org.junit.Test;
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.security.policy.rolebased.ISessionAwareAuthorizationPolicy;
+
+import javax.jcr.Session;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class DefaultAuthorizationPolicyWebServiceTest {
+
+  @Test
+  public void isAllowed_CallsSessionAwareDelegate() {
+    ISessionAwareAuthorizationPolicy policy = mock( ISessionAwareAuthorizationPolicy.class );
+    DefaultAuthorizationPolicyWebService ws = new DefaultAuthorizationPolicyWebService( policy );
+
+    final Session session = mock( Session.class );
+    final String action = "action";
+    ws.isAllowed( session, action );
+
+    verify( policy ).isAllowed( eq( session ), eq( action ) );
+  }
+
+  @Test( expected = UnsupportedOperationException.class )
+  public void isAllowed_ThrowsException_WhenDelegateIsNotSessionAware() {
+    IAuthorizationPolicy policy = mock( IAuthorizationPolicy.class );
+    new DefaultAuthorizationPolicyWebService( policy )
+      .isAllowed( mock( Session.class ), "action" );
+  }
+}


### PR DESCRIPTION
- introduce IAggregatingAuthorizationAction interface to hold actions which implicitly require other permissions
  - make Publish action aggregating
- change RoleAuthorizationPolicy to support aggregating actions
- introduce a brand new bean 'nonTransactedAuthorizationPolicy' that uses non-transacted Dao to avoid infinitive loop via indirect recursion
- remove code duplication in PentahoEntryCollector and force it to use non-transacted Policy instead of Dao
- add tests
- fix Checkstyle violations for all affected classes and make some cleanup

@pentaho-nbaker, @rmansoor, review it please  