### PR TITLE
[BISERVER-12794] Permissions can delete but not restore file

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -170,21 +170,21 @@ public class FileResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/backup" )
-  @StatusCodes ( {
-    @ResponseCode ( code = 200, condition = "Successfully exported the existing Pentaho System" ),
-    @ResponseCode ( code = 403, condition = "User does not have administrative permissions"),
-    @ResponseCode ( code = 500, condition = "Failure to complete the export." )
-  } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully exported the existing Pentaho System" ),
+    @ResponseCode( code = 403, condition = "User does not have administrative permissions" ),
+    @ResponseCode( code = 500, condition = "Failure to complete the export." )
+    } )
   public Response systemBackup( @HeaderParam ( "user-agent" ) String userAgent ) {
     FileService.DownloadFileWrapper wrapper = null;
-    try{
+    try {
       wrapper = fileService.systemBackup( userAgent );
       return buildZipOkResponse( wrapper );
-    } catch( IOException e ) {
+    } catch ( IOException e ) {
       throw new WebApplicationException( Response.Status.INTERNAL_SERVER_ERROR );
-    } catch( ExportException e ) {
+    } catch ( ExportException e ) {
       throw new WebApplicationException( Response.Status.INTERNAL_SERVER_ERROR );
-    } catch( SecurityException e ) {
+    } catch ( SecurityException e ) {
       throw new WebApplicationException( Response.Status.FORBIDDEN );
     }
   }
@@ -205,8 +205,9 @@ public class FileResource extends AbstractJaxRSResource {
     @ResponseCode( code = 200, condition = "Successfully imported the Pentaho System" ),
     @ResponseCode( code = 403, condition = "User does not have administrative permissions" ),
     @ResponseCode( code = 500, condition = "Failure to complete the import." )
-  } )
-  public Response systemRestore( @FormDataParam( "fileUpload" ) InputStream fileUpload, @FormDataParam ( "overwriteFile" ) String overwriteFile ) {
+    } )
+  public Response systemRestore( @FormDataParam( "fileUpload" ) InputStream fileUpload,
+                                 @FormDataParam( "overwriteFile" ) String overwriteFile ) {
     try {
       fileService.systemRestore( fileUpload, overwriteFile );
       return Response.ok().build();
@@ -235,7 +236,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully moved file to trash." ),
       @ResponseCode ( code = 500, condition = "Failure move the file to the trash." )
-  } )
+    } )
   public Response doDeleteFiles( String params ) {
     try {
       fileService.doDeleteFiles( params );
@@ -260,7 +261,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully deleted the comma seperated list of fileIds from the system." ),
     @ResponseCode ( code = 403, condition = "Failure to delete the file due to path not found." )
-  } )
+    } )
   public Response doDeleteFilesPermanent( String params ) {
     try {
       fileService.doDeleteFilesPermanent( params );
@@ -291,7 +292,7 @@ public class FileResource extends AbstractJaxRSResource {
       @ResponseCode ( code = 200, condition = "Successfully moved the file." ),
       @ResponseCode ( code = 403, condition = "Failure to move the file due to path not found." ),
       @ResponseCode ( code = 500, condition = "Failure to move the file." )
-  } )
+    } )
   public Response doMove( @PathParam ( "pathId" ) String destPathId, String params ) {
     try {
       fileService.doMoveFiles( destPathId, params );
@@ -327,10 +328,12 @@ public class FileResource extends AbstractJaxRSResource {
   @Facet( name = "Unsupported" )
   @StatusCodes( {
     @ResponseCode( code = 200, condition = "Successfully restored the file." ),
-    @ResponseCode( code = 307, condition = "Cannot restore in origin folder, can restore in home folder without conflicts" ),
+    @ResponseCode( code = 307, condition = "Cannot restore in origin folder, "
+      + "can restore in home folder without conflicts" ),
     @ResponseCode( code = 403, condition = "Failure to Restore the file." ),
-    @ResponseCode( code = 409, condition = "Cannot restore in origin folder, cannot restore in home folder without conflicts" ),
-  } )
+    @ResponseCode( code = 409, condition = "Cannot restore in origin folder, "
+      + "cannot restore in home folder without conflicts" )
+    } )
   public Response doRestore( String params,
                              @QueryParam( value = "overwriteMode" ) Integer mode ) {
     if ( mode != null ) {
@@ -385,7 +388,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully created the file." ),
       @ResponseCode ( code = 403, condition = "Failure to create the file due to permissions, file already exists, or invalid path id." )
-  } )
+    } )
   public Response createFile( @PathParam ( "pathId" ) String pathId, InputStream fileContents ) {
     try {
       checkCorrectExtension( pathId );
@@ -418,7 +421,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully copied the file." ),
       @ResponseCode ( code = 500, condition = "Failure to Copy file due to exception while getting file with id fileid..." ),
-  } )
+    } )
   public Response doCopyFiles( @PathParam ( "pathId" ) String pathId, @QueryParam ( "mode" ) Integer mode,
                                String params ) {
     try {
@@ -456,7 +459,7 @@ public class FileResource extends AbstractJaxRSResource {
       @ResponseCode ( code = 200, condition = "Successfully get the file or directory." ),
       @ResponseCode ( code = 404, condition = "Failed to find the file or resource." ),
       @ResponseCode ( code = 500, condition = "Failed to open content." )
-  } )
+    } )
   public Response doGetFileOrDir( @PathParam ( "pathId" ) String pathId ) {
     try {
       FileService.RepositoryFileToStreamWrapper wrapper = fileService.doGetFileOrDir( pathId );
@@ -536,7 +539,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully get the file or directory." ),
     @ResponseCode ( code = 404, condition = "Failed to find the file or resource." )
-  } )
+    } )
 
   // have to accept anything for browsers to work
   public String doIsParameterizable( @PathParam ( "pathId" ) String pathId ) throws FileNotFoundException {
@@ -621,16 +624,15 @@ public class FileResource extends AbstractJaxRSResource {
    *    </pre>
    */
   @GET
-  @Path ( "{pathId : .+}/download" )
-  @Produces ( WILDCARD )
-  @StatusCodes ( {
-      @ResponseCode ( code = 200, condition = "Successful download." ),
-      @ResponseCode ( code = 400, condition = "Usually a bad pathId." ),
-      @ResponseCode ( code = 403, condition = "pathId points at a file the user doesn't have access to." ),
-      @ResponseCode ( code = 404, condition = "File not found." ),
-      @ResponseCode ( code = 500, condition = "Failed to download file for another reason." )
-
-  } )
+  @Path( "{pathId : .+}/download" )
+  @Produces( WILDCARD )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successful download." ),
+    @ResponseCode( code = 400, condition = "Usually a bad pathId." ),
+    @ResponseCode( code = 403, condition = "pathId points at a file the user doesn't have access to." ),
+    @ResponseCode( code = 404, condition = "File not found." ),
+    @ResponseCode( code = 500, condition = "Failed to download file for another reason." )
+    } )
   // have to accept anything for browsers to work
   public Response doGetFileOrDirAsDownload( @HeaderParam ( "user-agent" ) String userAgent,
                                             @PathParam ( "pathId" ) String pathId, @QueryParam ( "withManifest" ) String strWithManifest ) {
@@ -681,7 +683,7 @@ public class FileResource extends AbstractJaxRSResource {
       @ResponseCode ( code = 403, condition = "Failed to retrieve file due to permission problem." ),
       @ResponseCode ( code = 404, condition = "Failed to retrieve file due because file was not found." ),
       @ResponseCode ( code = 500, condition = "Failed to download file because of some other error." )
-  } )
+    } )
   public Response doGetFileAsInline( @PathParam ( "pathId" ) String pathId ) {
     try {
       FileService.RepositoryFileToStreamWrapper wrapper = fileService.doGetFileAsInline( pathId );
@@ -727,7 +729,7 @@ public class FileResource extends AbstractJaxRSResource {
       @ResponseCode ( code = 403, condition = "Failed to save acls due to missing or incorrect properties." ),
       @ResponseCode ( code = 400, condition = "Failed to save acls due to malformed xml." ),
       @ResponseCode ( code = 500, condition = "Failed to save acls due to another error." )
-  } )
+    } )
 
   public Response setFileAcls( @PathParam ( "pathId" ) String pathId, RepositoryFileAclDto acl ) {
     try {
@@ -797,7 +799,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully retrieved file." ),
       @ResponseCode ( code = 500, condition = "Failed to download file because of some other error." )
-  } )
+    } )
   @Facet ( name = "Unsupported" )
   public Response doSetContentCreator( @PathParam ( "pathId" ) String pathId, RepositoryFileDto contentCreator ) {
     try {
@@ -852,13 +854,13 @@ public class FileResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "{pathId : .+}/locales" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
-  @StatusCodes ( {
-      @ResponseCode ( code = 200, condition = "Successfully retrieved locale information." ),
-      @ResponseCode ( code = 404, condition = "Failed to retrieve locales because the file was not found." ),
-      @ResponseCode ( code = 500, condition = "Unable to retrieve locales due to some other error." )
-  } )
-  public List<LocaleMapDto> doGetFileLocales( @PathParam ( "pathId" ) String pathId ) {
+  @Produces( { APPLICATION_XML, APPLICATION_JSON } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully retrieved locale information." ),
+    @ResponseCode( code = 404, condition = "Failed to retrieve locales because the file was not found." ),
+    @ResponseCode( code = 500, condition = "Unable to retrieve locales due to some other error." )
+    } )
+  public List<LocaleMapDto> doGetFileLocales( @PathParam( "pathId" ) String pathId ) {
     List<LocaleMapDto> locales = new ArrayList<LocaleMapDto>();
     try {
       locales = fileService.doGetFileLocales( pathId );
@@ -906,7 +908,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully retrieved locale properties." ),
       @ResponseCode ( code = 500, condition = "Unable to retrieve locale properties due to some other error." )
-  } )
+    } )
   public List<StringKeyStringValueDto> doGetLocaleProperties( @PathParam ( "pathId" ) String pathId,
                                                               @QueryParam ( "locale" ) String locale ) {
     return fileService.doGetLocaleProperties( pathId, locale );
@@ -935,13 +937,13 @@ public class FileResource extends AbstractJaxRSResource {
    *    </pre>
    */
   @PUT
-  @Path ( "{pathId : .+}/localeProperties" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
-  @StatusCodes ( {
-      @ResponseCode ( code = 200, condition = "Successfully updated locale properties." ),
-      @ResponseCode ( code = 500, condition = "Unable to update locale properties due to some other error." )
-  } )
-  public Response doSetLocaleProperties( @PathParam ( "pathId" ) String pathId, @QueryParam ( "locale" ) String locale,
+  @Path( "{pathId : .+}/localeProperties" )
+  @Produces( { APPLICATION_XML, APPLICATION_JSON } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully updated locale properties." ),
+    @ResponseCode( code = 500, condition = "Unable to update locale properties due to some other error." )
+    } )
+  public Response doSetLocaleProperties( @PathParam( "pathId" ) String pathId, @QueryParam( "locale" ) String locale,
                                          List<StringKeyStringValueDto> properties ) {
     try {
       fileService.doSetLocaleProperties( pathId, locale, properties );
@@ -978,7 +980,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully deleted the locale." ),
       @ResponseCode ( code = 500, condition = "Unable to delete the locale properties due to some other error." )
-  } )
+    } )
   public Response doDeleteLocale( @PathParam ( "pathId" ) String pathId, @QueryParam ( "locale" ) String locale ) {
     try {
       fileService.doDeleteLocale( pathId, locale );
@@ -1016,13 +1018,15 @@ public class FileResource extends AbstractJaxRSResource {
    *  </pre>
    */
   @GET
-  @Path ( "/properties" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
-  @StatusCodes ( {
-      @ResponseCode ( code = 200, condition = "Successfully retrieved the properties of the root directory." ),
-      @ResponseCode ( code = 404, condition = "Unable to retrieve the properties of the root directory due to file not found error." ),
-      @ResponseCode ( code = 500, condition = "Unable to retrieve the properties of the root directory due to some other error." )
-  } )
+  @Path( "/properties" )
+  @Produces( { APPLICATION_XML, APPLICATION_JSON } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully retrieved the properties of the root directory." ),
+    @ResponseCode( code = 404, condition = "Unable to retrieve the properties of the root directory due to file not "
+      + "found error." ),
+    @ResponseCode( code = 500, condition = "Unable to retrieve the properties of the root directory due to some other"
+      + " error." )
+    } )
   public RepositoryFileDto doGetRootProperties() {
     return fileService.doGetRootProperties();
   }
@@ -1051,7 +1055,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully retrieved the permissions of the file." ),
       @ResponseCode ( code = 500, condition = "Unable to retrieve the permissions of the file due to some other error." )
-  } )
+    } )
   public List<Setting> doGetCanAccessList( @PathParam ( "pathId" ) String pathId,
                                            @QueryParam ( "permissions" ) String permissions ) {
     return fileService.doGetCanAccessList( pathId, permissions );
@@ -1104,7 +1108,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully retrieved the permissions of the given paths." ),
       @ResponseCode ( code = 500, condition = "Unable to retrieve the permissions of the given paths due to some other error." )
-  } )
+    } )
   public List<Setting> doGetPathsAccessList( StringListWrapper pathsWrapper ) {
     return fileService.doGetPathsAccessList( pathsWrapper );
   }
@@ -1127,14 +1131,15 @@ public class FileResource extends AbstractJaxRSResource {
    *    </pre>
    */
   @GET
-  @Path ( "{pathId : .+}/canAccess" )
-  @Produces ( TEXT_PLAIN )
-  @StatusCodes ( {
-    @ResponseCode ( code = 200, condition = "Successfully retrieved the permissions of the given paths." ),
-    @ResponseCode ( code = 500, condition = "Unable to retrieve the permissions of the given paths due to some other error." )
-  } )
-  public String doGetCanAccess( @PathParam ( "pathId" ) String pathId,
-                                @QueryParam ( "permissions" ) String permissions ) {
+  @Path( "{pathId : .+}/canAccess" )
+  @Produces( TEXT_PLAIN )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully retrieved the permissions of the given paths." ),
+    @ResponseCode( code = 500, condition = "Unable to retrieve the permissions of the given paths due to some other "
+      + "error." )
+    } )
+  public String doGetCanAccess( @PathParam( "pathId" ) String pathId,
+                                @QueryParam( "permissions" ) String permissions ) {
     return fileService.doGetCanAccess( pathId, permissions );
   }
 
@@ -1157,7 +1162,7 @@ public class FileResource extends AbstractJaxRSResource {
   @Produces ( TEXT_PLAIN )
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully returns a boolean value, either true or false" )
-  } )
+    } )
   public String doGetCanAdminister() {
     try {
       return fileService.doCanAdminister() ? "true" : "false";
@@ -1185,7 +1190,7 @@ public class FileResource extends AbstractJaxRSResource {
   @Produces ( { TEXT_PLAIN } )
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully returns a list of repositroy reserved characters" )
-  } )
+    } )
   public Response doGetReservedChars() {
     StringBuffer buffer = fileService.doGetReservedChars();
     return buildPlainTextOkResponse( buffer.toString() );
@@ -1210,7 +1215,7 @@ public class FileResource extends AbstractJaxRSResource {
   @Produces ( { TEXT_PLAIN } )
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully returns a list of repositroy reserved characters" )
-  } )
+    } )
   public Response doGetReservedCharactersDisplay() {
     StringBuffer buffer = fileService.doGetReservedCharactersDisplay();
     return buildPlainTextOkResponse( buffer.toString() );
@@ -1235,7 +1240,7 @@ public class FileResource extends AbstractJaxRSResource {
   @Produces ( TEXT_PLAIN )
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully returns true or false depending on the users permissions" )
-  } )
+    } )
   public String doGetCanCreate() {
     return fileService.doGetCanCreate();
   }
@@ -1279,7 +1284,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Returns the requested file permissions in xml or json format" ),
       @ResponseCode ( code = 500, condition = "File failed to be retrieved. This could be caused by an invalid path, or the file does not exist." )
-  } )
+    } )
   public RepositoryFileAclDto doGetFileAcl( @PathParam ( "pathId" ) String pathId ) {
     return fileService.doGetFileAcl( pathId );
   }
@@ -1331,7 +1336,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully retrieved the properties for a file." ),
       @ResponseCode ( code = 204, condition = "Invalid file path." )
-  } )
+    } )
   public RepositoryFileDto doGetProperties( @PathParam ( "pathId" ) String pathId ) {
     try {
       return fileService.doGetProperties( pathId );
@@ -1356,7 +1361,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully retrieved the content creator for a file." ),
     @ResponseCode ( code = 403, condition = "Failure to move the file due to path not found." )
-  } )
+    } )
   public RepositoryFileDto doGetContentCreator( @PathParam ( "pathId" ) String pathId ) {
     try {
       return fileService.doGetContentCreator( pathId );
@@ -1428,7 +1433,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully retrieved the list of RepositoryFileDto objects." ),
       @ResponseCode ( code = 200, condition = "Empty list of RepositoryFileDto objects." )
-  } )
+    } )
   public List<RepositoryFileDto> doGetGeneratedContent( @PathParam ( "pathId" ) String pathId ) {
     List<RepositoryFileDto> repositoryFileDtoList = new ArrayList<RepositoryFileDto>();
     try {
@@ -1500,14 +1505,14 @@ public class FileResource extends AbstractJaxRSResource {
    * </pre>
    */
   @GET
-  @Path ( "{pathId : .+}/generatedContentForUser" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
-  @StatusCodes ( {
-      @ResponseCode ( code = 200, condition = "Successfully retrieved the list of RepositoryFileDto objects." ),
-      @ResponseCode ( code = 200, condition = "Empty list of RepositoryFileDto objects." ),
-      @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
-  public List<RepositoryFileDto> doGetGeneratedContentForUser( @PathParam ( "pathId" ) String pathId,
+  @Path( "{pathId : .+}/generatedContentForUser" )
+  @Produces( { APPLICATION_XML, APPLICATION_JSON } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully retrieved the list of RepositoryFileDto objects." ),
+    @ResponseCode( code = 200, condition = "Empty list of RepositoryFileDto objects." ),
+    @ResponseCode( code = 500, condition = "Server Error." )
+    } )
+  public List<RepositoryFileDto> doGetGeneratedContentForUser( @PathParam( "pathId" ) String pathId,
                                                                @QueryParam ( "user" ) String user ) {
     List<RepositoryFileDto> repositoryFileDtoList = new ArrayList<RepositoryFileDto>();
     try {
@@ -1573,16 +1578,18 @@ public class FileResource extends AbstractJaxRSResource {
    * </pre>
    */
   @GET
-  @Path ( "/tree" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
-  @StatusCodes ( {
-      @ResponseCode ( code = 200, condition = "Successfully retrieved the list of files from root of the repository." ),
-      @ResponseCode ( code = 404, condition = "Invalid parameters." ),
-      @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
-  public RepositoryFileTreeDto doGetRootTree( @QueryParam ( "depth" ) Integer depth,
-                                              @QueryParam ( "filter" ) String filter, @QueryParam ( "showHidden" ) Boolean showHidden,
-                                              @DefaultValue ( "false" ) @QueryParam ( "includeAcls" ) Boolean includeAcls ) {
+  @Path( "/tree" )
+  @Produces( { APPLICATION_XML, APPLICATION_JSON } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully retrieved the list of files from root of the repository." ),
+    @ResponseCode( code = 404, condition = "Invalid parameters." ),
+    @ResponseCode( code = 500, condition = "Server Error." )
+    } )
+  public RepositoryFileTreeDto doGetRootTree( @QueryParam( "depth" ) Integer depth,
+                                              @QueryParam( "filter" ) String filter,
+                                              @QueryParam( "showHidden" ) Boolean showHidden,
+                                              @DefaultValue( "false" ) @QueryParam( "includeAcls" )
+                                              Boolean includeAcls ) {
     return fileService.doGetTree( FileUtils.PATH_SEPARATOR, depth, filter, showHidden, includeAcls );
   }
 
@@ -1643,7 +1650,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully retrieved the list of child files from root of the repository." ),
       @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
+    } )
   public List<RepositoryFileDto> doGetRootChildren( @QueryParam ( "filter" ) String filter,
                                                     @QueryParam ( "showHidden" ) Boolean showHidden,
                                                     @DefaultValue ( "false" ) @QueryParam ( "includeAcls" ) Boolean includeAcls ) {
@@ -1711,7 +1718,7 @@ public class FileResource extends AbstractJaxRSResource {
       @ResponseCode ( code = 200, condition = "Successfully retrieved the list of files from root of the repository." ),
       @ResponseCode ( code = 404, condition = "Invalid parameters." ),
       @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
+    } )
   public RepositoryFileTreeDto doGetTree( @PathParam ( "pathId" ) String pathId, @QueryParam ( "depth" ) Integer depth,
                                           @QueryParam ( "filter" ) String filter, @QueryParam ( "showHidden" ) Boolean showHidden,
                                           @DefaultValue ( "false" ) @QueryParam ( "includeAcls" ) Boolean includeAcls ) {
@@ -1777,7 +1784,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully retrieved the list of child files from selected repository path of the repository." ),
       @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
+    } )
   public List<RepositoryFileDto> doGetChildren( @PathParam ( "pathId" ) String pathId,
                                                 @QueryParam ( "filter" ) String filter, @QueryParam ( "showHidden" ) Boolean showHidden,
                                                 @DefaultValue ( "false" ) @QueryParam ( "includeAcls" ) Boolean includeAcls ) {
@@ -1843,7 +1850,7 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully retrieved the list of files from trash folder of the repository." ),
       @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
+    } )
   public List<RepositoryFileDto> doGetDeletedFiles() {
     return fileService.doGetDeletedFiles();
   }
@@ -1878,7 +1885,7 @@ public class FileResource extends AbstractJaxRSResource {
       @ResponseCode ( code = 200, condition = "Successfully retrieved metadata." ),
       @ResponseCode ( code = 403, condition = "Invalid path." ),
       @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
+    } )
   public List<StringKeyStringValueDto> doGetMetadata( @PathParam ( "pathId" ) String pathId ) {
     try {
       return fileService.doGetMetadata( pathId );
@@ -1917,10 +1924,10 @@ public class FileResource extends AbstractJaxRSResource {
   @StatusCodes ( {
       @ResponseCode ( code = 200, condition = "Successfully renamed file." ),
       @ResponseCode ( code = 200, condition = "File to be renamed does not exist." )
-  } )
+    } )
   public Response doRename( @PathParam ( "pathId" ) String pathId, @QueryParam ( "newName" ) String newName ) {
     try {
-      JcrRepositoryFileUtils.checkName(newName);
+      JcrRepositoryFileUtils.checkName( newName );
 
       checkCorrectExtension( newName );
 
@@ -1966,7 +1973,7 @@ public class FileResource extends AbstractJaxRSResource {
       @ResponseCode ( code = 403, condition = "Invalid path." ),
       @ResponseCode ( code = 400, condition = "Invalid payload." ),
       @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
+    } )
   public Response doSetMetadata( @PathParam ( "pathId" ) String pathId, List<StringKeyStringValueDto> metadata ) {
     try {
       fileService.doSetMetadata( pathId, metadata );
@@ -2006,7 +2013,7 @@ public class FileResource extends AbstractJaxRSResource {
       @ResponseCode ( code = 200, condition = "Successfully created folder." ),
       @ResponseCode ( code = 409, condition = "Path already exists." ),
       @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
+    } )
   public Response doCreateDirs( @PathParam ( "pathId" ) String pathId ) {
     try {
       if ( fileService.doCreateDir( pathId ) ) {
@@ -2081,7 +2088,7 @@ public class FileResource extends AbstractJaxRSResource {
   @Produces( { APPLICATION_XML, APPLICATION_JSON } )
   @StatusCodes( {
       @ResponseCode( code = 200, condition = "Successfully got the generated content for schedule" )
-  } )
+    } )
   public List<RepositoryFileDto> doGetGeneratedContentForSchedule( @QueryParam( "lineageId" ) String lineageId ) {
 
     return schedulerResource.doGetGeneratedContentForSchedule( lineageId );
@@ -2108,16 +2115,16 @@ public class FileResource extends AbstractJaxRSResource {
    *  </pre>
    */
   @GET
-  @Path ( "{pathId : .+}/versioningConfiguration" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
-  @StatusCodes ( {
-      @ResponseCode ( code = 200, condition = "Successfully returns the versioning configuation" )
-  } )
+  @Path( "{pathId : .+}/versioningConfiguration" )
+  @Produces( { APPLICATION_XML, APPLICATION_JSON } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully returns the versioning configuation" )
+    } )
   public FileVersioningConfiguration doVersioningConfiguration( @PathParam( "pathId" ) String pathId ) {
     IRepositoryVersionManager repositoryVersionManager = PentahoSystem.get( IRepositoryVersionManager.class );
     return new FileVersioningConfiguration(
-        repositoryVersionManager.isVersioningEnabled( FileUtils.idToPath( pathId ) ), repositoryVersionManager
-            .isVersionCommentEnabled( FileUtils.idToPath( pathId ) ) );
+      repositoryVersionManager.isVersioningEnabled( FileUtils.idToPath( pathId ) ), repositoryVersionManager
+      .isVersionCommentEnabled( FileUtils.idToPath( pathId ) ) );
   }
 
   protected boolean isPathValid( String path ) {
@@ -2190,7 +2197,7 @@ public class FileResource extends AbstractJaxRSResource {
 
   protected Response buildSafeHtmlServerErrorResponse( Exception e ) {
     return Response.serverError()
-        .entity( new SafeHtmlBuilder().appendEscapedLines( e.getLocalizedMessage() ).toSafeHtml().asString() ).build();
+      .entity( new SafeHtmlBuilder().appendEscapedLines( e.getLocalizedMessage() ).toSafeHtml().asString() ).build();
   }
 
   protected Response buildOkResponse( FileService.RepositoryFileToStreamWrapper wrapper ) {
@@ -2201,12 +2208,12 @@ public class FileResource extends AbstractJaxRSResource {
     }
 
     return builder.header( "Content-Disposition", "inline; filename=\"" + wrapper.getRepositoryFile().getName() + "\"" )
-        .build();
+      .build();
   }
 
   protected Response buildZipOkResponse( FileService.DownloadFileWrapper wrapper ) {
     return Response.ok( wrapper.getOutputStream(), APPLICATION_ZIP + "; charset=UTF-8" )
-        .header( "Content-Disposition", wrapper.getAttachment() ).build();
+      .header( "Content-Disposition", wrapper.getAttachment() ).build();
   }
 
   protected Response buildOkResponse( Object o, String s ) {
@@ -2231,13 +2238,13 @@ public class FileResource extends AbstractJaxRSResource {
 
   protected boolean hasParameterUi( RepositoryFile repositoryFile ) {
     return ( PentahoSystem.get( IPluginManager.class ).getContentGenerator(
-        repositoryFile.getName().substring( repositoryFile.getName().lastIndexOf( '.' ) + 1 ), "parameterUi" )
-        != null );
+      repositoryFile.getName().substring( repositoryFile.getName().lastIndexOf( '.' ) + 1 ), "parameterUi" )
+      != null );
   }
 
   protected IContentGenerator getContentGenerator( RepositoryFile repositoryFile ) {
     return PentahoSystem.get( IPluginManager.class ).getContentGenerator(
-        repositoryFile.getName().substring( repositoryFile.getName().lastIndexOf( '.' ) + 1 ), "parameter" );
+      repositoryFile.getName().substring( repositoryFile.getName().lastIndexOf( '.' ) + 1 ), "parameter" );
   }
 
   protected SimpleParameterProvider getSimpleParameterProvider() {
@@ -2264,12 +2271,13 @@ public class FileResource extends AbstractJaxRSResource {
     return Messages.getInstance();
   }
 
-  private void checkCorrectExtension(String fileName) {
+  private void checkCorrectExtension( String fileName ) {
     IRepositoryContentConverterHandler handler = PentahoSystem.get( IRepositoryContentConverterHandler.class );
     String ext = RepositoryFilenameUtils.getExtension( fileName );
 
     if ( handler != null && handler.getConverter( ext ) == null ) {
-      throw new IllegalArgumentException( Messages.getInstance().getString( "FileResource.INCORRECT_EXTENSION", fileName ) );
+      throw new IllegalArgumentException(
+        Messages.getInstance().getString( "FileResource.INCORRECT_EXTENSION", fileName ) );
     }
   }
 

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/services/FileService.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/services/FileService.java
@@ -187,7 +187,7 @@ public class FileService {
         IOUtils.copy( inputStream, output );
       }
     };
-    }
+  }
   /**
    * Moves the list of files to the user's trash folder
    * <p/>
@@ -1909,7 +1909,7 @@ public class FileService {
   }
 
   private PentahoPlatformExporter getBackupExporter() {
-    if( backupExporter == null ) {
+    if ( backupExporter == null ) {
       backupExporter = new PentahoPlatformExporter( getRepository() );
     }
 

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/utils/FileUtils.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/utils/FileUtils.java
@@ -25,4 +25,12 @@ public class FileUtils {
     }
     return path;
   }
+
+  public static String[] convertCommaSeparatedStringToArray( String stringToConvert ) {
+    if ( stringToConvert == null || stringToConvert.isEmpty() ) {
+      throw new IllegalArgumentException( "String cannot be null or empty" );
+    }
+
+    return stringToConvert.split( "[,]" );
+  }
 }

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
@@ -20,7 +20,6 @@ package org.pentaho.platform.web.http.api.resources;
 import org.dom4j.Document;
 import org.dom4j.Element;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -100,7 +99,7 @@ public class FileResourceTest {
     when( handler.getConverter( XML_EXTENSION ) ).thenReturn( new StreamConverter() );
     PentahoSystem.registerObject( handler );
   }
-  
+
   @Test
   public void doDeleteFiles() throws Exception {
     String params = "params";
@@ -244,7 +243,7 @@ public class FileResourceTest {
     UnifiedRepositoryAccessDeniedException mockedException = mock( UnifiedRepositoryAccessDeniedException.class );
     doThrow( mockedException ).when( fileResource.fileService ).doRestoreFiles( FILE_ID );
     doReturn( "user/home" ).when( fileResource ).getUserHomeFolder();
-    doReturn( false ).when( fileResource.fileService ).canRestoreToFolderWithNoConflicts( anyString(), eq(FILE_ID) );
+    doReturn( false ).when( fileResource.fileService ).canRestoreToFolderWithNoConflicts( anyString(), eq( FILE_ID ) );
 
     Response response = fileResource.doRestore( FILE_ID, null );
     assertNotEquals( response.getStatus(), INTERNAL_SERVER_ERROR.getStatusCode() );
@@ -275,28 +274,28 @@ public class FileResourceTest {
     InputStream mockInputStream = mock( InputStream.class );
     Response testResponse = fileResource.createFile( PATH_ID_WITHOUTH_EXTENSION, mockInputStream );
     assertEquals( Status.INTERNAL_SERVER_ERROR.getStatusCode(), testResponse.getStatus() );
-    
+
     verify( fileResource, times( 1 ) ).buildServerErrorResponse( anyString() );
   }
-  
+
   @Test
   public void testCreateFileIncorrectExtension() throws Exception {
     InputStream mockInputStream = mock( InputStream.class );
     Response testResponse = fileResource.createFile( PATH_ID_INCORRECT_EXTENSION, mockInputStream );
     assertEquals( Status.INTERNAL_SERVER_ERROR.getStatusCode(), testResponse.getStatus() );
-    
+
     verify( fileResource, times( 1 ) ).buildServerErrorResponse( anyString() );
   }
-  
+
   @Test
   public void testCreateFileCorrectExtension() throws Exception {
     InputStream mockInputStream = mock( InputStream.class );
     Response testResponse = fileResource.createFile( PATH_ID, mockInputStream );
     assertEquals( Status.OK.getStatusCode(), testResponse.getStatus() );
-    
+
     verify( fileResource, times( 1 ) ).buildOkResponse();
   }
-  
+
   @Test
   public void testCreateFileError() throws Exception {
     String charsetName = "charsetName";
@@ -533,7 +532,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoIsParameterizable() throws Exception {
-    
+
 
     String path = "path";
     doReturn( path ).when( fileResource.fileService ).idToPath( PATH_ID );
@@ -625,7 +624,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoIsParameterizableError() throws Exception {
-    
+
 
     String path = "path";
     doReturn( path ).when( fileResource.fileService ).idToPath( PATH_ID );
@@ -667,7 +666,7 @@ public class FileResourceTest {
   @Test
   public void testDoGetFileOrDirAsDownload() throws Throwable {
     String userAgent = "userAgent";
-    
+
     String strWithManifest = "strWithManifest";
 
     FileService.DownloadFileWrapper mockDownloadFileWrapper = mock( FileService.DownloadFileWrapper.class );
@@ -687,7 +686,7 @@ public class FileResourceTest {
   @Test
   public void testDoGetFileOrDirAsDownloadError() throws Throwable {
     String userAgent = "userAgent";
-    
+
     String strWithManifest = "strWithManifest";
 
     Messages mockMessages = mock( Messages.class );
@@ -758,7 +757,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetFileAsInline() throws Exception {
-    
+
 
     FileService.RepositoryFileToStreamWrapper mockWrapper = mock( FileService.RepositoryFileToStreamWrapper.class );
     doReturn( mockWrapper ).when( fileResource.fileService ).doGetFileAsInline( PATH_ID );
@@ -775,7 +774,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetFileAsInlineError() throws Exception {
-    
+
 
     Response mockForbiddenResponse = mock( Response.class );
     doReturn( mockForbiddenResponse ).when( fileResource ).buildStatusResponse( FORBIDDEN );
@@ -815,7 +814,7 @@ public class FileResourceTest {
 
   @Test
   public void testSetFileAcls() throws Exception {
-    
+
     RepositoryFileAclDto mockRepositoryFileAclDto = mock( RepositoryFileAclDto.class );
 
     doNothing().when( fileResource.fileService ).setFileAcls( PATH_ID, mockRepositoryFileAclDto );
@@ -832,7 +831,7 @@ public class FileResourceTest {
 
   @Test
   public void testSetFileAclsError() throws Exception {
-    
+
     RepositoryFileAclDto mockRepositoryFileAclDto = mock( RepositoryFileAclDto.class );
 
     Messages mockMessages = mock( Messages.class );
@@ -854,7 +853,7 @@ public class FileResourceTest {
 
   @Test
   public void testSetContentCreator() throws Exception {
-    
+
     RepositoryFileDto mockRepositoryFileDto = mock( RepositoryFileDto.class );
 
     doNothing().when( fileResource.fileService ).doSetContentCreator( PATH_ID, mockRepositoryFileDto );
@@ -871,7 +870,7 @@ public class FileResourceTest {
 
   @Test
   public void testSetContentCreatorError() throws Exception {
-    
+
     RepositoryFileDto mockRepositoryFileDto = mock( RepositoryFileDto.class );
 
     Response mockNotFoundResponse = mock( Response.class );
@@ -907,7 +906,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetFileLocales() throws Exception {
-    
+
 
     List<LocaleMapDto> mockList = mock( List.class );
     doReturn( mockList ).when( fileResource.fileService ).doGetFileLocales( PATH_ID );
@@ -920,7 +919,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetFileLocalesError() throws Exception {
-    
+
 
     Messages mockMessages = mock( Messages.class );
     doReturn( mockMessages ).when( fileResource ).getMessagesInstance();
@@ -946,7 +945,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetLocaleProperties() {
-    
+
     String locale = "locale";
 
     List<StringKeyStringValueDto> mockList = mock( List.class );
@@ -958,7 +957,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoDeleteLocale() throws Exception {
-    
+
     String locale = "locale";
 
     doNothing().when( fileResource.fileService ).doDeleteLocale( PATH_ID, locale );
@@ -975,7 +974,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoDeleteLocaleError() throws Exception {
-    
+
     String locale = "locale";
 
     Throwable mockThrowable = mock( RuntimeException.class );
@@ -1017,7 +1016,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetCanAccessList() {
-    
+
     String permissions = "permissions";
 
     List<Setting> mockList = mock( List.class );
@@ -1031,7 +1030,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetCanAccess() {
-    
+
     String permissions = "permissions";
 
     String canAccess = "canAccess";
@@ -1101,7 +1100,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetFileAcl() {
-    
+
 
     RepositoryFileAclDto mockRepositoryFileAclDto = mock( RepositoryFileAclDto.class );
     doReturn( mockRepositoryFileAclDto ).when( fileResource.fileService ).doGetFileAcl( PATH_ID );
@@ -1112,7 +1111,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetProperties() throws Exception {
-    
+
 
     RepositoryFileDto mockRepositoryFileDto = mock( RepositoryFileDto.class );
     doReturn( mockRepositoryFileDto ).when( fileResource.fileService ).doGetProperties( PATH_ID );
@@ -1125,7 +1124,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetPropertiesError() throws Exception {
-    
+
 
     Exception mockFileNotFoundException = mock( FileNotFoundException.class );
     doThrow( mockFileNotFoundException ).when( fileResource.fileService ).doGetProperties( PATH_ID );
@@ -1143,7 +1142,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetContentCreator() throws Exception {
-    
+
 
     RepositoryFileDto mockRepositoryFileDto = mock( RepositoryFileDto.class );
     doReturn( mockRepositoryFileDto ).when( fileResource.fileService ).doGetContentCreator( PATH_ID );
@@ -1156,7 +1155,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetContentCreatorError() throws Exception {
-    
+
 
     Throwable mockThrowable = mock( RuntimeException.class );
     doThrow( mockThrowable ).when( fileResource.fileService ).doGetContentCreator( PATH_ID );
@@ -1169,7 +1168,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetGeneratedContent() throws Exception {
-    
+
 
     List<RepositoryFileDto> mockList = mock( List.class );
     doReturn( mockList ).when( fileResource.fileService ).doGetGeneratedContent( PATH_ID );
@@ -1182,7 +1181,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetGeneratedContentError() throws Exception {
-    
+
 
     Exception mockFileNotFoundException = mock( FileNotFoundException.class );
     doThrow( mockFileNotFoundException ).when( fileResource.fileService ).doGetGeneratedContent( PATH_ID );
@@ -1208,7 +1207,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetGeneratedContentForUser() throws Exception {
-    
+
     String user = "user";
 
     List<RepositoryFileDto> mockList = mock( List.class );
@@ -1222,7 +1221,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetGeneratedContentForUserError() throws Exception {
-    
+
     String user = "user";
 
     Exception mockFileNotFoundException = mock( FileNotFoundException.class );
@@ -1284,7 +1283,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetTree() {
-    
+
     Integer depth = 0;
     String filter = "filter";
     Boolean showHidden = Boolean.TRUE;
@@ -1302,7 +1301,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetChildren() {
-    
+
     String filter = "filter";
     Boolean showHidden = Boolean.TRUE;
     Boolean includeAcls = Boolean.TRUE;
@@ -1331,7 +1330,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetMetadata() throws Exception {
-    
+
 
     List<StringKeyStringValueDto> mockList = mock( List.class );
     doReturn( mockList ).when( fileResource.fileService ).doGetMetadata( PATH_ID );
@@ -1344,7 +1343,7 @@ public class FileResourceTest {
 
   @Test
   public void testDoGetMetadataError() throws Exception {
-    
+
 
     Exception mockFileNotFoundException = mock( FileNotFoundException.class );
     doThrow( mockFileNotFoundException ).when( fileResource.fileService ).doGetMetadata( PATH_ID );
@@ -1390,26 +1389,26 @@ public class FileResourceTest {
   public void testDoRenameWithoutExtension() throws Exception {
     Response testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
     assertEquals( Status.INTERNAL_SERVER_ERROR.getStatusCode(), testResponse.getStatus() );
-    
+
     verify( fileResource, times( 1 ) ).buildServerErrorResponse( anyString() );
   }
-  
+
   @Test
   public void testDoRenameIncorrectExtension() throws Exception {
     Response testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WRONG_EXTENSION );
     assertEquals( Status.INTERNAL_SERVER_ERROR.getStatusCode(), testResponse.getStatus() );
-    
+
     verify( fileResource, times( 1 ) ).buildServerErrorResponse( anyString() );
   }
-  
+
   @Test
   public void testDoRenameCorrectExtension() throws Exception {
     Response testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE );
     assertEquals( Status.OK.getStatusCode(), testResponse.getStatus() );
-    
+
     verify( fileResource, times( 1 ) ).buildOkResponse( anyString() );
   }
-  
+
   @Test
   public void testDoRenameError() throws Exception {
     Throwable mockThrowable = mock( RuntimeException.class );

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
@@ -146,11 +146,12 @@ public class FileServiceTest {
   @Test
   public void filesOverwrittenWhenConflict_overwriteMode() throws Exception {
     FileService fileService = mock( FileService.class );
-    mockSession(fileService, USER_NAME );
+    mockSession( fileService, USER_NAME );
     mockDoRestoreInHomeDir( fileService );
     final String filesToRestore = params;
 
-    when( fileService.getFolderFileIdsThatConflictWithSource( PATH_USER_HOME_FOLDER, filesToRestore ) ).thenCallRealMethod();
+    when( fileService.getFolderFileIdsThatConflictWithSource( PATH_USER_HOME_FOLDER, filesToRestore ) )
+      .thenCallRealMethod();
     when( fileService.getCommaSeparatedFileIds( anyListOf( String.class ) ) ).thenCallRealMethod();
 
     boolean result = fileService.doRestoreFilesInHomeDir( filesToRestore, FileService.MODE_OVERWRITE );
@@ -165,7 +166,7 @@ public class FileServiceTest {
   @Test
   public void filesOverwrittenWhenNoConflict_overwriteMode() throws Exception {
     FileService fileService = mock( FileService.class );
-    mockSession(fileService,  USER_NAME );
+    mockSession( fileService, USER_NAME );
     final String filesToRestore = params;
 
     when( fileService.doRestoreFilesInHomeDir( filesToRestore, FileService.MODE_OVERWRITE ) ).thenCallRealMethod();
@@ -232,7 +233,7 @@ public class FileServiceTest {
       .thenReturn( homeFolderFiles );
 
     when( fileService.getRepository() ).thenReturn( iUnifiedRepository );
-    when( fileService.doRestoreFilesInHomeDir( eq(params), anyInt() ) ).thenCallRealMethod();
+    when( fileService.doRestoreFilesInHomeDir( eq( params ), anyInt() ) ).thenCallRealMethod();
     RepositoryFile mockRepoFile1 = getMockedRepoFile( FILE_1 );
     RepositoryFile mockRepoFile2 = getMockedRepoFile( FILE_2 );
     when( iUnifiedRepository.getFileById( eq( FILE_1 ) ) ).thenReturn( mockRepoFile1 );
@@ -1400,7 +1401,8 @@ public class FileServiceTest {
 
     try {
       doReturn( fileDetailsMock ).when( fileService ).doGetProperties( pathId );
-      List<RepositoryFileDto> list = fileService.searchGeneratedContent(userFolder, lineageId, QuartzScheduler.RESERVEDMAPKEY_LINEAGE_ID );
+      List<RepositoryFileDto> list =
+        fileService.searchGeneratedContent( userFolder, lineageId, QuartzScheduler.RESERVEDMAPKEY_LINEAGE_ID );
       assertEquals( list.size(), 1 );
     } catch ( FileNotFoundException e ) {
       e.printStackTrace();
@@ -1423,7 +1425,7 @@ public class FileServiceTest {
 
     try {
       doReturn( null ).when( fileService ).doGetProperties( pathId );
-      fileService.searchGeneratedContent(userFolder, lineageId, QuartzScheduler.RESERVEDMAPKEY_LINEAGE_ID );
+      fileService.searchGeneratedContent( userFolder, lineageId, QuartzScheduler.RESERVEDMAPKEY_LINEAGE_ID );
       fail();
     } catch ( FileNotFoundException e ) {
     }

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/utils/FileUtilsTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/utils/FileUtilsTest.java
@@ -1,0 +1,53 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources.utils;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class FileUtilsTest {
+
+  @Test
+  public void convertCommaSeparatedString() {
+    String comma = ",";
+    String string2 = "string2";
+    String string1 = "string1";
+
+    String commaSeparatedStr = string1 + comma + string2;
+    String[] result = FileUtils.convertCommaSeparatedStringToArray( commaSeparatedStr );
+    assertEquals( result.length, 2 );
+    assertEquals( result[ 0 ], string1 );
+    assertEquals( result[ 1 ], string2 );
+  }
+
+  @Test
+  public void convertSingleString() {
+    String string = "string";
+
+    String[] result = FileUtils.convertCommaSeparatedStringToArray( string );
+    assertEquals( result.length, 1 );
+    assertEquals( result[ 0 ], string );
+  }
+
+  @Test( expected = IllegalArgumentException.class)
+  public void convertEmptyString() {
+    FileUtils.convertCommaSeparatedStringToArray( StringUtils.EMPTY );
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/utils/FileUtilsTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/utils/FileUtilsTest.java
@@ -46,7 +46,7 @@ public class FileUtilsTest {
     assertEquals( result[ 0 ], string );
   }
 
-  @Test( expected = IllegalArgumentException.class)
+  @Test( expected = IllegalArgumentException.class )
   public void convertEmptyString() {
     FileUtils.convertCommaSeparatedStringToArray( StringUtils.EMPTY );
   }

--- a/user-console/source/org/pentaho/mantle/client/commands/RestoreFileCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/RestoreFileCommand.java
@@ -210,13 +210,14 @@ public class RestoreFileCommand implements Command {
             }
 
             public void okPressed() {
-              String restoreFilesUrl = contextURL + "api/repo/files/restore?overwriteMode=" + overwriteDialog.getOverwriteMode(); //$NON-NLS-1$
+              String restoreFilesUrl =
+                contextURL + "api/repo/files/restore?overwriteMode=" + overwriteDialog.getOverwriteMode(); //$NON-NLS-1$
               RequestBuilder builder = new RequestBuilder( RequestBuilder.PUT, restoreFilesUrl );
               try {
                 builder.sendRequest( filesList, new RequestCallback() {
                   @Override
                   public void onResponseReceived( Request request, Response response ) {
-                    if (response.getStatusCode() == Response.SC_OK) {
+                    if ( response.getStatusCode() == Response.SC_OK ) {
                       new RefreshRepositoryCommand().execute( false );
                       event.setMessage( "Success" );
                       EventBusUtil.EVENT_BUS.fireEvent( event );
@@ -237,10 +238,7 @@ public class RestoreFileCommand implements Command {
           };
           overwriteDialog.setCallback( callback );
           overwriteDialog.center();
-        }
-        // We can't write to origin file folder, and there are
-        // no files in homeFolder with same names and extension
-        else if ( restoreResponseStatusCode == Response.SC_TEMPORARY_REDIRECT ) {
+        } else if ( restoreResponseStatusCode == Response.SC_TEMPORARY_REDIRECT ) {
           String moveFilesURL = contextURL + "api/repo/files/" + encodedUserHomeFolderPath + "/move";
           RequestBuilder builder = new RequestBuilder( RequestBuilder.PUT, moveFilesURL );
           try {
@@ -268,7 +266,7 @@ public class RestoreFileCommand implements Command {
     restoreFileWarningDialogBox.center();
   }
 
-  public void showErrorDialogBox(SolutionFileActionEvent event) {
+  public void showErrorDialogBox( SolutionFileActionEvent event ) {
     MessageDialogBox dialogBox =
       new MessageDialogBox( Messages.getString( "error" ), Messages.getString( "restoreError" ), //$NON-NLS-1$ //$NON-NLS-2$
         false, false, true );

--- a/user-console/source/org/pentaho/mantle/client/commands/RestoreFileCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/RestoreFileCommand.java
@@ -24,18 +24,23 @@ import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.http.client.RequestException;
 import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.HTML;
+import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
+import org.pentaho.gwt.widgets.client.dialogs.PromptDialogBox;
 import org.pentaho.gwt.widgets.client.filechooser.FileChooserDialog;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFile;
+import org.pentaho.mantle.client.dialogs.OverwritePromptDialog;
 import org.pentaho.mantle.client.events.EventBusUtil;
 import org.pentaho.mantle.client.events.SolutionFileActionEvent;
 import org.pentaho.mantle.client.messages.Messages;
+import org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel;
 
 import java.util.List;
 
 /**
  * @author wseyler
- * 
+ *
  */
 public class RestoreFileCommand implements Command {
   String moduleBaseURL = GWT.getModuleBaseURL();
@@ -76,7 +81,7 @@ public class RestoreFileCommand implements Command {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see com.google.gwt.user.client.Command#execute()
    */
   @Override
@@ -118,11 +123,38 @@ public class RestoreFileCommand implements Command {
         }
 
         @Override
-        public void onResponseReceived( Request request, Response response ) {
-          if ( response.getStatusCode() == 200 ) {
+        public void onResponseReceived( final Request request, final Response response ) {
+          if ( response.getStatusCode() == Response.SC_OK ) {
             new RefreshRepositoryCommand().execute( false );
             event.setMessage( "Success" );
             EventBusUtil.EVENT_BUS.fireEvent( event );
+          } else if ( response.getStatusCode() == Response.SC_CONFLICT
+            || response.getStatusCode() == Response.SC_TEMPORARY_REDIRECT ) {
+            final int restoreResponseStatusCode = response.getStatusCode();
+
+            final String userHomeDirUrl = GWT.getHostPageBaseURL() + "api/session/userWorkspaceDir";
+
+            final RequestBuilder builder = new RequestBuilder( RequestBuilder.GET, userHomeDirUrl );
+            try {
+              // Get user home folder string
+              builder.sendRequest( "", new RequestCallback() {
+                @Override
+                public void onResponseReceived( final Request request, final Response response ) {
+                  if ( response.getStatusCode() == 200 ) {
+                    // API returns /user/home_folder/workspace
+                    String userHomeFolderPath = response.getText().replaceAll( "/workspace", "" );
+                    performRestoreToHomeFolder( filesList, restoreResponseStatusCode, userHomeFolderPath, event );
+                  }
+                }
+
+                @Override
+                public void onError( Request request, Throwable exception ) {
+                  showErrorDialogBox( event );
+                }
+              } );
+            } catch ( RequestException e ) {
+              showErrorDialogBox( event );
+            }
           } else {
             MessageDialogBox dialogBox =
                 new MessageDialogBox(
@@ -137,14 +169,114 @@ public class RestoreFileCommand implements Command {
         }
       } );
     } catch ( RequestException e ) {
-      MessageDialogBox dialogBox =
-          new MessageDialogBox( Messages.getString( "error" ), Messages.getString( "restoreError" ), //$NON-NLS-1$ //$NON-NLS-2$
-              false, false, true );
-      dialogBox.center();
-      event.setMessage( Messages.getString( "restoreError" ) );
-      EventBusUtil.EVENT_BUS.fireEvent( event );
+      showErrorDialogBox( event );
     }
   }
+
+  private void performRestoreToHomeFolder( final String filesList, final int restoreResponseStatusCode,
+                                           final String userHomeFolderPath, final SolutionFileActionEvent event ) {
+
+    final String encodedUserHomeFolderPath = SolutionBrowserPanel.pathToId( userHomeFolderPath );
+    String fileListDescription = "files";
+    // if there is one file
+    if ( filesList.split( "," ).length == 1 ) {
+      fileListDescription = "file";
+    }
+
+    HTML messageTextBox = new HTML();
+    String cannotRestoreToOrigFolder = Messages.getString( "cannotRestoreToOriginFolder", fileListDescription );
+    String restoreToHomeFolder = Messages.getString( "restoreToHomeFolder", userHomeFolderPath );
+
+    messageTextBox.setHTML( cannotRestoreToOrigFolder + "<br> <br>" + restoreToHomeFolder + "<br>" );
+    final PromptDialogBox restoreFileWarningDialogBox =
+      new PromptDialogBox( Messages.getString( "couldNotWriteToFolder" ), "Restore File", "Cancel", true, true );
+    restoreFileWarningDialogBox.setContent( messageTextBox );
+
+    final IDialogCallback callback = new IDialogCallback() {
+
+      public void cancelPressed() {
+        restoreFileWarningDialogBox.hide();
+      }
+
+      public void okPressed() {
+        // We can't write to origin file folder, and there are
+        // files in homeFolder with same names
+        if ( restoreResponseStatusCode == Response.SC_CONFLICT ) {
+          final OverwritePromptDialog overwriteDialog = new OverwritePromptDialog();
+          final IDialogCallback callback = new IDialogCallback() {
+            public void cancelPressed() {
+              event.setMessage( "Cancel" );
+              overwriteDialog.hide();
+            }
+
+            public void okPressed() {
+              String restoreFilesUrl = contextURL + "api/repo/files/restore?overwriteMode=" + overwriteDialog.getOverwriteMode(); //$NON-NLS-1$
+              RequestBuilder builder = new RequestBuilder( RequestBuilder.PUT, restoreFilesUrl );
+              try {
+                builder.sendRequest( filesList, new RequestCallback() {
+                  @Override
+                  public void onResponseReceived( Request request, Response response ) {
+                    if (response.getStatusCode() == Response.SC_OK) {
+                      new RefreshRepositoryCommand().execute( false );
+                      event.setMessage( "Success" );
+                      EventBusUtil.EVENT_BUS.fireEvent( event );
+                    } else {
+                      showErrorDialogBox( event );
+                    }
+                  }
+
+                  @Override
+                  public void onError( Request request, Throwable exception ) {
+                    showErrorDialogBox( event );
+                  }
+                } );
+              } catch ( RequestException e ) {
+                showErrorDialogBox( event );
+              }
+            }
+          };
+          overwriteDialog.setCallback( callback );
+          overwriteDialog.center();
+        }
+        // We can't write to origin file folder, and there are
+        // no files in homeFolder with same names and extension
+        else if ( restoreResponseStatusCode == Response.SC_TEMPORARY_REDIRECT ) {
+          String moveFilesURL = contextURL + "api/repo/files/" + encodedUserHomeFolderPath + "/move";
+          RequestBuilder builder = new RequestBuilder( RequestBuilder.PUT, moveFilesURL );
+          try {
+            builder.sendRequest( filesList, new RequestCallback() {
+              @Override
+              public void onResponseReceived( Request request, Response response ) {
+                new RefreshRepositoryCommand().execute( false );
+                event.setMessage( "Success" );
+                EventBusUtil.EVENT_BUS.fireEvent( event );
+              }
+
+              @Override
+              public void onError( Request request, Throwable exception ) {
+                showErrorDialogBox( event );
+              }
+            } );
+          } catch ( RequestException e ) {
+            showErrorDialogBox( event );
+          }
+        }
+      }
+    };
+
+    restoreFileWarningDialogBox.setCallback( callback );
+    restoreFileWarningDialogBox.center();
+  }
+
+  public void showErrorDialogBox(SolutionFileActionEvent event) {
+    MessageDialogBox dialogBox =
+      new MessageDialogBox( Messages.getString( "error" ), Messages.getString( "restoreError" ), //$NON-NLS-1$ //$NON-NLS-2$
+        false, false, true );
+    dialogBox.center();
+    event.setMessage( Messages.getString( "restoreError" ) );
+    EventBusUtil.EVENT_BUS.fireEvent( event );
+  }
+
   private static native void setBrowseRepoDirty( boolean isDirty )
   /*-{
     $wnd.mantle_isBrowseRepoDirty=isDirty;


### PR DESCRIPTION
- Expanded doRestore functionality (added ability to restore files in home folder, choosing one of overwrite modes)
- Created new user dialog, suggesting user to restore files in his home folder when he has no write permissions to original file folder.
- Test written
- Checkstyle applied

Should be merged after https://github.com/pentaho/pentaho-commons-gwt-modules/pull/336