### PR TITLE
[SP-2333] - Backport of BISERVER-12506 - Folder creation: reserved character validation is only being done client-side (6.0 Suite)

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/DirectoryResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/DirectoryResource.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
@@ -73,16 +73,15 @@ public class DirectoryResource extends AbstractJaxRSResource {
    *  </pre>
    */
   @PUT
-  @Path ( "{pathId : .+}" )
-  @Consumes ( { WILDCARD } )
-  @StatusCodes ( {
-      @ResponseCode ( code = 200, condition = "Successfully created folder." ),
-      @ResponseCode ( code = 409, condition = "Path already exists." ),
-      @ResponseCode ( code = 500, condition = "Server Error." )
-  } )
+  @Path( "{pathId : .+}" )
+  @Consumes( { WILDCARD } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully created folder." ),
+    @ResponseCode( code = 409, condition = "Path already exists." ),
+    @ResponseCode( code = 500, condition = "Server Error." ) } )
   public Response createDirs( @PathParam ( "pathId" ) String pathId ) {
     try {
-      if ( fileService.doCreateDir( pathId ) ) {
+      if ( fileService.doCreateDirSafe( pathId ) ) {
         return Response.ok().build();
       } else {
         return Response.status( Response.Status.CONFLICT ).entity( "couldNotCreateFolderDuplicate" ).build();

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
@@ -1981,7 +1981,7 @@ public class FileResource extends AbstractJaxRSResource {
   } )
   public Response doCreateDirs( @PathParam ( "pathId" ) String pathId ) {
     try {
-      if ( fileService.doCreateDir( pathId ) ) {
+      if ( fileService.doCreateDirSafe( pathId ) ) {
         return buildOkResponse();
       } else {
         return Response.status( Response.Status.CONFLICT ).entity( "couldNotCreateFolderDuplicate" ).build();

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/utils/FileUtils.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/utils/FileUtils.java
@@ -1,6 +1,25 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
 package org.pentaho.platform.web.http.api.resources.utils;
 
-
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.util.RepositoryPathEncoder;
@@ -12,17 +31,34 @@ public class FileUtils {
   private static final Log logger = LogFactory.getLog( FileUtils.class );
 
   public static String idToPath( String pathId ) {
-    String path = null;
     // slashes in pathId are illegal.. we scrub them out so the file will not be found
     // if the pathId was given in slash separated format
     if ( pathId.contains( PATH_SEPARATOR ) ) {
       logger.warn( Messages.getInstance().getString( "FileResource.ILLEGAL_PATHID", pathId ) );
     }
-    path = pathId.replaceAll( PATH_SEPARATOR, ENCODED_PATH_SEPARATOR );
+    String path = pathId.replaceAll( PATH_SEPARATOR, ENCODED_PATH_SEPARATOR );
     path = RepositoryPathEncoder.decodeRepositoryPath( path );
     if ( !path.startsWith( PATH_SEPARATOR ) ) {
       path = PATH_SEPARATOR + path;
     }
     return path;
+  }
+
+  /**
+   * Checks whether {@code path} contains any of {@code reserved}.
+   *
+   * @param path unix-style path
+   * @param reserved array of reserved characters
+   * @return {@code true} if any of {@code reserved} is contained by {@code path}
+   */
+  public static boolean containsReservedCharacter( String path, char[] reserved ) {
+    while ( !path.isEmpty() ) {
+      String name = FilenameUtils.getName( path );
+      if ( StringUtils.containsAny( name, reserved ) ) {
+        return true;
+      }
+      path = FilenameUtils.getPathNoEndSeparator( path );
+    }
+    return false;
   }
 }

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/FileService_CreateDir_IT.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/FileService_CreateDir_IT.java
@@ -1,0 +1,134 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources.services;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.repository2.unified.DefaultUnifiedRepositoryBase;
+import org.pentaho.platform.util.RepositoryPathEncoder;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+@RunWith( SpringJUnit4ClassRunner.class )
+@ContextConfiguration( locations = { "classpath:/repository.spring.xml",
+  "classpath:/repository-test-override.spring.xml" } )
+public class FileService_CreateDir_IT implements ApplicationContextAware {
+
+  @BeforeClass
+  public static void init() throws Exception {
+    DefaultUnifiedRepositoryBase.setUpClass();
+  }
+
+  @AfterClass
+  public static void dispose() throws Exception {
+    DefaultUnifiedRepositoryBase.tearDownClass();
+  }
+
+  @Override
+  public void setApplicationContext( final ApplicationContext applicationContext ) throws BeansException {
+    testBase.setApplicationContext( applicationContext );
+    repository = (IUnifiedRepository) applicationContext.getBean( "unifiedRepository" );
+  }
+
+  private final DefaultUnifiedRepositoryBase testBase = new DefaultUnifiedRepositoryBase();
+  private IUnifiedRepository repository;
+
+  private FileService service;
+
+  @Before
+  public void setUp() throws Exception {
+    testBase.setUp();
+    testBase.loginAsSysTenantAdmin();
+
+    service = new FileService();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    testBase.tearDown();
+  }
+
+
+  @Test
+  public void doCreateDir_ValidName() throws Exception {
+    assertTrue( callCreateDirSafe( "/public/valid-name" ) );
+    assertNotNull( repository.getFile( "/public/valid-name" ) );
+  }
+
+  @Test
+  public void doCreateDir_ValidName_WithDot() throws Exception {
+    assertTrue( callCreateDirSafe( "/public/valid.name" ) );
+    assertNotNull( repository.getFile( "/public/valid.name" ) );
+  }
+
+  @Test( expected = FileService.InvalidNameException.class )
+  public void doCreateDir_InvalidName_Dot() throws Exception {
+    callCreateDirSafe( "/public/." );
+  }
+
+  @Test( expected = FileService.InvalidNameException.class )
+  public void doCreateDir_InvalidName_TwoDots() throws Exception {
+    callCreateDirSafe( "/public/.." );
+  }
+
+  @Test( expected = FileService.InvalidNameException.class )
+  public void doCreateDir_InvalidName_NewLine() throws Exception {
+    callCreateDirSafe( "/public/pre-\n-post" );
+  }
+
+  @Test( expected = FileService.InvalidNameException.class )
+  public void doCreateDir_InvalidName_Slash() throws Exception {
+    service.doCreateDirSafe( ":public:pre-/-post" );
+  }
+
+  @Test( expected = FileService.InvalidNameException.class )
+  public void doCreateDir_InvalidName_BackSlash() throws Exception {
+    callCreateDirSafe( "/public/pre-\\-post" );
+  }
+
+  @Test
+  public void doCreateDir_Exists() throws Exception {
+    repository.createFolder(
+      repository.getFile( "/public" ).getId(),
+      new RepositoryFile.Builder( "existing" ).folder( true ).build(),
+      null
+    );
+    assertNotNull( repository.getFile( "/public/existing" ) );
+
+    assertFalse( "When folder exists, false should be returned", callCreateDirSafe( "/public/existing" ) );
+  }
+
+  private boolean callCreateDirSafe( String path ) throws Exception {
+    String pathId = RepositoryPathEncoder.encodeRepositoryPath( path );
+    return service.doCreateDirSafe( pathId );
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/utils/FileUtilsTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/utils/FileUtilsTest.java
@@ -1,0 +1,72 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.pentaho.platform.web.http.api.resources.utils.FileUtils.containsReservedCharacter;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class FileUtilsTest {
+
+  private static final char[] TEST_RESERVED = new char[] {'/', '%'};
+
+  @Test
+  public void containsReservedCharacter_Empty() {
+    assertFalse( containsReservedCharacter( "", TEST_RESERVED ) );
+  }
+
+  @Test
+  public void containsReservedCharacter_Root() {
+    assertFalse( containsReservedCharacter( "/", TEST_RESERVED ) );
+  }
+
+  @Test
+  public void containsReservedCharacter_Folder_NoSlashAtEnd_Ok() {
+    assertFalse( containsReservedCharacter( "/a", TEST_RESERVED ) );
+  }
+
+  @Test
+  public void containsReservedCharacter_Folder_NoSlashAtEnd_Bad() {
+    assertTrue( containsReservedCharacter( "/a%", TEST_RESERVED ) );
+  }
+
+  @Test
+  public void containsReservedCharacter_Folder_SlashAtEnd_Ok() {
+    assertFalse( containsReservedCharacter( "/a/", TEST_RESERVED ) );
+  }
+
+  @Test
+  public void containsReservedCharacter_Folder_SlashAtEnd_Bad() {
+    assertTrue( containsReservedCharacter( "/a%/", TEST_RESERVED ) );
+  }
+
+  @Test
+  public void containsReservedCharacter_File_Ok() {
+    assertFalse( containsReservedCharacter( "/a/b/c/qwerty.txt", TEST_RESERVED ) );
+  }
+
+  @Test
+  public void containsReservedCharacter_File_Bad() {
+    assertTrue( containsReservedCharacter( "/a/b/c/qwerty%.txt", TEST_RESERVED ) );
+  }
+}

--- a/repository/test-src/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryBase.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryBase.java
@@ -274,7 +274,7 @@ public class DefaultUnifiedRepositoryBase implements ApplicationContextAware {
     assertNotNull( SimpleJcrTestUtils.getItem( testJcrTemplate, rootFolderPath ) );
   }
 
-  protected void loginAsSysTenantAdmin() {
+  public void loginAsSysTenantAdmin() {
     login( sysAdminUserName, systemTenant, new String[]{ tenantAdminRoleName, tenantAuthenticatedRoleName } );
   }
 


### PR DESCRIPTION
- introduce new method in FileService with validation of input path
- change FileResource and DirectoryResource to use it
- extract common procedure for validation
- add tests
- fix Checkstyle violations for all affected classes and make some cleanup
(adopted from commit bfa720450f2f982e238862dd1f040e9e054ece35)

@rmansoor, review it please. This is a backport of https://github.com/pentaho/pentaho-platform/pull/2722 