### PR TITLE
[SP-2345] - Backport of PPP-3452 - Mantle uses eval() for parsing JSON - this is a tremendous security vulnerability. It should use JSON.parse (5.4 Suite)

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/admin/ContentCleanerPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/admin/ContentCleanerPanel.java
@@ -283,7 +283,7 @@ public class ContentCleanerPanel extends DockPanel implements ISysAdminPanel {
     if (null == json || "" == json) {
       return null;
     }
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj;
   }-*/;
 

--- a/user-console/source/org/pentaho/mantle/client/admin/JsEmailConfiguration.java
+++ b/user-console/source/org/pentaho/mantle/client/admin/JsEmailConfiguration.java
@@ -89,7 +89,7 @@ public class JsEmailConfiguration extends JavaScriptObject {
 
   private static final native JavaScriptObject parseEmailConfig( String json )
   /*-{
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj;
   }-*/;
 }

--- a/user-console/source/org/pentaho/mantle/client/admin/PermissionsPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/admin/PermissionsPanel.java
@@ -211,7 +211,7 @@ public class PermissionsPanel extends VerticalPanel {
   private final native JavaScriptObject parseRoleMappings( String json )
   /*-{
     var arr = [];
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     if (obj != null) {
       if (obj.assignments.constructor.toString().indexOf("Array") == -1) {
         arr.push(obj.assignments);

--- a/user-console/source/org/pentaho/mantle/client/commands/NewDropdownCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/NewDropdownCommand.java
@@ -213,7 +213,7 @@ public class NewDropdownCommand extends AbstractCommand {
   
   private native JsArray<JsCreateNewConfig> parseJson( String json )
   /*-{
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj.Item;
   }-*/;
 

--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/SelectUserOrRoleDialog.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/fileproperties/SelectUserOrRoleDialog.java
@@ -150,13 +150,13 @@ public class SelectUserOrRoleDialog extends PromptDialogBox {
 
   private final native JsArrayString parseUsersJson( String json )
   /*-{
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj.users;
   }-*/;
 
   private final native JsArrayString parseRolesJson( String json )
   /*-{
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj.roles;
   }-*/;
 

--- a/user-console/source/org/pentaho/mantle/client/ui/xul/JsPerspective.java
+++ b/user-console/source/org/pentaho/mantle/client/ui/xul/JsPerspective.java
@@ -43,7 +43,7 @@ public class JsPerspective extends JavaScriptObject {
 
   public static final native JsArray<JsPerspective> parseJson( String json )
   /*-{
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj.pluginPerspective;
   }-*/;
 

--- a/user-console/source/org/pentaho/mantle/client/ui/xul/JsTheme.java
+++ b/user-console/source/org/pentaho/mantle/client/ui/xul/JsTheme.java
@@ -32,7 +32,7 @@ public class JsTheme extends JavaScriptObject {
 
   public static final native JsArray<JsTheme> getThemes( String json )
   /*-{
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
 
     // Sort themes alphabetically
     obj.theme = obj.theme.sort(function(a, b) {

--- a/user-console/source/org/pentaho/mantle/client/ui/xul/JsXulOverlay.java
+++ b/user-console/source/org/pentaho/mantle/client/ui/xul/JsXulOverlay.java
@@ -40,7 +40,7 @@ public class JsXulOverlay extends JavaScriptObject {
 
   public static final native JsArray<JsXulOverlay> parseJson( String json )
   /*-{
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj.overlay;
   }-*/;
 

--- a/user-console/source/org/pentaho/mantle/client/usersettings/JsSetting.java
+++ b/user-console/source/org/pentaho/mantle/client/usersettings/JsSetting.java
@@ -32,7 +32,7 @@ public class JsSetting extends JavaScriptObject {
   public static final native JsArray<JsSetting> parseSettingsJson( String json )
   /*-{
     if(json == null || json === '') { return null; }
-    var obj = eval('(' + json + ')');
+    var obj = JSON.parse(json);
     return obj != null ? obj.setting : obj;
   }-*/;
 

--- a/user-console/source/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/user-console/source/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -1089,7 +1089,7 @@ public class SchedulesPanel extends SimplePanel {
 
   private native JsArray<JsJob> parseJson( String json )
   /*-{
-      var obj = eval('(' + json + ')');
+      var obj = JSON.parse(json);
       if (obj != null && obj.hasOwnProperty("job")) {
           return obj.job;
       }
@@ -1098,7 +1098,7 @@ public class SchedulesPanel extends SimplePanel {
 
   private native JsJob parseJsonJob( String json )
   /*-{
-      var obj = eval('(' + json + ')');
+      var obj = JSON.parse(json);
       return obj;
   }-*/;
 


### PR DESCRIPTION
- replace all eval() with JSON.parse() in self-written javascript functions (cherry picked from commit 515f8a6)

@pentaho-nbaker, @rmansoor, @pamval, review it please. This is a backport of #2742