### PR TITLE
[SP - 2397] - Backport of BISERVER-12614 - Changing password not active on BA cluster environment (6.0 Suite)

### DIFF
--- a/repository/src/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDao.java
+++ b/repository/src/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDao.java
@@ -120,6 +120,8 @@ public abstract class AbstractJcrBackedUserRoleDao implements IUserRoleDao {
 
   private UserCache userDetailsCache = new NullUserCache();
 
+  private boolean useJackrabbitUserCache = true;
+
   public AbstractJcrBackedUserRoleDao( ITenantedPrincipleNameResolver userNameUtils,
       ITenantedPrincipleNameResolver roleNameUtils, String authenticatedRoleName, String tenantAdminRoleName,
       String repositoryAdminUsername, IRepositoryFileAclDao repositoryFileAclDao, IRepositoryFileDao repositoryFileDao,
@@ -471,7 +473,10 @@ public abstract class AbstractJcrBackedUserRoleDao implements IUserRoleDao {
         new PentahoUser( tenantedUserNameUtils.getTenant( jackrabbitUser.getID() ), tenantedUserNameUtils
             .getPrincipleName( jackrabbitUser.getID() ), password, description, !jackrabbitUser.isDisabled() );
 
-    userCache.put( jackrabbitUser.getID(), pentahoUser );
+    if ( isUseJackrabbitUserCache() ) {
+      userCache.put( jackrabbitUser.getID(), pentahoUser );
+    }
+
     return pentahoUser;
   }
 
@@ -885,5 +890,13 @@ public abstract class AbstractJcrBackedUserRoleDao implements IUserRoleDao {
       }
     }
     return usersToBeRemoved.toArray( new String[0] );
+  }
+
+  public boolean isUseJackrabbitUserCache() {
+    return useJackrabbitUserCache;
+  }
+
+  public void setUseJackrabbitUserCache( boolean useJackrabbitUserCache ) {
+    this.useJackrabbitUserCache = useJackrabbitUserCache;
   }
 }

--- a/repository/src/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDao.java
+++ b/repository/src/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDao.java
@@ -36,6 +36,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.collections.map.LRUMap;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.AuthorizableExistsException;
@@ -448,9 +449,10 @@ public abstract class AbstractJcrBackedUserRoleDao implements IUserRoleDao {
     return getRoles( session, JcrTenantUtils.getCurrentTenant() );
   }
 
-  private IPentahoUser convertToPentahoUser( User jackrabbitUser ) throws RepositoryException {
-    if ( userCache.containsKey( jackrabbitUser.getID() ) ) {
-      return (IPentahoUser) userCache.get( jackrabbitUser.getID() );
+  @VisibleForTesting
+  IPentahoUser convertToPentahoUser( User jackrabbitUser ) throws RepositoryException {
+    if ( getUserCache().containsKey( jackrabbitUser.getID() ) ) {
+      return (IPentahoUser) getUserCache().get( jackrabbitUser.getID() );
     }
     IPentahoUser pentahoUser = null;
     Value[] propertyValues = null;
@@ -470,11 +472,11 @@ public abstract class AbstractJcrBackedUserRoleDao implements IUserRoleDao {
     }
 
     pentahoUser =
-        new PentahoUser( tenantedUserNameUtils.getTenant( jackrabbitUser.getID() ), tenantedUserNameUtils
+        new PentahoUser( getTenantedUserNameUtils().getTenant( jackrabbitUser.getID() ), getTenantedUserNameUtils()
             .getPrincipleName( jackrabbitUser.getID() ), password, description, !jackrabbitUser.isDisabled() );
 
     if ( isUseJackrabbitUserCache() ) {
-      userCache.put( jackrabbitUser.getID(), pentahoUser );
+      getUserCache().put( jackrabbitUser.getID(), pentahoUser );
     }
 
     return pentahoUser;
@@ -898,5 +900,10 @@ public abstract class AbstractJcrBackedUserRoleDao implements IUserRoleDao {
 
   public void setUseJackrabbitUserCache( boolean useJackrabbitUserCache ) {
     this.useJackrabbitUserCache = useJackrabbitUserCache;
+  }
+
+  @VisibleForTesting
+  LRUMap getUserCache() {
+    return userCache;
   }
 }

--- a/repository/test-src/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDaoTest.java
+++ b/repository/test-src/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDaoTest.java
@@ -1,0 +1,83 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.security.userroledao.jackrabbit;
+
+import org.apache.commons.collections.map.LRUMap;
+import org.apache.jackrabbit.api.security.user.User;
+import org.junit.Test;
+import org.pentaho.platform.api.mt.ITenantedPrincipleNameResolver;
+
+import javax.jcr.RepositoryException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link org.pentaho.platform.security.userroledao.jackrabbit.AbstractJcrBackedUserRoleDao}
+ * Class is created in order to have access to package-private methods.
+ *
+ * @author Yury_Bakhmutski
+ */
+public class AbstractJcrBackedUserRoleDaoTest {
+
+  @Test
+  public void testConvertToPentahoUserEnableCache() throws RepositoryException {
+    AbstractJcrBackedUserRoleDao abstractJcrBackedUserRoleDaoMock = mock( AbstractJcrBackedUserRoleDao.class );
+    doCallRealMethod().when( abstractJcrBackedUserRoleDaoMock ).convertToPentahoUser( any( User.class ) );
+
+    ITenantedPrincipleNameResolver resolverMock = mock( ITenantedPrincipleNameResolver.class );
+    when( abstractJcrBackedUserRoleDaoMock.getTenantedUserNameUtils() ).thenReturn( resolverMock );
+
+    when( abstractJcrBackedUserRoleDaoMock.isUseJackrabbitUserCache() ).thenReturn( true );
+
+    //Cache mocking
+    LRUMap cacheMock = mock( LRUMap.class );
+    when( abstractJcrBackedUserRoleDaoMock.getUserCache() ).thenReturn( cacheMock );
+
+    User userMock = mock( User.class );
+    abstractJcrBackedUserRoleDaoMock.convertToPentahoUser( userMock );
+
+    verify( cacheMock ).put( anyObject(), anyString() );
+  }
+
+  @Test
+  public void testConvertToPentahoUserDisableCache() throws RepositoryException {
+    AbstractJcrBackedUserRoleDao abstractJcrBackedUserRoleDaoMock = mock( AbstractJcrBackedUserRoleDao.class );
+    doCallRealMethod().when( abstractJcrBackedUserRoleDaoMock ).convertToPentahoUser( any( User.class ) );
+
+    ITenantedPrincipleNameResolver resolverMock = mock( ITenantedPrincipleNameResolver.class );
+    when( abstractJcrBackedUserRoleDaoMock.getTenantedUserNameUtils() ).thenReturn( resolverMock );
+
+    //Cache mocking
+    LRUMap cacheMock = mock( LRUMap.class );
+    when( abstractJcrBackedUserRoleDaoMock.getUserCache() ).thenReturn( cacheMock );
+
+    User userMock = mock( User.class );
+    abstractJcrBackedUserRoleDaoMock.convertToPentahoUser( userMock );
+
+    verify( cacheMock, never() ).put( anyObject(), anyString() );
+  }
+
+}


### PR DESCRIPTION
@pentaho-nbaker, @pamval, could you merge it please. This is backport of https://github.com/pentaho/pentaho-platform/pull/2718 to 6.0. Here is one for 5.4: https://github.com/pentaho/pentaho-platform/pull/2760