### PR TITLE
[BISERVER-12794] Permissions can delete but not restore file

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -348,7 +348,7 @@ public class FileResource extends AbstractJaxRSResource {
         if ( !fileService.canRestoreToFolderWithNoConflicts( getUserHomeFolder(), params ) ) {
           return buildStatusResponse( Response.Status.CONFLICT );
         } else {
-          return buildStatusResponse( Response.Status.TEMPORARY_REDIRECT );
+          return buildStatusResponse( Response.Status.NOT_ACCEPTABLE );
         }
       } catch ( InternalError e ) {
         logger.error( Messages.getInstance().getString( "FileResource.FILE_GET_LOCALES" ), e );

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/operations/CopyFilesOperation.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/operations/CopyFilesOperation.java
@@ -1,0 +1,355 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources.operations;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAdapter;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileDto;
+import org.pentaho.platform.web.http.api.resources.services.FileService;
+import org.pentaho.platform.web.http.api.resources.utils.FileUtils;
+import org.pentaho.platform.web.http.messages.Messages;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.pentaho.platform.web.http.api.resources.services.FileService.MODE_NO_OVERWRITE;
+import static org.pentaho.platform.web.http.api.resources.services.FileService.MODE_OVERWRITE;
+import static org.pentaho.platform.web.http.api.resources.utils.RepositoryFileHelper.getFileData;
+
+public class CopyFilesOperation {
+
+  private RepositoryFile destDir;
+  private List<String> sourceFileIds;
+  private String path;
+  private int mode;
+
+  private IUnifiedRepository repository;
+  private DefaultUnifiedRepositoryWebService defaultUnifiedRepositoryWebService;
+
+  private static final Log logger = LogFactory.getLog( FileService.class );
+  public static final Integer DEEPNESS_DEFAULT = 10;
+
+  public CopyFilesOperation( List<String> sourceFileIds, String destDirPath, int overrideMode ) {
+    this( PentahoSystem.get( IUnifiedRepository.class ), new DefaultUnifiedRepositoryWebService(), sourceFileIds,
+      destDirPath, overrideMode );
+  }
+
+  public CopyFilesOperation( IUnifiedRepository repository,
+                             DefaultUnifiedRepositoryWebService defaultUnifiedRepositoryWebService,
+                             List<String> sourceFileIds, String destDirPath, int overrideMode ) {
+
+    if ( repository == null ) {
+      throw new IllegalArgumentException( "repository cannot be null" );
+    }
+    this.repository = repository;
+
+    if ( defaultUnifiedRepositoryWebService == null ) {
+      throw new IllegalArgumentException( "defaultUnifiedRepositoryWebService  cannot be null" );
+    }
+    this.defaultUnifiedRepositoryWebService = defaultUnifiedRepositoryWebService;
+
+    if ( sourceFileIds == null ) {
+      throw new IllegalArgumentException( "sourceFileIds cannot be null" );
+    }
+
+    if ( sourceFileIds.isEmpty() ) {
+      throw new IllegalArgumentException( "Nothing to copy, list of files shouldn't be empty" );
+    }
+
+    this.sourceFileIds = sourceFileIds;
+
+    if ( destDirPath == null ) {
+      throw new IllegalArgumentException( "destDirPath cannot be null" );
+    }
+
+    destDir = getRepository().getFile( destDirPath );
+
+    if ( destDir == null ) {
+      throw new IllegalArgumentException( "Directory with destPath: " + destDirPath + " doesn't exist" );
+    }
+
+    if ( !destDir.isFolder() ) {
+      throw new IllegalArgumentException( destDirPath + " should be a folder" );
+    }
+
+
+    this.mode = overrideMode;
+    this.path = destDirPath;
+
+  }
+
+  public void execute() {
+    for ( String sourceFileId : getSourceFileIds() ) {
+      RepositoryFile sourceFile = getRepository().getFileById( sourceFileId );
+
+      if ( sourceFile == null ) {
+        logger.warn( "File with id: " + sourceFileId + " is not found" );
+        continue;
+      }
+
+      if ( mode == MODE_OVERWRITE ) {
+        copyOverrideMode( sourceFile );
+      } else if ( mode == MODE_NO_OVERWRITE ) {
+        copyNoOverrideMode( sourceFile );
+      } else {
+        copyRenameMode( sourceFile );
+      }
+    }
+  }
+
+  private void copyOverrideMode( RepositoryFile file ) {
+    if ( sourceAndDestDirAreSame( file.getPath() ) ) {
+      return;
+    }
+
+    RepositoryFileAcl acl = getRepository().getAcl( file.getId() );
+
+    RepositoryFile destFile = getRepository()
+      .getFile( destDir.getPath() + FileUtils.PATH_SEPARATOR + file.getName() );
+
+    if ( destFile == null ) {
+      // destFile doesn't exist so we'll create it.
+      RepositoryFile duplicateFile =
+        new RepositoryFile.Builder( file.getName() ).hidden( file.isHidden() ).versioned(
+          file.isVersioned() ).build();
+      final RepositoryFile repositoryFile =
+        getRepository()
+          .createFile( destDir.getId(), duplicateFile, getFileData( file ), acl,
+            null );
+      getRepository()
+        .setFileMetadata( repositoryFile.getId(), getRepository().getFileMetadata( file.getId() ) );
+
+      return;
+    }
+
+    RepositoryFileDto destFileDto = toFileDto( destFile, null, false );
+    destFileDto.setHidden( file.isHidden() );
+    destFile = toFile( destFileDto );
+
+    final RepositoryFile repositoryFile = getRepository().updateFile( destFile, getFileData( file ), null );
+    getRepository().updateAcl( acl );
+    getRepository()
+      .setFileMetadata( repositoryFile.getId(), getRepository().getFileMetadata( file.getId() ) );
+  }
+
+  private void copyNoOverrideMode( RepositoryFile repoFile ) {
+    if ( sourceAndDestDirAreSame( repoFile.getPath() ) ) {
+      return;
+    }
+
+    RepositoryFile destFile =
+      getRepository().getFile( destDir.getPath() + FileUtils.PATH_SEPARATOR + repoFile.getName() );
+
+    if ( destFile != null ) {
+      // file exists already
+      return;
+    }
+
+    final RepositoryFile repositoryFile;
+    final RepositoryFile duplicateFile;
+
+    if ( repoFile.isFolder() ) {
+      duplicateFile = repoFile.clone();
+      repositoryFile = getRepository()
+        .createFolder( destDir.getId(), duplicateFile, getRepository().getAcl( repoFile.getId() ), null );
+
+      performFolderDeepCopy( repoFile, repositoryFile, DEEPNESS_DEFAULT );
+    } else {
+      duplicateFile = new RepositoryFile.
+        Builder( repoFile.getName() )
+        .hidden( repoFile.isHidden() )
+        .folder( repoFile.isFolder() )
+        .versioned( repoFile.isVersioned() )
+        .build();
+
+      repositoryFile = getRepository()
+        .createFile( destDir.getId(), duplicateFile, getFileData( repoFile ),
+          getRepository().getAcl( repoFile.getId() ),
+          null );
+    }
+
+    getRepository()
+      .setFileMetadata( repositoryFile.getId(), getRepository().getFileMetadata( repoFile.getId() ) );
+  }
+
+  private void copyRenameMode( RepositoryFile repoFile ) {
+    // First try to see if regular name is available
+    String repoFileName = repoFile.getName();
+    String copyText = "";
+    String rootCopyText = "";
+    String nameNoExtension = repoFileName;
+    String extension = "";
+    int indexOfDot = repoFileName.lastIndexOf( '.' );
+    if ( !( indexOfDot == -1 ) ) {
+      nameNoExtension = repoFileName.substring( 0, indexOfDot );
+      extension = repoFileName.substring( indexOfDot );
+    }
+
+    RepositoryFileDto
+      testFile =
+      getRepoWs().getFile( path + FileUtils.PATH_SEPARATOR + nameNoExtension + extension ); //$NON-NLS-1$
+    if ( testFile != null ) {
+      // Second try COPY_PREFIX, If the name already ends with a COPY_PREFIX don't append twice
+      if ( !nameNoExtension
+        .endsWith( Messages.getInstance().getString( "FileResource.COPY_PREFIX" ) ) ) { //$NON-NLS-1$
+        copyText = rootCopyText = Messages.getInstance().getString( "FileResource.COPY_PREFIX" );
+        repoFileName = nameNoExtension + copyText + extension;
+        testFile = getRepoWs().getFile( path + FileUtils.PATH_SEPARATOR + repoFileName );
+      }
+    }
+
+    // Third try COPY_PREFIX + DUPLICATE_INDICATOR
+    Integer nameCount = 1;
+    while ( testFile != null ) {
+      nameCount++;
+      copyText =
+        rootCopyText + Messages.getInstance().getString( "FileResource.DUPLICATE_INDICATOR", nameCount );
+      repoFileName = nameNoExtension + copyText + extension;
+      testFile = getRepoWs().getFile( path + FileUtils.PATH_SEPARATOR + repoFileName );
+    }
+    IRepositoryFileData data = getFileData( repoFile );
+    RepositoryFileAcl acl = getRepository().getAcl( repoFile.getId() );
+    RepositoryFile duplicateFile = null;
+    final RepositoryFile repositoryFile;
+
+    if ( repoFile.isFolder() ) {
+      // If the title is different than the source file, copy it separately
+      if ( !repoFile.getName().equals( repoFile.getTitle() ) ) {
+        duplicateFile =
+          new RepositoryFile.Builder( repoFileName ).title( RepositoryFile.DEFAULT_LOCALE,
+            repoFile.getTitle() + copyText ).hidden( repoFile.isHidden() ).versioned(
+            repoFile.isVersioned() ).folder( true ).build();
+      } else {
+        duplicateFile = new RepositoryFile.Builder( repoFileName ).hidden( repoFile.isHidden() ).folder( true ).build();
+      }
+      repositoryFile = getRepository()
+        .createFolder( destDir.getId(), duplicateFile, acl, null );
+
+      performFolderDeepCopy( repoFile, repositoryFile, DEEPNESS_DEFAULT );
+    } else {
+      // If the title is different than the source file, copy it separately
+      if ( !repoFile.getName().equals( repoFile.getTitle() ) ) {
+        duplicateFile =
+          new RepositoryFile.Builder( repoFileName ).title( RepositoryFile.DEFAULT_LOCALE,
+            repoFile.getTitle() + copyText ).hidden( repoFile.isHidden() ).versioned(
+            repoFile.isVersioned() ).build();
+      } else {
+        duplicateFile = new RepositoryFile.Builder( repoFileName ).hidden( repoFile.isHidden() ).build();
+      }
+
+      repositoryFile =
+        getRepository().createFile( destDir.getId(), duplicateFile, data, acl, null );
+    }
+
+
+    getRepository().setFileMetadata( repositoryFile.getId(), getRepository().getFileMetadata( repoFile.getId() ) );
+  }
+
+  private boolean sourceAndDestDirAreSame( String path ) {
+    String pathWithoutFileName =
+      path.substring( 0, path.lastIndexOf( FileUtils.PATH_SEPARATOR ) );
+
+    return pathWithoutFileName.equals( destDir.getPath() );
+  }
+
+
+  /**
+   * @param from     folder, from witch we will copy content
+   * @param to       folder, in witch we will copy content
+   * @param deepness deepness of child entries in each folder
+   */
+  protected void performFolderDeepCopy( RepositoryFile from, RepositoryFile to, Integer deepness ) {
+    if ( from == null || to == null ) {
+      throw new IllegalArgumentException( "Folder should not be null" );
+    }
+
+    if ( !from.isFolder() ) {
+      throw new IllegalArgumentException( from.getPath() + " is not a folder" );
+    }
+
+    if ( !to.isFolder() ) {
+      throw new IllegalArgumentException( to.getPath() + " is not a folder" );
+    }
+
+    if ( deepness == null || deepness < 0 ) {
+      deepness = DEEPNESS_DEFAULT;
+    }
+
+    List<RepositoryFile> children =
+      getRepository().getChildren( createRepoRequest( from, deepness ) );
+
+    for ( RepositoryFile repoFile : children ) {
+      if ( repoFile.isFolder() ) {
+        RepositoryFile childFolder =
+          getRepository().createFolder( to.getId(), repoFile, getRepository().getAcl( repoFile.getId() ), null );
+        performFolderDeepCopy( repoFile, childFolder, deepness );
+      } else {
+        getRepository().createFile( to.getId(), repoFile, getFileData( repoFile ), null );
+      }
+    }
+  }
+
+  protected IUnifiedRepository getRepository() {
+    if ( repository == null ) {
+      repository = PentahoSystem.get( IUnifiedRepository.class );
+    }
+    return repository;
+  }
+
+  protected DefaultUnifiedRepositoryWebService getRepoWs() {
+    if ( defaultUnifiedRepositoryWebService == null ) {
+      defaultUnifiedRepositoryWebService = new DefaultUnifiedRepositoryWebService();
+    }
+    return defaultUnifiedRepositoryWebService;
+  }
+
+  public List<String> getSourceFileIds() {
+    return new ArrayList<>( sourceFileIds );
+  }
+
+  /**
+   * For testing
+   */
+  protected RepositoryRequest createRepoRequest( RepositoryFile repoFile, int deepness ) {
+    return new RepositoryRequest( String.valueOf( repoFile.getId() ), true, deepness, null );
+  }
+
+  /**
+   * For testing
+   */
+  protected RepositoryFileDto toFileDto( RepositoryFile repositoryFile, Set<String> memberSet, boolean exclude ) {
+    return RepositoryFileAdapter.toFileDto( repositoryFile, memberSet, exclude );
+  }
+
+  /**
+   * For testing
+   */
+  protected RepositoryFile toFile( RepositoryFileDto repositoryFileDto ) {
+    return RepositoryFileAdapter.toFile( repositoryFileDto );
+  }
+}

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/services/FileService.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/services/FileService.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2015 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources.services;

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/services/FileService.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/services/FileService.java
@@ -34,6 +34,7 @@ import java.security.GeneralSecurityException;
 import java.security.InvalidParameterException;
 import java.text.Collator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -57,9 +58,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Level;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IPentahoSession;
-import org.pentaho.platform.api.repository2.unified.Converter;
-import org.pentaho.platform.api.mimetype.IPlatformMimeResolver;
-import org.pentaho.platform.api.repository2.unified.IRepositoryContentConverterHandler;
 import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
@@ -82,7 +80,6 @@ import org.pentaho.platform.plugin.services.importexport.IRepositoryImportLogger
 import org.pentaho.platform.plugin.services.importexport.SimpleExportProcessor;
 import org.pentaho.platform.plugin.services.importexport.ZipExportProcessor;
 import org.pentaho.platform.repository.RepositoryDownloadWhitelist;
-import org.pentaho.platform.repository.RepositoryFilenameUtils;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
 import org.pentaho.platform.repository2.locale.PentahoLocale;
 import org.pentaho.platform.repository2.unified.fileio.RepositoryFileInputStream;
@@ -104,7 +101,9 @@ import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadActi
 import org.pentaho.platform.web.http.api.resources.SessionResource;
 import org.pentaho.platform.web.http.api.resources.Setting;
 import org.pentaho.platform.web.http.api.resources.StringListWrapper;
+import org.pentaho.platform.web.http.api.resources.operations.CopyFilesOperation;
 import org.pentaho.platform.web.http.api.resources.utils.FileUtils;
+import org.pentaho.platform.web.http.api.resources.utils.RepositoryFileHelper;
 import org.pentaho.platform.web.http.messages.Messages;
 
 public class FileService {
@@ -394,12 +393,13 @@ public class FileService {
       // we can delete from trash only non-conflict files,
       // because conflict files won't be restored
       String nonConflictFileIds = getSourceFileIdsThatNotConflictWithFolderFiles( userHomeFolderPath, params );
-      doCopyFiles( userHomeFolderPath, overwriteMode, params );
 
       if ( nonConflictFileIds.isEmpty() ) {
-        // all files were restored. Nothing to delete
+        // all files are conflict, so nothing to restore in this mode
         return true;
       }
+
+      doCopyFiles( userHomeFolderPath, overwriteMode, nonConflictFileIds );
       filesToDeletePermanent = nonConflictFileIds;
     } else if ( overwriteMode == MODE_OVERWRITE ) {
       String conflictFileIdsInHomeDir = getFolderFileIdsThatConflictWithSource( userHomeFolderPath, params );
@@ -739,102 +739,12 @@ public class FileService {
     }
 
     String path = idToPath( pathId );
-    RepositoryFile destDir = getRepository().getFile( path );
     String[] sourceFileIds = FileUtils.convertCommaSeparatedStringToArray( params ); //$NON-NLS-1$
-    if ( mode == MODE_OVERWRITE || mode == MODE_NO_OVERWRITE ) {
-      for ( String sourceFileId : sourceFileIds ) {
-        RepositoryFile sourceFile = getRepository().getFileById( sourceFileId );
-        if ( destDir != null && destDir.isFolder() && sourceFile != null && !sourceFile.isFolder() ) {
-          String fileName = sourceFile.getName();
-          String
-              sourcePath =
-              sourceFile.getPath().substring( 0, sourceFile.getPath().lastIndexOf( FileUtils.PATH_SEPARATOR ) );
-          if ( !sourcePath.equals( destDir.getPath() ) ) { // We're saving to a different folder than we're copying
-            // from
-            IRepositoryFileData data = getData( sourceFile );
-            RepositoryFileAcl acl = getRepository().getAcl( sourceFileId );
-            RepositoryFile
-                destFile =
-                getRepository().getFile( destDir.getPath() + FileUtils.PATH_SEPARATOR + fileName );
-            if ( destFile == null ) { // destFile doesn't exist so we'll create it.
-              RepositoryFile duplicateFile =
-                  new RepositoryFile.Builder( fileName ).hidden( sourceFile.isHidden() ).versioned(
-                      sourceFile.isVersioned() ).build();
-              final RepositoryFile repositoryFile =
-                  getRepository().createFile( destDir.getId(), duplicateFile, data, acl, null );
-              getRepository()
-                  .setFileMetadata( repositoryFile.getId(), getRepository().getFileMetadata( sourceFileId ) );
-            } else if ( mode == MODE_OVERWRITE ) { // destFile exists so check to see if we want to overwrite it.
-              RepositoryFileDto destFileDto = toFileDto( destFile, null, false );
-              destFileDto.setHidden( sourceFile.isHidden() );
-              destFile = toFile( destFileDto );
-              final RepositoryFile repositoryFile = getRepository().updateFile( destFile, data, null );
-              getRepository().updateAcl( acl );
-              getRepository()
-                  .setFileMetadata( repositoryFile.getId(), getRepository().getFileMetadata( sourceFileId ) );
-            }
-          }
-        }
-      }
-    } else {
-      for ( String sourceFileId : sourceFileIds ) {
-        RepositoryFile sourceFile = getRepository().getFileById( sourceFileId );
-        if ( destDir != null && destDir.isFolder() && sourceFile != null && !sourceFile.isFolder() ) {
 
-          // First try to see if regular name is available
-          String fileName = sourceFile.getName();
-          String copyText = "";
-          String rootCopyText = "";
-          String nameNoExtension = fileName;
-          String extension = "";
-          int indexOfDot = fileName.lastIndexOf( '.' );
-          if ( !( indexOfDot == -1 ) ) {
-            nameNoExtension = fileName.substring( 0, indexOfDot );
-            extension = fileName.substring( indexOfDot );
-          }
+    CopyFilesOperation copyFilesOperation =
+      new CopyFilesOperation( getRepository(), getRepoWs(), Arrays.asList( sourceFileIds ), path, mode );
 
-          RepositoryFileDto
-              testFile =
-              getRepoWs().getFile( path + FileUtils.PATH_SEPARATOR + nameNoExtension + extension ); //$NON-NLS-1$
-          if ( testFile != null ) {
-            // Second try COPY_PREFIX, If the name already ends with a COPY_PREFIX don't append twice
-            if ( !nameNoExtension
-                .endsWith( Messages.getInstance().getString( "FileResource.COPY_PREFIX" ) ) ) { //$NON-NLS-1$
-              copyText = rootCopyText = Messages.getInstance().getString( "FileResource.COPY_PREFIX" );
-              fileName = nameNoExtension + copyText + extension;
-              testFile = getRepoWs().getFile( path + FileUtils.PATH_SEPARATOR + fileName );
-            }
-          }
-
-          // Third try COPY_PREFIX + DUPLICATE_INDICATOR
-          Integer nameCount = 1;
-          while ( testFile != null ) {
-            nameCount++;
-            copyText =
-                rootCopyText + Messages.getInstance().getString( "FileResource.DUPLICATE_INDICATOR", nameCount );
-            fileName = nameNoExtension + copyText + extension;
-            testFile = getRepoWs().getFile( path + FileUtils.PATH_SEPARATOR + fileName );
-          }
-          IRepositoryFileData data = getData( sourceFile );
-          RepositoryFileAcl acl = getRepository().getAcl( sourceFileId );
-          RepositoryFile duplicateFile = null;
-
-          // If the title is different than the source file, copy it separately
-          if ( !sourceFile.getName().equals( sourceFile.getTitle() ) ) {
-            duplicateFile =
-                new RepositoryFile.Builder( fileName ).title( RepositoryFile.DEFAULT_LOCALE,
-                    sourceFile.getTitle() + copyText ).hidden( sourceFile.isHidden() ).versioned(
-                    sourceFile.isVersioned() ).build();
-          } else {
-            duplicateFile = new RepositoryFile.Builder( fileName ).hidden( sourceFile.isHidden() ).build();
-          }
-
-          final RepositoryFile repositoryFile =
-              getRepository().createFile( destDir.getId(), duplicateFile, data, acl, null );
-          getRepository().setFileMetadata( repositoryFile.getId(), getRepository().getFileMetadata( sourceFileId ) );
-        }
-      }
-    }
+    copyFilesOperation.execute();
   }
 
   /**
@@ -879,67 +789,7 @@ public class FileService {
     return wrapper;
   }
 
-  public IRepositoryFileData getData( RepositoryFile repositoryFile ) {
-    IRepositoryContentConverterHandler converterHandler;
-    Map<String, Converter> converters;
-    IPlatformMimeResolver mimeResolver;
-
-    IRepositoryFileData repositoryFileData = null;
-
-    if ( !repositoryFile.isFolder() ) {
-      // Get the extension
-      final String ext = RepositoryFilenameUtils.getExtension( repositoryFile.getName() );
-      if ( ( ext == null ) || ( ext.isEmpty() ) ) {
-        return null;
-      }
-
-      // Find the converter
-
-      // If we have not been given a handler, try PentahoSystem
-      converterHandler = PentahoSystem.get( IRepositoryContentConverterHandler.class );
-
-      // fail if we have no converter handler
-      if ( converterHandler == null ) {
-        return null;
-      }
-
-      converters = converterHandler.getConverters();
-
-      final Converter converter = converters.get( ext );
-      if ( converter == null ) {
-        return null;
-      }
-
-      // Check the mime type
-      mimeResolver = PentahoSystem.get( IPlatformMimeResolver.class );
-
-      // fail if we have no mime resolver
-      if ( mimeResolver == null ) {
-        return null;
-      }
-
-      final String mimeType = mimeResolver.resolveMimeTypeForFileName( repositoryFile.getName() ).getName();
-      if ( ( mimeType == null ) || ( mimeType.isEmpty() ) ) {
-        return null;
-      }
-
-      // Get the input stream
-      InputStream inputStream = converter.convert( repositoryFile.getId() );
-      if ( inputStream == null ) {
-        return null;
-      }
-
-      // Get the file data
-      repositoryFileData = converter.convert( inputStream, "UTF-8", mimeType );
-      if ( repositoryFileData == null ) {
-        return null;
-      }
-    }
-
-    return repositoryFileData;
-  }
-
-  /**
+   /**
    * Save the acls of the selected file to the repository
    *
    * This method is used to update and save the acls of the selected file to the repository
@@ -1216,7 +1066,7 @@ public class FileService {
         // add the existing acls and file data
         RepositoryFileAcl acl = getRepository().getAcl( sourceFile.getId() );
         if ( !file.isFolder() ) {
-          IRepositoryFileData data = getData( sourceFile );
+          IRepositoryFileData data = RepositoryFileHelper.getFileData( sourceFile );
 
           getRepository().updateFile( destFile, data, null );
           getRepository().updateAcl( acl );
@@ -1669,7 +1519,7 @@ public class FileService {
         RepositoryFile updatedFile =
           new RepositoryFile.Builder( movedFile ).localePropertiesMap( localePropertiesMap ).name( newName ).title(
             newName ).build();
-        repository.updateFile( updatedFile, getData( movedFile ), "Updating the file" );
+        repository.updateFile( updatedFile, RepositoryFileHelper.getFileData( movedFile ), "Updating the file" );
       }
       return true;
     } else {

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/utils/RepositoryFileHelper.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/utils/RepositoryFileHelper.java
@@ -1,0 +1,94 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources.utils;
+
+import org.pentaho.platform.api.mimetype.IPlatformMimeResolver;
+import org.pentaho.platform.api.repository2.unified.Converter;
+import org.pentaho.platform.api.repository2.unified.IRepositoryContentConverterHandler;
+import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.repository.RepositoryFilenameUtils;
+
+import java.io.InputStream;
+import java.util.Map;
+
+
+public class RepositoryFileHelper {
+
+  public static IRepositoryFileData getFileData( RepositoryFile repositoryFile ) {
+    IRepositoryContentConverterHandler converterHandler;
+    Map<String, Converter> converters;
+    IPlatformMimeResolver mimeResolver;
+
+    IRepositoryFileData repositoryFileData = null;
+
+    if ( !repositoryFile.isFolder() ) {
+      // Get the extension
+      final String ext = RepositoryFilenameUtils.getExtension( repositoryFile.getName() );
+      if ( ( ext == null ) || ( ext.isEmpty() ) ) {
+        return null;
+      }
+
+      // Find the converter
+
+      // If we have not been given a handler, try PentahoSystem
+      converterHandler = PentahoSystem.get( IRepositoryContentConverterHandler.class );
+
+      // fail if we have no converter handler
+      if ( converterHandler == null ) {
+        return null;
+      }
+
+      converters = converterHandler.getConverters();
+
+      final Converter converter = converters.get( ext );
+      if ( converter == null ) {
+        return null;
+      }
+
+      // Check the mime type
+      mimeResolver = PentahoSystem.get( IPlatformMimeResolver.class );
+
+      // fail if we have no mime resolver
+      if ( mimeResolver == null ) {
+        return null;
+      }
+
+      final String mimeType = mimeResolver.resolveMimeTypeForFileName( repositoryFile.getName() ).getName();
+      if ( ( mimeType == null ) || ( mimeType.isEmpty() ) ) {
+        return null;
+      }
+
+      // Get the input stream
+      InputStream inputStream = converter.convert( repositoryFile.getId() );
+      if ( inputStream == null ) {
+        return null;
+      }
+
+      // Get the file data
+      repositoryFileData = converter.convert( inputStream, "UTF-8", mimeType );
+      if ( repositoryFileData == null ) {
+        return null;
+      }
+    }
+
+    return repositoryFileData;
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/operations/CopyFilesOperation_CopyTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/operations/CopyFilesOperation_CopyTest.java
@@ -1,0 +1,272 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources.operations;
+
+
+import edu.emory.mathcs.backport.java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileDto;
+import org.pentaho.platform.web.http.api.resources.services.FileService;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+public class CopyFilesOperation_CopyTest {
+  private IUnifiedRepository repo;
+  private DefaultUnifiedRepositoryWebService webService;
+
+  private RepositoryFile file1;
+  private RepositoryFile file2;
+  private static final String EXTENSION_PRPT = ".prpt";
+
+
+  private RepositoryFile destFolder;
+  private RepositoryFile folder1;
+  private RepositoryFile folder2;
+
+  private static final String SEPARATOR = "/";
+  private static final String DEFAULT = "<def>";
+
+  private static final String NAME_FILE_1 = "file-1" + EXTENSION_PRPT;
+  private static final String NAME_FILE_2 = "file-2" + EXTENSION_PRPT;
+
+  private static final String PATH_FILE_1 = "path/to/file1/" + NAME_FILE_1;
+  private static final String PATH_FILE_2 = "path/to/file2/" + NAME_FILE_2;
+
+
+  private static final String PATH_DEST_DIR = "/directory/destination";
+  private static final String NAME_DEST_DIR = "destination";
+
+  private static final String NAME_DIR_1 = "dir-1";
+  private static final String NAME_DIR_2 = "dir-2";
+
+  private static final String PATH_DIR_1 = "path/to/dir1/" + NAME_DIR_1;
+  private static final String PATH_DIR_2 = "path/to/dir1/" + NAME_DIR_2;
+
+  @Before
+  public void init() {
+    repo = mock( IUnifiedRepository.class );
+    webService = mock( DefaultUnifiedRepositoryWebService.class );
+
+    file1 = mockFile( generateID(), NAME_FILE_1, PATH_FILE_1 );
+    file2 = mockFile( generateID(), NAME_FILE_2, PATH_FILE_2 );
+
+    destFolder = mockFolder( generateID(), NAME_DEST_DIR, PATH_DEST_DIR );
+    doReturn( PATH_DEST_DIR ).when( destFolder ).getPath();
+    doReturn( destFolder ).when( repo ).getFile( PATH_DEST_DIR );
+    Serializable destFolderId = destFolder.getId();
+
+    doReturn( mockFile( generateID(), DEFAULT, DEFAULT ) ).when( repo )
+      .createFile( eq( destFolderId ), any( RepositoryFile.class ), any( IRepositoryFileData.class ),
+        any( RepositoryFileAcl.class ), anyString() );
+
+    doReturn( mockFolder( generateID(), DEFAULT, DEFAULT ) ).when( repo )
+      .createFolder( eq( destFolderId ), any( RepositoryFile.class ), any( RepositoryFileAcl.class ), anyString() );
+
+    folder1 = mockFolder( generateID(), NAME_DIR_1, PATH_DIR_1 );
+    folder2 = mockFolder( generateID(), NAME_DIR_2, PATH_DIR_2 );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void copyFails_whenDestIsNotFolder() {
+    List<String> listOfFiles = new ArrayList<>();
+    listOfFiles.add( DEFAULT );
+
+    String destDirPath = "/destintion";
+    mockFile( generateID(), DEFAULT, destDirPath );
+    new CopyFilesOperation( repo, webService, listOfFiles, destDirPath, 2 );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  @SuppressWarnings( "unchecked" )
+  public void copyFails_whenNoFilesGiven() {
+    new CopyFilesOperation( repo, webService, Collections.emptyList(), PATH_DEST_DIR, 2 );
+  }
+
+  @Test
+  public void copyFiles_OverwriteMode() {
+    CopyFilesOperation operation =
+      new CopyFilesOperation( repo, webService, getIdList( file1, file2 ), PATH_DEST_DIR,
+        FileService.MODE_OVERWRITE );
+
+    // emulate, file with the same name exists.
+    RepositoryFile conflictFile = mockFile( generateID(), DEFAULT, PATH_DEST_DIR + SEPARATOR + NAME_FILE_1 );
+
+    operation = spy( operation );
+
+    RepositoryFileDto fileDto = mock( RepositoryFileDto.class );
+    doReturn( conflictFile ).when( operation ).toFile( fileDto );
+    doReturn( fileDto ).when( operation ).toFileDto( eq( conflictFile ), anySet(), anyBoolean() );
+
+    doReturn( conflictFile ).when( repo )
+      .updateFile( eq( conflictFile ), any( IRepositoryFileData.class ), anyString() );
+
+    operation.execute();
+
+    verify( repo ).updateFile( eq( conflictFile ), any( IRepositoryFileData.class ), anyString() );
+  }
+
+  @Test
+  public void copyFiles_NoOverwriteMode() {
+    CopyFilesOperation operation =
+      new CopyFilesOperation( repo, webService, getIdList( file1, file2 ), PATH_DEST_DIR,
+        FileService.MODE_NO_OVERWRITE );
+
+    // emulate, file with the same name exists.
+    mockFile( generateID(), DEFAULT, PATH_DEST_DIR + SEPARATOR + NAME_FILE_1 );
+
+    operation.execute();
+
+    Serializable destFolderId = destFolder.getId();
+
+    // one file should be created, as there was 2 files, and 1 conflict
+    verify( repo, times( 1 ) )
+      .createFile( eq( destFolderId ), any( RepositoryFile.class ), any( IRepositoryFileData.class ), any(
+        RepositoryFileAcl.class ), anyString() );
+    verify( repo, never() )
+      .createFolder( any( Serializable.class ), any( RepositoryFile.class ), any( RepositoryFileAcl.class ),
+        anyString() );
+  }
+
+  @Test
+  public void copyFolders_NoOverwriteMode() {
+    CopyFilesOperation operation =
+      new CopyFilesOperation( repo, webService, getIdList( folder1, folder2 ), PATH_DEST_DIR,
+        FileService.MODE_NO_OVERWRITE );
+
+    // emulate, file with the same name exists.
+    mockFolder( generateID(), DEFAULT, PATH_DEST_DIR + SEPARATOR + NAME_DIR_1 );
+
+    operation = spy( operation );
+    doNothing().when( operation )
+      .performFolderDeepCopy( any( RepositoryFile.class ), any( RepositoryFile.class ), anyInt() );
+
+    operation.execute();
+
+    Serializable destFolderId = destFolder.getId();
+
+    verify( repo, times( 1 ) ).createFolder( eq( destFolderId ), any( RepositoryFile.class ),
+      any( RepositoryFileAcl.class ), anyString() );
+
+    verify( operation, times( 1 ) )
+      .performFolderDeepCopy( any( RepositoryFile.class ), any( RepositoryFile.class ), anyInt() );
+
+    verify( repo, never() )
+      .createFile( any( RepositoryFile.class ), any( RepositoryFile.class ), any( IRepositoryFileData.class ), any(
+        RepositoryFileAcl.class ), anyString() );
+  }
+
+  @Test
+  public void copyFiles_RenameMode() {
+    CopyFilesOperation operation =
+      new CopyFilesOperation( repo, webService, getIdList( file1, file2 ), PATH_DEST_DIR,
+        FileService.MODE_RENAME );
+
+    // emulate, file with the same name exists.
+    RepositoryFile conflict = mockFile( generateID(), DEFAULT, PATH_DEST_DIR + SEPARATOR + NAME_FILE_1 );
+    String conflictFilePath = conflict.getPath();
+    RepositoryFileDto dtoConflictFile = mock( RepositoryFileDto.class );
+
+    doReturn( dtoConflictFile ).when( webService ).getFile( eq( conflictFilePath ) );
+
+    operation.execute();
+
+    verify( repo, times( 2 ) )
+      .createFile( eq( destFolder.getId() ), any( RepositoryFile.class ), any( IRepositoryFileData.class ),
+        any( RepositoryFileAcl.class ), anyString() );
+
+    verify( repo, never() )
+      .createFolder( any( RepositoryFile.class ), any( RepositoryFile.class ), any( RepositoryFileAcl.class ),
+        anyString() );
+  }
+
+  @Test
+  public void copyFolders_RenameMode() {
+    CopyFilesOperation operation =
+      new CopyFilesOperation( repo, webService, getIdList( folder1, folder2 ), PATH_DEST_DIR,
+        FileService.MODE_RENAME );
+
+    // emulate, file with the same name exists.
+    RepositoryFile conflict = mockFolder( generateID(), DEFAULT, PATH_DEST_DIR + SEPARATOR + NAME_DIR_2 );
+    String conflictFolderPath = conflict.getPath();
+    RepositoryFileDto dtoConflictFolder = mock( RepositoryFileDto.class );
+
+    doReturn( dtoConflictFolder ).when( webService ).getFile( eq( conflictFolderPath ) );
+
+    operation = spy( operation );
+
+    operation.execute();
+
+    verify( repo, times( 2 ) )
+      .createFolder( eq( destFolder.getId() ), any( RepositoryFile.class ), any( RepositoryFileAcl.class ),
+        anyString() );
+
+    verify( operation, times( 2 ) )
+      .performFolderDeepCopy( any( RepositoryFile.class ), any( RepositoryFile.class ), anyInt() );
+
+    verify( repo, never() )
+      .createFile( any( Serializable.class ), any( RepositoryFile.class ), any( IRepositoryFileData.class ),
+        any( RepositoryFileAcl.class ), anyString() );
+  }
+
+  private List<String> getIdList( final RepositoryFile... files ) {
+    return new ArrayList<String>() {
+      {
+        for ( RepositoryFile file : files ) {
+          add( file.getId().toString() );
+        }
+      }
+    };
+  }
+
+  private static String generateID() {
+    return UUID.randomUUID().toString();
+  }
+
+  public RepositoryFile mockFile( Serializable id, String fileName, String path ) {
+    return mockRepoFile( id, fileName, path, false );
+  }
+
+  public RepositoryFile mockFolder( Serializable id, String fileName, String path ) {
+    return mockRepoFile( id, fileName, path, true );
+  }
+
+  private RepositoryFile mockRepoFile( Serializable id, String fileName, String path, boolean isFolder ) {
+    RepositoryFile repoFile = mock( RepositoryFile.class );
+    doReturn( id ).when( repoFile ).getId();
+    doReturn( isFolder ).when( repoFile ).isFolder();
+    doReturn( fileName ).when( repoFile ).getName();
+    doReturn( path ).when( repoFile ).getPath();
+
+    doReturn( repoFile ).when( repo ).getFileById( id );
+    doReturn( repoFile ).when( repo ).getFile( path );
+    return repoFile;
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/operations/CopyFilesOperation_DeepFolderCopyTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/operations/CopyFilesOperation_DeepFolderCopyTest.java
@@ -1,0 +1,221 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+package org.pentaho.platform.web.http.api.resources.operations;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Ivan Nikolaichuk
+ */
+
+/**
+ * Goals of this test are: 1. verify, that recursion ends. 2. verify, that accurate number of files and folders were
+ * created.
+ * <p/>
+ * Tests are called N_LevelDeepness, where by deepness meant folders-hierarchy deepness.
+ * <p/>
+ * Example:
+ * <p/>
+ * 1 level deepness: -folder -file -file
+ * <p/>
+ * 3 level deepness: -folder -folder -file -folder -folder
+ */
+public class CopyFilesOperation_DeepFolderCopyTest {
+  private static IUnifiedRepository repo;
+  private static CopyFilesOperation operation;
+  private RepositoryFile from;
+  private RepositoryFile to;
+
+  @Before
+  public void init() {
+    repo = mock( IUnifiedRepository.class );
+    operation = mock( CopyFilesOperation.class );
+    doReturn( repo ).when( operation ).getRepository();
+
+    from = mockFolder();
+    to = mockFolder();
+
+    doReturn( mockFolder() ).when( repo )
+      .createFolder( any( Serializable.class ), any( RepositoryFile.class ), any(
+        RepositoryFileAcl.class ), anyString() );
+
+    doCallRealMethod().when( operation ).performFolderDeepCopy( any( RepositoryFile.class ),
+      any( RepositoryFile.class ), anyInt() );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void deepCopyOfFile_Fails() {
+    RepositoryFile file1 = mockFile();
+    RepositoryFile file2 = mockFile();
+    doCallRealMethod().when( operation ).performFolderDeepCopy( file1, file2, null );
+
+    operation.performFolderDeepCopy( file1, file2, null );
+  }
+
+  @Test
+  public void one_LevelDeepness() {
+    List<RepositoryFile> files = listOfMockedFiles( 3 );
+    mockRequest( from, files );
+
+    operation.performFolderDeepCopy( from, to, CopyFilesOperation.DEEPNESS_DEFAULT );
+
+    performVerification( 0, files.size() );
+  }
+
+  @Test
+  public void two_LevelDeepness() {
+    int numberOfFolders = 3;
+    int filesInEachFolder = 3;
+    List<RepositoryFile> folders = listOfMockedFolders( numberOfFolders );
+    mockRequest( from, folders );
+
+    for ( RepositoryFile folder : folders ) {
+      mockRequest( folder, listOfMockedFiles( filesInEachFolder ) );
+    }
+
+    operation.performFolderDeepCopy( from, to, CopyFilesOperation.DEEPNESS_DEFAULT );
+
+    // one stands for root folder.
+    performVerification( numberOfFolders, numberOfFolders * filesInEachFolder );
+  }
+
+  @Test
+  public void six_LevelDeepness_Folders() {
+    int expectedFolders = 62;
+    int foldersInEachFolderNotLastLevel = 2;
+
+    List<RepositoryFile> foldersSecondLevel = listOfMockedFolders( foldersInEachFolderNotLastLevel );
+    List<RepositoryFile> foldersThirdLevel = listOfMockedFolders( foldersInEachFolderNotLastLevel );
+    List<RepositoryFile> foldersForthLevel = listOfMockedFolders( foldersInEachFolderNotLastLevel );
+    List<RepositoryFile> foldersFiveLevel = listOfMockedFolders( foldersInEachFolderNotLastLevel );
+    List<RepositoryFile> foldersSixLevel = listOfMockedFolders( foldersInEachFolderNotLastLevel );
+
+    mockRequest( from, foldersSecondLevel );
+
+    for ( RepositoryFile folder : foldersSecondLevel ) {
+      mockRequest( folder, foldersThirdLevel );
+    }
+
+    for ( RepositoryFile folder : foldersThirdLevel ) {
+      mockRequest( folder, foldersForthLevel );
+    }
+
+    for ( RepositoryFile folder : foldersForthLevel ) {
+      mockRequest( folder, foldersFiveLevel );
+    }
+
+    for ( RepositoryFile folder : foldersFiveLevel ) {
+      mockRequest( folder, foldersSixLevel );
+    }
+
+    operation.performFolderDeepCopy( from, to, CopyFilesOperation.DEEPNESS_DEFAULT );
+
+    performVerification( expectedFolders, 0 );
+  }
+
+
+  /**
+   * Verifies: - performFolderDeepCopy method was called {@code newFolders + 1} times, where 1 performs as the first
+   * method call.
+   * <p/>
+   * - there were created {@code numberOfFiles} files. - there were created {@code newFolders} folders.
+   */
+  private void performVerification( int newFolders, int newFiles ) {
+    // 1 stands for first method-call
+    verify( operation, times( newFolders + 1 ) )
+      .performFolderDeepCopy( any( RepositoryFile.class ), any( RepositoryFile.class ), anyInt() );
+
+    verify( repo, times( newFolders ) )
+      .createFolder( any( Serializable.class ), any( RepositoryFile.class ), any( RepositoryFileAcl.class ),
+        anyString() );
+
+    verify( repo, times( newFiles ) ).createFile( any( RepositoryFile.class ), any( RepositoryFile.class ), any(
+      IRepositoryFileData.class ), anyString() );
+  }
+
+  /**
+   * Enforces to return provided {@code children}, when making a RepositoryRequest to know {@code folder} content.
+   */
+  private void mockRequest( RepositoryFile folder, List<RepositoryFile> children ) {
+    RepositoryRequest mockedRequest = mock( RepositoryRequest.class );
+    doReturn( mockedRequest ).when( operation ).createRepoRequest( eq( folder ), anyInt() );
+    doReturn( children ).when( repo ).getChildren( mockedRequest );
+  }
+
+  private List<RepositoryFile> listOfMockedFiles( final int files ) {
+    return listOfMockedRepoFiles( files, false );
+  }
+
+  private List<RepositoryFile> listOfMockedFolders( final int files ) {
+    return listOfMockedRepoFiles( files, true );
+  }
+
+  private List<RepositoryFile> listOfMockedRepoFiles( final int files, final boolean isFolder ) {
+    return new ArrayList<RepositoryFile>() {{
+      for ( int i = 0; i < files; i++ ) {
+        if ( isFolder ) {
+          add( mockFolder() );
+        } else {
+          add( mockFile() );
+        }
+      }
+    }};
+  }
+
+  public static RepositoryFile mockFile( String id ) {
+    RepositoryFile file = mock( RepositoryFile.class );
+    doReturn( id ).when( file ).getId();
+    doReturn( false ).when( file ).isFolder();
+
+    return file;
+  }
+
+  public static RepositoryFile mockFile() {
+    return mockFile( generateID() );
+  }
+
+
+  public static RepositoryFile mockFolder( String id ) {
+    RepositoryFile folder = mock( RepositoryFile.class );
+    doReturn( id ).when( folder ).getId();
+    doReturn( true ).when( folder ).isFolder();
+
+    return folder;
+  }
+
+  public static RepositoryFile mockFolder() {
+    return mockFolder( generateID() );
+  }
+
+  private static String generateID() {
+    return UUID.randomUUID().toString();
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/operations/CopyFilesOperation_DeepFolderCopyTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/operations/CopyFilesOperation_DeepFolderCopyTest.java
@@ -179,15 +179,16 @@ public class CopyFilesOperation_DeepFolderCopyTest {
   }
 
   private List<RepositoryFile> listOfMockedRepoFiles( final int files, final boolean isFolder ) {
-    return new ArrayList<RepositoryFile>() {{
-      for ( int i = 0; i < files; i++ ) {
-        if ( isFolder ) {
-          add( mockFolder() );
-        } else {
-          add( mockFile() );
+    return new ArrayList<RepositoryFile>() { {
+        for ( int i = 0; i < files; i++ ) {
+          if ( isFolder ) {
+            add( mockFolder() );
+          } else {
+            add( mockFile() );
+          }
         }
       }
-    }};
+    };
   }
 
   public static RepositoryFile mockFile( String id ) {

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
@@ -55,6 +55,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
@@ -271,49 +272,6 @@ public class FileServiceTest {
     } catch ( Exception e ) {
       fail();
     }
-  }
-
-  @Test
-  public void testDoCopyFiles() throws Exception {
-
-    String destinationPath = "/path/to/destination";
-    String destinationPathColon = ":path:to:destination";
-
-    String filePath1 = "/path/to/source/file1.ext";
-    String fileId1 = "file1";
-
-    String filePath2 = "/path/to/source/file2.ext";
-    String fileId2 = "file2";
-
-    when( fileService.policy.isAllowed( anyString() ) ).thenReturn( true );
-
-    RepositoryFile repositoryFile = mock( RepositoryFile.class );
-    when( fileService.repository.createFile( any( Serializable.class ), any( RepositoryFile.class ), any(
-      IRepositoryFileData.class ), any( RepositoryFileAcl.class ), anyString() ) ).thenReturn( repositoryFile );
-
-    RepositoryFile destDir = mock( RepositoryFile.class );
-    when( destDir.isFolder() ).thenReturn( true );
-    when( destDir.getPath() ).thenReturn( destinationPath );
-    when( fileService.repository.getFile( destinationPath ) ).thenReturn( destDir );
-
-    RepositoryFile repositoryFile1 = mock( RepositoryFile.class );
-    when( repositoryFile1.isFolder() ).thenReturn( false );
-    when( repositoryFile1.getPath() ).thenReturn( filePath1 );
-    when( fileService.repository.getFileById( fileId1 ) ).thenReturn( repositoryFile1 );
-
-    RepositoryFile repositoryFile2 = mock( RepositoryFile.class );
-    when( repositoryFile2.isFolder() ).thenReturn( false );
-    when( repositoryFile2.getPath() ).thenReturn( filePath2 );
-    when( fileService.repository.getFileById( fileId2 ) ).thenReturn( repositoryFile2 );
-
-    fileService.doCopyFiles( destinationPathColon, 1, fileId1 + "," + fileId2 );
-
-    verify( fileService.repository, times( 2 ) )
-      .createFile( any( Serializable.class ), any( RepositoryFile.class ), any(
-        IRepositoryFileData.class ), any( RepositoryFileAcl.class ), anyString() );
-    verify( fileService.repository ).getFile( destinationPath );
-    verify( fileService.repository ).getFileById( fileId1 );
-    verify( fileService.repository ).getFileById( fileId2 );
   }
 
   @Test
@@ -1679,9 +1637,6 @@ public class FileServiceTest {
     RepositoryFileAcl acl = mock( RepositoryFileAcl.class );
     doReturn( acl ).when( fileService.repository ).getAcl( acl );
 
-    IRepositoryFileData data = mock( IRepositoryFileData.class );
-    doReturn( data ).when( fileService ).getData( sourceFile );
-
     // Test 1 - canManage should be true at start
     try {
       fileService.doSetMetadata( pathId, stringKeyStringValueDtos );
@@ -1795,7 +1750,6 @@ public class FileServiceTest {
     verify( fileService, times( 8 ) ).toFile( any( RepositoryFileDto.class ) );
     verify( destFileDto, times( 8 ) ).setHidden( anyBoolean() );
     verify( fileService.repository, times( 8 ) ).getAcl( anyString() );
-    verify( fileService, times( 7 ) ).getData( any( RepositoryFile.class ) );
     verify( fileService.repository, times( 7 ) )
       .updateFile( any( RepositoryFile.class ), any( IRepositoryFileData.class ),
         anyString() );

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
@@ -12,8 +12,9 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
+
 package org.pentaho.platform.web.http.api.resources.services;
 
 import static org.junit.Assert.assertEquals;
@@ -55,7 +56,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;

--- a/extensions/test-src/org/pentaho/test/platform/web/http/api/FileResourceIT.java
+++ b/extensions/test-src/org/pentaho/test/platform/web/http/api/FileResourceIT.java
@@ -422,44 +422,6 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   }
 
   @Test
-  public void testCopyFiles() throws Exception {
-    mp.defineInstance( IUnifiedRepository.class, repo );
-    loginAsRepositoryAdmin();
-    ITenant systemTenant =
-        tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
-            authenticatedAuthorityName, "Anonymous" );
-    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[]{adminAuthorityName} );
-    login( sysAdminUserName, systemTenant, new String[]{adminAuthorityName, authenticatedAuthorityName} );
-
-    ITenant mainTenant_1 =
-        tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
-            "Anonymous" );
-    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[]{adminAuthorityName} );
-    login( "admin", mainTenant_1, new String[]{authenticatedAuthorityName} );
-
-    try{
-      final String destFolderPath = "public:folder3:folder4";
-      final String fileName = "file.txt";
-
-      String publicFolderPath = ClientRepositoryPaths.getPublicFolderPath();
-      createTestFile( publicFolderPath.replaceAll( "/", ":" ) + ":" + fileName, "abcdefg" );
-      WebResource webResource = resource();
-      RepositoryFile file = repo.getFile( ClientRepositoryPaths.getPublicFolderPath() + "/" + fileName );
-      ClientResponse r =
-          webResource.path( "repo/files/" + destFolderPath + "/children" ).accept( TEXT_PLAIN ).put(
-              ClientResponse.class, file.getId() );
-      assertResponse( r, Status.OK );
-    }
-    catch(Throwable ex){
-      TestCase.fail();
-    }
-    finally{
-      cleanupUserAndRoles( mainTenant_1 );
-      cleanupUserAndRoles( systemTenant );
-    }
-  }
-
-  @Test
   public void testGetWhenFileDNE() {
     mp.defineInstance( IUnifiedRepository.class, repo );
     loginAsRepositoryAdmin();

--- a/extensions/test-src/org/pentaho/test/platform/web/http/api/FileResourceIT.java
+++ b/extensions/test-src/org/pentaho/test/platform/web/http/api/FileResourceIT.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.test.platform.web.http.api;
@@ -266,7 +266,8 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   protected void createTestFileBinary( String pathId, byte[] data ) {
     WebResource webResource = resource();
     ClientResponse response =
-        webResource.path( "repo/files/" + pathId ).type( APPLICATION_OCTET_STREAM ).put( ClientResponse.class, new String(data) );
+      webResource.path( "repo/files/" + pathId ).type( APPLICATION_OCTET_STREAM )
+        .put( ClientResponse.class, new String( data ) );
     assertResponse( response, Status.OK );
   }
 
@@ -281,27 +282,29 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   public void testDummy() {
 
   }
-@Test
+
+  @Test
   public void testWriteBinaryFile() throws InterruptedException {
     final String str = "some binary text";
     final String fileName = "file.bn";
 
     // set object in PentahoSystem
     mp.defineInstance( IUnifiedRepository.class, repo );
-    
+
     loginAsRepositoryAdmin();
     ITenant systemTenant =
-        tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
-            authenticatedAuthorityName, "Anonymous" );
-    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[]{adminAuthorityName} );
+      tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
+        authenticatedAuthorityName, "Anonymous" );
+    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[] { adminAuthorityName } );
 
     ITenant mainTenant_1 =
-        tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
-            "Anonymous" );
-    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[]{adminAuthorityName, authenticatedAuthorityName} );
-    try{
-      login( sysAdminUserName, systemTenant, new String[]{adminAuthorityName} );
-      login( "admin", mainTenant_1, new String[]{ adminAuthorityName, authenticatedAuthorityName } );
+      tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
+        "Anonymous" );
+    userRoleDao.createUser( mainTenant_1, "admin", "password", "",
+      new String[] { adminAuthorityName, authenticatedAuthorityName } );
+    try {
+      login( sysAdminUserName, systemTenant, new String[] { adminAuthorityName } );
+      login( "admin", mainTenant_1, new String[] { adminAuthorityName, authenticatedAuthorityName } );
 
       WebResource webResource = resource();
       final byte[] blob = str.getBytes();
@@ -309,20 +312,18 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
       createTestFileBinary( publicFolderPath.replaceAll( "/", ":" ) + ":" + fileName, blob );
 
       // the file might not actually be ready.. wait a second
-      Thread.sleep(20000);
+      Thread.sleep( 20000 );
 
       ClientResponse response =
-          webResource.path( "repo/files/:public:file.bn" ).accept( APPLICATION_OCTET_STREAM )
-              .get( ClientResponse.class );
+        webResource.path( "repo/files/:public:file.bn" ).accept( APPLICATION_OCTET_STREAM )
+          .get( ClientResponse.class );
       assertResponse( response, Status.OK, APPLICATION_OCTET_STREAM );
 
       byte[] data = response.getEntity( byte[].class );
       assertEquals( "contents of file incorrect/missing", str, new String( data ) );
-    }
-    catch(Exception ex){
+    } catch ( Exception ex ) {
       TestCase.fail();
-    }
-    finally{
+    } finally {
       cleanupUserAndRoles( mainTenant_1 );
       cleanupUserAndRoles( systemTenant );
     }
@@ -337,33 +338,31 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
     loginAsRepositoryAdmin();
     ITenant systemTenant =
-        tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
-            authenticatedAuthorityName, "Anonymous" );
-    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[]{adminAuthorityName} );
+      tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
+        authenticatedAuthorityName, "Anonymous" );
+    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[] { adminAuthorityName } );
 
     ITenant mainTenant_1 =
-        tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
-            "Anonymous" );
-    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[]{adminAuthorityName} );
-    try{
-      login( sysAdminUserName, systemTenant, new String[]{adminAuthorityName, authenticatedAuthorityName} );
+      tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
+        "Anonymous" );
+    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[] { adminAuthorityName } );
+    try {
+      login( sysAdminUserName, systemTenant, new String[] { adminAuthorityName, authenticatedAuthorityName } );
 
-      login( "admin", mainTenant_1, new String[]{authenticatedAuthorityName} );
+      login( "admin", mainTenant_1, new String[] { authenticatedAuthorityName } );
 
       WebResource webResource = resource();
       String publicFolderPath = ClientRepositoryPaths.getPublicFolderPath();
       createTestFile( publicFolderPath.replaceAll( "/", ":" ) + ":" + fileName, text );
 
       ClientResponse response =
-          webResource.path( "repo/files/:public:" + fileName ).accept( TEXT_PLAIN ).get( ClientResponse.class );
+        webResource.path( "repo/files/:public:" + fileName ).accept( TEXT_PLAIN ).get( ClientResponse.class );
       assertResponse( response, Status.OK, TEXT_PLAIN );
       assertEquals( "contents of file incorrect/missing", text, response.getEntity( String.class ) );
 
-    }
-    catch(Throwable th){
-        TestCase.fail();
-    }
-    finally{
+    } catch ( Throwable th ) {
+      TestCase.fail();
+    } finally {
       cleanupUserAndRoles( mainTenant_1 );
       cleanupUserAndRoles( systemTenant );
     }
@@ -375,17 +374,17 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     mp.defineInstance( IUnifiedRepository.class, repo );
     loginAsRepositoryAdmin();
     ITenant systemTenant =
-        tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
-            authenticatedAuthorityName, "Anonymous" );
-    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[]{adminAuthorityName} );
-    login( sysAdminUserName, systemTenant, new String[]{adminAuthorityName, authenticatedAuthorityName} );
+      tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
+        authenticatedAuthorityName, "Anonymous" );
+    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[] { adminAuthorityName } );
+    login( sysAdminUserName, systemTenant, new String[] { adminAuthorityName, authenticatedAuthorityName } );
 
     ITenant mainTenant_1 =
-        tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
-            "Anonymous" );
-    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[]{adminAuthorityName} );
-    try{
-      login( "admin", mainTenant_1, new String[]{authenticatedAuthorityName} );
+      tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
+        "Anonymous" );
+    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[] { adminAuthorityName } );
+    try {
+      login( "admin", mainTenant_1, new String[] { authenticatedAuthorityName } );
 
       final String fileName = "file.txt";
 
@@ -395,27 +394,25 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
 
       ClientResponse r1 =
-          webResource.path( "repo/files/:public:" + fileName ).accept( TEXT_PLAIN ).get( ClientResponse.class );
+        webResource.path( "repo/files/:public:" + fileName ).accept( TEXT_PLAIN ).get( ClientResponse.class );
       assertResponse( r1, Status.OK, MediaType.TEXT_PLAIN );
       assertEquals( text, r1.getEntity( String.class ) );
 
-    // check again but with no Accept header
+      // check again but with no Accept header
       ClientResponse r2 = webResource.path( "repo/files/:public:" + fileName ).get( ClientResponse.class );
       assertResponse( r2, Status.OK, MediaType.TEXT_PLAIN );
       assertEquals( text, r2.getEntity( String.class ) );
 
-    // check again but with */*
+      // check again but with */*
       ClientResponse r3 =
-          webResource.path( "repo/files/:public:" + fileName ).accept( TEXT_PLAIN ).accept( MediaType.WILDCARD ).get(
-              ClientResponse.class );
+        webResource.path( "repo/files/:public:" + fileName ).accept( TEXT_PLAIN ).accept( MediaType.WILDCARD ).get(
+          ClientResponse.class );
       assertResponse( r3, Status.OK, MediaType.TEXT_PLAIN );
       assertEquals( text, r3.getEntity( String.class ) );
 
-    }
-    catch(Throwable ex){
+    } catch ( Throwable ex ) {
       TestCase.fail();
-    }
-    finally{
+    } finally {
       cleanupUserAndRoles( mainTenant_1 );
       cleanupUserAndRoles( systemTenant );
     }
@@ -429,7 +426,7 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     WebResource webResource = resource();
     try {
       webResource.path( "repo/files/public:thisfiledoesnotexist.txt" ).accept( TEXT_PLAIN ).get(
-              ClientResponse.class );
+        ClientResponse.class );
     } catch ( UnifiedRepositoryException ure ) {
       assertNotNull( ure );
     }
@@ -452,16 +449,16 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
     loginAsRepositoryAdmin();
     ITenant systemTenant =
-        tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
-            authenticatedAuthorityName, "Anonymous" );
-    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[]{adminAuthorityName} );
-    login( sysAdminUserName, systemTenant, new String[]{adminAuthorityName, authenticatedAuthorityName} );
+      tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
+        authenticatedAuthorityName, "Anonymous" );
+    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[] { adminAuthorityName } );
+    login( sysAdminUserName, systemTenant, new String[] { adminAuthorityName, authenticatedAuthorityName } );
 
     ITenant mainTenant_1 =
-        tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
-            "Anonymous" );
-    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[]{adminAuthorityName} );
-    try{
+      tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
+        "Anonymous" );
+    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[] { adminAuthorityName } );
+    try {
       login( "admin", mainTenant_1, new String[] { authenticatedAuthorityName, adminAuthorityName } );
 
       mp.defineInstance( IUnifiedRepository.class, repo );
@@ -470,7 +467,7 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
       final String fileName = "file.txt";
       createTestFile( "/public".replaceAll( "/", ":" ) + ":" + fileName, text );
 
-    // test download of file
+      // test download of file
       WebResource webResource = resource();
       webResource.path( "repo/files/public:file.txt/download" ).get( ClientResponse.class );
 
@@ -478,11 +475,9 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
       ClientResponse r2 = webResource.path( "repo/files/public:file.txt/download" ).get( ClientResponse.class );
       assertResponse( r2, Status.OK );
       JerseyTestUtil.assertResponseIsZip( r2 );
-    }
-    catch( Throwable ex ){
+    } catch ( Throwable ex ) {
       TestCase.fail();
-    }
-    finally{
+    } finally {
       cleanupUserAndRoles( mainTenant_1 );
       cleanupUserAndRoles( systemTenant );
     }
@@ -493,33 +488,31 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   public void testGetDirChildren() {
     loginAsRepositoryAdmin();
     ITenant systemTenant =
-        tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
-            authenticatedAuthorityName, "Anonymous" );
+      tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
+        authenticatedAuthorityName, "Anonymous" );
     userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[] { adminAuthorityName } );
     ITenant mainTenant_1 =
-        tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
-            "Anonymous" );
+      tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
+        "Anonymous" );
     userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[] { adminAuthorityName } );
-    try{
+    try {
       login( "admin", mainTenant_1, new String[] { authenticatedAuthorityName } );
 
-    // set object in PentahoSystem
+      // set object in PentahoSystem
       mp.defineInstance( IUnifiedRepository.class, repo );
       final String fileName = "file.txt";
       createTestFile( "/public".replaceAll( "/", ":" ) + ":" + fileName, "abcdefg" );
       WebResource webResource = resource();
       ClientResponse response =
-          webResource.path( "repo/files/public/children" ).accept( APPLICATION_XML ).get( ClientResponse.class );
+        webResource.path( "repo/files/public/children" ).accept( APPLICATION_XML ).get( ClientResponse.class );
 
       assertResponse( response, Status.OK, APPLICATION_XML );
 
       String xml = response.getEntity( String.class );
       assertTrue( xml.startsWith( "<?" ) );
-    }
-    catch( Throwable ex ){
+    } catch ( Throwable ex ) {
       TestCase.fail();
-    }
-    finally {
+    } finally {
       cleanupUserAndRoles( mainTenant_1 );
       cleanupUserAndRoles( systemTenant );
     }
@@ -529,15 +522,15 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   public void testFileAcls() throws InterruptedException {
     loginAsRepositoryAdmin();
     ITenant systemTenant =
-        tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
-            authenticatedAuthorityName, "Anonymous" );
-    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[]{adminAuthorityName} );
+      tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
+        authenticatedAuthorityName, "Anonymous" );
+    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[] { adminAuthorityName } );
     ITenant mainTenant_1 =
-        tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
-            "Anonymous" );
-    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[]{adminAuthorityName} );
-    try{
-      login( "admin", mainTenant_1, new String[]{authenticatedAuthorityName} );
+      tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
+        "Anonymous" );
+    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[] { adminAuthorityName } );
+    try {
+      login( "admin", mainTenant_1, new String[] { authenticatedAuthorityName } );
       mp.defineInstance( IUnifiedRepository.class, repo );
 
       String publicFolderPath = ClientRepositoryPaths.getPublicFolderPath();
@@ -545,8 +538,8 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
       WebResource webResource = resource();
       RepositoryFileAclDto fileAcls =
-          webResource.path( "repo/files/public:aclFile.txt/acl" ).accept( APPLICATION_XML ).get(
-              RepositoryFileAclDto.class );
+        webResource.path( "repo/files/public:aclFile.txt/acl" ).accept( APPLICATION_XML ).get(
+          RepositoryFileAclDto.class );
       List<RepositoryFileAclAceDto> aces = fileAcls.getAces();
       assertEquals( 2, aces.size() );
       RepositoryFileAclAceDto ace = aces.get( 0 );
@@ -568,14 +561,12 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
       fileAcls.setAces( aces );
 
       ClientResponse putResponse2 =
-          webResource.path( "repo/files/public:aclFile.txt/acl" ).type( APPLICATION_XML ).put( ClientResponse.class,
-              fileAcls );
+        webResource.path( "repo/files/public:aclFile.txt/acl" ).type( APPLICATION_XML ).put( ClientResponse.class,
+          fileAcls );
       assertResponse( putResponse2, Status.OK );
-    }
-    catch(Throwable ex){
+    } catch ( Throwable ex ) {
       TestCase.fail();
-    }
-    finally{
+    } finally {
       cleanupUserAndRoles( mainTenant_1 );
       cleanupUserAndRoles( systemTenant );
     }
@@ -585,20 +576,20 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   public void testDeleteFiles() {
     loginAsRepositoryAdmin();
     ITenant systemTenant =
-        tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
-            authenticatedAuthorityName, "Anonymous" );
-    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[]{adminAuthorityName} );
+      tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
+        authenticatedAuthorityName, "Anonymous" );
+    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[] { adminAuthorityName } );
     ITenant mainTenant_1 =
-        tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
-            "Anonymous" );
-    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[]{adminAuthorityName} );
-    try{
-      login( "admin", mainTenant_1, new String[]{authenticatedAuthorityName} );
+      tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
+        "Anonymous" );
+    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[] { adminAuthorityName } );
+    try {
+      login( "admin", mainTenant_1, new String[] { authenticatedAuthorityName } );
 
       String testFile1Id = "abc.txt";
       String testFile2Id = "def.txt";
 
-    // set object in PentahoSystem
+      // set object in PentahoSystem
       mp.defineInstance( IUnifiedRepository.class, repo );
 
       String publicFolderPath = ClientRepositoryPaths.getPublicFolderPath();
@@ -616,11 +607,9 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
       assertEquals( 2, deletedFiles.length );
 
       webResource.path( "repo/files/deletepermanent" ).entity( file2.getId() ).put();
-    }
-    catch(Throwable ex){
+    } catch ( Throwable ex ) {
       TestCase.fail();
-    }
-    finally{
+    } finally {
       cleanupUserAndRoles( mainTenant_1 );
       cleanupUserAndRoles( systemTenant );
     }
@@ -630,17 +619,17 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   public void testFileCreator() {
     loginAsRepositoryAdmin();
     ITenant systemTenant =
-        tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
-            authenticatedAuthorityName, "Anonymous" );
-    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[]{adminAuthorityName} );
+      tenantManager.createTenant( null, ServerRepositoryPaths.getPentahoRootFolderName(), adminAuthorityName,
+        authenticatedAuthorityName, "Anonymous" );
+    userRoleDao.createUser( systemTenant, sysAdminUserName, "password", "", new String[] { adminAuthorityName } );
     ITenant mainTenant_1 =
-        tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
-            "Anonymous" );
-    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[]{adminAuthorityName} );
-    try{
-      login( "admin", mainTenant_1, new String[]{authenticatedAuthorityName} );
+      tenantManager.createTenant( systemTenant, MAIN_TENANT_1, adminAuthorityName, authenticatedAuthorityName,
+        "Anonymous" );
+    userRoleDao.createUser( mainTenant_1, "admin", "password", "", new String[] { adminAuthorityName } );
+    try {
+      login( "admin", mainTenant_1, new String[] { authenticatedAuthorityName } );
 
-    // set object in PentahoSystem
+      // set object in PentahoSystem
       mp.defineInstance( IUnifiedRepository.class, repo );
 
       WebResource webResource = resource();
@@ -650,16 +639,14 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
       RepositoryFileDto file2 = new RepositoryFileDto();
       file2.setId( file1.getId().toString() );
       webResource.path( "repo/files/public:file1.txt/creator" ).entity( file2 ).put();
-    }
-    catch(Throwable ex){
+    } catch ( Throwable ex ) {
       TestCase.fail();
-    }
-    finally{
+    } finally {
       cleanupUserAndRoles( mainTenant_1 );
       cleanupUserAndRoles( systemTenant );
       logout();
     }
-    
+
   }
 
   @Test
@@ -685,8 +672,8 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     sysAdminUserName = (String) applicationContext.getBean( "superAdminUserName" );
     authorizationPolicy = (IAuthorizationPolicy) applicationContext.getBean( "authorizationPolicy" );
     roleBindingDaoTarget =
-        (IRoleAuthorizationPolicyRoleBindingDao) applicationContext
-            .getBean( "roleAuthorizationPolicyRoleBindingDaoTarget" );
+      (IRoleAuthorizationPolicyRoleBindingDao) applicationContext
+        .getBean( "roleAuthorizationPolicyRoleBindingDaoTarget" );
     tenantManager = (ITenantManager) applicationContext.getBean( "tenantMgrTxn" );
     repositoryFileDao = (IRepositoryFileDao) applicationContext.getBean( "repositoryFileDao" );
     userRoleDao = (IUserRoleDao) applicationContext.getBean( "userRoleDaoTxn" );
@@ -695,7 +682,7 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     repo = (IUnifiedRepository) applicationContext.getBean( "unifiedRepository" );
     TestPrincipalProvider.userRoleDao = (IUserRoleDao) applicationContext.getBean( "userRoleDaoTxn" );
     TestPrincipalProvider.adminCredentialsStrategy =
-        (CredentialsStrategy) applicationContext.getBean( "jcrAdminCredentialsStrategy" );
+      (CredentialsStrategy) applicationContext.getBean( "jcrAdminCredentialsStrategy" );
     TestPrincipalProvider.repository = (Repository) applicationContext.getBean( "jcrRepository" );
   }
 
@@ -703,12 +690,12 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     StandaloneSession pentahoSession = new StandaloneSession( repositoryAdminUsername );
     pentahoSession.setAuthenticated( repositoryAdminUsername );
     final GrantedAuthority[] repositoryAdminAuthorities =
-        new GrantedAuthority[]{new GrantedAuthorityImpl( sysAdminAuthorityName )};
+      new GrantedAuthority[] { new GrantedAuthorityImpl( sysAdminAuthorityName ) };
     final String password = "ignored";
     UserDetails repositoryAdminUserDetails =
-        new User( repositoryAdminUsername, password, true, true, true, true, repositoryAdminAuthorities );
+      new User( repositoryAdminUsername, password, true, true, true, true, repositoryAdminAuthorities );
     Authentication repositoryAdminAuthentication =
-        new UsernamePasswordAuthenticationToken( repositoryAdminUserDetails, password, repositoryAdminAuthorities );
+      new UsernamePasswordAuthenticationToken( repositoryAdminUserDetails, password, repositoryAdminAuthorities );
     PentahoSessionHolder.setSession( pentahoSession );
     // this line necessary for Spring Security's MethodSecurityInterceptor
     SecurityContextHolder.getContext().setAuthentication( repositoryAdminAuthentication );
@@ -742,7 +729,7 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     for ( String roleName : roles ) {
       authList.add( new GrantedAuthorityImpl( roleName ) );
     }
-    GrantedAuthority[] authorities = authList.toArray( new GrantedAuthority[0] );
+    GrantedAuthority[] authorities = authList.toArray( new GrantedAuthority[ 0 ] );
     UserDetails userDetails = new User( username, password, true, true, true, true, authorities );
     Authentication auth = new UsernamePasswordAuthenticationToken( userDetails, password, authorities );
     PentahoSessionHolder.setSession( pentahoSession );
@@ -768,7 +755,7 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     if ( tenantAdmin ) {
       authList.add( new GrantedAuthorityImpl( adminAuthorityName ) );
     }
-    GrantedAuthority[] authorities = authList.toArray( new GrantedAuthority[0] );
+    GrantedAuthority[] authorities = authList.toArray( new GrantedAuthority[ 0 ] );
     UserDetails userDetails = new User( username, password, true, true, true, true, authorities );
     Authentication auth = new UsernamePasswordAuthenticationToken( userDetails, password, authorities );
     PentahoSessionHolder.setSession( pentahoSession );

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
@@ -915,12 +915,12 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
             destParentFolderNode );
         String finalEncodedSrcAbsPath = srcFileNode.getPath();
         String finalEncodedDestAbsPath = null;
-        if ( appendFileName && !file.isFolder() ) {
-          if ( JcrStringHelper.pathDecode( srcFileNode.getName() ).equals( srcFileNode.getName() ) ) {
-            finalEncodedDestAbsPath = JcrStringHelper.pathEncode( cleanDestAbsPath + RepositoryFile.SEPARATOR + srcFileNode.getName() );
+        if ( appendFileName ) {
+          final String fileName = srcFileNode.getName();
+          if ( JcrStringHelper.isEncoded( fileName ) ) {
+            finalEncodedDestAbsPath = JcrStringHelper.pathEncode( cleanDestAbsPath ) + RepositoryFile.SEPARATOR + fileName;
           } else {
-            //name is already encoded (BISERVER-12569)
-            finalEncodedDestAbsPath = JcrStringHelper.pathEncode( cleanDestAbsPath ) + RepositoryFile.SEPARATOR + srcFileNode.getName();
+            finalEncodedDestAbsPath = JcrStringHelper.pathEncode( cleanDestAbsPath + RepositoryFile.SEPARATOR + fileName );
           }
         } else {
           finalEncodedDestAbsPath = JcrStringHelper.pathEncode( cleanDestAbsPath );

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelper.java
@@ -31,6 +31,7 @@ public class JcrStringHelper {
 
   private static boolean useMultiByteEncoding = false;
   private static boolean multiByteValueInitialized = false;
+  private static final String SEPARATOR = "/";
 
   private JcrStringHelper() {
   }
@@ -92,12 +93,12 @@ public class JcrStringHelper {
    * @return
    */
   public static String pathEncode( String path ) {
-    String[] folders = path.split( "/" );
+    String[] folders = path.split( SEPARATOR );
     StringBuilder encodedPath = new StringBuilder( path.length() * 2 );
     for ( int i = 0; i < folders.length; i++ ) {
       encodedPath.append( fileNameEncode( folders[i] ) );
-      if ( i != folders.length - 1 || path.endsWith( "/" ) ) {
-        encodedPath.append( "/" );
+      if ( i != folders.length - 1 || path.endsWith( SEPARATOR ) ) {
+        encodedPath.append( SEPARATOR );
       }
     }
     return encodedPath.toString();
@@ -111,12 +112,12 @@ public class JcrStringHelper {
    * @return
    */
   public static String pathEncode( String path, boolean useMultiByte ) {
-    String[] folders = path.split( "/" );
+    String[] folders = path.split( SEPARATOR );
     StringBuilder encodedPath = new StringBuilder( path.length() * 2 );
     for ( int i = 0; i < folders.length; i++ ) {
       encodedPath.append( fileNameEncode( folders[i], useMultiByte ) );
-      if ( i != folders.length - 1 || path.endsWith( "/" ) ) {
-        encodedPath.append( "/" );
+      if ( i != folders.length - 1 || path.endsWith( SEPARATOR ) ) {
+        encodedPath.append( SEPARATOR );
       }
     }
     return encodedPath.toString();
@@ -129,12 +130,12 @@ public class JcrStringHelper {
    * @return
    */
   public static String pathDecode( String encodedPath ) {
-    String[] folders = encodedPath.split( "/" );
+    String[] folders = encodedPath.split( SEPARATOR );
     StringBuilder decodedPath = new StringBuilder( encodedPath.length() * 2 );
     for ( int i = 0; i < folders.length; i++ ) {
       decodedPath.append( fileNameDecode( folders[i] ) );
-      if ( i != folders.length - 1 || encodedPath.endsWith( "/" ) ) {
-        decodedPath.append( "/" );
+      if ( i != folders.length - 1 || encodedPath.endsWith( SEPARATOR ) ) {
+        decodedPath.append( SEPARATOR );
       }
     }
     return decodedPath.toString();
@@ -148,12 +149,12 @@ public class JcrStringHelper {
    * @return
    */
   public static String pathDecode( String encodedPath, boolean useMultiByte ) {
-    String[] folders = encodedPath.split( "/" );
+    String[] folders = encodedPath.split( SEPARATOR );
     StringBuilder decodedPath = new StringBuilder( encodedPath.length() * 2 );
     for ( int i = 0; i < folders.length; i++ ) {
       decodedPath.append( fileNameDecode( folders[i], useMultiByte ) );
-      if ( i != folders.length - 1 || encodedPath.endsWith( "/" ) ) {
-        decodedPath.append( "/" );
+      if ( i != folders.length - 1 || encodedPath.endsWith( SEPARATOR ) ) {
+        decodedPath.append( SEPARATOR );
       }
     }
     return decodedPath.toString();
@@ -175,9 +176,27 @@ public class JcrStringHelper {
 
   /**
    *
-   * @param versioningEnabled
+   * @param useMultiByteEncoding
+   *
    */
   public static void setMultiByteEncodingEnabled( boolean useMultiByteEncoding ) {
     JcrStringHelper.useMultiByteEncoding = useMultiByteEncoding;
   }
+
+  /**
+   *
+   * Assume that path is encoded and try to decode it.
+   * If it changes from original, it is already encoded,
+   * else - it is not.
+   * @param path
+   *          path, needed to be evaluated
+   * @return
+   *      true if path is already encoded,
+   *      false otherwise
+   *
+   */
+  public static boolean isEncoded( String path ) {
+    return !path.equals( pathDecode( path ) );
+  }
+
 }

--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelper.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelper.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2006 - 2014 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
  *
  */
 
@@ -133,7 +133,7 @@ public class JcrStringHelper {
     String[] folders = encodedPath.split( SEPARATOR );
     StringBuilder decodedPath = new StringBuilder( encodedPath.length() * 2 );
     for ( int i = 0; i < folders.length; i++ ) {
-      decodedPath.append( fileNameDecode( folders[i] ) );
+      decodedPath.append( fileNameDecode( folders[ i ] ) );
       if ( i != folders.length - 1 || encodedPath.endsWith( SEPARATOR ) ) {
         decodedPath.append( SEPARATOR );
       }
@@ -163,8 +163,8 @@ public class JcrStringHelper {
   public static boolean isMultiByteEncodingEnabled() {
     if ( !multiByteValueInitialized && PentahoSystem.getInitializedOK() ) {
       Boolean setting =
-          PentahoSystem.get( Boolean.class, "useMultiByteEncoding", PentahoSessionHolder.getSession() );
-      if( setting == null ){
+        PentahoSystem.get( Boolean.class, "useMultiByteEncoding", PentahoSessionHolder.getSession() );
+      if ( setting == null ) {
         useMultiByteEncoding = false;
       } else {
         useMultiByteEncoding = setting;

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelperTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelperTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.repository2.unified.jcr;
@@ -124,7 +124,7 @@ public class JcrStringHelperTest {
 
   @Test
   public void testFileIsNotEncoded() {
-     assertFalse( JcrStringHelper.isEncoded( PATH_TO_REPORT_NOT_ENCODED ) );
+    assertFalse( JcrStringHelper.isEncoded( PATH_TO_REPORT_NOT_ENCODED ) );
   }
 
   @Test

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelperTest.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/JcrStringHelperTest.java
@@ -21,10 +21,13 @@ import org.junit.Test;
 import org.pentaho.platform.engine.core.system.boot.PlatformInitializationException;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 
+import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 
 public class JcrStringHelperTest {
+  private static final String PATH_TO_REPORT_NOT_ENCODED = "/home/admin/[~!@#$%^&*(){}|.,]-=_+|;'\"?<>~`.prpti";
+  private static final String PATH_TO_REPORT_ENCODED = "/home/admin/%5B~!@#$%25^&%2A(){}%7C.,%5D-=_+%7C;'\"?<>~`.prpti";
 
   @Test
   public void testLetterDigitIDEncode() {
@@ -113,10 +116,20 @@ public class JcrStringHelperTest {
 
   @Test
   public void testPathWithSpecificCharactersDecode() {
-    String path = "/home/admin/[~!@#$%^&*(){}|.,]-=_+|;'\"?<>~`.prpti";
-    String encodedPath = JcrStringHelper.pathEncode( path );
-    assertFalse( path.equals( encodedPath ) );
+    String encodedPath = JcrStringHelper.pathEncode( PATH_TO_REPORT_NOT_ENCODED );
+    assertFalse( PATH_TO_REPORT_NOT_ENCODED.equals( encodedPath ) );
     String decodedPath = JcrStringHelper.pathDecode( encodedPath );
-    assertEquals( path, decodedPath );
+    assertEquals( PATH_TO_REPORT_NOT_ENCODED, decodedPath );
   }
+
+  @Test
+  public void testFileIsNotEncoded() {
+     assertFalse( JcrStringHelper.isEncoded( PATH_TO_REPORT_NOT_ENCODED ) );
+  }
+
+  @Test
+  public void testFileIsEncoded() {
+    assertTrue( JcrStringHelper.isEncoded( PATH_TO_REPORT_ENCODED ) );
+  }
+
 }

--- a/user-console/source/org/pentaho/mantle/client/commands/RestoreFileCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/RestoreFileCommand.java
@@ -130,7 +130,7 @@ public class RestoreFileCommand implements Command {
             event.setMessage( "Success" );
             EventBusUtil.EVENT_BUS.fireEvent( event );
           } else if ( response.getStatusCode() == Response.SC_CONFLICT
-            || response.getStatusCode() == Response.SC_TEMPORARY_REDIRECT ) {
+            || response.getStatusCode() == Response.SC_NOT_ACCEPTABLE ) {
             final int restoreResponseStatusCode = response.getStatusCode();
 
             final String userHomeDirUrl = GWT.getHostPageBaseURL() + "api/session/userWorkspaceDir";
@@ -238,7 +238,7 @@ public class RestoreFileCommand implements Command {
           };
           overwriteDialog.setCallback( callback );
           overwriteDialog.center();
-        } else if ( restoreResponseStatusCode == Response.SC_TEMPORARY_REDIRECT ) {
+        } else if ( restoreResponseStatusCode == Response.SC_NOT_ACCEPTABLE ) {
           String moveFilesURL = contextURL + "api/repo/files/" + encodedUserHomeFolderPath + "/move";
           RequestBuilder builder = new RequestBuilder( RequestBuilder.PUT, moveFilesURL );
           try {

--- a/user-console/source/org/pentaho/mantle/client/commands/RestoreFileCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/RestoreFileCommand.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.commands;


### PR DESCRIPTION
**FileService**

- Move the logic of file-copy method to CopyFilesOperation class, represent copy file operation as an immutable object, and move specific method (used only from copyFiles method) to this CopyFilesOperation class.
- Small optimisation in doRestoreFilesToHomeFolder method, when no overwrite mode (passing only non-conflict files for copy operation)

**CopyFilesOperation**

- Contains all the logic of FileService  doCopyFiles method (copy with every possible mode is devided into a separete method). 
- Added a possibility to copy folders, performing deep copy folder.

*Note:* I found no reason to limit deepness of folders hierarchy (the worst possible consequence - long scanning)


**RepositoryFileHelper**
- Class, where some methods from FileService were replaced (so as to be able to use them from CopyFilesOperation class.

**FileResource, RestoreFileCommand**

- Changed returned responce status, that is sent when restoring files in user home directory and there are no conlicts in it. Need to do it, because of IE bug, that doesn't see some statuses ([link to this bug](https://connect.microsoft.com/IE/feedback/details/785990/ie-10-on-win8-does-not-assign-the-correct-status-to-xmlhttprequest-when-the-result-is-401))

**FileServiceTest**
Due to refactoring few tests related to copy operation were changed (behavior wasn't changed and new tests, that test everything, that was tested in previouse tests (and much more) were written ). 

**FileResourceIT** 
One test for copy operation was deleted, as it was dummy. In short: it tested nothing, as destination directory was null  (In my approach, I validate it in constructor), so copy operation didn't even start. If more explicit report needed, I will provide it.

**CopyFilesOperation_DeepFolderCopyTest, CopyFilesOperation_CopyTest**
- Tests for CopyFilesOperation class

**JcrRepositoryFileDao**
- Provided a way to copy/move folders, not only files.
- Small refactoring made (to increase code readility)

**JcrStringHelper**
- Method, checking if the path is decoded or not.
- Test written
- Small refactoring

***Final Note:*** The changes are big enough, and after making them I tested them as carefully as possible. So, I made tests on:
- Simple copy of files (so as to be sure, I didn't break something): here I found a bug (not because of my changed), and it is reproducible since 6.0 version (I made a [JIRA ticket](http://jira.pentaho.com/browse/BISERVER-13022) for it)
- Restoring files.
- Restoring folders with 10 folder hierarchy.



@rmansoor, @pentaho-nbaker, review it please