### PR TITLE
[SP-2412] - Backport of BISERVER-12851 - Restore (import/export) - Schedules are not being restored. (6.0 Suite)

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -270,24 +270,7 @@ public class SolutionImportHandler implements IPlatformImportHandler {
       }
     }
     if ( manifest != null ) {
-      List<JobScheduleRequest> scheduleList = manifest.getScheduleList();
-      if ( scheduleList != null ) {
-        SchedulerResource schedulerResource = new SchedulerResource();
-        for ( JobScheduleRequest jobScheduleRequest : scheduleList ) {
-          try {
-            Response response = createSchedulerJob( schedulerResource, jobScheduleRequest );
-            if ( response.getStatus() == Response.Status.OK.getStatusCode() ) {
-              if ( response.getEntity() != null ) {
-                // get the schedule job id from the response and add it to the import session
-                ImportSession.getSession().addImportedScheduleJobId( response.getEntity().toString() );
-              }
-            }
-          } catch ( Exception e ) {
-            throw new PlatformImportException( Messages.getInstance()
-                .getString( "SolutionImportHandler.ERROR_0001_ERROR_CREATING_SCHEDULE", e.getMessage() ) );
-          }
-        }
-      }
+      importSchedules( manifest.getScheduleList() );
 
       // Add Pentaho Connections
       List<org.pentaho.database.model.DatabaseConnection> datasourceList = manifest.getDatasourceList();
@@ -319,6 +302,56 @@ public class SolutionImportHandler implements IPlatformImportHandler {
     }
     // Process locale files.
     localeFilesProcessor.processLocaleFiles( importer );
+  }
+
+  protected void importSchedules( List<JobScheduleRequest> scheduleList ) throws PlatformImportException {
+    if ( scheduleList != null ) {
+      SchedulerResource schedulerResource = new SchedulerResource();
+      for ( JobScheduleRequest jobScheduleRequest : scheduleList ) {
+        try {
+          Response response = createSchedulerJob( schedulerResource, jobScheduleRequest );
+          if ( response.getStatus() == Response.Status.OK.getStatusCode() ) {
+            if ( response.getEntity() != null ) {
+              // get the schedule job id from the response and add it to the import session
+              ImportSession.getSession().addImportedScheduleJobId( response.getEntity().toString() );
+            }
+          }
+        } catch ( Exception e ) {
+          // there is a scenario where if the file scheduled has a space in the file name, that it won't work. the di server
+          // replaces spaces with underscores and the export mechanism can't determine if it needs this to happen or not
+          // so, if we failed to import and there is a space in the path, try again but this time with replacing the space(s)
+          if ( jobScheduleRequest.getInputFile().contains( " " ) || jobScheduleRequest.getOutputFile().contains( " " ) ) {
+            log.info( "Could not import schedule, attempting to replace spaces with underscores and retrying: "
+              + jobScheduleRequest.getInputFile() );
+            File inFile = new File( jobScheduleRequest.getInputFile() );
+            File outFile = new File( jobScheduleRequest.getOutputFile() );
+            String inputFileName = inFile.getParent() + RepositoryFile.SEPARATOR
+              + inFile.getName().replaceAll( " ", "_" );
+            String outputFileName = outFile.getParent() + RepositoryFile.SEPARATOR
+              + outFile.getName().replaceAll( " ", "_" );
+            jobScheduleRequest.setInputFile( inputFileName );
+            jobScheduleRequest.setOutputFile( outputFileName );
+            try {
+              Response response = createSchedulerJob( schedulerResource, jobScheduleRequest );
+              if ( response.getStatus() == Response.Status.OK.getStatusCode() ) {
+                if ( response.getEntity() != null ) {
+                  // get the schedule job id from the response and add it to the import session
+                  ImportSession.getSession().addImportedScheduleJobId( response.getEntity().toString() );
+                }
+              }
+            } catch ( Exception ex ) {
+              // log it and keep going. we should stop processing all schedules just because one fails.
+              log.error( Messages.getInstance()
+                .getString( "SolutionImportHandler.ERROR_0001_ERROR_CREATING_SCHEDULE", e.getMessage() ) );
+            }
+          } else {
+            // log it and keep going. we should stop processing all schedules just because one fails.
+            log.error( Messages.getInstance()
+              .getString( "SolutionImportHandler.ERROR_0001_ERROR_CREATING_SCHEDULE", e.getMessage() ) );
+          }
+        }
+      }
+    }
   }
 
   protected void importMetaStore( ExportManifest manifest, boolean overwrite ) {
@@ -437,7 +470,7 @@ public class SolutionImportHandler implements IPlatformImportHandler {
             }
           }
         }
-      } catch( SecurityException e) {
+      } catch ( SecurityException e ) {
         log.error( Messages.getInstance().getString( "ERROR.ImportingUserSetting", user.getUsername() ) );
         log.debug( Messages.getInstance().getString( "ERROR.ImportingUserSetting", user.getUsername() ), e );
       }

--- a/extensions/test-src/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
@@ -3,6 +3,7 @@ package org.pentaho.platform.plugin.services.importer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 import org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException;
 import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
 import org.pentaho.platform.api.mimetype.IMimeType;
@@ -12,17 +13,23 @@ import org.pentaho.platform.api.usersettings.IUserSettingService;
 import org.pentaho.platform.api.usersettings.pojo.IUserSetting;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.services.importexport.ExportManifestUserSetting;
+import org.pentaho.platform.plugin.services.importexport.ImportSession;
 import org.pentaho.platform.plugin.services.importexport.RoleExport;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetaStore;
 import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
+import org.pentaho.platform.web.http.api.resources.JobScheduleRequest;
+import org.pentaho.platform.web.http.api.resources.SchedulerResource;
 
+import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.commons.io.FilenameUtils.separatorsToUnix;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -393,8 +400,86 @@ public class SolutionImportHandlerTest {
 
   }
 
+  @Test
+  public void testImportSchedules() throws Exception {
+    List<JobScheduleRequest> schedules = new ArrayList<>();
+    JobScheduleRequest scheduleRequest = spy( new JobScheduleRequest() );
+    schedules.add( scheduleRequest );
+
+    SolutionImportHandler spyHandler = spy( importHandler );
+    Response response = mock ( Response.class );
+    when( response.getStatus() ).thenReturn( Response.Status.OK.getStatusCode() );
+    when( response.getEntity() ).thenReturn( "job id" );
+
+    doReturn( response ).when( spyHandler ).createSchedulerJob( any( SchedulerResource.class ), eq( scheduleRequest ) );
+
+    spyHandler.importSchedules( schedules );
+
+    verify( spyHandler ).createSchedulerJob( any( SchedulerResource.class ), eq( scheduleRequest ) );
+    assertEquals( 1, ImportSession.getSession().getImportedScheduleJobIds().size() );
+  }
+
+  @Test
+  public void testImportSchedules_FailsToCreateSchedule() throws Exception {
+    List<JobScheduleRequest> schedules = new ArrayList<>();
+    JobScheduleRequest scheduleRequest = spy( new JobScheduleRequest() );
+    scheduleRequest.setInputFile( "/home/admin/scheduledTransform.ktr" );
+    scheduleRequest.setOutputFile( "/home/admin/scheduledTransform*" );
+    schedules.add( scheduleRequest );
+
+    SolutionImportHandler spyHandler = spy( importHandler );
+
+    doThrow( new IOException( "error creating schedule" ) ).when( spyHandler ).createSchedulerJob(
+      any( SchedulerResource.class ), eq( scheduleRequest ) );
+
+    spyHandler.importSchedules( schedules );
+    assertEquals( 0, ImportSession.getSession().getImportedScheduleJobIds().size() );
+  }
+
+  @Test
+  public void testImportSchedules_FailsToCreateScheduleWithSpace() throws Exception {
+    List<JobScheduleRequest> schedules = new ArrayList<>();
+    JobScheduleRequest scheduleRequest = spy( new JobScheduleRequest() );
+    scheduleRequest.setInputFile( "/home/admin/scheduled Transform.ktr" );
+    scheduleRequest.setOutputFile( "/home/admin/scheduled Transform*" );
+    schedules.add( scheduleRequest );
+
+    SolutionImportHandler spyHandler = spy( importHandler );
+
+    ScheduleRequestMatcher throwMatcher = new ScheduleRequestMatcher( "/home/admin/scheduled Transform.ktr", "/home/admin/scheduled Transform*" );
+    doThrow( new IOException( "error creating schedule" ) ).when( spyHandler ).createSchedulerJob(
+      any( SchedulerResource.class ), argThat( throwMatcher ) );
+
+    Response response = mock( Response.class );
+    when( response.getStatus() ).thenReturn( Response.Status.OK.getStatusCode() );
+    when( response.getEntity() ).thenReturn( "job id" );
+    ScheduleRequestMatcher goodMatcher = new ScheduleRequestMatcher( "/home/admin/scheduled_Transform.ktr", "/home/admin/scheduled_Transform*" );
+    doReturn( response ).when( spyHandler ).createSchedulerJob( any( SchedulerResource.class ), argThat(
+      goodMatcher ) );
+
+    spyHandler.importSchedules( schedules );
+    verify( spyHandler, times( 2 ) ).createSchedulerJob( any( SchedulerResource.class ), any( JobScheduleRequest.class ) );
+    assertEquals( 1, ImportSession.getSession().getImportedScheduleJobIds().size() );
+  }
+
+  private class ScheduleRequestMatcher extends ArgumentMatcher<JobScheduleRequest> {
+    private String input;
+    private String output;
+    public ScheduleRequestMatcher( String input, String output ) {
+      this.input = input;
+      this.output = output;
+    }
+    @Override public boolean matches( Object argument ) {
+      JobScheduleRequest jsr = (JobScheduleRequest) argument;
+      boolean matchedInput = input.equals( separatorsToUnix( jsr.getInputFile() ) );
+      boolean matchedOutput = output.equals( separatorsToUnix( jsr.getOutputFile() ) );
+      return matchedInput && matchedOutput;
+    }
+  }
+
   @After
   public void tearDown() throws Exception {
+    ImportSession.getSession().getImportedScheduleJobIds().clear();
     PentahoSystem.clearObjectFactory();
   }
 }


### PR DESCRIPTION
- backport the original fix
- make SolutionImportHandlerTest OS-independent
(adopted from commits 96dbdd5, 8ddb236)

@rfellows, review it please. This is a backport pf https://github.com/pentaho/pentaho-platform/pull/2647 and https://github.com/pentaho/pentaho-platform/pull/2774 