### PR TITLE
[PPP-3455] - Dynamic code injection vulnerabilities found

### DIFF
--- a/user-console/source/org/pentaho/mantle/rebind/EventBusUtilGenerator.java
+++ b/user-console/source/org/pentaho/mantle/rebind/EventBusUtilGenerator.java
@@ -290,9 +290,9 @@ public class EventBusUtilGenerator extends Generator {
               propertyName = propertyName.substring( 0, 1 ).toLowerCase() + propertyName.substring( 1 );
               String simpleType = implementingType.getField( propertyName ).getType().getSimpleSourceName();
               if ( "string".equalsIgnoreCase( simpleType ) ) {
-                parameterJSON += "\'" + propertyName + "\': \'\" + event." + eventMethod.getName() + "() + \"\',";
+                parameterJSON += "\\\"" + propertyName + "\\\": \\\"\\\\\\\" + event." + eventMethod.getName() + "() + \\\\\\\"\\\",";
               } else {
-                parameterJSON += "\'" + propertyName + "\': \" + event." + eventMethod.getName() + "() + \",";
+                parameterJSON += "\\\"" + propertyName + "\\\": \\\" + event." + eventMethod.getName() + "() + \\\",";
               }
             }
           }


### PR DESCRIPTION
- in EventBusUtilGenerator, change JSON object generating approach: use `"` instead of `'` to follow ECMA standard

@mdamour1976, review it please. This previous commit broke PUC, as `JSON.parse` rejects `'` as quoting signs.

We need a lot of backslashes here, because  " inside "" should be escaped as `\"`, and that `\` should be escaped as well -- `\\`, and two quotes need their own escaping...

I build mantle locally, and Browse File works now.

/cc @pamval 