### PR TITLE
[BACKLOG-6516] Relocate and rename pentaho.xml's 'verify-user-on-prin…

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
@@ -28,15 +28,6 @@
 	<log-level>DEBUG</log-level>
 
 	<!--
-		This flag indicates whether or not UserDetailsService is called during creation of user's principal.
-
-		If the service is external (e.g. LDAP or JDBC-based auth is used) then such calls can be expensive.
-		On the other hand, if user has been removed within external service, then it becomes impossible to
-		prevent principal creation when the verification is muted
-	-->
-	<verify-user-on-principal-creation>true</verify-user-on-principal-creation>
-
-	<!--
 		The configuration of publishers, system listeners, and session actions has been moved to
 		the systemListeners.xml, adminPlugins.xml, and sessionStartupActions.xml files which 
 		can be found in the "system" folder within your configured pentaho solution directory.

--- a/assembly/package-res/biserver/pentaho-solutions/system/security.properties
+++ b/assembly/package-res/biserver/pentaho-solutions/system/security.properties
@@ -1,2 +1,8 @@
 provider=jackrabbit
 requestParameterAuthenticationEnabled=false
+
+# This flag indicates whether or not UserDetailsService is called during creation of user's principal.
+# If the service is external (e.g. LDAP or JDBC-based auth is used) then such calls can be expensive.
+# On the other hand, if user has been removed within external service, then it becomes impossible to
+# prevent principal creation when the verification is muted
+skipUserVerificationOnPrincipalCreation=true


### PR DESCRIPTION
…cipal-creation' property

	- relocated property from pentaho.xml to security.properties
	- renamed it to it's opposite: from 'verify-user-on-principal-creation' to 'SkipUserVerificationOnPrincipalCreation'
	- ensured property is set to a default value of 'true'
	- safeguard/fallback behaviour: if property does not exist or is set to empty, assumes default value of 'true'
	- added a INFO-level log message with the property's value
	- sanitization: this property's value is checked only once on initialization ( rather that constantly reading its value from pentaho-xml/security.properties )
	- updated unit tests