### PR TITLE
[SP-2412] - Backport of BISERVER-12851 - Restore (import/export) - Schedules are not being restored. (6.0 Suite)

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.services.importer;
@@ -332,6 +332,11 @@ public class SolutionImportHandler implements IPlatformImportHandler {
             jobScheduleRequest.setInputFile( inputFileName );
             jobScheduleRequest.setOutputFile( outputFileName );
             try {
+              if ( File.separator != RepositoryFile.SEPARATOR ) {
+                // on windows systems, the backslashes will result in the file not being found in the repository
+                jobScheduleRequest.setInputFile( inputFileName.replace( File.separator, RepositoryFile.SEPARATOR ) );
+                jobScheduleRequest.setOutputFile( outputFileName.replace( File.separator, RepositoryFile.SEPARATOR ) );
+              }
               Response response = createSchedulerJob( schedulerResource, jobScheduleRequest );
               if ( response.getStatus() == Response.Status.OK.getStatusCode() ) {
                 if ( response.getEntity() != null ) {


### PR DESCRIPTION
- Restore (import/export) fails on windows when referenced files have spaces in the name

@DFieldFL, review it please as soon as you accept https://github.com/pentaho/pentaho-platform/pull/2781. This is a backport of that PR to 6.0

/cc @rfellows 