### PR TITLE
[BISERVER-11649] Mondrian role mappers don't pass the role name of a user when his username and group are both 'Admin'

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
@@ -24,6 +24,7 @@ import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
@@ -60,6 +61,8 @@ import org.pentaho.platform.web.http.api.resources.services.UserRoleDaoService;
 import org.pentaho.platform.web.http.api.resources.services.UserRoleDaoService.ValidationFailedException;
 
 import com.sun.jersey.api.NotFoundException;
+import org.springframework.security.GrantedAuthority;
+import org.springframework.security.GrantedAuthorityImpl;
 
 /**
  * UserRoleDao manages Pentaho Security user and roles in the BA platform.
@@ -324,6 +327,9 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
                                      @QueryParam( "roleNames" ) String roleNames ) {
     try {
       userRoleDaoService.assignRolesToUser( userName, roleNames );
+      if ( userName.equals( getSession().getName() ) ) {
+        updateRolesForCurrentSession();
+      }
       return Response.ok().build();
     } catch ( org.pentaho.platform.api.engine.security.userroledao.NotFoundException e ) {
       throw new WebApplicationException( Response.Status.INTERNAL_SERVER_ERROR );
@@ -359,6 +365,9 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
                                        @QueryParam( "roleNames" ) String roleNames ) {
     try {
       userRoleDaoService.removeRolesFromUser( userName, roleNames );
+      if ( userName.equals( getSession().getName() ) ) {
+        updateRolesForCurrentSession();
+      }
       return Response.ok().build();
     } catch ( org.pentaho.platform.api.engine.security.userroledao.NotFoundException e ) {
       throw new WebApplicationException( Response.status( Response.Status.NOT_FOUND ).entity( e.getLocalizedMessage() ).build() );
@@ -637,13 +646,17 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
   @Facet ( name = "Unsupported" )
   public Response assignAllRolesToUser( @QueryParam ( "tenant" ) String tenantPath,
                                         @QueryParam ( "userName" ) String userName ) {
-    IUserRoleDao roleDao =
-        PentahoSystem.get( IUserRoleDao.class, "userRoleDaoProxy", PentahoSessionHolder.getSession() );
+    IUserRoleDao roleDao = getUserRoleDao();
     Set<String> assignedRoles = new HashSet<String>();
     for ( IPentahoRole pentahoRole : roleDao.getRoles( getTenant( tenantPath ) ) ) {
       assignedRoles.add( pentahoRole.getName() );
     }
-    roleDao.setUserRoles( getTenant( tenantPath ), userName, assignedRoles.toArray( new String[0] ) );
+    roleDao.setUserRoles( getTenant( tenantPath ), userName, assignedRoles.toArray( new String[ 0 ] ) );
+
+    if ( userName.equals( getSession().getName() ) ) {
+      updateRolesForCurrentSession();
+    }
+
     return Response.ok().build();
   }
 
@@ -662,9 +675,13 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
                                           @QueryParam ( "userName" ) String userName ) {
     if ( canAdminister() ) {
       try {
-        IUserRoleDao roleDao =
-            PentahoSystem.get( IUserRoleDao.class, "userRoleDaoProxy", PentahoSessionHolder.getSession() );
+        IUserRoleDao roleDao = getUserRoleDao();
         roleDao.setUserRoles( getTenant( tenantPath ), userName, new String[0] );
+
+        if ( userName.equals( getSession().getName() ) ) {
+          updateRolesForCurrentSession();
+        }
+
         return Response.ok().build();
       } catch ( Throwable th ) {
         return processErrorResponse( th.getLocalizedMessage() );
@@ -689,8 +706,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
   public Response assignUserToRole( @QueryParam ( "tenant" ) String tenantPath,
                                     @QueryParam ( "userNames" ) String userNames, @QueryParam ( "roleName" ) String roleName ) {
     if ( canAdminister() ) {
-      IUserRoleDao roleDao =
-          PentahoSystem.get( IUserRoleDao.class, "userRoleDaoProxy", PentahoSessionHolder.getSession() );
+      IUserRoleDao roleDao = getUserRoleDao();
       StringTokenizer tokenizer = new StringTokenizer( userNames, "\t" );
       Set<String> assignedUserNames = new HashSet<String>();
       for ( IPentahoUser pentahoUser : roleDao.getRoleMembers( getTenant( tenantPath ), roleName ) ) {
@@ -701,6 +717,11 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
       }
       try {
         roleDao.setRoleMembers( getTenant( tenantPath ), roleName, assignedUserNames.toArray( new String[ 0 ] ) );
+
+        if ( assignedUserNames.contains( getSession().getName() ) ) {
+          updateRolesForCurrentSession();
+        }
+
         return Response.ok().build();
       } catch ( Throwable th ) {
         return processErrorResponse( th.getLocalizedMessage() );
@@ -726,8 +747,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
                                       @QueryParam ( "userNames" ) String userNames, @QueryParam ( "roleName" ) String roleName ) {
     if ( canAdminister() ) {
       try {
-        IUserRoleDao roleDao =
-            PentahoSystem.get( IUserRoleDao.class, "userRoleDaoProxy", PentahoSessionHolder.getSession() );
+        IUserRoleDao roleDao = getUserRoleDao();
         StringTokenizer tokenizer = new StringTokenizer( userNames, "\t" );
         Set<String> assignedUserNames = new HashSet<String>();
         for ( IPentahoUser pentahoUser : roleDao.getRoleMembers( getTenant( tenantPath ), roleName ) ) {
@@ -736,7 +756,10 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         while ( tokenizer.hasMoreTokens() ) {
           assignedUserNames.remove( tokenizer.nextToken() );
         }
-        roleDao.setRoleMembers( getTenant( tenantPath ), roleName, assignedUserNames.toArray( new String[0] ) );
+        roleDao.setRoleMembers( getTenant( tenantPath ), roleName, assignedUserNames.toArray( new String[ 0 ] ) );
+        if (assignedUserNames.contains( getSession().getName() )) {
+          updateRolesForCurrentSession();
+        }
         return Response.ok().build();
       } catch ( Throwable th ) {
         return processErrorResponse( th.getLocalizedMessage() );
@@ -759,13 +782,17 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
   @Facet ( name = "Unsupported" )
   public Response assignAllUsersToRole( @QueryParam ( "tenant" ) String tenantPath,
                                         @QueryParam ( "roleName" ) String roleName ) {
-    IUserRoleDao roleDao =
-        PentahoSystem.get( IUserRoleDao.class, "userRoleDaoProxy", PentahoSessionHolder.getSession() );
+    IUserRoleDao roleDao = getUserRoleDao();
     Set<String> assignedUserNames = new HashSet<String>();
     for ( IPentahoUser pentahoUser : roleDao.getUsers( getTenant( tenantPath ) ) ) {
       assignedUserNames.add( pentahoUser.getUsername() );
     }
-    roleDao.setRoleMembers( getTenant( tenantPath ), roleName, assignedUserNames.toArray( new String[0] ) );
+    roleDao.setRoleMembers( getTenant( tenantPath ), roleName, assignedUserNames.toArray( new String[ 0 ] ) );
+
+    if ( assignedUserNames.contains( getSession().getName() ) ) {
+      updateRolesForCurrentSession();
+    }
+
     return Response.ok().build();
   }
 
@@ -784,9 +811,9 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
                                           @QueryParam ( "roleName" ) String roleName ) {
     if ( canAdminister() ) {
       try {
-        IUserRoleDao roleDao =
-            PentahoSystem.get( IUserRoleDao.class, "userRoleDaoProxy", PentahoSessionHolder.getSession() );
+        IUserRoleDao roleDao = getUserRoleDao();
         roleDao.setRoleMembers( getTenant( tenantPath ), roleName, new String[0] );
+        updateRolesForCurrentSession();
         return Response.ok().build();
       } catch ( Throwable th ) {
         return processErrorResponse( th.getLocalizedMessage() );
@@ -838,7 +865,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
     }
   }
 
-  private ITenant getTenant( String tenantId ) throws NotFoundException {
+  protected ITenant getTenant( String tenantId ) throws NotFoundException {
     ITenant tenant = null;
     if ( tenantId != null ) {
       tenant = tenantManager.getTenant( tenantId );
@@ -846,7 +873,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         throw new NotFoundException( "Tenant not found." );
       }
     } else {
-      IPentahoSession session = PentahoSessionHolder.getSession();
+      IPentahoSession session = getSession();
       String tenantPath = (String) session.getAttribute( IPentahoSession.TENANT_ID_KEY );
       if ( tenantPath != null ) {
         tenant = new Tenant( tenantPath, true );
@@ -868,9 +895,32 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
     return Response.ok( errMessage ).build();
   }
 
-  private boolean canAdminister() {
+  protected boolean canAdminister() {
     IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
     return policy.isAllowed( RepositoryReadAction.NAME ) && policy.isAllowed( RepositoryCreateAction.NAME )
       && ( policy.isAllowed( AdministerSecurityAction.NAME ) );
+  }
+
+  protected void updateRolesForCurrentSession() {
+    List<String> userRoles = userRoleDaoService.getRolesForUser( getSession().getName() ).getRoles();
+    GrantedAuthority[] authoritys = new GrantedAuthority[ userRoles.size() ];
+
+    for ( int i = 0; i < authoritys.length; i++ ) {
+      authoritys[ i ] = new GrantedAuthorityImpl( userRoles.get( i ) );
+    }
+
+    getSession().setAttribute( IPentahoSession.SESSION_ROLES, authoritys );
+  }
+
+  protected IPentahoSession getSession() {
+    return PentahoSessionHolder.getSession();
+  }
+
+  /**
+   * For testing
+   *
+   **/
+  protected IUserRoleDao getUserRoleDao() {
+    return PentahoSystem.get( IUserRoleDao.class, "userRoleDaoProxy", getSession() );
   }
 }

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
@@ -12,15 +12,10 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
-
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
-import static javax.ws.rs.core.MediaType.WILDCARD;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -35,6 +30,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.logging.Log;
@@ -132,13 +128,13 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/createUser" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes( {
     @ResponseCode( code = 200, condition = "Successfully created new user." ),
     @ResponseCode( code = 400, condition = "Provided data has invalid format." ),
     @ResponseCode( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode( code = 412, condition = "Unable to create user." )
-  } )
+    } )
   public Response createUser( User user ) {
     try {
       userRoleDaoService.createUser( user );
@@ -167,12 +163,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/deleteUsers" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully deleted the list of users." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "Internal server error prevented the system from properly retrieving either the user or roles." )
-  } )
+    } )
   public Response deleteUsers( @QueryParam( "userNames" ) String userNames ) {
     try {
       userRoleDaoService.deleteUsers( userNames );
@@ -220,7 +216,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
     @ResponseCode( code = 400, condition = "Provided data has invalid format." ),
     @ResponseCode( code = 403, condition = "Provided user name or password is incorrect." ),
     @ResponseCode( code = 412, condition = "An error occurred in the platform." )
-  } )
+    } )
   public Response changeUserPassword( ChangePasswordUser user ) {
     try {
       userRoleDaoService.changeUserPassword( user.getUserName(), user.getNewPassword(), user.getOldPassword() );
@@ -257,11 +253,11 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/users" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes( {
       @ResponseCode ( code = 200, condition = "Successfully returned the list of users." ),
       @ResponseCode ( code = 500, condition = "An error occurred in the platform while trying to access the list of users." )
-  } )
+    } )
   public UserListWrapper getUsers() throws WebApplicationException {
     try {
       return userRoleDaoService.getUsers();
@@ -289,11 +285,11 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/userRoles" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully retrieved the list of roles." ),
     @ResponseCode ( code = 500, condition = "Invalid user parameter." )
-  } )
+    } )
   public RoleListWrapper getRolesForUser( @QueryParam( "userName" ) String user ) throws Exception {
     try {
       return userRoleDaoService.getRolesForUser( user );
@@ -317,12 +313,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/assignRoleToUser" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully append the roles to the user." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "Internal server error prevented the system from properly retrieving either the user or roles." )
-  } )
+    } )
   public Response assignRolesToUser( @QueryParam( "userName" ) String userName,
                                      @QueryParam( "roleNames" ) String roleNames ) {
     try {
@@ -355,12 +351,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/removeRoleFromUser" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully removed the roles from the user." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "Internal server error prevented the system from properly retrieving either the user or roles." )
-  } )
+    } )
   public Response removeRolesFromUser( @QueryParam( "userName" ) String userName,
                                        @QueryParam( "roleNames" ) String roleNames ) {
     try {
@@ -393,14 +389,14 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/createRole" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes( {
     @ResponseCode( code = 200, condition = "Successfully created new role." ),
     @ResponseCode( code = 400, condition = "Provided data has invalid format." ),
     @ResponseCode( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode( code = 412, condition = "Unable to create role objects." )
-  } )
-  public Response createRole( @QueryParam( "roleName" ) String roleName) {
+    } )
+  public Response createRole( @QueryParam( "roleName" ) String roleName ) {
     try {
       userRoleDaoService.createRole( roleName );
     } catch ( SecurityException e ) {
@@ -427,12 +423,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/deleteRoles" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes( {
     @ResponseCode( code = 200, condition = "Successfully deleted the list of roles." ),
     @ResponseCode( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode( code = 500, condition = "The system was unable to delete the roles passed in." )
-  } )
+    } )
   public Response deleteRoles( @QueryParam( "roleNames" ) String roleNames ) {
     try {
       userRoleDaoService.deleteRoles( roleNames );
@@ -460,11 +456,11 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path( "/roles" )
-  @Produces( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully retrieved the list of roles." ),
     @ResponseCode ( code = 500, condition = "The system was not able to return the list of roles." )
-  } )
+    } )
   public RoleListWrapper getRoles() throws Exception {
     try {
       return userRoleDaoService.getRoles();
@@ -491,12 +487,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/roleMembers" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully retrieved the list of Users." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "The system was not able to return the list of users." )
-  } )
+    } )
   public UserListWrapper getRoleMembers( @QueryParam ( "roleName" ) String roleName ) throws Exception {
     try {
       return userRoleDaoService.getRoleMembers( roleName );
@@ -532,12 +528,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    * @return Response code determining the success of the operation.
    */
   @PUT
-  @Consumes ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Consumes ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @Path ( "/roleAssignments" )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully applied the logical role assignment." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." )
-  } )
+    } )
   public Response setLogicalRoles( LogicalRoleAssignments roleAssignments ) {
     try {
       userRoleDaoService.setLogicalRoles( roleAssignments );
@@ -621,10 +617,10 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/logicalRoleMap" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes ( {
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." )
-  } )
+    } )
   public SystemRolesMap getRoleBindingStruct( @QueryParam ( "locale" ) String locale ) {
     try {
       return userRoleDaoService.getRoleBindingStruct( locale );
@@ -642,7 +638,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignAllRolesToUser" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignAllRolesToUser( @QueryParam ( "tenant" ) String tenantPath,
                                         @QueryParam ( "userName" ) String userName ) {
@@ -669,7 +665,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeAllRolesFromUser" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeAllRolesFromUser( @QueryParam ( "tenant" ) String tenantPath,
                                           @QueryParam ( "userName" ) String userName ) {
@@ -687,7 +683,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -701,7 +697,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignUserToRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignUserToRole( @QueryParam ( "tenant" ) String tenantPath,
                                     @QueryParam ( "userNames" ) String userNames, @QueryParam ( "roleName" ) String roleName ) {
@@ -727,7 +723,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -741,7 +737,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeUserFromRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeUserFromRole( @QueryParam ( "tenant" ) String tenantPath,
                                       @QueryParam ( "userNames" ) String userNames, @QueryParam ( "roleName" ) String roleName ) {
@@ -757,7 +753,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
           assignedUserNames.remove( tokenizer.nextToken() );
         }
         roleDao.setRoleMembers( getTenant( tenantPath ), roleName, assignedUserNames.toArray( new String[ 0 ] ) );
-        if (assignedUserNames.contains( getSession().getName() )) {
+        if ( assignedUserNames.contains( getSession().getName() ) ) {
           updateRolesForCurrentSession();
         }
         return Response.ok().build();
@@ -765,7 +761,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -778,10 +774,10 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignAllUsersToRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignAllUsersToRole( @QueryParam ( "tenant" ) String tenantPath,
-                                        @QueryParam ( "roleName" ) String roleName ) {
+                                        @QueryParam( "roleName" ) String roleName ) {
     IUserRoleDao roleDao = getUserRoleDao();
     Set<String> assignedUserNames = new HashSet<String>();
     for ( IPentahoUser pentahoUser : roleDao.getUsers( getTenant( tenantPath ) ) ) {
@@ -805,7 +801,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeAllUsersFromRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeAllUsersFromRole( @QueryParam ( "tenant" ) String tenantPath,
                                           @QueryParam ( "roleName" ) String roleName ) {
@@ -819,7 +815,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -850,12 +846,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/updatePassword" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully deleted the list of users." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "Internal server error prevented the system from properly retrieving either the user or roles." )
-  } )
+    } )
   public Response updatePassword( User user ) {
     try {
       userRoleDaoService.updatePassword( user );

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
@@ -21,10 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 
@@ -33,6 +30,8 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
@@ -109,6 +108,12 @@ public class UserRoleDaoResourceTest {
     String user = "testUser1";
     String roles = "testRole1";
 
+    userRoleResource = spy( userRoleResource );
+    IPentahoSession session = mock( IPentahoSession.class );
+    doReturn( user ).when( session ).getName();
+    doReturn( session ).when( userRoleResource ).getSession();
+    doNothing().when( userRoleResource ).updateRolesForCurrentSession();
+
     Response response = userRoleResource.assignRolesToUser( user, roles );
     assertEquals( Response.Status.OK.getStatusCode(), response.getStatus() );
   }
@@ -160,6 +165,12 @@ public class UserRoleDaoResourceTest {
   public void testRemoveRolesFromUser() {
     String user = "testUser1";
     String roles = "testRole1";
+
+    userRoleResource = spy( userRoleResource );
+    IPentahoSession session = mock( IPentahoSession.class );
+    doReturn( user ).when( session ).getName();
+    doReturn( session ).when( userRoleResource ).getSession();
+    doNothing().when( userRoleResource ).updateRolesForCurrentSession();
 
     Response response = userRoleResource.removeRolesFromUser( user, roles );
     assertEquals( Response.Status.OK.getStatusCode(), response.getStatus() );

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
@@ -30,7 +30,6 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
@@ -367,21 +366,21 @@ public class UserRoleDaoResourceTest {
 
   @Test
   public void testSetLogicalRoles() {
-    LogicalRoleAssignments logicalRoles = mock(LogicalRoleAssignments.class);
+    LogicalRoleAssignments logicalRoles = mock( LogicalRoleAssignments.class );
     userRoleResource.setLogicalRoles( logicalRoles );
     verify( userRoleService ).setLogicalRoles( logicalRoles );
   }
 
   @Test
   public void testSetLogicalRolesSecurityException() {
-    LogicalRoleAssignments logicalRoles = mock(LogicalRoleAssignments.class);
+    LogicalRoleAssignments logicalRoles = mock( LogicalRoleAssignments.class );
     try {
       userRoleResource.setLogicalRoles( logicalRoles );
     } catch ( WebApplicationException e ) {
       assertEquals( Response.Status.FORBIDDEN.getStatusCode(), e.getResponse().getStatus() );
     }
   }
-  
+
   @Test
   public void testCreateUser() throws Exception {
     Response response = userRoleResource.createUser( new User( "name", "password" ) );
@@ -393,7 +392,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new SecurityException() ).when( mockService ).createUser( any( User.class ) );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createUser( new User( "not", "admin" ) );
     } catch ( WebApplicationException e ) {
@@ -406,7 +405,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new UserRoleDaoService.ValidationFailedException() ).when( mockService ).createUser( any( User.class ) );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createUser( new User( "\\/validation", "failed" ) );
     } catch ( WebApplicationException e ) {
@@ -419,7 +418,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new AlreadyExistsException( "message" ) ).when( mockService ).createUser( any( User.class ) );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createUser( new User( "user", "duplicate" ) );
     } catch ( WebApplicationException e ) {
@@ -432,7 +431,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( ex ).when( mockService ).changeUserPassword( anyString(), anyString(), anyString() );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.changeUserPassword( new ChangePasswordUser( name, newPass, oldPass ) );
     } catch ( WebApplicationException exception ) {
@@ -449,27 +448,27 @@ public class UserRoleDaoResourceTest {
   @Test
   public void testChangePasswordWrongName() throws Exception {
     changePassException( new SecurityException(), Response.Status.FORBIDDEN.getStatusCode(), "wrong_name",
-        "newPass", "oldPass" );
+      "newPass", "oldPass" );
   }
 
   @Test
   public void testChangePasswordWrongPass() throws Exception {
     changePassException( new SecurityException(), Response.Status.FORBIDDEN.getStatusCode(), "name",
-        "wrong_newPass", "oldPass" );
+      "wrong_newPass", "oldPass" );
   }
 
   @Test
   public void testChangePasswordInvalidInput() throws Exception {
     changePassException( new UserRoleDaoService.ValidationFailedException(), Response.Status.BAD_REQUEST
-        .getStatusCode(), null, null, "oldPass" );
+      .getStatusCode(), null, null, "oldPass" );
   }
-  
+
   @Test
   public void testChangePasswordInternalError() throws Exception {
     changePassException( new Exception(), Response.Status.PRECONDITION_FAILED
-        .getStatusCode(), null, null, "oldPass" );
+      .getStatusCode(), null, null, "oldPass" );
   }
-  
+
   @Test
   public void testCreateRole() throws Exception {
     Response response = userRoleResource.createRole( "newRole" );
@@ -481,7 +480,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new SecurityException() ).when( mockService ).createRole( anyString() );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createRole( "anyRoleName" );
     } catch ( WebApplicationException e ) {
@@ -494,14 +493,14 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new UserRoleDaoService.ValidationFailedException() ).when( mockService ).createRole( anyString() );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createRole( "" );
     } catch ( WebApplicationException e ) {
       assertEquals( Response.Status.BAD_REQUEST.getStatusCode(), e.getResponse().getStatus() );
     }
   }
-  
+
   @Test
   public void testUpdatePassword() throws Exception {
     Response response = userRoleResource.updatePassword( new User( "name", "newPassword" ) );
@@ -513,7 +512,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new SecurityException() ).when( mockService ).updatePassword( any( User.class ) );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.updatePassword( new User( "name", "newPassword" ) );
     } catch ( WebApplicationException e ) {

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
@@ -1,0 +1,229 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
+import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
+import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.mt.ITenantManager;
+import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
+import org.pentaho.platform.web.http.api.resources.services.UserRoleDaoService;
+import org.pentaho.test.mock.MockPentahoUser;
+import org.springframework.security.GrantedAuthority;
+import org.springframework.security.GrantedAuthorityImpl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class UserRoleDaoResource_RolesUpdatedTest {
+  private UserRoleDaoResource resource;
+  private IPentahoSession session;
+  private IUserRoleDao userRoleDao;
+
+  private static final String SESSION_USER_NAME = "admin";
+  private static final String NON_SESSION_USER_NAME = "pat";
+  private static final String ROLE_NAME_DEVELOPER = "Developer";
+  private static final String ROLE_NAME_ADMINISTRATOR = "Administrator";
+  private static final String ROLE_NAME_POWER_USER = "Power User";
+  private static final String ROLE_NAME_REPORT_AUTHOR = "Report Author";
+  private static final String DEFAULT_STRING = "<def>";
+
+  private static final List<String> allRoles = new ArrayList<String>() {
+    private static final long serialVersionUID = -8595421204195219594L;
+
+    {
+      add( ROLE_NAME_DEVELOPER );
+      add( ROLE_NAME_POWER_USER );
+      add( ROLE_NAME_REPORT_AUTHOR );
+      add( ROLE_NAME_ADMINISTRATOR );
+    }
+  };
+
+  @Before
+  public void setUp() {
+    UserRoleDaoService service = mock( UserRoleDaoService.class );
+    doReturn( new RoleListWrapper( allRoles ) ).when( service ).getRolesForUser( eq( SESSION_USER_NAME ) );
+    resource =
+      new UserRoleDaoResource( mock( IRoleAuthorizationPolicyRoleBindingDao.class ), mock( ITenantManager.class ),
+        new ArrayList<String>(), ROLE_NAME_ADMINISTRATOR, service );
+
+    session = mock( IPentahoSession.class );
+    resource = spy( resource );
+    doReturn( session ).when( resource ).getSession();
+    doReturn( SESSION_USER_NAME ).when( session ).getName();
+    userRoleDao = mock( IUserRoleDao.class );
+    doReturn( new ArrayList<IPentahoRole>() ).when( userRoleDao ).getRoles( any( ITenant.class ) );
+    doReturn( mock( ITenant.class ) ).when( resource ).getTenant( anyString() );
+    doReturn( userRoleDao ).when( resource ).getUserRoleDao();
+    doReturn( true ).when( resource ).canAdminister();
+  }
+
+  @Test
+  public void sessionAttributeIsSetCorrectly_WhenRolesAreUpdated() {
+    resource.updateRolesForCurrentSession();
+
+    GrantedAuthority[] authoritys = new GrantedAuthority[ allRoles.size() ];
+    for ( int i = 0; i < allRoles.size(); i++ ) {
+      authoritys[ i ] = new GrantedAuthorityImpl( allRoles.get( i ) );
+    }
+
+    verify( session ).setAttribute( eq( IPentahoSession.SESSION_ROLES ), eq( authoritys ) );
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssigningRoles_ToSessionUser() {
+    resource.assignRolesToUser( SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssigningRoles_ToNonSessionUser() {
+    resource.assignRolesToUser( NON_SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssigningAllRoles_ToSessionUser() {
+    resource.assignAllRolesToUser( DEFAULT_STRING, SESSION_USER_NAME );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssigningAllRoles_ToNonSessionUser() {
+    resource.assignAllRolesToUser( DEFAULT_STRING, NON_SESSION_USER_NAME );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenRemoveRoles_FromSessionUser() {
+    resource.removeRolesFromUser( SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenRemoveRoles_FromNonSessionUser() {
+    resource.removeRolesFromUser( NON_SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+
+  @Test
+  public void rolesUpdated_WhenRemoveAllRoles_FromSessionUser() {
+    resource.removeAllRolesFromUser( DEFAULT_STRING, SESSION_USER_NAME );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenRemoveAllRoles_FromNonSessionUser() {
+    resource.removeAllRolesFromUser( DEFAULT_STRING, NON_SESSION_USER_NAME );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignToRole_SessionUser() {
+    resource.assignUserToRole( DEFAULT_STRING, SESSION_USER_NAME, ROLE_NAME_POWER_USER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssignToRole_NonSessionUser() {
+    resource.assignUserToRole( DEFAULT_STRING, NON_SESSION_USER_NAME, ROLE_NAME_POWER_USER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignToRole_NonSessionAndSessionUser() {
+    resource.assignUserToRole( DEFAULT_STRING, NON_SESSION_USER_NAME + "\t" + SESSION_USER_NAME, ROLE_NAME_POWER_USER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignAllUsersToRole_WithSessionUser() {
+    ITenant tenant = mock( ITenant.class );
+    doReturn( tenant ).when( resource ).getTenant( DEFAULT_STRING );
+    IPentahoUser sessionUser = new MockPentahoUser( tenant, SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+    doReturn( Collections.singletonList( sessionUser ) ).when( userRoleDao ).getUsers( tenant );
+
+    resource.assignAllUsersToRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssignAllUsersToRole_WithNoSessionUser() {
+    ITenant tenant = mock( ITenant.class );
+    doReturn( tenant ).when( resource ).getTenant( DEFAULT_STRING );
+    IPentahoUser nonSessionUser =
+      new MockPentahoUser( tenant, NON_SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+    doReturn( Collections.singletonList( nonSessionUser ) ).when( userRoleDao ).getUsers( tenant );
+
+    resource.assignAllUsersToRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignAllUsersToRole_WithSessionAndNonSessionUser() {
+    ITenant tenant = mock( ITenant.class );
+    doReturn( tenant ).when( resource ).getTenant( DEFAULT_STRING );
+    final IPentahoUser sessionUser =
+      new MockPentahoUser( tenant, SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+    final IPentahoUser nonSessionUser =
+      new MockPentahoUser( tenant, NON_SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+
+    List<IPentahoUser> users = new ArrayList<IPentahoUser>() {
+      private static final long serialVersionUID = -2545330937522265495L;
+
+      {
+        add( sessionUser );
+        add( nonSessionUser );
+      }
+    };
+
+    doReturn( users ).when( userRoleDao ).getUsers( tenant );
+
+    resource.assignAllUsersToRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+
+  @Test
+  public void rolesUpdated_WhenRemoveAllUsersFromRole() {
+    resource.removeAllUsersFromRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+    verify( resource ).updateRolesForCurrentSession();
+  }
+}


### PR DESCRIPTION
**UserRoleDaoResource**

- Track every update of roles, and if this update is touching a user in current session, updating IPentahoSession.SESSION_ROLES attribute, that represents the roles, avalible for current user.

We are doing it via userRoleDaoService, because data there is always up-to-date
- Added few helper methods and changed visibility of some methods for testing reasongs

**UserRoleDaoResource_RoleUpdatesTest**
- A separate test, written specially for checking, that roles were/were not (depending on whether user is session-user or not) updated.

**UserRoleDaoResourceTest**
- Changed few tests a little,(added several mocks), as method content changed.


@rmansoor, @mdamour1976, @pentaho-nbaker, @e-cuellar , review it please