### PR TITLE
[BACKLOG-6516] Relocate and rename pentaho.xml's 'verify-user-on-prin…

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider.java
@@ -515,7 +515,10 @@ public class SpringSecurityPrincipalProvider implements PrincipalProvider {
 
   private void initSkipUserVerification( final Properties prop ) {
 
-    if ( prop != null && prop.containsKey( SKIP_USER_VERIFICATION_PROP_KEY ) ) {
+    skipUserVerification = SKIP_USER_VERIFICATION_DEFAULT_VALUE; // default behaviour
+
+    if ( prop != null && prop.containsKey( SKIP_USER_VERIFICATION_PROP_KEY )
+      && !prop.getProperty( SKIP_USER_VERIFICATION_PROP_KEY ).isEmpty() ) {
 
       // reading property from the class initialization properties is useful for unit testing
       skipUserVerification = Boolean.valueOf( prop.getProperty( SKIP_USER_VERIFICATION_PROP_KEY,
@@ -528,7 +531,8 @@ public class SpringSecurityPrincipalProvider implements PrincipalProvider {
         // reading property from security.properties ( standard behaviour )
         IConfiguration config = this.systemConfig.getConfiguration( "security" ); // security.properties
 
-        if ( config != null ) {
+        if ( config != null && config.getProperties().containsKey( SKIP_USER_VERIFICATION_PROP_KEY )
+          && !config.getProperties().getProperty( SKIP_USER_VERIFICATION_PROP_KEY ).isEmpty() ) {
 
           skipUserVerification = Boolean.valueOf( config.getProperties().getProperty( SKIP_USER_VERIFICATION_PROP_KEY,
                 String.valueOf( SKIP_USER_VERIFICATION_DEFAULT_VALUE ) ) );
@@ -536,14 +540,7 @@ public class SpringSecurityPrincipalProvider implements PrincipalProvider {
 
       } catch ( Exception ex ) {
         logger.error( ex );
-
-        // safeguard / fallback behaviour
-        skipUserVerification = SKIP_USER_VERIFICATION_DEFAULT_VALUE;
       }
-
-    } else {
-      // safeguard / fallback behaviour
-      skipUserVerification = SKIP_USER_VERIFICATION_DEFAULT_VALUE;
     }
 
     logger.info( "Property '" + SKIP_USER_VERIFICATION_PROP_KEY + "' is '" + skipUserVerification + "'" );

--- a/repository/test-src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider_PrincipalCreation_Test.java
+++ b/repository/test-src/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider_PrincipalCreation_Test.java
@@ -121,6 +121,13 @@ public class SpringSecurityPrincipalProvider_PrincipalCreation_Test {
   }
 
   @Test
+  public void getPrincipal_User_SkipsAccessingUserDetailsServiceAccordingToEmptyProperty() throws Exception {
+    Principal principal = callGetPrincipalForUserString( "", mock( UserDetails.class ) );
+    assertEquals( USERNAME, principal.getName() );
+    verify( provider, never() ).internalGetUserDetails( USERNAME );
+  }
+
+  @Test
   public void getPrincipal_User_AccessesUserDetailsServiceAccordingToProperty() throws Exception {
     Principal principal = callGetPrincipalForUser( Boolean.FALSE, null );
     assertNull( principal );
@@ -142,13 +149,18 @@ public class SpringSecurityPrincipalProvider_PrincipalCreation_Test {
   }
 
   private Principal callGetPrincipalForUser( Boolean verifyUser, UserDetails dummyDetails ) throws Exception {
+    return verifyUser != null ? callGetPrincipalForUserString( verifyUser.toString(), dummyDetails )
+      : callGetPrincipalForUserString( null, dummyDetails );
+  }
+
+  private Principal callGetPrincipalForUserString( String verifyUser, UserDetails dummyDetails ) throws Exception {
     when( userResolver.isValid( USERNAME ) ).thenReturn( true );
     when( userResolver.getTenant( USERNAME ) ).thenReturn( new Tenant( USERNAME, true ) );
 
-    if( verifyUser != null ) {
+    if ( verifyUser != null ) {
 
       Properties p = createBasicProperties();
-      p.put( SKIP_USER_VERIFICATION_PROP_KEY, verifyUser.toString() );
+      p.put( SKIP_USER_VERIFICATION_PROP_KEY, verifyUser );
       setUpProvider( p );
     }
 


### PR DESCRIPTION
…cipal-creation' property

	- QA identified one scenario where this was not working as expected, namely a scenario where the property exists but it is set to empty
	- added additional unit tests that focus on that particular scenario