### PR TITLE
[BACKLOG-6643] Pentaho "merged" Server CE: List of capabilities cross…

### DIFF
--- a/assembly/package-res-merged-server/biserver/pentaho-solutions/system/repository.spring.properties
+++ b/assembly/package-res-merged-server/biserver/pentaho-solutions/system/repository.spring.properties
@@ -12,8 +12,8 @@ systemTenantAdminUserName=system
 systemTenantAdminPassword=cGFzc3dvcmQ=
 cache-size=100
 cache-ttl=300
-versioningEnabled=true
-versionCommentsEnabled=true
+versioningEnabled=false
+versionCommentsEnabled=false
 # This is the property to enable/disable multi byte encoding in the repository
 # This property can only be changed to "true" if you are installing it fresh. For upgrades,
 # this must be set to false. 


### PR DESCRIPTION
…-check

	- Versioning should be *disabled* by default in Pentaho Server CE
	- Versioning disabling should be done via the 'master flags' in repository.spring.properties