### PR TITLE
[TEST] - fix some tests for Windows and non-EST users

### DIFF
--- a/extensions/test-src/org/pentaho/platform/config/SystemConfigFolderTest.java
+++ b/extensions/test-src/org/pentaho/platform/config/SystemConfigFolderTest.java
@@ -1,3 +1,20 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
 package org.pentaho.platform.config;
 
 import org.junit.Before;
@@ -27,15 +44,20 @@ public class SystemConfigFolderTest {
 
   @Test
   public void testGetters() throws Exception {
-    assertEquals( path + "/systemListeners.xml", systemConfigFolder.getSystemListenersConfigFile().getPath() );
-    assertEquals( path + "/pentaho.xml", systemConfigFolder.getPentahoXmlFile().getPath() );
-    assertEquals( path + "/adminPlugins.xml", systemConfigFolder.getAdminPluginsFile().getPath() );
-    assertEquals( path + "/pentahoObjects.spring.xml", systemConfigFolder.getPentahoObjectsConfigFile().getPath() );
-    assertEquals( path + "/sessionStartupActions.xml", systemConfigFolder.getSessionStartupActionsFile().getPath() );
-    assertEquals( path + "/applicationContext-spring-security.xml", systemConfigFolder.getSpringSecurityXmlFile().getPath() );
-    assertEquals( path + "/applicationContext-pentaho-security-ldap.xml", systemConfigFolder.getPentahoSecurityXmlFile().getPath() );
-    assertEquals( path + "/applicationContext-spring-security-ldap.xml", systemConfigFolder.getSpringSecurityLdapXmlFile().getPath() );
-    assertEquals( path + "/applicationContext-common-authorization.xml", systemConfigFolder.getCommonAuthorizationXmlFile().getPath() );
+    assertPathsAreEqual( "systemListeners.xml", systemConfigFolder.getSystemListenersConfigFile() );
+    assertPathsAreEqual( "pentaho.xml", systemConfigFolder.getPentahoXmlFile() );
+    assertPathsAreEqual( "adminPlugins.xml", systemConfigFolder.getAdminPluginsFile() );
+    assertPathsAreEqual( "pentahoObjects.spring.xml", systemConfigFolder.getPentahoObjectsConfigFile() );
+    assertPathsAreEqual( "sessionStartupActions.xml", systemConfigFolder.getSessionStartupActionsFile() );
+    assertPathsAreEqual( "applicationContext-spring-security.xml", systemConfigFolder.getSpringSecurityXmlFile() );
+    assertPathsAreEqual( "applicationContext-pentaho-security-ldap.xml", systemConfigFolder.getPentahoSecurityXmlFile() );
+    assertPathsAreEqual( "applicationContext-spring-security-ldap.xml", systemConfigFolder.getSpringSecurityLdapXmlFile() );
+    assertPathsAreEqual( "applicationContext-common-authorization.xml", systemConfigFolder.getCommonAuthorizationXmlFile() );
+  }
+
+  private void assertPathsAreEqual( String expectedFile, File actual ) {
+    String expectedPath = path + File.separatorChar + expectedFile;
+    assertEquals( actual.getPath(), expectedPath );
   }
 
   @Test

--- a/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
@@ -19,6 +19,7 @@
 package org.pentaho.platform.plugin.services.metadata;
 
 import junit.framework.TestCase;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -785,7 +786,9 @@ public class PentahoMetadataDomainRepositoryTest extends TestCase {
 
     RepositoryFile domainFile = mock( RepositoryFile.class );
     doReturn( domainFileId ).when( domainFile ).getId();
-    assertEquals( "/etc/metadata/" + annotationsId, domainRepositorySpy.resolveAnnotationsFilePath( domainFile ) );
+
+    String actualPath = domainRepositorySpy.resolveAnnotationsFilePath( domainFile );
+    assertEquals( "/etc/metadata/" + annotationsId, FilenameUtils.separatorsToUnix( actualPath ) );
   }
 
   private InputStream toInputStream( final Properties newProperties ) {

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtilTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtilTest.java
@@ -21,6 +21,7 @@
 
 package org.pentaho.platform.web.http.api.resources;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,13 +62,24 @@ public class SchedulerResourceUtilTest {
   ComplexJobTriggerProxy complex;
   Date now;
 
+  private TimeZone system;
+
   @Before
   public void setUp() throws Exception {
+    // this makes the test non-deterministic!
     now = new Date();
 
     complex = new ComplexJobTriggerProxy();
     complex.setStartTime( now );
 
+    system = TimeZone.getDefault();
+    TimeZone.setDefault( TimeZone.getTimeZone( "EST" ) );
+  }
+
+  @After
+  public void tearDown() {
+    TimeZone.setDefault( system );
+    system = null;
   }
 
   @Test

--- a/extensions/test-src/org/pentaho/test/platform/web/http/api/JerseyTestUtil.java
+++ b/extensions/test-src/org/pentaho/test/platform/web/http/api/JerseyTestUtil.java
@@ -20,10 +20,12 @@ package org.pentaho.test.platform.web.http.api;
 import com.sun.jersey.api.client.ClientResponse;
 import junit.framework.AssertionFailedError;
 
+import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.zip.ZipInputStream;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
 
 @SuppressWarnings( "nls" )
 public class JerseyTestUtil {
@@ -33,18 +35,42 @@ public class JerseyTestUtil {
   }
 
   public static void assertResponse( ClientResponse response, ClientResponse.Status expectedStatus,
-      String expectedMediaType ) {
+      String expectedContentType ) {
     try {
       assertEquals( expectedStatus, response.getClientResponseStatus() );
     } catch ( AssertionFailedError e ) {
       throw new AssertionFailedError( "Response status incorrect: " + e.getMessage() );
     }
 
-    if ( expectedMediaType != null ) {
+    if ( expectedContentType != null ) {
       try {
-        assertEquals( expectedMediaType, response.getType().toString() );
+        assertContentType( response.getType(), expectedContentType );
       } catch ( AssertionFailedError e ) {
         throw new AssertionFailedError( "Response media type incorrect: " + e.getMessage() );
+      }
+    }
+  }
+
+  private static void assertContentType( MediaType type, String expectedContentType ) {
+    assertNotNull( type );
+    if ( expectedContentType.indexOf( ';' ) == -1 ) {
+      // no parameters, just a mime-type
+      assertEquals( expectedContentType, type.toString() );
+    } else {
+      // strictly speaking, the regex below is not correct, as semicolon can be a part of value
+      // and should be quoted; see: https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
+      // however, in tests, there are no such cases
+      String[] parts = expectedContentType.split( ";" );
+      String typeSubtype = parts[ 0 ];
+      assertEquals( "Mime Type should match", typeSubtype, type.getType() + '/' + type.getSubtype() );
+      assertEquals( "Amount of parameters should match", parts.length - 1, type.getParameters().size() );
+
+      for ( int i = 1; i < parts.length; i++ ) {
+        String[] pair = parts[ i ].split( "=" );
+        String expectedKey = pair[ 0 ];
+        String expectedValue = pair[ 1 ];
+        String actualValue = type.getParameters().get( expectedKey );
+        assertEquals( expectedKey, actualValue, expectedValue );
       }
     }
   }


### PR DESCRIPTION
- in SystemConfigFolderTest, use slashes explicitly
- in PentahoMetadataDomainRepositoryTest, ensure the path is separated with slashes
- in SchedulerResourceUtilTest, explicitly set EST timezone
- in JerseyTestUtil, replace direct strings comparing with separate elements validation, as Jersey has started adding space between mime type and parameters since some version

@rmansoor, @pamval, @kolinus, @aliakseihaidukou, review it please