### PR TITLE
[SP-2512] Backport of BISERVER-11649 - Mondrian role mappers don't pass the role name of a user when his username and group are both 'Admin' (6.0 Suite)

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
@@ -12,15 +12,10 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
-
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
-import static javax.ws.rs.core.MediaType.WILDCARD;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -35,6 +30,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.logging.Log;
@@ -125,11 +121,11 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/users" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes( {
       @ResponseCode ( code = 200, condition = "Successfully returned the list of users." ),
       @ResponseCode ( code = 500, condition = "An error occurred in the platform while trying to access the list of users." )
-  } )
+    } )
   public UserListWrapper getUsers() throws WebApplicationException {
     try {
       return userRoleDaoService.getUsers();
@@ -157,11 +153,11 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/userRoles" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully retrieved the list of roles." ),
     @ResponseCode ( code = 500, condition = "Invalid user parameter." )
-  } )
+    } )
   public RoleListWrapper getRolesForUser( @QueryParam( "userName" ) String user ) throws Exception {
     try {
       return userRoleDaoService.getRolesForUser( user );
@@ -186,11 +182,11 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path( "/roles" )
-  @Produces( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully retrieved the list of roles." ),
     @ResponseCode ( code = 500, condition = "The system was not able to return the list of roles." )
-  } )
+    } )
   public RoleListWrapper getRoles() throws Exception {
     try {
       return userRoleDaoService.getRoles();
@@ -217,12 +213,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/roleMembers" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully retrieved the list of Users." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "The system was not able to return the list of users." )
-  } )
+    } )
   public UserListWrapper getRoleMembers( @QueryParam ( "roleName" ) String roleName ) throws Exception {
     try {
       return userRoleDaoService.getRoleMembers( roleName );
@@ -248,12 +244,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/assignRoleToUser" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully append the roles to the user." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "Internal server error prevented the system from properly retrieving either the user or roles." )
-  } )
+    } )
   public Response assignRolesToUser( @QueryParam( "userName" ) String userName,
                                      @QueryParam( "roleNames" ) String roleNames ) {
     try {
@@ -286,12 +282,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/removeRoleFromUser" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully removed the roles from the user." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "Internal server error prevented the system from properly retrieving either the user or roles." )
-  } )
+    } )
   public Response removeRolesFromUser( @QueryParam( "userName" ) String userName,
                                        @QueryParam( "roleNames" ) String roleNames ) {
     try {
@@ -318,7 +314,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignAllRolesToUser" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignAllRolesToUser( @QueryParam ( "tenant" ) String tenantPath,
                                         @QueryParam ( "userName" ) String userName ) {
@@ -345,7 +341,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeAllRolesFromUser" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeAllRolesFromUser( @QueryParam ( "tenant" ) String tenantPath,
                                           @QueryParam ( "userName" ) String userName ) {
@@ -363,7 +359,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -377,7 +373,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignUserToRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignUserToRole( @QueryParam ( "tenant" ) String tenantPath,
                                     @QueryParam ( "userNames" ) String userNames, @QueryParam ( "roleName" ) String roleName ) {
@@ -403,7 +399,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -417,7 +413,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeUserFromRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeUserFromRole( @QueryParam ( "tenant" ) String tenantPath,
                                       @QueryParam ( "userNames" ) String userNames, @QueryParam ( "roleName" ) String roleName ) {
@@ -441,7 +437,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -454,7 +450,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignAllUsersToRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignAllUsersToRole( @QueryParam ( "tenant" ) String tenantPath,
                                         @QueryParam ( "roleName" ) String roleName ) {
@@ -481,7 +477,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeAllUsersFromRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeAllUsersFromRole( @QueryParam ( "tenant" ) String tenantPath,
                                           @QueryParam ( "roleName" ) String roleName ) {
@@ -495,7 +491,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -527,13 +523,13 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/createUser" )
-  @Consumes( { WILDCARD } )
-  @StatusCodes( { 
-    @ResponseCode( code = 200, condition = "Successfully created new user." ), 
-    @ResponseCode( code = 400, condition = "Provided data has invalid format." ), 
+  @Consumes( { MediaType.WILDCARD } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully created new user." ),
+    @ResponseCode( code = 400, condition = "Provided data has invalid format." ),
     @ResponseCode( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode( code = 412, condition = "Unable to create user." )
-  } )
+    } )
   public Response createUser( User user ) {
     try {
       userRoleDaoService.createUser( user );
@@ -578,12 +574,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/user" )
-  @StatusCodes( { 
-    @ResponseCode( code = 200, condition = "Successfully changed password." ), 
-    @ResponseCode( code = 400, condition = "Provided data has invalid format." ), 
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully changed password." ),
+    @ResponseCode( code = 400, condition = "Provided data has invalid format." ),
     @ResponseCode( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode( code = 412, condition = "An error occurred in the platform." )
-  } )
+    } )
   public Response changeUserPassword( ChangePasswordUser user ) {
     try {
       userRoleDaoService.changeUserPassword( user.getUserName(), user.getNewPassword(), user.getOldPassword() );
@@ -614,14 +610,14 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/createRole" )
-  @Consumes( { WILDCARD } )
-  @StatusCodes( { 
-    @ResponseCode( code = 200, condition = "Successfully created new role." ), 
-    @ResponseCode( code = 400, condition = "Provided data has invalid format." ), 
+  @Consumes( { MediaType.WILDCARD } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully created new role." ),
+    @ResponseCode( code = 400, condition = "Provided data has invalid format." ),
     @ResponseCode( code = 403, condition = "Only users with administrative privileges can access this method." ),
-    @ResponseCode( code = 412, condition = "Unable to create role objects." ) 
-  } )
-  public Response createRole( @QueryParam( "roleName" ) String roleName) {
+    @ResponseCode( code = 412, condition = "Unable to create role objects." )
+    } )
+  public Response createRole( @QueryParam( "roleName" ) String roleName ) {
     try {
       userRoleDaoService.createRole( roleName );
     } catch ( SecurityException e ) {
@@ -648,12 +644,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/deleteRoles" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes( {
     @ResponseCode( code = 200, condition = "Successfully deleted the list of roles." ),
     @ResponseCode( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode( code = 500, condition = "The system was unable to delete the roles passed in." )
-  } )
+    } )
   public Response deleteRoles( @QueryParam( "roleNames" ) String roleNames ) {
     try {
       userRoleDaoService.deleteRoles( roleNames );
@@ -679,12 +675,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/deleteUsers" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully deleted the list of users." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "Internal server error prevented the system from properly retrieving either the user or roles." )
-  } )
+    } )
   public Response deleteUsers( @QueryParam( "userNames" ) String userNames ) {
     try {
       userRoleDaoService.deleteUsers( userNames );
@@ -725,12 +721,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path( "/updatePassword" )
-  @Consumes( { WILDCARD } )
+  @Consumes( { MediaType.WILDCARD } )
   @StatusCodes ( {
     @ResponseCode ( code = 200, condition = "Successfully deleted the list of users." ),
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." ),
     @ResponseCode ( code = 500, condition = "Internal server error prevented the system from properly retrieving either the user or roles." )
-  } )
+    } )
   public Response updatePassword( User user ) {
     try {
       userRoleDaoService.updatePassword( user );
@@ -814,15 +810,15 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/logicalRoleMap" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes ( {
     @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." )
-  } )
+    } )
   public SystemRolesMap getRoleBindingStruct( @QueryParam ( "locale" ) String locale ) {
     try {
       return userRoleDaoService.getRoleBindingStruct( locale );
     } catch ( Exception e ) {
-     throw new WebApplicationException( Response.Status.FORBIDDEN );
+      throw new WebApplicationException( Response.Status.FORBIDDEN );
     }
   }
 
@@ -851,12 +847,12 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    * @return Response code determining the success of the operation.
    */
   @PUT
-  @Consumes ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Consumes ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @Path ( "/roleAssignments" )
-  @StatusCodes ( {
-    @ResponseCode ( code = 200, condition = "Successfully applied the logical role assignment." ),
-    @ResponseCode ( code = 403, condition = "Only users with administrative privileges can access this method." )
-  } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully applied the logical role assignment." ),
+    @ResponseCode( code = 403, condition = "Only users with administrative privileges can access this method." )
+    } )
   public Response setLogicalRoles( LogicalRoleAssignments roleAssignments ) {
     try {
       userRoleDaoService.setLogicalRoles( roleAssignments );

--- a/extensions/test-src/org/pentaho/platform/admin/GeneratedContentCleanerTest.java
+++ b/extensions/test-src/org/pentaho/platform/admin/GeneratedContentCleanerTest.java
@@ -1,0 +1,96 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.admin;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileTree;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.scheduler2.quartz.QuartzScheduler;
+
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by rfellows on 10/19/15.
+ */
+@RunWith( MockitoJUnitRunner.class )
+public class GeneratedContentCleanerTest {
+
+  @Mock IUnifiedRepository repo;
+
+  private static final String FILE_ID = "fileId";
+  private static final String FOlDER_ID = "folderId";
+  private static final String DEFAULT_STRING = "<def>";
+
+  GeneratedContentCleaner generatedContentCleaner;
+
+  @Before
+  public void setUp() throws Exception {
+    PentahoSystem.registerObject( repo );
+    generatedContentCleaner = new GeneratedContentCleaner();
+    generatedContentCleaner.setAge( 0 );
+  }
+
+  @Test
+  public void testExecute_noFilesToDelete() throws Exception {
+    final Date fixedDate = new SimpleDateFormat( "d/m/yyyy" ).parse( "1/1/2015" );
+    RepositoryFile file =
+      new RepositoryFile.Builder( DEFAULT_STRING, FILE_ID ).folder( false ).createdDate( fixedDate ).build();
+    RepositoryFileTree tree = new RepositoryFileTree( file, null );
+    when( repo.getTree( anyString(), eq( -1 ), anyString(), eq( false ) ) ).thenReturn( tree );
+
+    generatedContentCleaner.execute();
+    verify( repo, never() ).deleteFile( any( Serializable.class ), eq( true ), anyString() );
+  }
+
+  @Test
+  public void testExecute_oldFilesInFolderDeleted() throws Exception {
+    final Date fixedDate = new SimpleDateFormat( "d/m/yyyy" ).parse( "1/1/2015" );
+    RepositoryFile folder =
+      new RepositoryFile.Builder( FOlDER_ID, DEFAULT_STRING ).folder( true ).build();
+    RepositoryFile file =
+      new RepositoryFile.Builder( FILE_ID, DEFAULT_STRING ).folder( false ).createdDate( fixedDate ).build();
+
+    RepositoryFileTree childRepoFileTree = new RepositoryFileTree( file, null );
+    RepositoryFileTree rootRepoFileTree =
+      new RepositoryFileTree( folder, Collections.singletonList( childRepoFileTree ) );
+    when( repo.getTree( anyString(), eq( -1 ), anyString(), eq( false ) ) ).thenReturn( rootRepoFileTree );
+
+    Map<String, Serializable> values = new HashMap<String, Serializable>();
+    values.put( QuartzScheduler.RESERVEDMAPKEY_LINEAGE_ID, "lineageIdGoesHere" );
+    when( repo.getFileMetadata( FILE_ID ) ).thenReturn( values );
+
+    generatedContentCleaner.execute();
+    verify( repo ).deleteFile( eq( FILE_ID ), eq( true ), anyString() );
+    assertEquals( 0, generatedContentCleaner.getAge() );
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
@@ -29,7 +29,6 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
@@ -296,7 +295,8 @@ public class UserRoleDaoResourceTest {
   @Test
   public void testGetRoleMembersUncategorizedUserRoleDaoException() throws Exception {
     String role = "Report Author";
-    when( userRoleService.getRoleMembers( role ) ).thenThrow( new UncategorizedUserRoleDaoException( "expectedException" ) );
+    when( userRoleService.getRoleMembers( role ) )
+      .thenThrow( new UncategorizedUserRoleDaoException( "expectedException" ) );
 
     try {
       userRoleResource.getRoleMembers( role );
@@ -364,21 +364,21 @@ public class UserRoleDaoResourceTest {
 
   @Test
   public void testSetLogicalRoles() {
-    LogicalRoleAssignments logicalRoles = mock(LogicalRoleAssignments.class);
+    LogicalRoleAssignments logicalRoles = mock( LogicalRoleAssignments.class );
     userRoleResource.setLogicalRoles( logicalRoles );
     verify( userRoleService ).setLogicalRoles( logicalRoles );
   }
 
   @Test
   public void testSetLogicalRolesSecurityException() {
-    LogicalRoleAssignments logicalRoles = mock(LogicalRoleAssignments.class);
+    LogicalRoleAssignments logicalRoles = mock( LogicalRoleAssignments.class );
     try {
       userRoleResource.setLogicalRoles( logicalRoles );
     } catch ( WebApplicationException e ) {
       assertEquals( Response.Status.FORBIDDEN.getStatusCode(), e.getResponse().getStatus() );
     }
   }
-  
+
   @Test
   public void testCreateUser() throws Exception {
     Response response = userRoleResource.createUser( new User( "name", "password" ) );
@@ -390,7 +390,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new SecurityException() ).when( mockService ).createUser( any( User.class ) );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createUser( new User( "not", "admin" ) );
     } catch ( WebApplicationException e ) {
@@ -403,7 +403,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new UserRoleDaoService.ValidationFailedException() ).when( mockService ).createUser( any( User.class ) );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createUser( new User( "\\/validation", "failed" ) );
     } catch ( WebApplicationException e ) {
@@ -416,7 +416,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new AlreadyExistsException( "message" ) ).when( mockService ).createUser( any( User.class ) );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createUser( new User( "user", "duplicate" ) );
     } catch ( WebApplicationException e ) {
@@ -429,7 +429,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( ex ).when( mockService ).changeUserPassword( anyString(), anyString(), anyString() );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.changeUserPassword( new ChangePasswordUser( name, newPass, oldPass ) );
     } catch ( WebApplicationException exception ) {
@@ -446,27 +446,27 @@ public class UserRoleDaoResourceTest {
   @Test
   public void testChangePasswordWrongName() throws Exception {
     changePassException( new SecurityException(), Response.Status.FORBIDDEN.getStatusCode(), "wrong_name",
-        "newPass", "oldPass" );
+      "newPass", "oldPass" );
   }
 
   @Test
   public void testChangePasswordWrongPass() throws Exception {
     changePassException( new SecurityException(), Response.Status.FORBIDDEN.getStatusCode(), "name",
-        "wrong_newPass", "oldPass" );
+      "wrong_newPass", "oldPass" );
   }
 
   @Test
   public void testChangePasswordInvalidInput() throws Exception {
     changePassException( new UserRoleDaoService.ValidationFailedException(), Response.Status.BAD_REQUEST
-        .getStatusCode(), null, null, "oldPass" );
+      .getStatusCode(), null, null, "oldPass" );
   }
-  
+
   @Test
   public void testChangePasswordInternalError() throws Exception {
     changePassException( new Exception(), Response.Status.PRECONDITION_FAILED
-        .getStatusCode(), null, null, "oldPass" );
+      .getStatusCode(), null, null, "oldPass" );
   }
-  
+
   @Test
   public void testCreateRole() throws Exception {
     Response response = userRoleResource.createRole( "newRole" );
@@ -478,7 +478,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new SecurityException() ).when( mockService ).createRole( anyString() );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createRole( "anyRoleName" );
     } catch ( WebApplicationException e ) {
@@ -491,14 +491,14 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new UserRoleDaoService.ValidationFailedException() ).when( mockService ).createRole( anyString() );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.createRole( "" );
     } catch ( WebApplicationException e ) {
       assertEquals( Response.Status.BAD_REQUEST.getStatusCode(), e.getResponse().getStatus() );
     }
   }
-  
+
   @Test
   public void testUpdatePassword() throws Exception {
     Response response = userRoleResource.updatePassword( new User( "name", "newPassword" ) );
@@ -510,7 +510,7 @@ public class UserRoleDaoResourceTest {
     UserRoleDaoService mockService = mock( UserRoleDaoService.class );
     doThrow( new SecurityException() ).when( mockService ).updatePassword( any( User.class ) );
     UserRoleDaoResource resource =
-        new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
+      new UserRoleDaoResource( roleBindingDao, tenantManager, systemRoles, adminRole, mockService );
     try {
       resource.updatePassword( new User( "name", "newPassword" ) );
     } catch ( WebApplicationException e ) {

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
@@ -20,10 +20,7 @@ package org.pentaho.platform.web.http.api.resources;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 
@@ -32,6 +29,8 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
@@ -108,6 +107,12 @@ public class UserRoleDaoResourceTest {
     String user = "testUser1";
     String roles = "testRole1";
 
+    userRoleResource = spy( userRoleResource );
+    IPentahoSession session = mock( IPentahoSession.class );
+    doReturn( user ).when( session ).getName();
+    doReturn( session ).when( userRoleResource ).getSession();
+    doNothing().when( userRoleResource ).updateRolesForCurrentSession();
+
     Response response = userRoleResource.assignRolesToUser( user, roles );
     assertEquals( Response.Status.OK.getStatusCode(), response.getStatus() );
   }
@@ -159,6 +164,12 @@ public class UserRoleDaoResourceTest {
   public void testRemoveRolesFromUser() {
     String user = "testUser1";
     String roles = "testRole1";
+
+    userRoleResource = spy( userRoleResource );
+    IPentahoSession session = mock( IPentahoSession.class );
+    doReturn( user ).when( session ).getName();
+    doReturn( session ).when( userRoleResource ).getSession();
+    doNothing().when( userRoleResource ).updateRolesForCurrentSession();
 
     Response response = userRoleResource.removeRolesFromUser( user, roles );
     assertEquals( Response.Status.OK.getStatusCode(), response.getStatus() );
@@ -297,7 +308,8 @@ public class UserRoleDaoResourceTest {
   @Test
   public void testDeleteRole() {
     String roleList = "role1\trole2";
-
+    userRoleResource = spy( userRoleResource );
+    doNothing().when( userRoleResource ).updateRolesForCurrentSession();
     assertEquals( Response.Status.OK.getStatusCode(), userRoleResource.deleteRoles( roleList ).getStatus() );
   }
 

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
@@ -1,0 +1,224 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
+import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
+import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.mt.ITenantManager;
+import org.pentaho.platform.engine.core.system.StandaloneSession;
+import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
+import org.pentaho.platform.web.http.api.resources.services.UserRoleDaoService;
+import org.pentaho.test.mock.MockPentahoUser;
+import org.springframework.security.GrantedAuthority;
+import org.springframework.security.GrantedAuthorityImpl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class UserRoleDaoResource_RolesUpdatedTest {
+  private UserRoleDaoResource resource;
+  private IPentahoSession session;
+  private IUserRoleDao userRoleDao;
+
+  private static final String SESSION_USER_NAME = "admin";
+  private static final String NON_SESSION_USER_NAME = "pat";
+  private static final String ROLE_NAME_DEVELOPER = "Developer";
+  private static final String ROLE_NAME_ADMINISTRATOR = "Administrator";
+  private static final String ROLE_NAME_POWER_USER = "Power User";
+  private static final String ROLE_NAME_REPORT_AUTHOR = "Report Author";
+  private static final String DEFAULT_STRING = "<def>";
+
+  private static final List<String> allRoles =
+    Arrays.asList( ROLE_NAME_DEVELOPER, ROLE_NAME_POWER_USER, ROLE_NAME_REPORT_AUTHOR, ROLE_NAME_ADMINISTRATOR );
+
+  @Before
+  public void setUp() {
+    UserRoleDaoService service = mock( UserRoleDaoService.class );
+    doReturn( new RoleListWrapper( allRoles ) ).when( service ).getRolesForUser( eq( SESSION_USER_NAME ) );
+    resource =
+      new UserRoleDaoResource( mock( IRoleAuthorizationPolicyRoleBindingDao.class ), mock( ITenantManager.class ),
+        new ArrayList<String>(), ROLE_NAME_ADMINISTRATOR, service );
+
+    session = new StandaloneSession( SESSION_USER_NAME );
+    resource = spy( resource );
+    doReturn( session ).when( resource ).getSession();
+    userRoleDao = mock( IUserRoleDao.class );
+    doReturn( new ArrayList<IPentahoRole>() ).when( userRoleDao ).getRoles( any( ITenant.class ) );
+    doReturn( mock( ITenant.class ) ).when( resource ).getTenant( anyString() );
+    doReturn( userRoleDao ).when( resource ).getUserRoleDao();
+    doReturn( true ).when( resource ).canAdminister();
+  }
+
+  @Test
+  public void sessionAttributeIsSetCorrectly_WhenRolesAreUpdated() {
+    resource.updateRolesForCurrentSession();
+
+    GrantedAuthority[] authoritys = new GrantedAuthority[ allRoles.size() ];
+    for ( int i = 0; i < allRoles.size(); i++ ) {
+      authoritys[ i ] = new GrantedAuthorityImpl( allRoles.get( i ) );
+    }
+
+    GrantedAuthority[] seessionAuthoritys = (GrantedAuthority[]) session.getAttribute( IPentahoSession.SESSION_ROLES );
+    assertTrue( Arrays.equals( authoritys, seessionAuthoritys ) );
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssigningRoles_ToSessionUser() {
+    resource.assignRolesToUser( SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssigningRoles_ToNonSessionUser() {
+    resource.assignRolesToUser( NON_SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssigningAllRoles_ToSessionUser() {
+    resource.assignAllRolesToUser( DEFAULT_STRING, SESSION_USER_NAME );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssigningAllRoles_ToNonSessionUser() {
+    resource.assignAllRolesToUser( DEFAULT_STRING, NON_SESSION_USER_NAME );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenRemoveRoles_FromSessionUser() {
+    resource.removeRolesFromUser( SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenRemoveRoles_FromNonSessionUser() {
+    resource.removeRolesFromUser( NON_SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+
+  @Test
+  public void rolesUpdated_WhenRemoveAllRoles_FromSessionUser() {
+    resource.removeAllRolesFromUser( DEFAULT_STRING, SESSION_USER_NAME );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenRemoveAllRoles_FromNonSessionUser() {
+    resource.removeAllRolesFromUser( DEFAULT_STRING, NON_SESSION_USER_NAME );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignToRole_SessionUser() {
+    resource.assignUserToRole( DEFAULT_STRING, SESSION_USER_NAME, ROLE_NAME_POWER_USER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssignToRole_NonSessionUser() {
+    resource.assignUserToRole( DEFAULT_STRING, NON_SESSION_USER_NAME, ROLE_NAME_POWER_USER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignToRole_NonSessionAndSessionUser() {
+    resource.assignUserToRole( DEFAULT_STRING, NON_SESSION_USER_NAME + "\t" + SESSION_USER_NAME, ROLE_NAME_POWER_USER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignAllUsersToRole_WithSessionUser() {
+    ITenant tenant = mock( ITenant.class );
+    doReturn( tenant ).when( resource ).getTenant( DEFAULT_STRING );
+    IPentahoUser sessionUser = new MockPentahoUser( tenant, SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+    doReturn( Collections.singletonList( sessionUser ) ).when( userRoleDao ).getUsers( tenant );
+
+    resource.assignAllUsersToRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssignAllUsersToRole_WithNoSessionUser() {
+    ITenant tenant = mock( ITenant.class );
+    doReturn( tenant ).when( resource ).getTenant( DEFAULT_STRING );
+    IPentahoUser nonSessionUser =
+      new MockPentahoUser( tenant, NON_SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+    doReturn( Collections.singletonList( nonSessionUser ) ).when( userRoleDao ).getUsers( tenant );
+
+    resource.assignAllUsersToRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignAllUsersToRole_WithSessionAndNonSessionUser() {
+    ITenant tenant = mock( ITenant.class );
+    doReturn( tenant ).when( resource ).getTenant( DEFAULT_STRING );
+    final IPentahoUser sessionUser =
+      new MockPentahoUser( tenant, SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+    final IPentahoUser nonSessionUser =
+      new MockPentahoUser( tenant, NON_SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+
+    List<IPentahoUser> users = Arrays.asList( sessionUser, nonSessionUser );
+
+    doReturn( users ).when( userRoleDao ).getUsers( tenant );
+
+    resource.assignAllUsersToRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+
+  @Test
+  public void rolesUpdated_WhenRemoveAllUsersFromRole() {
+    resource.removeAllUsersFromRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAnyRoleIsDeleted() {
+    resource.deleteRoles( ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+}


### PR DESCRIPTION
**UserRoleDaoResource**

- Track every update of roles, and if this update is touching a user in current session, updating IPentahoSession.SESSION_ROLES attribute, that represents the roles, avalible for current user.

We are doing it via userRoleDaoService, because data there is always up-to-date
- Added few helper methods and changed visibility of some methods for testing reasongs

**UserRoleDaoResource_RoleUpdatesTest**
- A separate test, written specially for checking, that roles were/were not (depending on whether user is session-user or not) updated.

**UserRoleDaoResourceTest**
- Changed few tests a little,(added several mocks), as method content changed.

@akhayrutdinov, could you please review it? It is a backport of https://github.com/pentaho/pentaho-platform/pull/2788