### PR TITLE
[BISERVER-11649] Mondrian role mappers don't pass the role name of a user when his username and group are both 'Admin'

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
@@ -432,6 +432,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
   public Response deleteRoles( @QueryParam( "roleNames" ) String roleNames ) {
     try {
       userRoleDaoService.deleteRoles( roleNames );
+      updateRolesForCurrentSession();
       return Response.ok().build();
     } catch ( SecurityException e ) {
       throw new WebApplicationException( Response.Status.FORBIDDEN );

--- a/extensions/test-src/org/pentaho/platform/admin/GeneratedContentCleanerTest.java
+++ b/extensions/test-src/org/pentaho/platform/admin/GeneratedContentCleanerTest.java
@@ -1,3 +1,20 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
 package org.pentaho.platform.admin;
 
 import org.junit.Before;
@@ -12,6 +29,8 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.scheduler2.quartz.QuartzScheduler;
 
 import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +46,10 @@ import static org.mockito.Mockito.*;
 public class GeneratedContentCleanerTest {
 
   @Mock IUnifiedRepository repo;
-  @Mock RepositoryFileTree tree;
+
+  private static final String FILE_ID = "fileId";
+  private static final String FOlDER_ID = "folderId";
+  private static final String DEFAULT_STRING = "<def>";
 
   GeneratedContentCleaner generatedContentCleaner;
 
@@ -40,31 +62,35 @@ public class GeneratedContentCleanerTest {
 
   @Test
   public void testExecute_noFilesToDelete() throws Exception {
+    final Date fixedDate = new SimpleDateFormat( "d/m/yyyy" ).parse( "1/1/2015" );
+    RepositoryFile file =
+      new RepositoryFile.Builder( DEFAULT_STRING, FILE_ID ).folder( false ).createdDate( fixedDate ).build();
+    RepositoryFileTree tree = new RepositoryFileTree( file, null );
     when( repo.getTree( anyString(), eq( -1 ), anyString(), eq( false ) ) ).thenReturn( tree );
-    RepositoryFile file = mock( RepositoryFile.class );
-    when( tree.getFile() ).thenReturn( file );
-    when( file.isFolder() ).thenReturn( false );
-    when( file.getCreatedDate() ).thenReturn( new Date() );
 
     generatedContentCleaner.execute();
     verify( repo, never() ).deleteFile( any( Serializable.class ), eq( true ), anyString() );
   }
 
   @Test
-  public void testExecute() throws Exception {
-    when( repo.getTree( anyString(), eq( -1 ), anyString(), eq( false ) ) ).thenReturn( tree );
-    RepositoryFile file = mock( RepositoryFile.class );
-    when( tree.getFile() ).thenReturn( file );
-    when( file.isFolder() ).thenReturn( false );
-    when( file.getCreatedDate() ).thenReturn( new Date() );
-    when( file.getId() ).thenReturn( "fileId" );
+  public void testExecute_oldFilesInFolderDeleted() throws Exception {
+    final Date fixedDate = new SimpleDateFormat( "d/m/yyyy" ).parse( "1/1/2015" );
+    RepositoryFile folder =
+      new RepositoryFile.Builder( FOlDER_ID, DEFAULT_STRING ).folder( true ).build();
+    RepositoryFile file =
+      new RepositoryFile.Builder( FILE_ID, DEFAULT_STRING ).folder( false ).createdDate( fixedDate ).build();
+
+    RepositoryFileTree childRepoFileTree = new RepositoryFileTree( file, null );
+    RepositoryFileTree rootRepoFileTree =
+      new RepositoryFileTree( folder, Collections.singletonList( childRepoFileTree ) );
+    when( repo.getTree( anyString(), eq( -1 ), anyString(), eq( false ) ) ).thenReturn( rootRepoFileTree );
+
     Map<String, Serializable> values = new HashMap<String, Serializable>();
     values.put( QuartzScheduler.RESERVEDMAPKEY_LINEAGE_ID, "lineageIdGoesHere" );
-    when( repo.getFileMetadata( "fileId" ) ).thenReturn( values );
+    when( repo.getFileMetadata( FILE_ID ) ).thenReturn( values );
 
     generatedContentCleaner.execute();
-    verify( repo ).deleteFile( eq( "fileId" ), eq( true ), anyString() );
+    verify( repo ).deleteFile( eq( FILE_ID ), eq( true ), anyString() );
     assertEquals( 0, generatedContentCleaner.getAge() );
   }
-
 }

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
@@ -311,7 +311,8 @@ public class UserRoleDaoResourceTest {
   @Test
   public void testDeleteRole() {
     String roleList = "role1\trole2";
-
+    userRoleResource = spy( userRoleResource );
+    doNothing().when( userRoleResource ).updateRolesForCurrentSession();
     assertEquals( Response.Status.OK.getStatusCode(), userRoleResource.deleteRoles( roleList ).getStatus() );
   }
 

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
@@ -214,4 +214,12 @@ public class UserRoleDaoResource_RolesUpdatedTest {
     resource.removeAllUsersFromRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
     verify( resource ).updateRolesForCurrentSession();
   }
+
+
+  @Test
+  public void rolesUpdated_WhenAnyRoleIsDeleted() {
+    resource.deleteRoles( ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
 }


### PR DESCRIPTION
- Updating roles in current session, after any role is deleted
- Test witten

@akhayrutdinov, that's another PR, related to https://github.com/pentaho/pentaho-platform/pull/2788. It solves a problem of updating user-session after deleting any roles. Review it please.

@pedrovfteixeira, @pamval, could you please start WM?