### PR TITLE
[SP-2513] Backport of BISERVER-11649 - Mondrian role mappers don't pass the role name of a user when his username and group are both 'Admin' (5.4 Suite)

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
@@ -47,6 +47,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -56,9 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
-
-import static javax.ws.rs.core.MediaType.*;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 /**
  * UserRoleDao manage pentaho security user and roles in the platform.
@@ -103,7 +101,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/users" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @Facet( name = "Unsupported" )
   public UserListWrapper getUsers() throws Exception {
     if ( canAdminister() ) {
@@ -127,7 +125,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/roles" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @Facet ( name = "Unsupported" )
   public RoleListWrapper getRoles() throws Exception {
     if ( canAdminister() ) {
@@ -153,7 +151,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/userRoles" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @Facet ( name = "Unsupported" )
   public RoleListWrapper getUserRoles( @QueryParam ( "tenant" ) String tenantPath,
                                        @QueryParam ( "userName" ) String userName ) throws Exception {
@@ -180,7 +178,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/roleMembers" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @Facet ( name = "Unsupported" )
   public UserListWrapper getRoleMembers( @QueryParam ( "tenant" ) String tenantPath,
                                          @QueryParam ( "roleName" ) String roleName ) throws Exception {
@@ -199,7 +197,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignRoleToUser" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignRoleToUser( @QueryParam ( "tenant" ) String tenantPath,
                                     @QueryParam ( "userName" ) String userName, @QueryParam ( "roleNames" ) String roleNames ) {
@@ -223,7 +221,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
       }
       return Response.ok().build();
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -237,7 +235,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeRoleFromUser" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeRoleFromUser( @QueryParam ( "tenant" ) String tenantPath,
                                       @QueryParam ( "userName" ) String userName, @QueryParam ( "roleNames" ) String roleNames ) {
@@ -261,7 +259,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -274,7 +272,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignAllRolesToUser" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignAllRolesToUser( @QueryParam ( "tenant" ) String tenantPath,
                                         @QueryParam ( "userName" ) String userName ) {
@@ -301,14 +299,14 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeAllRolesFromUser" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeAllRolesFromUser( @QueryParam ( "tenant" ) String tenantPath,
                                           @QueryParam ( "userName" ) String userName ) {
     if ( canAdminister() ) {
       try {
         IUserRoleDao roleDao = getUserRoleDao();
-        roleDao.setUserRoles( getTenant( tenantPath ), userName, new String[0] );
+        roleDao.setUserRoles( getTenant( tenantPath ), userName, new String[ 0 ] );
 
         if ( userName.equals( getSession().getName() ) ) {
           updateRolesForCurrentSession();
@@ -319,7 +317,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -333,7 +331,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignUserToRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignUserToRole( @QueryParam ( "tenant" ) String tenantPath,
                                     @QueryParam ( "userNames" ) String userNames, @QueryParam ( "roleName" ) String roleName ) {
@@ -359,7 +357,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -373,7 +371,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeUserFromRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeUserFromRole( @QueryParam ( "tenant" ) String tenantPath,
                                       @QueryParam ( "userNames" ) String userNames, @QueryParam ( "roleName" ) String roleName ) {
@@ -400,7 +398,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -413,7 +411,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/assignAllUsersToRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response assignAllUsersToRole( @QueryParam ( "tenant" ) String tenantPath,
                                         @QueryParam ( "roleName" ) String roleName ) {
@@ -440,7 +438,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/removeAllUsersFromRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response removeAllUsersFromRole( @QueryParam ( "tenant" ) String tenantPath,
                                           @QueryParam ( "roleName" ) String roleName ) {
@@ -454,7 +452,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         return processErrorResponse( th.getLocalizedMessage() );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -467,7 +465,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/createUser" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response createUser( @QueryParam ( "tenant" ) String tenantPath, User user ) {
     IUserRoleDao roleDao =
@@ -499,7 +497,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/createRole" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response createRole( @QueryParam ( "tenant" ) String tenantPath, @QueryParam ( "roleName" ) String roleName ) {
     IUserRoleDao roleDao =
@@ -516,7 +514,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/deleteRoles" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response deleteRole( @QueryParam ( "roleNames" ) String roleNames ) {
     if ( canAdminister() ) {
@@ -535,7 +533,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
       }
       return Response.ok().build();
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -547,7 +545,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/deleteUsers" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response deleteUser( @QueryParam ( "userNames" ) String userNames ) {
     if ( canAdminister() ) {
@@ -566,7 +564,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
       }
       return Response.ok().build();
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -578,7 +576,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @PUT
   @Path ( "/updatePassword" )
-  @Consumes ( { WILDCARD } )
+  @Consumes ( { MediaType.WILDCARD } )
   @Facet ( name = "Unsupported" )
   public Response updatePassword( User user ) {
     if ( canAdminister() ) {
@@ -608,7 +606,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
         throw new WebApplicationException( t );
       }
     } else {
-      return Response.status( UNAUTHORIZED ).build();
+      return Response.status( Response.Status.UNAUTHORIZED ).build();
     }
   }
 
@@ -620,7 +618,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    */
   @GET
   @Path ( "/logicalRoleMap" )
-  @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @Facet ( name = "Unsupported" )
   public SystemRolesMap getRoleBindingStruct( @QueryParam ( "locale" ) String locale ) {
     if ( canAdminister() ) {
@@ -653,7 +651,7 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
    * @return
    */
   @PUT
-  @Consumes ( { APPLICATION_XML, APPLICATION_JSON } )
+  @Consumes ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @Path ( "/roleAssignments" )
   @Facet ( name = "Unsupported" )
   public Response setLogicalRoles( LogicalRoleAssignments roleAssignments ) {
@@ -702,13 +700,13 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
   protected void updateRolesForCurrentSession() {
     List<IPentahoRole> roles = getUserRoleDao().getUserRoles( getTenant( null ), getSession().getName() );
     List<String> userRoles = new RoleListWrapper( roles ).getRoles();
-    GrantedAuthority[] authoritys = new GrantedAuthority[ userRoles.size() ];
+    GrantedAuthority[] authorities = new GrantedAuthority[ userRoles.size() ];
 
-    for ( int i = 0; i < authoritys.length; i++ ) {
-      authoritys[ i ] = new GrantedAuthorityImpl( userRoles.get( i ) );
+    for ( int i = 0; i < authorities.length; i++ ) {
+      authorities[ i ] = new GrantedAuthorityImpl( userRoles.get( i ) );
     }
 
-    getSession().setAttribute( IPentahoSession.SESSION_ROLES, authoritys );
+    getSession().setAttribute( IPentahoSession.SESSION_ROLES, authorities );
   }
 
   protected IPentahoSession getSession() {

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
@@ -39,8 +39,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -237,3 +235,4 @@ public class UserRoleDaoResource_RolesUpdatedTest {
     verify( resource ).updateRolesForCurrentSession();
   }
 }
+

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
@@ -1,0 +1,239 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+import org.junit.Test;
+
+
+import org.junit.Before;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
+import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
+import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.mt.ITenantManager;
+import org.pentaho.platform.engine.core.system.StandaloneSession;
+import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
+import org.pentaho.platform.security.userroledao.PentahoRole;
+import org.pentaho.test.mock.MockPentahoUser;
+import org.springframework.security.GrantedAuthority;
+import org.springframework.security.GrantedAuthorityImpl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class UserRoleDaoResource_RolesUpdatedTest {
+  private UserRoleDaoResource resource;
+  private IPentahoSession session;
+  private IUserRoleDao userRoleDao;
+
+  private static final String SESSION_USER_NAME = "admin";
+  private static final String NON_SESSION_USER_NAME = "pat";
+  private static final String ROLE_NAME_DEVELOPER = "Developer";
+  private static final String ROLE_NAME_ADMINISTRATOR = "Administrator";
+  private static final String ROLE_NAME_POWER_USER = "Power User";
+  private static final String ROLE_NAME_REPORT_AUTHOR = "Report Author";
+  private static final String DEFAULT_STRING = "<def>";
+
+  private static final List<String> allRoles =
+    Arrays.asList( ROLE_NAME_DEVELOPER, ROLE_NAME_POWER_USER, ROLE_NAME_REPORT_AUTHOR, ROLE_NAME_ADMINISTRATOR );
+
+  @Before
+  public void setUp() {
+    userRoleDao = mock( IUserRoleDao.class );
+    resource =
+      new UserRoleDaoResource( mock( IRoleAuthorizationPolicyRoleBindingDao.class ), mock( ITenantManager.class ),
+        new ArrayList<String>(), ROLE_NAME_ADMINISTRATOR );
+
+    resource = spy( resource );
+
+    doReturn( userRoleDao ).when( resource ).getUserRoleDao();
+
+
+    List<IPentahoRole> pentahoRoles = new ArrayList<IPentahoRole>();
+    pentahoRoles.add( new PentahoRole( ROLE_NAME_DEVELOPER ) );
+    pentahoRoles.add( new PentahoRole( ROLE_NAME_POWER_USER ) );
+    pentahoRoles.add( new PentahoRole( ROLE_NAME_REPORT_AUTHOR ) );
+    pentahoRoles.add( new PentahoRole( ROLE_NAME_ADMINISTRATOR ) );
+
+    doReturn( pentahoRoles ).when( userRoleDao ).getUserRoles( any( ITenant.class ),
+      eq( SESSION_USER_NAME ) );
+
+
+    session = new StandaloneSession( SESSION_USER_NAME );
+    doReturn( session ).when( resource ).getSession();
+    doReturn( new ArrayList<IPentahoRole>() ).when( userRoleDao ).getRoles( any( ITenant.class ) );
+    doReturn( mock( ITenant.class ) ).when( resource ).getTenant( anyString() );
+    doReturn( true ).when( resource ).canAdminister();
+  }
+
+  @Test
+  public void sessionAttributeIsSetCorrectly_WhenRolesAreUpdated() {
+    resource.updateRolesForCurrentSession();
+
+    GrantedAuthority[] authoritys = new GrantedAuthority[ allRoles.size() ];
+    for ( int i = 0; i < allRoles.size(); i++ ) {
+      authoritys[ i ] = new GrantedAuthorityImpl( allRoles.get( i ) );
+    }
+
+    GrantedAuthority[] seessionAuthoritys = (GrantedAuthority[]) session.getAttribute( IPentahoSession.SESSION_ROLES );
+    assertTrue( Arrays.equals( authoritys, seessionAuthoritys ) );
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssigningRoles_ToSessionUser() {
+    resource.assignRoleToUser( null, SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssigningRoles_ToNonSessionUser() {
+    resource.assignRoleToUser( null, NON_SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssigningAllRoles_ToSessionUser() {
+    resource.assignAllRolesToUser( DEFAULT_STRING, SESSION_USER_NAME );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssigningAllRoles_ToNonSessionUser() {
+    resource.assignAllRolesToUser( DEFAULT_STRING, NON_SESSION_USER_NAME );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenRemoveRoles_FromSessionUser() {
+    resource.removeRoleFromUser( null, SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenRemoveRoles_FromNonSessionUser() {
+    resource.removeRoleFromUser( null, NON_SESSION_USER_NAME, ROLE_NAME_DEVELOPER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+
+  @Test
+  public void rolesUpdated_WhenRemoveAllRoles_FromSessionUser() {
+    resource.removeAllRolesFromUser( DEFAULT_STRING, SESSION_USER_NAME );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenRemoveAllRoles_FromNonSessionUser() {
+    resource.removeAllRolesFromUser( DEFAULT_STRING, NON_SESSION_USER_NAME );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignToRole_SessionUser() {
+    resource.assignUserToRole( DEFAULT_STRING, SESSION_USER_NAME, ROLE_NAME_POWER_USER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssignToRole_NonSessionUser() {
+    resource.assignUserToRole( DEFAULT_STRING, NON_SESSION_USER_NAME, ROLE_NAME_POWER_USER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignToRole_NonSessionAndSessionUser() {
+    resource.assignUserToRole( DEFAULT_STRING, NON_SESSION_USER_NAME + "\t" + SESSION_USER_NAME, ROLE_NAME_POWER_USER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignAllUsersToRole_WithSessionUser() {
+    ITenant tenant = mock( ITenant.class );
+    doReturn( tenant ).when( resource ).getTenant( DEFAULT_STRING );
+    IPentahoUser sessionUser = new MockPentahoUser( tenant, SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+    doReturn( Collections.singletonList( sessionUser ) ).when( userRoleDao ).getUsers( tenant );
+
+    resource.assignAllUsersToRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesNotUpdated_WhenAssignAllUsersToRole_WithNoSessionUser() {
+    ITenant tenant = mock( ITenant.class );
+    doReturn( tenant ).when( resource ).getTenant( DEFAULT_STRING );
+    IPentahoUser nonSessionUser =
+      new MockPentahoUser( tenant, NON_SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+    doReturn( Collections.singletonList( nonSessionUser ) ).when( userRoleDao ).getUsers( tenant );
+
+    resource.assignAllUsersToRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+
+    verify( resource, never() ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAssignAllUsersToRole_WithSessionAndNonSessionUser() {
+    ITenant tenant = mock( ITenant.class );
+    doReturn( tenant ).when( resource ).getTenant( DEFAULT_STRING );
+    final IPentahoUser sessionUser =
+      new MockPentahoUser( tenant, SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+    final IPentahoUser nonSessionUser =
+      new MockPentahoUser( tenant, NON_SESSION_USER_NAME, DEFAULT_STRING, DEFAULT_STRING, true );
+
+    List<IPentahoUser> users = Arrays.asList( sessionUser, nonSessionUser );
+
+    doReturn( users ).when( userRoleDao ).getUsers( tenant );
+
+    resource.assignAllUsersToRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+
+  @Test
+  public void rolesUpdated_WhenRemoveAllUsersFromRole() {
+    resource.removeAllUsersFromRole( DEFAULT_STRING, ROLE_NAME_DEVELOPER );
+    verify( resource ).updateRolesForCurrentSession();
+  }
+
+  @Test
+  public void rolesUpdated_WhenAnyRoleIsDeleted() {
+    resource.deleteRole( ROLE_NAME_DEVELOPER );
+
+    verify( resource ).updateRolesForCurrentSession();
+  }
+}


### PR DESCRIPTION
**UserRoleDaoResource**

- Track every update of roles, and if this update is touching a user in current session, updating IPentahoSession.SESSION_ROLES attribute, that represents the roles, avalible for current user.

We are doing it via userRoleDaoService, because data there is always up-to-date
- Added few helper methods and changed visibility of some methods for testing reasongs

**UserRoleDaoResource_RoleUpdatesTest**
- A separate test, written specially for checking, that roles were/were not (depending on whether user is session-user or not) updated.

**UserRoleDaoResourceTest**
- Changed few tests a little,(added several mocks), as method content changed.

@akhayrutdinov, could you please review it? It is a backport of https://github.com/pentaho/pentaho-platform/pull/2788

It's done in a little bit different way, as in 5.4 version we don't have a UserRoleDaoService class (which performs as delegate-class in 6.0 and master).
I checked it localy - it works fine.