### PR TITLE
[PDI-15058] - Read only install fix

### DIFF
--- a/extensions/src/org/pentaho/platform/osgi/KarafBoot.java
+++ b/extensions/src/org/pentaho/platform/osgi/KarafBoot.java
@@ -79,18 +79,7 @@ public class KarafBoot implements IPentahoSystemListener {
         }
       }
 
-      String root = karafDir.toURI().getPath();
-
-      if ( karafDir.exists() ) {
-        // This test will let us know whether we need to make our own copy of Karaf before starting (happens in PMR)
-        if ( !canOpenConfigPropertiesForEdit( root ) ) {
-          String newDir =
-              new File( karafDir.getParentFile().getParentFile(), karafDir.getName() + "-copy" ).toURI().getPath();
-          File destDir = new File( newDir );
-          FileUtils.copyDirectory( karafDir, destDir );
-          root = newDir;
-        }
-      }
+      final String root = karafDir.toURI().getPath();
 
       configureSystemProperties( solutionRootPath, root );
 

--- a/extensions/test-src/org/pentaho/platform/osgi/KarafInstanceTest.java
+++ b/extensions/test-src/org/pentaho/platform/osgi/KarafInstanceTest.java
@@ -16,18 +16,17 @@
  */
 package org.pentaho.platform.osgi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.platform.settings.PortAssigner;
 import org.pentaho.platform.settings.ServerPortRegistry;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
 
 /**
  * 
@@ -45,7 +44,7 @@ public class KarafInstanceTest {
       FileUtils.deleteDirectory( folder );
     }
   }
-  
+
   @After
   public void tearDown() throws IOException {
     // clean up
@@ -54,7 +53,7 @@ public class KarafInstanceTest {
       FileUtils.deleteDirectory( folder );
     }
   }
-  
+
   @Test
   public void testKarafInstance() throws Exception {
     KarafInstance karafInstance1 = createTestInstance( 1 );
@@ -73,12 +72,26 @@ public class KarafInstanceTest {
     karafInstance4.close();
   }
 
+  @Test
+  public void testWorkingDirAsKarafDataParentFolder() {
+    String property = System.getProperty( KarafInstance.WORKING_DIR_AS_KARAF_DATA_PARENT_FOLDER );
+    try {
+      System.setProperty( KarafInstance.WORKING_DIR_AS_KARAF_DATA_PARENT_FOLDER, "false" );
+      assertNotEquals( new File( "." ).toURI().getPath(),
+        new KarafInstance( TEST_CACHE_FOLDER ).getCacheParentFolder() );
+      System.setProperty( KarafInstance.WORKING_DIR_AS_KARAF_DATA_PARENT_FOLDER, "true" );
+      assertEquals( new File( "." ).toURI().getPath(), new KarafInstance( TEST_CACHE_FOLDER ).getCacheParentFolder() );
+    } finally {
+      System.setProperty( KarafInstance.WORKING_DIR_AS_KARAF_DATA_PARENT_FOLDER, property );
+    }
+  }
+
   private KarafInstance createTestInstance( int expectedInstanceNumber ) throws Exception {
     //Simulate a new JVM
     KarafInstancePortFactory.karafInstance = null;
     PortAssigner.getInstance().clear();
     ServerPortRegistry.clear();
-    
+
     //Now start up the instance
     KarafInstance instance = new KarafInstance( TEST_CACHE_FOLDER );
     new KarafInstancePortFactory( "./test-res/KarafInstanceTest/KarafPorts.yaml" ).process();


### PR DESCRIPTION
Removing config read test, adding property to tell Karaf to use working dir as parent cache dir