### PR TITLE
[TEST] - fix failed tests

### DIFF
--- a/extensions/test-src/org/pentaho/platform/osgi/KarafBootTest.java
+++ b/extensions/test-src/org/pentaho/platform/osgi/KarafBootTest.java
@@ -295,6 +295,8 @@ public class KarafBootTest {
 
   @Test
   public void testClearDataCacheSetting() throws Exception {
+    // clear Karaf's property to avoid tests' interdependency
+    System.clearProperty( "karaf.data" );
 
     PentahoSystem.init( new StandaloneApplicationContext( "test-res/karafBootTest", "." ) );
     //set property

--- a/extensions/test-src/org/pentaho/platform/web/http/filters/ProxyTrustingFilterTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/filters/ProxyTrustingFilterTest.java
@@ -1,9 +1,28 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
 package org.pentaho.platform.web.http.filters;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.ISecurityHelper;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.security.SecurityHelper;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockFilterConfig;
@@ -12,6 +31,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.concurrent.Callable;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -32,9 +53,9 @@ public class ProxyTrustingFilterTest {
     securityHelper = mock( ISecurityHelper.class );
     SecurityHelper.setMockInstance( securityHelper );
 
-    request = new MockHttpServletRequest(  );
+    request = new MockHttpServletRequest();
 
-    MockFilterConfig cfg = new MockFilterConfig(  );
+    MockFilterConfig cfg = new MockFilterConfig();
     cfg.addInitParameter( "TrustedIpAddrs", "1.1.1.1," + TRUSTED_IP );
 
     filter = new ProxyTrustingFilter();
@@ -54,7 +75,10 @@ public class ProxyTrustingFilterTest {
 
     filter.doFilter( request, new MockHttpServletResponse(), new MockFilterChain() );
 
-    verify( securityHelper ).runAsUser( anyString(), any( Callable.class ) );
+    IPentahoSession session =
+      (IPentahoSession) request.getSession().getAttribute( PentahoSystem.PENTAHO_SESSION_KEY );
+    assertNotNull( session );
+    assertEquals( "user", session.getName() );
   }
 
   @Test


### PR DESCRIPTION
- in KarafBootTest, clear "karaf.data" property to eliminate other tests' influence
- ProxyTrustingFilterTest, re-implement assertions and fix Checkstyle violations

@pamval, @rmansoor, @pentaho-nbaker, review it please. This is a backport of   
https://github.com/pentaho/pentaho-platform/commit/a330dd2e192146b191de9e358db2c76f5c3cec4b to fix failing test