### PR TITLE
[BACKLOG-7135]Default Carte to PurRepository

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/action/kettle/DIServerConfig.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/kettle/DIServerConfig.java
@@ -1,0 +1,161 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.platform.plugin.action.kettle;
+
+import com.google.common.base.Throwables;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.plugins.RepositoryPluginType;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryMeta;
+import org.pentaho.di.www.SlaveServerConfig;
+import org.pentaho.metastore.stores.delegate.DelegatingMetaStore;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.util.logging.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.util.Collections;
+
+/**
+ * Slave Server Config for Carte Servlet running within the DI Server.
+ * Overrides {@link #getRepository()} and {@link #getMetaStore()} to use an in-process PurRepository connection
+ * with active user credentials if not otherwise configured via slaveserverconfig.xml
+ *
+ * @author nhudak
+ */
+public class DIServerConfig extends SlaveServerConfig {
+  public static final String SINGLE_DI_SERVER_INSTANCE = "singleDiServerInstance";
+  public static final String PUR_REPOSITORY_PLUGIN_ID = "PentahoEnterpriseRepository";
+  private RepositoryMeta repositoryMeta;
+  private final PluginRegistry pluginRegistry;
+
+  public DIServerConfig( LogChannel logChannel, Node configNode ) throws KettleXMLException {
+    this( logChannel, configNode, PluginRegistry.getInstance() );
+  }
+
+  public DIServerConfig( LogChannel logChannel, Node configNode, PluginRegistry pluginRegistry ) throws KettleXMLException {
+    super( logChannel, configNode );
+    this.pluginRegistry = pluginRegistry;
+  }
+
+  @Override
+  public Repository getRepository() throws KettleException {
+    Repository repository = super.getRepository();
+
+    if ( repository == null && repositoryInProcess() ) {
+      try {
+        repository = connectInProcessRepository();
+      } catch ( Exception e ) {
+        // Something failed, give up and return null
+        Logger.warn( this, e.getMessage(), e ); //$NON-NLS-1$
+        repository = null;
+      }
+    }
+    return repository;
+  }
+
+  @Override
+  public DelegatingMetaStore getMetaStore() {
+    DelegatingMetaStore metaStore = super.getMetaStore();
+
+    try {
+      Repository configuredRepository = super.getRepository();
+      if ( configuredRepository == null && repositoryInProcess() ) {
+        Repository inProcessRepository = connectInProcessRepository();
+        if ( inProcessRepository != null ) {
+          metaStore = new DelegatingMetaStore( inProcessRepository.getMetaStore() );
+          metaStore.setActiveMetaStoreName( inProcessRepository.getMetaStore().getName() );
+        }
+      }
+    } catch ( Exception e ) {
+      // Something failed, give up and use default
+      Logger.warn( this, e.getMessage(), e );
+      metaStore = super.getMetaStore();
+    }
+    return metaStore;
+  }
+
+  private boolean repositoryInProcess() {
+    return PentahoSystem.getApplicationContext() != null
+      && "true".equals( PentahoSystem.getSystemSetting( SINGLE_DI_SERVER_INSTANCE, "true" ) );
+  }
+
+
+  private Repository connectInProcessRepository() throws KettleException {
+    Repository repository = null;
+
+    // Get active user
+    IPentahoSession user = PentahoSessionHolder.getSession();
+
+    if ( user != null ) {
+      // Connect to repository
+      repository = pluginRegistry.loadClass( RepositoryPluginType.class, PUR_REPOSITORY_PLUGIN_ID, Repository.class );
+      try {
+        repository.init( getRepositoryMeta() );
+      } catch ( Exception e ) {
+        Throwables.propagateIfPossible( e, KettleException.class );
+        throw new KettleException( e );
+      }
+
+      // Connect as current user, password will not actually be used
+      repository.connect( user.getName(), "" );
+    }
+
+    return repository;
+  }
+
+  private RepositoryMeta getRepositoryMeta() throws KettleException, ParserConfigurationException {
+    if ( repositoryMeta == null ) {
+      // Load Repository Meta
+      RepositoryMeta repositoryMeta = pluginRegistry.loadClass( RepositoryPluginType.class, PUR_REPOSITORY_PLUGIN_ID, RepositoryMeta.class );
+
+      DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+      Document document = docBuilder.newDocument();
+      Element repnode = document.createElement( RepositoryMeta.XML_TAG );
+
+      Element id = document.createElement( "id" );
+      id.setTextContent( PUR_REPOSITORY_PLUGIN_ID );
+      repnode.appendChild( id );
+
+      Element name = document.createElement( "name" );
+      name.setTextContent( SINGLE_DI_SERVER_INSTANCE );
+      repnode.appendChild( name );
+
+      Element description = document.createElement( "description" );
+      description.setTextContent( SINGLE_DI_SERVER_INSTANCE );
+      repnode.appendChild( description );
+
+      Element location = document.createElement( "repository_location_url" );
+      location.setTextContent( PentahoSystem.getApplicationContext().getFullyQualifiedServerURL() );
+      repnode.appendChild( location );
+
+      repositoryMeta.loadXML( repnode, Collections.<DatabaseMeta>emptyList() );
+      this.repositoryMeta = repositoryMeta;
+    }
+    return repositoryMeta;
+  }
+}

--- a/extensions/src/org/pentaho/platform/plugin/action/kettle/KettleSystemListener.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/kettle/KettleSystemListener.java
@@ -12,14 +12,12 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
-
 package org.pentaho.platform.plugin.action.kettle;
 
 import org.apache.commons.lang.StringUtils;
 import org.pentaho.di.cluster.SlaveServer;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.KettleLogStore;
@@ -90,7 +88,7 @@ public class KettleSystemListener implements IPentahoSystemListener {
         InputStream is = new FileInputStream( slaveServerConfigFile );
         Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse( is );
         Node configNode = XMLHandler.getSubNode( document, SlaveServerConfig.XML_TAG );
-        SlaveServerConfig config = new SlaveServerConfig( new LogChannel( "Slave server config" ), configNode );
+        SlaveServerConfig config = new DIServerConfig( new LogChannel( "Slave server config" ), configNode );
         config.setFilename( slaveServerConfigFile.getAbsolutePath() );
         SlaveServer slaveServer = new SlaveServer();
         config.setSlaveServer( slaveServer );

--- a/extensions/test-src/org/pentaho/platform/plugin/action/kettle/DIServerConfigTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/action/kettle/DIServerConfigTest.java
@@ -1,0 +1,158 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.platform.plugin.action.kettle;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.plugins.PluginRegistry;
+import org.pentaho.di.core.plugins.RepositoryPluginType;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.repository.RepositoryMeta;
+import org.pentaho.di.www.SlaveServerConfig;
+import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.stores.delegate.DelegatingMetaStore;
+import org.pentaho.platform.api.engine.IApplicationContext;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class DIServerConfigTest {
+
+  public static final String SERVER_URL = "http://mockurl:9080/pentaho-di";
+  public static final String MOCK_USER = "mockUser";
+  private final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+
+  private SlaveServerConfig baseConfig;
+  private PluginRegistry pluginRegistry;
+  private Repository purRepository;
+  private RepositoryMeta purRepositoryMeta;
+  private IMetaStore purMetaStore;
+  private LogChannel logChannel;
+
+  @Before
+  public void setup() throws Exception {
+    IApplicationContext mockAppContext = mock( IApplicationContext.class );
+    when( mockAppContext.getFullyQualifiedServerURL() ).thenReturn( SERVER_URL );
+    PentahoSystem.setApplicationContext( mockAppContext );
+
+    IPentahoSession pentahoSession = mock( IPentahoSession.class );
+    when( pentahoSession.getName() ).thenReturn( MOCK_USER );
+    PentahoSessionHolder.setSession( pentahoSession );
+
+    baseConfig = new SlaveServerConfig();
+
+    pluginRegistry = mock( PluginRegistry.class );
+    purRepositoryMeta = mock( RepositoryMeta.class );
+    purRepository = mock( Repository.class );
+    purMetaStore = mock( IMetaStore.class );
+
+    when( pluginRegistry
+      .loadClass( RepositoryPluginType.class, DIServerConfig.PUR_REPOSITORY_PLUGIN_ID, Repository.class ) )
+      .thenReturn( purRepository );
+    when( pluginRegistry
+      .loadClass( RepositoryPluginType.class, DIServerConfig.PUR_REPOSITORY_PLUGIN_ID, RepositoryMeta.class ) )
+      .thenReturn( purRepositoryMeta );
+
+    when( purRepository.getMetaStore() ).thenReturn( purMetaStore );
+    when( purMetaStore.getName() ).thenReturn( "Mock MetaStore" );
+
+    logChannel = mock( LogChannel.class );
+  }
+
+  private Node getConfigNode() throws Exception {
+    InputSource xmlSource = new InputSource( new StringReader( baseConfig.getXML() ) );
+    Document document = documentBuilderFactory.newDocumentBuilder().parse( xmlSource );
+    return XMLHandler.getSubNode( document, SlaveServerConfig.XML_TAG );
+  }
+
+  @Test
+  public void testGetRepositoryWithDefault() throws Exception {
+    DIServerConfig diConfig = new DIServerConfig( logChannel, getConfigNode(), pluginRegistry );
+    assertEquals( purRepository, diConfig.getRepository() );
+
+    verifyConnection();
+  }
+
+  @Test
+  public void testGetRepositoryWithConfig() throws Exception {
+    Repository repo = mock( Repository.class );
+
+    DIServerConfig diConfig = new DIServerConfig( logChannel, getConfigNode(), pluginRegistry );
+    diConfig.setRepository( repo );
+    assertEquals( repo, diConfig.getRepository() );
+
+    verify( purRepository, never() ).init( any( RepositoryMeta.class ) );
+    verify( purRepository, never() ).connect( anyString(), anyString() );
+  }
+
+  @Test
+  public void testGetMetaStoreWithDefault() throws Exception {
+    DIServerConfig diConfig = new DIServerConfig( logChannel, getConfigNode(), pluginRegistry );
+    DelegatingMetaStore delegatingMetaStore = diConfig.getMetaStore();
+    assertEquals( purMetaStore, delegatingMetaStore.getActiveMetaStore() );
+
+    verifyConnection();
+  }
+
+  @Test
+  public void testGetMetaStoreWithConfig() throws Exception {
+    Repository repo = mock( Repository.class );
+    DelegatingMetaStore delegatingMetaStore = mock( DelegatingMetaStore.class );
+    DIServerConfig diConfig = new DIServerConfig( logChannel, getConfigNode(), pluginRegistry );
+
+    diConfig.setRepository( repo );
+    diConfig.setMetaStore( delegatingMetaStore );
+
+    assertEquals( delegatingMetaStore, diConfig.getMetaStore() );
+
+    verifyNoMoreInteractions( delegatingMetaStore );
+    verify( purRepository, never() ).init( any( RepositoryMeta.class ) );
+    verify( purRepository, never() ).connect( anyString(), anyString() );
+  }
+
+  private void verifyConnection() throws KettleException {
+    InOrder connectionProcess = inOrder( purRepositoryMeta, purRepository );
+
+    connectionProcess.verify( purRepositoryMeta ).loadXML( any( Node.class ), anyListOf( DatabaseMeta.class ) );
+    connectionProcess.verify( purRepository ).init( purRepositoryMeta );
+    connectionProcess.verify( purRepository ).connect( eq( MOCK_USER ), anyString() );
+  }
+
+}


### PR DESCRIPTION
If repository is not configured, use in-process PurRepository as current user

BACKPORT for https://github.com/pentaho/pentaho-platform/pull/2855
http://jira.pentaho.com/browse/BACKLOG-7135

