### PR TITLE
[BACKLOG-7869] Use the admin vs non admin check & home folder check t…

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/browser/index.jsp
+++ b/user-console/source/org/pentaho/mantle/public/browser/index.jsp
@@ -79,7 +79,7 @@
 
   var FileBrowser = null;
 
-  function initBrowser(canDownload, showHiddenFiles, showDescriptions, canPublish) {
+  function initBrowser(canDownload, showHiddenFiles, showDescriptions, canPublish, canRead, canCreate) {
     require(["js/browser"], function (pentahoFileBrowser) {
       FileBrowser = pentahoFileBrowser;
       FileBrowser.setOpenFileHandler(openRepositoryFile);
@@ -88,6 +88,8 @@
       FileBrowser.setShowDescriptions(showDescriptions);
       FileBrowser.setCanDownload(canDownload);
       FileBrowser.setCanPublish(canPublish);
+      FileBrowser.setCanRead(canRead);
+      FileBrowser.setCanCreate(canCreate);
       
       var open_dir = window.parent.HOME_FOLDER;
       
@@ -332,10 +334,38 @@
       type: "GET",
       async: true,
       success: function (response) {
-        initBrowser(canDownload, showHiddenFiles, showDescriptions, (response == "true"));
+        checkCanRead(canDownload, showHiddenFiles, showDescriptions, (response == "true"));
       },
       error: function (response) {
-        initBrowser(canDownload, showHiddenFiles, showDescriptions, false);
+        checkCanRead(canDownload, showHiddenFiles, showDescriptions, false);
+      }
+    });
+  }
+
+  function checkCanRead(canDownload, showHiddenFiles, showDescriptions, canPublish) {
+    $.ajax({
+      url: CONTEXT_PATH + "api/authorization/action/isauthorized?authAction=org.pentaho.repository.read",
+      type: "GET",
+      async: true,
+      success: function (response) {
+        checkCanCreate(canDownload, showHiddenFiles, showDescriptions, canPublish, (response == "true") );
+      },
+      error: function (response) {
+        checkCanCreate(canDownload, showHiddenFiles, showDescriptions, canPublish, false);
+      }
+    });
+  }
+
+  function checkCanCreate(canDownload, showHiddenFiles, showDescriptions, canPublish, canRead) {
+    $.ajax({
+      url: CONTEXT_PATH + "api/authorization/action/isauthorized?authAction=org.pentaho.repository.create",
+      type: "GET",
+      async: true,
+      success: function (response) {
+        initBrowser(canDownload, showHiddenFiles, showDescriptions, canPublish, canRead, (response == "true") );
+      },
+      error: function (response) {
+        initBrowser(canDownload, showHiddenFiles, showDescriptions, canPublish, canRead, false);
       }
     });
   }

--- a/user-console/source/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/source/org/pentaho/mantle/public/browser/js/browser.js
@@ -81,6 +81,8 @@ define([
   FileBrowser.showDescriptions = false;
   FileBrowser.canDownload = false;
   FileBrowser.canPublish = false;
+  FileBrowser.canRead = false;
+  FileBrowser.canCreate = false;
 
   /**
    * Encode a path that has the slashes converted to colons
@@ -103,6 +105,14 @@ define([
 
   FileBrowser.setCanPublish = function (value) {
     this.canPublish = value;
+  }
+
+  FileBrowser.setCanRead = function (value) {
+    this.canRead = value;
+  }
+
+  FileBrowser.setCanCreate = function (value) {
+    this.canCreate = value;
   }
 
   FileBrowser.updateShowDescriptions = function (value) {
@@ -175,6 +185,8 @@ define([
       showDescriptions: _showDescriptions,
       canDownload: myself.canDownload,
       canPublish: myself.canPublish,
+      canRead: myself.canRead,
+      canCreate: myself.canCreate,
 	  startFolder: initialPath,
 	  clickedFolder: _clikedFolder,
       clickedFile: _clickedFile,
@@ -320,6 +332,25 @@ define([
         folderButtons.canPublish(this.get("canPublish"));
         //Leaving this here...if UX decides they want the hiddenFileLabel style preserved when switching folders
         //model.get('browserUtils').applyCutItemsStyle();
+
+        /* 
+         * BACKLOG-7846: a non-admin user will be granted upload/download permissions when:
+         * 1) is located in his home folder
+         * 2) has 'Read Content' permission
+         * 3) has 'Create Content' permission
+         */
+        var inHomeFolder = ( folderPath == userHomePath );
+        var canUploadAndDownload = this.get("canDownload") && this.get("canPublish");
+        
+        if( !canUploadAndDownload && inHomeFolder ) {
+          var hasReadPermission = this.get("canRead");
+          var hasCreatePermission = this.get("canCreate")
+
+          if( hasReadPermission && hasCreatePermission ) {
+            folderButtons.canPublish(true); // enable upload button
+            folderButtons.canDownload(true); // enable download button
+          }
+        }
 
         //Ajax request to check write permissions for folder
       $.ajax({
@@ -1400,6 +1431,8 @@ define([
     setShowDescriptions: FileBrowser.setShowDescriptions,
     setCanDownload: FileBrowser.setCanDownload,
     setCanPublish: FileBrowser.setCanPublish,
+    setCanRead: FileBrowser.setCanRead,
+    setCanCreate: FileBrowser.setCanCreate,
     updateShowDescriptions: FileBrowser.updateShowDescriptions,
     update: FileBrowser.update,
     updateData: FileBrowser.updateData,


### PR DESCRIPTION
…o enable and disable import and export button

	- admin user has upload and download action:
		- on all files and folders
	- non-admin user has upload and download actions:
		- enabled only in his home folder, and only when he has "Read Content" and "Create Content" permissions
		- disabled anywhere outside of his home folder ( even if he has "Read Content" and "Create Content" permissions )
		- disabled as soon as he loses either "Read Content" or "Create Content" permissions ( even in his home folder )