### PR TITLE
[BISERVER-13184] IE8 - Empty UI after login to PUC

### DIFF
--- a/user-console/build-res/subfloor-gwt.xml
+++ b/user-console/build-res/subfloor-gwt.xml
@@ -188,6 +188,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <fileset dir="${gwt.output.dir}" includes="**/*.cache.html" />
     </replaceregexp>
 
+    <!-- Adding doctype to the start of file to force using Standards Mode in IE9 and earlier -->
+    <replaceregexp match="^^" replace="&lt;!DOCTYPE html&gt;${line.separator}">
+      <fileset dir="${gwt.output.dir}" includes="**/*.cache.html" />
+    </replaceregexp>
   </target>
 
 


### PR DESCRIPTION
added doctype adding to html generated by GWT to force IE9 and earlier using Standards Mode