### PR TITLE
[BACKLOG-7741] java.io.FileNotFoundException, Could not create cache …

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/ehcache.xml
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/ehcache.xml
@@ -9,8 +9,7 @@
        user.home - User's home directory
        user.dir - User's current working directory
        java.io.tmpdir - Default temp file path -->
-  <diskStore path="java.io.tmpdir/_pentaho"/>
-
+  <diskStore path="user.home/.pentaho/caches/ehcache"/>
 
   <!--Default Cache configuration. These will applied to caches programmatically created through
       the CacheManager.


### PR DESCRIPTION
…directory & Failed to register plugin sparkl errors in Spoon when starting it from user with read permisions
We do not use persistent caches so they are removed upon shutdown and in worst case disk usage bump we're getting is in case of multiple user scenario (e.g spoon), which is (number of users - 1)*size of cache.

@pentaho-nbaker 