### PR TITLE
[BACKLOG-7075] - do not mask interrupted exception

### DIFF
--- a/repository/src/org/pentaho/platform/repository2/unified/jcr/sejcr/GuavaCachePoolPentahoJcrSessionFactory.java
+++ b/repository/src/org/pentaho/platform/repository2/unified/jcr/sejcr/GuavaCachePoolPentahoJcrSessionFactory.java
@@ -74,7 +74,15 @@ class GuavaCachePoolPentahoJcrSessionFactory extends NoCachePentahoJcrSessionFac
       }
     } ).recordStats().build( new CacheLoader<CacheKey, Session>() {
       @Override public Session load( CacheKey credKey ) throws Exception {
-        return GuavaCachePoolPentahoJcrSessionFactory.super.getSession( credKey.creds );
+        try {
+          return GuavaCachePoolPentahoJcrSessionFactory.super.getSession( credKey.creds );
+        } catch ( RepositoryException e ) {
+          if ( e.getCause() instanceof InterruptedException ) {
+            // do not mask interruptions from caller.
+            throw new InterruptedException( "session cache interrupted" );
+          }
+          throw e;
+        }
       }
     } );
 


### PR DESCRIPTION
When obtaining session if thread was interrupted - JCR throw
RepositoryException wrapped over InterruptedException.

Since InterruptedException was thrown (for example during login phase
trying to acuire read write lock) - interrupted flag is cleared.

In our code we intercept and supress this RepositoryException during
session extraction - so InterruptedException is suppressed AND interrupted
flag is cleared both.

This cause we unable to interrupt callable using future.cancel( true )
call. And report keep running.

Guava code from the other hand inspect exception - and if it is
InterruptedException thrown from loader code - it is restore interrupted
status.
That what exactly we expect - to be able to handle interruption and stop
parent execution.

So in case RepositoryException was caused by InterruptedException - we
have to throw interrupted exception  and let the guava cache loader
implementation to restore interrupted flag.