### PR TITLE
[BACKLOG-8251] Webcontext.js changes

### DIFF
--- a/extensions/src/org/pentaho/platform/web/servlet/ThemeServlet.java
+++ b/extensions/src/org/pentaho/platform/web/servlet/ThemeServlet.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.servlet;
@@ -67,6 +67,8 @@ public class ThemeServlet extends ServletBase {
       resp.setHeader( "Cache-Control", "no-cache" ); //$NON-NLS-1$
 
       IUserSettingService settingsService = PentahoSystem.get( IUserSettingService.class, getPentahoSession( req ) );
+
+      // NOTE: this code should be kept in sync with that of PentahoWebContextFilter.java
 
       String activeTheme = (String) getPentahoSession( req ).getAttribute( "pentaho-user-theme" );
 


### PR DESCRIPTION
@pentaho/millenniumfalcon please review.

* Antecipation of the declaration of the `active_theme` variable so that it is visible by require-js-cfg files is needed for the theming technique used by the VizAPI.

* The new global variable `PENTAHO_CONTEXT_NAME` is needed for the VizAPI to know the current context and provide a current/default context `pentaho.type.Context` instance/singleton.