### PR TITLE
[BACKLOG-8389] - Upgrade antlr to version 3.5.2 across Pentaho product suite - changes for pentaho platform repository

### DIFF
--- a/core/ivy.xml
+++ b/core/ivy.xml
@@ -57,10 +57,11 @@
       		<exclude org="dom4j" name="dom4j" />
       		<exclude org="net.sf.ehcache" name="ehcache" />
       		<!-- CM-241 -->
-      		<exclude org="cglib" name="cglib" />      
+      		<exclude org="cglib" name="cglib" />
+					<exclude org="antlr" name="antlr" />
     	</dependency>
     		<!-- CM-241 -->
-		<dependency org="antlr"             name="antlr"     rev="2.7.6"    transitive="false"/>
+		<dependency org="org.antlr"         name="antlr-complete"     rev="3.5.2"    transitive="false"/>
 		<dependency org="asm"               name="asm"       rev="3.1"    transitive="false"/>
 		<dependency org="asm"               name="asm-attrs" rev="2.2.3"    transitive="false"/>
     	<dependency org="cglib" name="cglib-nodep" rev="2.2" transitive="false" />

--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -92,7 +92,7 @@
     <!-- Hibernate and dependencies -->
     <dependency org="org.hibernate" name="hibernate-core" rev="3.6.9.Final" transitive="false"/>
     <dependency org="org.hibernate" name="hibernate-c3p0" rev="3.6.9.Final" transitive="false"/>
-    <dependency org="antlr" name="antlr" rev="2.7.6" transitive="false"/>
+    <dependency org="org.antlr" name="antlr-complete" rev="3.5.2" transitive="false"/>
     <dependency org="asm" name="asm" rev="3.1" transitive="false"/>
     <dependency org="asm" name="asm-attrs" rev="1.5.3" transitive="false"/>
     <dependency org="javax.transaction" name="jta" rev="1.1" transitive="false"/>
@@ -290,7 +290,6 @@
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="1.1" conf="default->default"
                 transitive="false"/>
     <dependency org="jsonpath" name="jsonpath" rev="1.0" conf="default->default" transitive="false"/>
-    <dependency org="org.antlr" name="antlr-runtime" rev="3.1.1" conf="default->default" transitive="false"/>
     <dependency org="org.drools" name="drools-api" rev="5.0.1" conf="default->default" transitive="false"/>
     <dependency org="org.drools" name="drools-compiler" rev="5.0.1" conf="default->default" transitive="false"/>
     <dependency org="org.drools" name="drools-core" rev="5.0.1" conf="default->default" transitive="false"/>
@@ -417,6 +416,7 @@
 
     <!-- CM-241 -->
     <exclude org="cglib" module="cglib"/>
+    <exclude org="antlr" module="antlr"/>
 
     <override org="junit" module="junit" rev="4.12"/>
     <override org="asm" module="asm" rev="3.1"/>

--- a/repository/ivy.xml
+++ b/repository/ivy.xml
@@ -60,7 +60,7 @@
 		<!-- Hibernate and dependencies -->
 		<dependency org="org.hibernate"     name="hibernate-core"    rev="3.6.9.Final" transitive="false"/>
     <dependency org="org.hibernate"     name="hibernate-ehcache"    rev="3.6.0.Final" transitive="false"/>
-		<dependency org="antlr"             name="antlr"        rev="2.7.6"    transitive="false"/>
+		<dependency org="org.antlr"         name="antlr-complete"     rev="3.5.2"    transitive="false"/>
 		<dependency org="asm"               name="asm"          rev="3.1"    transitive="false"/>
 		<dependency org="asm"               name="asm-attrs"    rev="2.2.3"    transitive="false"/>
 		<dependency org="javax.transaction" name="jta"          rev="1.1"   transitive="false"/>
@@ -159,6 +159,8 @@
 		<dependency org="org.jmock" 			name="jmock-junit4" rev="2.5.1" conf="test->default"/>
 	    <dependency org="org.jmock" 			name="jmock-legacy" rev="2.5.1" conf="test->default" />
 	    <dependency org="com.sun.jersey" 		name="jersey-test-framework" rev="1.8" conf="test->default"/>
+
+				<exclude org="antlr" module="antlr"/>
 
         <override org="pentaho-kettle" rev="${dependency.kettle.revision}" />
 	</dependencies>


### PR DESCRIPTION
Replace antrl-2.7.6, antlr-runtime-3.1.1 with antlr-3.5.2 which contains antlr-2.7.7.

antlr-2.7.6 is used by hibernate-core version 3.6.9.Final. Differences between antrl-2.7.6 and antrl-2.7.7 do not impact on hibernate-core;

To build pentaho-platform it previously needs to build:

- pentaho-reporting (pentaho-reporting-engine-classic-core) as it was changed to use antlr-complete-3.5.2 (pentaho/pentaho-reporting#792);
- pentaho-kettle (pentaho/pentaho-kettle#2665) as it has dependency on pentaho-reporting.