### PR TITLE
[BACKLOG-9273] Create a configuration property that controls the show…

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/default-plugin/plugin.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/default-plugin/plugin.xml
@@ -44,16 +44,4 @@
     <static-path url="/default-plugin/resources" localFolder="resources"/>
   </static-paths>
 
-   <!-- Adds a new menu item 'Kettle Status' under Tools menu. This menuitem makes the Data Integration status page available in Pentaho server. -->
-
-	<!-- overlays>
-	<overlay id="startup_tools_kettle_status" resourcebundle="content/default-plugin/resources/messages/messages">
-	   <menubar id="toolsmenu">
-	        <menuitem id="kettleStatusPageMenuItemId" label="${kettle.status.page}"
-	              command="mantleXulHandler.openUrl('${kettle.status.page}','${kettle.status.page}', 'kettle/status')"	>
-	        </menuitem>
-	   </menubar>
-	</overlay>
-	</overlays -->
-
 </plugin>

--- a/assembly/package-res/biserver/pentaho-solutions/system/default-plugin/resources/messages/messages.properties
+++ b/assembly/package-res/biserver/pentaho-solutions/system/default-plugin/resources/messages/messages.properties
@@ -4,4 +4,3 @@ schedules=Schedules
 admin=Administration
 home=Home
 browse=Browse Files
-kettle.status.page=PDI Status

--- a/user-console/source/org/pentaho/mantle/client/commands/OpenKettleStatusCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/OpenKettleStatusCommand.java
@@ -1,0 +1,64 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.mantle.client.commands;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.pentaho.mantle.client.usersettings.MantleSettingsManager;
+
+import java.util.HashMap;
+
+/**
+ * Executes the Open Kettle Status command.
+ *
+ */
+public class OpenKettleStatusCommand extends AbstractCommand {
+
+  private static final String KETTLE_STATUS_URL = "/kettle/status";
+
+  public OpenKettleStatusCommand() {
+
+  }
+
+  /**
+   * Executes the command to open the kettle status page.
+   */
+  protected void performOperation() {
+    performOperation( true );
+  }
+
+  protected void performOperation( boolean feedback ) {
+    MantleSettingsManager.getInstance().getMantleSettings( new AsyncCallback<HashMap<String, String>>() {
+
+      public void onSuccess( HashMap<String, String> result ) {
+        // we're working with a relative URL, this is relative to the web-app not the GWT module
+        String kettleStatusUrl = GWT.getHostPageBaseURL() + KETTLE_STATUS_URL;
+        /*
+         * Open in a named tab as in opposed to '_blank' or '_self';
+         * We want to keep PUC open and in addition to that we want to have one single 'Kettle Status' page open
+         */
+        Window.open( kettleStatusUrl, "KettleStatus", "" ); //$NON-NLS-1$ //$NON-NLS-2$
+      }
+
+      public void onFailure( Throwable caught ) {
+      }
+    }, false );
+  }
+
+}

--- a/user-console/source/org/pentaho/mantle/client/ui/xul/MantleController.java
+++ b/user-console/source/org/pentaho/mantle/client/ui/xul/MantleController.java
@@ -992,6 +992,11 @@ public class MantleController extends AbstractXulEventHandler {
     model.openDocumentation();
   }
 
+  @Bindable
+  public void kettleStatusPageClicked() {
+    model.openKettleStatusPage();
+  }
+
   public void loadOverlay( String id ) {
     // TODO We need to convert ths to use the common interface method,
     // once they become available

--- a/user-console/source/org/pentaho/mantle/client/ui/xul/MantleModel.java
+++ b/user-console/source/org/pentaho/mantle/client/ui/xul/MantleModel.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.ui.xul;
@@ -26,6 +26,7 @@ import org.pentaho.mantle.client.commands.FilePropertiesCommand;
 import org.pentaho.mantle.client.commands.NewDropdownCommand;
 import org.pentaho.mantle.client.commands.OpenDocCommand;
 import org.pentaho.mantle.client.commands.OpenFileCommand;
+import org.pentaho.mantle.client.commands.OpenKettleStatusCommand;
 import org.pentaho.mantle.client.commands.PrintCommand;
 import org.pentaho.mantle.client.commands.RefreshRepositoryCommand;
 import org.pentaho.mantle.client.commands.RefreshSchedulesCommand;
@@ -301,6 +302,12 @@ public class MantleModel extends XulEventSourceAdapter implements SolutionBrowse
   @Bindable
   public void openDocumentation() {
     OpenDocCommand cmd = new OpenDocCommand();
+    cmd.execute();
+  }
+
+  @Bindable
+  public void openKettleStatusPage() {
+    OpenKettleStatusCommand cmd = new OpenKettleStatusCommand();
     cmd.execute();
   }
 

--- a/user-console/source/org/pentaho/mantle/public/xul/mantle.xul
+++ b/user-console/source/org/pentaho/mantle/public/xul/mantle.xul
@@ -49,6 +49,10 @@
         <menuitem id="purgeReportingDataCacheMenuItem" label="${purgeReportingDataCache}"
                   command="mantleXulHandler.executeMantleCommand('PurgeReportingDataCacheCommand')"/>
       </menubar>
+
+      <!-- Uncomment line below to enable 'PDI Status page' menu item -->
+      <!-- <menuitem id="kettleStatusMenuItem" label="${kettleStatusMenuItem}" command="mantleXulHandler.kettleStatusPageClicked()"/> -->
+
     </menubar>
 
     <menubar id="helpmenu" label="${help}" layout="vertical">


### PR DESCRIPTION
…/hide of the 'Tools' sub-menu. This sub-menu sould be hidden by default

	- applying new logic that implements the behaviour stated by PO, which is:
		- The menu item will open a new browser tab (not PUC tab) which is a full page view of the status screen as it exists in DI Server 6.1 and before).
		- The PUC page should remain
		- The new browser tab should have a target name so if the user goes to PUC and selects the menu item again, they do not get a 2nd new browser window with the PDI status page. Instead they are taken to the existing page and the page is refreshed.