### PR TITLE
[BACKLOG-9273] Create a configuration property that controls the show…

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/commands/OpenKettleStatusCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/OpenKettleStatusCommand.java
@@ -51,11 +51,7 @@ public class OpenKettleStatusCommand extends AbstractCommand {
           ? GWT.getHostPageBaseURL() : ( GWT.getHostPageBaseURL() + "/" );
         String kettleStatusUrl = hostBaseUrl + KETTLE_STATUS_URL;
 
-        /*
-         * Open in a named tab as in opposed to '_blank' or '_self';
-         * We want to keep PUC open and in addition to that we want to have one single 'Kettle Status' page open
-         */
-        openNewWindow( kettleStatusUrl, "KettleStatus", true );
+        openNewWindow( kettleStatusUrl, "_blank", false );
       }
 
       public void onFailure( Throwable caught ) {


### PR DESCRIPTION
…/hide of the 'Tools' sub-menu. This sub-menu sould be hidden by default

	- "Tools > PDI Status" menu item shall assume the same behaviour as "Help > Documentation"