### PR TITLE
[PPP-3536] - Updated groovy to version 2.4.7 due to CVE-2015-3253

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -217,7 +217,7 @@
 
 
     <dependency org="com.lowagie" name="itext-rtf" rev="${dependency.itextrtf.revision}" changing="true" transitive="false"/>
-    <dependency org="org.codehaus.groovy"  name="groovy"  rev="1.8.0"  changing="true" transitive="false"/>
+    <dependency org="org.codehaus.groovy"  name="groovy"  rev="2.4.7"  changing="true" transitive="false"/>
 
     <!-- olap -->
     <dependency org="pentaho" name="mondrian" rev="${dependency.mondrian.revision}" changing="true">


### PR DESCRIPTION
security vulnerability CVE-2015-3253 - groovy before version 2.4.4