### PR TITLE
[BACKLOG-9732] Remove Execute permission from Authenticated role and …

### DIFF
--- a/assembly/package-res-merged-server/biserver/pentaho-solutions/system/repository.spring.xml
+++ b/assembly/package-res-merged-server/biserver/pentaho-solutions/system/repository.spring.xml
@@ -595,7 +595,7 @@
     <constructor-arg ref="pathConversionHelper"/>
     <property name="rolesNeedingExecutePermission">
       <util:list>
-        <ref bean="singleTenantAuthenticatedAuthorityName"/>
+        <!-- <ref bean="singleTenantAuthenticatedAuthorityName"/> --> <!-- 'Authenticated' system role -->
         <value>Power User</value>
       </util:list>
     </property>


### PR DESCRIPTION
…grant that permission to the Power User role

	- leaving this one commented-out as a means to ease the documentation on how-to re-enable execute permission for the authenticated role
	- all unit tests regarding the adding of the execute permission to a list of roles function just as well nowadays