### PR TITLE
[BACKLOG-8388] - Upgrade Jersey to 1.19.1 across the suite for Java 8 compatibility

### DIFF
--- a/build-utils/ivy.xml
+++ b/build-utils/ivy.xml
@@ -16,8 +16,8 @@
   <dependencies defaultconf="default->default">
     <!--  external dependencies -->
     <dependency org="xerces" name="xercesImpl" rev="2.9.1" transitive="false" conf="default, test->default"/>
-    <dependency org="com.sun.jersey" name="jersey-server" rev="1.16" transitive="false" conf="default, test->default"/>
-    <dependency org="com.sun.jersey.contribs" name="wadl-resourcedoc-doclet" rev="1.19" transitive="false" conf="default, test->default" />
+    <dependency org="com.sun.jersey" name="jersey-server" rev="1.19.1" transitive="false" conf="default, test->default"/>
+    <dependency org="com.sun.jersey.contribs" name="wadl-resourcedoc-doclet" rev="1.19.1" transitive="false" conf="default, test->default" />
 
     <dependency org="junit" name="junit" rev="4.12" conf="test->default"/>
     <dependency org="org.mockito" name="mockito-all" rev="1.9.5" transitive="false" conf="test->default"/>

--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -128,15 +128,18 @@
     </dependency>
 
     <!-- jersey -->
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.16"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.14" transitive="false"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-spring" rev="1.16" transitive="false"/>
+    <dependency org="javax.ws.rs" name="jsr311-api" rev="1.1.1" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.19.1" transitive="false"/>
+    <dependency org="org.jvnet.mimepull" name="mimepull" rev="1.9.3" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-spring" rev="1.19.1" transitive="false"/>
 
-    <dependency org="com.sun.jersey" name="jersey-core" rev="1.16" transitive="false"/>
-    <dependency org="com.sun.jersey" name="jersey-json" rev="1.16" transitive="false"/>
-    <dependency org="com.sun.jersey" name="jersey-client" rev="1.16" transitive="false"/>
-    <dependency org="com.sun.jersey" name="jersey-server" rev="1.16" transitive="false" />
-    <dependency org="com.sun.jersey" name="jersey-servlet" rev="1.16" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-core" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-bundle" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-json" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-client" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-server" rev="1.19.1" transitive="false" />
+    <dependency org="com.sun.jersey" name="jersey-servlet" rev="1.19.1" transitive="false"/>
 
     <!-- END JAX-WS (Service extension) dependencies -->
     <dependency org="org.codehaus.jettison" name="jettison" rev="${dependency.jettison.revision}"/>
@@ -384,11 +387,22 @@
     </dependency>
     <!-- end security test dependencies -->
 
-    <dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-core" rev="1.16"
-                conf="test->default"/>
-    <dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-grizzly" rev="1.16"
-                conf="test->default"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.16" conf="test->default"/>
+    <dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-core" rev="1.19.1"
+                conf="test->default" transitive="false"/>
+    <dependency org="com.sun.jersey.jersey-test-framework" name="jersey-test-framework-grizzly" rev="1.19.1"
+                conf="test->default" transitive="false"/>
+    <!-- here jersey-test-framework-grizzly transitive dependecies start -->
+    <dependency org="com.sun.grizzly" name="grizzly-framework" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-lzma" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-portunif" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-rcm" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-servlet-webserver" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-utils" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-http" rev="1.9.45" transitive="false" conf="test->default"/>
+    <dependency org="com.sun.grizzly" name="grizzly-http-servlet" rev="1.9.45" transitive="false" conf="test->default"/>
+    <!-- here jersey-test-framework-grizzly transitive dependecies finish -->
+    
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.19.1" conf="test->default" transitive="false"/>
 
     <dependency org="org.springframework" name="spring-test" rev="${dependency.spring.framework.revision}" conf="test->default"/>
 
@@ -402,7 +416,7 @@
       <exclude org="log4j" name="log4j"/>
     </dependency>
 
-    <dependency org="com.sun.jersey.contribs" name="wadl-resourcedoc-doclet" rev="1.19" transitive="false" />
+    <dependency org="com.sun.jersey.contribs" name="wadl-resourcedoc-doclet" rev="1.19.1" transitive="false" />
 
     <dependency org="com.google.guava" name="guava" rev="17.0" conf="test->default"/>
 

--- a/repository/ivy.xml
+++ b/repository/ivy.xml
@@ -39,15 +39,28 @@
         <dependency org="org.yaml" name="snakeyaml" rev="1.7" conf="default->default" transitive="false"/>
 
     	<!-- jersey -->
-    	<dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.16"/>
-    	<dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.16" transitive="false"/>
-    	<dependency org="com.sun.jersey.contribs" name="jersey-spring" rev="1.16" transitive="false"/>
+      <dependency org="javax.ws.rs" name="jsr311-api" rev="1.1.1" transitive="false"/>
+    	<dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.19.1" transitive="false"/>
+      <dependency org="org.jvnet.mimepull" name="mimepull" rev="1.9.3" transitive="false"/> 
+    	<dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.19.1" transitive="false"/>
+    	<dependency org="com.sun.jersey.contribs" name="jersey-spring" rev="1.19.1" transitive="false"/>
 
-    	<dependency org="com.sun.jersey" name="jersey-core" rev="1.16"    transitive="false"/>
-    	<dependency org="com.sun.jersey" name="jersey-json" rev="1.16"    transitive="true"/>
-    	<dependency org="com.sun.jersey" name="jersey-client" rev="1.16"  transitive="false"/>
-    	<dependency org="com.sun.jersey" name="jersey-server" rev="1.16"  transitive="false"/>
-    	<dependency org="com.sun.jersey" name="jersey-servlet" rev="1.16" transitive="false"/>
+    	<dependency org="com.sun.jersey" name="jersey-core" rev="1.19.1"    transitive="false"/>
+    	<dependency org="com.sun.jersey" name="jersey-json" rev="1.19.1"    transitive="false"/>
+      <!--here jersey-json transitive dependencies started-->
+      <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.2" transitive="false"/>
+      <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.2" transitive="false"/>
+      <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.9.2" transitive="false"/>
+      <dependency org="org.codehaus.jackson" name="jackson-jaxrs" rev="1.9.2" transitive="false"/>
+      <dependency org="org.codehaus.jettison" name="jettison" rev="1.1" transitive="false"/>
+      <dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.2.3-1" transitive="false"/>
+      <dependency org="javax.xml.bind" name="jaxb-api" rev="2.2.2" transitive="false"/>
+      <dependency org="javax.xml.stream" name="stax-api" rev="1.0-2" transitive="false"/>
+      <dependency org="javax.activation" name="activation" rev="1.1" transitive="false"/>
+      <!--here jersey-json transitive dependencies finished-->
+    	<dependency org="com.sun.jersey" name="jersey-client" rev="1.19.1"  transitive="false"/>
+    	<dependency org="com.sun.jersey" name="jersey-server" rev="1.19.1"  transitive="false"/>
+    	<dependency org="com.sun.jersey" name="jersey-servlet" rev="1.19.1" transitive="false"/>
 
 
 		<!-- metro -->
@@ -159,7 +172,7 @@
 	    <dependency org="org.mockito"          	name="mockito-all"  rev="1.10.19"   conf="test->default"/>
 		<dependency org="org.jmock" 			name="jmock-junit4" rev="2.5.1" conf="test->default"/>
 	    <dependency org="org.jmock" 			name="jmock-legacy" rev="2.5.1" conf="test->default" />
-	    <dependency org="com.sun.jersey" 		name="jersey-test-framework" rev="1.8" conf="test->default"/>
+	    <dependency org="com.sun.jersey" 		name="jersey-test-framework" rev="1.19.1" conf="test->default" transitive="false"/>
 
 		<exclude org="javassist" module="javassist"/>
         <override org="pentaho-kettle" rev="${dependency.kettle.revision}" />


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor