### PR TITLE
[BACKLOG-8389] - Upgrade antlr to latest stable version across Pentaho product suite - changes for pentaho platform repository

### DIFF
--- a/core/ivy.xml
+++ b/core/ivy.xml
@@ -46,20 +46,10 @@
     <dependency org="com.google.guava" name="guava" rev="17.0" conf="default->default"/>
 		<dependency org="org.apache.felix" name="org.apache.felix.main" rev="4.2.1"/>
 		<!-- Hibernate and dependencies -->
-    	<dependency org="org.hibernate" name="hibernate-core" rev="3.6.9.Final">
-      		<!--
-        		include these jars, needed for unit tests. child projects may choose to exclude these, if deploying to an app
-        		server, etc. <exclude org="net.sf.ehcache" name="ehcache" /> <exclude org="asm" name="asm" /> <exclude org="asm"
-        		name="asm-attrs" />
-      		-->
-      		<exclude org="commons-logging" name="commons-logging" />
-      		<exclude org="commons-collections" />
-      		<exclude org="dom4j" name="dom4j" />
-      		<exclude org="net.sf.ehcache" name="ehcache" />
-      		<!-- CM-241 -->
-      		<exclude org="cglib" name="cglib" />
-					<exclude org="antlr" name="antlr" />
-    	</dependency>
+		<!--Set transitive to false for hibernate-core and explicitly add necessary dependencies-->
+		<dependency org="org.hibernate" name="hibernate-core" rev="3.6.9.Final" transitive="false"/>
+		<dependency org="org.hibernate" name="hibernate-commons-annotations" rev="3.2.0.Final" transitive="false"/>
+		<dependency org="org.hibernate.javax.persistence" name="hibernate-jpa-2.0-api" rev="1.0.1.Final" transitive="false"/>
     		<!-- CM-241 -->
 		<dependency org="org.antlr"         name="antlr-complete"     rev="3.5.2"    transitive="false"/>
 		<dependency org="asm"               name="asm"       rev="3.1"    transitive="false"/>

--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -430,7 +430,6 @@
 
     <!-- CM-241 -->
     <exclude org="cglib" module="cglib"/>
-    <exclude org="antlr" module="antlr"/>
 
     <exclude org="org.apache.xmlgraphics" module="batik-js" />
 

--- a/repository/ivy.xml
+++ b/repository/ivy.xml
@@ -173,7 +173,6 @@
 		<dependency org="org.jmock" 			name="jmock-junit4" rev="2.5.1" conf="test->default"/>
 	    <dependency org="org.jmock" 			name="jmock-legacy" rev="2.5.1" conf="test->default" />
 	    <dependency org="com.sun.jersey" 		name="jersey-test-framework" rev="1.19.1" conf="test->default" transitive="false"/>
-
 		<exclude org="javassist" module="javassist"/>
         <override org="pentaho-kettle" rev="${dependency.kettle.revision}" />
 	</dependencies>


### PR DESCRIPTION
Set transitive to false for hibernate-core and explicitly added necessary dependencies to the core module;
Removed the exclude tag for antlr from the extensions module.