### PR TITLE
[SP-2821] - Backport of PPP-3536 - Use of vulnerable component  org.c…

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -217,7 +217,7 @@
     
     
     <dependency org="com.lowagie" name="itext-rtf" rev="${dependency.itextrtf.revision}" changing="true" transitive="false"/>
-    <dependency org="org.codehaus.groovy"  name="groovy"  rev="1.8.0"  changing="true" transitive="false"/>
+    <dependency org="org.codehaus.groovy"  name="groovy"  rev="2.4.7"  changing="true" transitive="false"/>
 
     <!-- olap -->
     <dependency org="pentaho" name="mondrian" rev="${dependency.mondrian.revision}" changing="true">


### PR DESCRIPTION
…odehaus.groovy v.1.8.0 CVE-2015-3253 (6.1 Suite)

@pamval, @mchen-len-son, here is the backport of https://github.com/pentaho/pentaho-platform/pull/2999/files to 6.1. Thanks.