### PR TITLE
[BISERVER-13332] The ACLs selection disappear from all groups/roles on BA server after doing a RESTORE using the Import-Export utility

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/exporter/strategies/ExportStrategyUtil.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/exporter/strategies/ExportStrategyUtil.java
@@ -1,0 +1,51 @@
+package org.pentaho.platform.plugin.services.exporter.strategies;
+
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.importexport.RoleExport;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
+import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
+
+import java.util.List;
+
+/**
+ * Class with general methods of all strategies
+ *
+ * @author Andrei Abramov <Andrei_Abramov@epam.com>
+ */
+class ExportStrategyUtil {
+
+  /**
+   * Bind a role name and its permissions and export into the manifest file
+   *
+   * @param exportManifest ExportManifest XML-file to be written
+   * @param roles          List<String> of roles' names
+   */
+  public static void exportRoles( ExportManifest exportManifest, List<String> roles ) {
+    IRoleAuthorizationPolicyRoleBindingDao roleBindingDao = PentahoSystem.get(
+      IRoleAuthorizationPolicyRoleBindingDao.class );
+
+    for ( String role : roles ) {
+      RoleExport roleExport = new RoleExport();
+      roleExport.setRolename( role );
+      roleExport.setPermission( roleBindingDao.getRoleBindingStruct( null ).bindingMap.get( role ) );
+      exportManifest.addRoleExport( roleExport );
+    }
+  }
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/exporter/strategies/IExportStrategy.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/exporter/strategies/IExportStrategy.java
@@ -1,0 +1,35 @@
+package org.pentaho.platform.plugin.services.exporter.strategies;
+
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
+
+/**
+ * Export strategy interface
+ *
+ * @author Andrei Abramov
+ */
+public interface IExportStrategy {
+
+  /**
+   * Exports all users and roles into the specified file
+   *
+   * @param exportManifest ExportManifest XML-file to be written
+   */
+  void exportUsersAndRoles( ExportManifest exportManifest );
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/exporter/strategies/JackrabbitExportStrategy.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/exporter/strategies/JackrabbitExportStrategy.java
@@ -1,0 +1,105 @@
+package org.pentaho.platform.plugin.services.exporter.strategies;
+
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
+import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
+import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.usersettings.IAnyUserSettingService;
+import org.pentaho.platform.api.usersettings.IUserSettingService;
+import org.pentaho.platform.api.usersettings.pojo.IUserSetting;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.core.system.TenantUtils;
+import org.pentaho.platform.plugin.services.importexport.ExportManifestUserSetting;
+import org.pentaho.platform.plugin.services.importexport.UserExport;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Strategy that exports users' roles from Jackrabbit
+ *
+ * @author Andrei Abramov
+ */
+public class JackrabbitExportStrategy implements IExportStrategy {
+  @Override
+  public void exportUsersAndRoles( ExportManifest exportManifest ) {
+    IUserRoleDao roleDao = PentahoSystem.get( IUserRoleDao.class );
+    ITenant tenant = TenantUtils.getCurrentTenant();
+
+    //  get the user settings for this user
+    IUserSettingService service = PentahoSystem.get( IUserSettingService.class, PentahoSessionHolder.getSession() );
+
+    doUserExport( exportManifest, roleDao, tenant, service );
+    doGlobalUserSettingsExport( exportManifest, service );
+    doRoleExport( exportManifest, roleDao );
+  }
+
+  // export the global user settings
+  private void doGlobalUserSettingsExport( ExportManifest exportManifest, IUserSettingService service ) {
+    if ( service != null ) {
+      List<IUserSetting> globalUserSettings = service.getGlobalUserSettings();
+      if ( globalUserSettings != null ) {
+        for ( IUserSetting setting : globalUserSettings ) {
+          exportManifest.addGlobalUserSetting( new ExportManifestUserSetting( setting ) );
+        }
+      }
+    }
+  }
+
+  //RoleExport
+  private void doRoleExport( ExportManifest exportManifest, IUserRoleDao roleDao ) {
+    List<IPentahoRole> roles = roleDao.getRoles();
+    List<String> rolesNames = new ArrayList<>();
+    for ( IPentahoRole role : roles ) {
+      rolesNames.add( role.getName() );
+    }
+
+    ExportStrategyUtil.exportRoles( exportManifest, rolesNames );
+  }
+
+  //User Export
+  private void doUserExport( ExportManifest exportManifest, IUserRoleDao roleDao, ITenant tenant,
+                             IUserSettingService service ) {
+    List<IPentahoUser> userList = roleDao.getUsers( tenant );
+    for ( IPentahoUser user : userList ) {
+      UserExport userExport = new UserExport();
+      userExport.setUsername( user.getUsername() );
+      userExport.setPassword( user.getPassword() );
+
+      for ( IPentahoRole role : roleDao.getUserRoles( tenant, user.getUsername() ) ) {
+        userExport.setRole( role.getName() );
+      }
+
+      if ( service != null && service instanceof IAnyUserSettingService ) {
+        IAnyUserSettingService userSettings = (IAnyUserSettingService) service;
+        List<IUserSetting> settings = userSettings.getUserSettings( user.getUsername() );
+        if ( settings != null ) {
+          for ( IUserSetting setting : settings ) {
+            userExport.addUserSetting( new ExportManifestUserSetting( setting ) );
+          }
+        }
+      }
+
+      exportManifest.addUserExport( userExport );
+    }
+  }
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/exporter/strategies/LdapExportStrategy.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/exporter/strategies/LdapExportStrategy.java
@@ -1,0 +1,40 @@
+package org.pentaho.platform.plugin.services.exporter.strategies;
+
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+import org.pentaho.platform.api.engine.IUserRoleListService;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
+
+import java.util.List;
+
+/**
+ * Strategy that exports users' roles from LDAP
+ *
+ * @author Andrei Abramov
+ */
+public class LdapExportStrategy implements IExportStrategy {
+  @Override
+  public void exportUsersAndRoles( ExportManifest exportManifest ) {
+
+    IUserRoleListService userRoleListService = PentahoSystem.get( IUserRoleListService.class );
+    List<String> roles = userRoleListService.getAllRoles();
+
+    ExportStrategyUtil.exportRoles( exportManifest, roles );
+  }
+}

--- a/extensions/test-src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporterTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporterTest.java
@@ -1,5 +1,22 @@
 package org.pentaho.platform.plugin.services.exporter;
 
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,7 +25,9 @@ import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.platform.api.engine.IConfiguration;
 import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.ISystemConfig;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
 import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
@@ -21,12 +40,12 @@ import org.pentaho.platform.api.scheduler2.Job;
 import org.pentaho.platform.api.scheduler2.JobTrigger;
 import org.pentaho.platform.api.scheduler2.SchedulerException;
 import org.pentaho.platform.api.usersettings.IAnyUserSettingService;
-import org.pentaho.platform.api.usersettings.IUserSettingService;
 import org.pentaho.platform.api.usersettings.pojo.IUserSetting;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
+import org.pentaho.platform.plugin.services.exporter.strategies.JackrabbitExportStrategy;
 import org.pentaho.platform.plugin.services.importexport.ExportManifestUserSetting;
 import org.pentaho.platform.plugin.services.importexport.RoleExport;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
@@ -46,6 +65,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -62,7 +82,6 @@ public class PentahoPlatformExporterTest {
   IPentahoSession session;
   IMondrianCatalogService mondrianCatalogService;
   MondrianCatalogRepositoryHelper mondrianCatalogRepositoryHelper;
-
   ExportManifest exportManifest;
 
   @Before
@@ -73,6 +92,16 @@ public class PentahoPlatformExporterTest {
     mondrianCatalogService = mock( IMondrianCatalogService.class );
     mondrianCatalogRepositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
     exportManifest = spy( new ExportManifest() );
+
+    Properties properties = mock( Properties.class );
+    IConfiguration config = mock( IConfiguration.class );
+    ISystemConfig systemConfig = mock( ISystemConfig.class );
+    PentahoSystem.registerObject( systemConfig );
+
+    doReturn( config ).when( systemConfig ).getConfiguration( "security" );
+    doReturn( "1234" ).when( config ).getId();
+    doReturn( properties ).when( config ).getProperties();
+    doReturn( "jackrabbit" ).when( properties ).getProperty( "provider" );
 
     PentahoSessionHolder.setSession( session );
     exporterSpy = spy( new PentahoPlatformExporter( repo ) );
@@ -126,6 +155,7 @@ public class PentahoPlatformExporterTest {
 
   @Test
   public void testExportUsersAndRoles() {
+    exporter.setExportStrategy( new JackrabbitExportStrategy() );
     IUserRoleDao mockDao = mock( IUserRoleDao.class );
     IAnyUserSettingService userSettingService = mock( IAnyUserSettingService.class );
     PentahoSystem.registerObject( mockDao );

--- a/extensions/test-src/org/pentaho/platform/plugin/services/exporter/strategies/JackrabbitExportStrategyTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/exporter/strategies/JackrabbitExportStrategyTest.java
@@ -1,0 +1,130 @@
+package org.pentaho.platform.plugin.services.exporter.strategies;
+
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
+import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
+import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.usersettings.IAnyUserSettingService;
+import org.pentaho.platform.api.usersettings.pojo.IUserSetting;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.importexport.ExportManifestUserSetting;
+import org.pentaho.platform.plugin.services.importexport.RoleExport;
+import org.pentaho.platform.plugin.services.importexport.UserExport;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
+import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
+import org.pentaho.platform.security.policy.rolebased.RoleBindingStruct;
+import org.pentaho.platform.security.userroledao.PentahoRole;
+import org.pentaho.platform.security.userroledao.PentahoUser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Andrei Abramov
+ */
+public class JackrabbitExportStrategyTest {
+
+  IPentahoSession session;
+  ExportManifest exportManifest;
+  JackrabbitExportStrategy jackrabbitExportStrategy;
+
+  @Before
+  public void setUp() throws Exception {
+    session = mock( IPentahoSession.class );
+    exportManifest = spy( new ExportManifest() );
+    jackrabbitExportStrategy = new JackrabbitExportStrategy();
+    PentahoSessionHolder.setSession( session );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    PentahoSystem.clearObjectFactory();
+  }
+
+  @Test
+  public void testExportUsersAndRoles() throws Exception {
+
+    IUserRoleDao mockDao = mock( IUserRoleDao.class );
+    IAnyUserSettingService userSettingService = mock( IAnyUserSettingService.class );
+    PentahoSystem.registerObject( mockDao );
+    PentahoSystem.registerObject( userSettingService );
+
+    IRoleAuthorizationPolicyRoleBindingDao roleBindingDao = mock( IRoleAuthorizationPolicyRoleBindingDao.class );
+    PentahoSystem.registerObject( roleBindingDao );
+
+    String tenantPath = "path";
+    when( session.getAttribute( IPentahoSession.TENANT_ID_KEY ) ).thenReturn( tenantPath );
+
+    List<IPentahoUser> userList = new ArrayList<IPentahoUser>();
+    IPentahoUser user = new PentahoUser( "testUser" );
+    IPentahoRole role = new PentahoRole( "testRole" );
+    userList.add( user );
+    when( mockDao.getUsers( any( ITenant.class ) ) ).thenReturn( userList );
+
+    List<IPentahoRole> roleList = new ArrayList<IPentahoRole>();
+    roleList.add( role );
+    when( mockDao.getRoles() ).thenReturn( roleList );
+
+    Map<String, List<String>> map = new HashMap<String, List<String>>();
+    List<String> permissions = new ArrayList<String>();
+    permissions.add( "read" );
+    map.put( "testRole", permissions );
+    RoleBindingStruct struct = mock( RoleBindingStruct.class );
+    struct.bindingMap = map;
+    when( roleBindingDao.getRoleBindingStruct( anyString() ) ).thenReturn( struct );
+
+    ArgumentCaptor<UserExport> userCaptor = ArgumentCaptor.forClass( UserExport.class );
+    ArgumentCaptor<RoleExport> roleCaptor = ArgumentCaptor.forClass( RoleExport.class );
+    ExportManifest manifest = mock( ExportManifest.class );
+
+    List<IUserSetting> settings = new ArrayList<>();
+    IUserSetting setting = mock( IUserSetting.class );
+    settings.add( setting );
+    when( userSettingService.getUserSettings( user.getUsername() ) ).thenReturn( settings );
+    when( userSettingService.getGlobalUserSettings() ).thenReturn( settings );
+    jackrabbitExportStrategy.exportUsersAndRoles( manifest );
+
+    verify( manifest ).addUserExport( userCaptor.capture() );
+    verify( manifest ).addRoleExport( roleCaptor.capture() );
+    verify( userSettingService ).getGlobalUserSettings();
+    verify( manifest ).addGlobalUserSetting( any( ExportManifestUserSetting.class ) );
+    assertEquals( settings.size(), userCaptor.getValue().getUserSettings().size() );
+
+    UserExport userExport = userCaptor.getValue();
+    assertEquals( "testUser", userExport.getUsername() );
+    RoleExport roleExport = roleCaptor.getValue();
+    assertEquals( "testRole", roleExport.getRolename() );
+  }
+
+}

--- a/extensions/test-src/org/pentaho/platform/plugin/services/exporter/strategies/LdapExportStrategyTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/exporter/strategies/LdapExportStrategyTest.java
@@ -1,0 +1,101 @@
+package org.pentaho.platform.plugin.services.exporter.strategies;
+
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.IUserRoleListService;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.importexport.RoleExport;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
+import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
+import org.pentaho.platform.security.policy.rolebased.RoleBindingStruct;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Andrei Abramov
+ */
+public class LdapExportStrategyTest {
+
+  IPentahoSession session;
+  ExportManifest exportManifest;
+  LdapExportStrategy ldapExportStrategy;
+
+
+  @Before
+  public void setUp() throws Exception {
+    session = mock( IPentahoSession.class );
+    exportManifest = spy( new ExportManifest() );
+    ldapExportStrategy = new LdapExportStrategy();
+    PentahoSessionHolder.setSession( session );
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    PentahoSystem.clearObjectFactory();
+  }
+
+  @Test
+  public void exportUsersAndRoles() throws Exception {
+    IUserRoleListService mockService = mock( IUserRoleListService.class );
+    PentahoSystem.registerObject( mockService );
+
+    IRoleAuthorizationPolicyRoleBindingDao roleBindingDao = mock( IRoleAuthorizationPolicyRoleBindingDao.class );
+    PentahoSystem.registerObject( roleBindingDao );
+
+    String tenantPath = "path";
+    when( session.getAttribute( IPentahoSession.TENANT_ID_KEY ) ).thenReturn( tenantPath );
+
+    String role = "testRole";
+    List<String> roleList = new ArrayList<>();
+    roleList.add( role );
+    when( mockService.getAllRoles() ).thenReturn( roleList );
+
+    Map<String, List<String>> map = new HashMap<String, List<String>>();
+    List<String> permissions = new ArrayList<String>();
+    permissions.add( "read" );
+    map.put( "testRole", permissions );
+    RoleBindingStruct struct = mock( RoleBindingStruct.class );
+    struct.bindingMap = map;
+    when( roleBindingDao.getRoleBindingStruct( anyString() ) ).thenReturn( struct );
+
+    ArgumentCaptor<RoleExport> roleCaptor = ArgumentCaptor.forClass( RoleExport.class );
+    ExportManifest manifest = mock( ExportManifest.class );
+
+    ldapExportStrategy.exportUsersAndRoles( manifest );
+
+    verify( manifest ).addRoleExport( roleCaptor.capture() );
+
+    RoleExport roleExport = roleCaptor.getValue();
+    assertEquals( "testRole", roleExport.getRolename() );
+  }
+
+}


### PR DESCRIPTION
- fixed
@rmansoor 
@pentaho-nbaker
Wingman failed test, that is not connected with my changes (at first run).