### PR TITLE
[BACKLOG-10323] Standardize of javassist version 3.20.0-GA

### DIFF
--- a/extensions/build.properties
+++ b/extensions/build.properties
@@ -42,3 +42,4 @@ junit.maxmemory=2048m
 tests.publish=true
 
 dependency.pentaho-simple-jndi.revision=1.0.0
+dependency.javassist.revision=3.20.0-GA

--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -242,7 +242,7 @@
     <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="0.9.5" conf="default->default" transitive="false"/>
     <dependency org="janino" name="janino" rev="2.5.16" conf="default->default" transitive="false"/>
     <!-- java assist version 3.12.1.GA for hibernate 3.6.9 -->
-    <dependency org="javassist" name="javassist" rev="3.12.1.GA" conf="default->default" transitive="false"/>
+    <dependency org="org.javassist" name="javassist" rev="${dependency.javassist.revision}" conf="default->default" transitive="false"/>
     <dependency org="org.scannotation" name="scannotation" rev="1.0.2" conf="default->default" transitive="false"/>
     <dependency org="org.syslog4j" name="syslog4j" rev="0.9.34" conf="default->default" transitive="false"/>
     <dependency org="ldapjdk" name="ldapjdk" rev="20000524" conf="default->default" transitive="false"/>

--- a/scheduler/.classpath
+++ b/scheduler/.classpath
@@ -32,7 +32,7 @@
 	<classpathentry kind="lib" path="lib/hibernate-commons-annotations-3.2.0.Final.jar"/>
 	<classpathentry kind="lib" path="lib/hibernate-core-3.6.9.Final.jar"/>
 	<classpathentry kind="lib" path="lib/hibernate-jpa-2.0-api-1.0.1.Final.jar"/>
-	<classpathentry kind="lib" path="lib/javassist-3.4.GA.jar"/>
+	<classpathentry kind="lib" path="lib/javassist-3.20.0-GA.jar"/>
 	<classpathentry kind="lib" path="lib/jaxen-1.1.jar"/>
 	<classpathentry kind="lib" path="lib/jcommon-1.0.14.jar"/>
 	<classpathentry kind="lib" path="lib/jfreechart-1.0.13.jar"/>
@@ -108,7 +108,7 @@
 	<classpathentry kind="lib" path="test-lib/hibernate-commons-annotations-3.2.0.Final.jar"/>
 	<classpathentry kind="lib" path="test-lib/hibernate-core-3.6.9.Final.jar"/>
 	<classpathentry kind="lib" path="test-lib/hibernate-jpa-2.0-api-1.0.1.Final.jar"/>
-	<classpathentry kind="lib" path="test-lib/javassist-3.4.GA.jar"/>
+	<classpathentry kind="lib" path="test-lib/javassist-3.20.0-GA.jar"/>
 	<classpathentry kind="lib" path="test-lib/jaxen-1.1.jar"/>
 	<classpathentry kind="lib" path="test-lib/jcommon-1.0.14.jar"/>
 	<classpathentry kind="lib" path="test-lib/jfreechart-1.0.13.jar"/>


### PR DESCRIPTION
                For extensions module, defined the property dependency.javassist.revision and
		used it in ivy.xml