### PR TITLE
[SP-2889] Backport of BISERVER-12719 - When creating a schedule the dialog window where the type of schedule is selected isn't fully localized (5.4 Suite)

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/workspace/FilterDialog.java
+++ b/user-console/source/org/pentaho/mantle/client/workspace/FilterDialog.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.workspace;
@@ -53,12 +53,14 @@ public class FilterDialog extends PromptDialogBox {
 
   public FilterDialog() {
     super(
-        Messages.getString( "filterSchedules" ), Messages.getString( "ok" ), Messages.getString( "cancel" ), false, true ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+      Messages.getString( "filterSchedules" ), Messages.getString( "ok" ), Messages.getString( "cancel" ), false,
+      true ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
   }
 
   public FilterDialog( JsArray<JsJob> jobs, IDialogCallback callback ) {
     super(
-        Messages.getString( "filterSchedules" ), Messages.getString( "ok" ), Messages.getString( "cancel" ), false, true ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+      Messages.getString( "filterSchedules" ), Messages.getString( "ok" ), Messages.getString( "cancel" ), false,
+      true ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     initUI( jobs );
     // setSize("800px", "500px");
     setCallback( callback );
@@ -125,12 +127,12 @@ public class FilterDialog extends PromptDialogBox {
     scheduleStateListBox.clear();
     // NORMAL, PAUSED, COMPLETE, ERROR, BLOCKED, UNKNOWN
     scheduleStateListBox.addItem( showAll );
-    scheduleStateListBox.addItem( "Normal" );
-    scheduleStateListBox.addItem( "Paused" );
-    scheduleStateListBox.addItem( "Complete" );
-    scheduleStateListBox.addItem( "Error" );
-    scheduleStateListBox.addItem( "Blocked" );
-    scheduleStateListBox.addItem( "Unknown" );
+    scheduleStateListBox.addItem( Messages.getString( "normal" ) );
+    scheduleStateListBox.addItem( Messages.getString( "paused" ) );
+    scheduleStateListBox.addItem( Messages.getString( "complete" ) );
+    scheduleStateListBox.addItem( Messages.getString( "error" ) );
+    scheduleStateListBox.addItem( Messages.getString( "blocked" ) );
+    scheduleStateListBox.addItem( Messages.getString( "unknown" ) );
     scheduleStateListBox.setSelectedIndex( selectedIndex );
 
     // state filter
@@ -139,10 +141,10 @@ public class FilterDialog extends PromptDialogBox {
     scheduleTypeListBox.clear();
     // NORMAL, PAUSED, COMPLETE, ERROR, BLOCKED, UNKNOWN
     scheduleTypeListBox.addItem( showAll );
-    scheduleTypeListBox.addItem( "Daily" );
-    scheduleTypeListBox.addItem( "Weekly" );
-    scheduleTypeListBox.addItem( "Monthly" );
-    scheduleTypeListBox.addItem( "Yearly" );
+    scheduleTypeListBox.addItem( Messages.getString( "schedule.daily" ) );
+    scheduleTypeListBox.addItem( Messages.getString( "schedule.weekly" ) );
+    scheduleTypeListBox.addItem( Messages.getString( "schedule.monthly" ) );
+    scheduleTypeListBox.addItem( Messages.getString( "schedule.yearly" ) );
     scheduleTypeListBox.setSelectedIndex( selectedIndex );
 
     FlexTable filterPanel = new FlexTable();


### PR DESCRIPTION
- backported
@rmansoor 
@pentaho-nbaker