### PR TITLE
[BACKLOG-10534][BACKLOG-10159] Operation Permissions from plugins are…

### DIFF
--- a/repository/src/org/pentaho/platform/security/policy/rolebased/AbstractJcrBackedRoleBindingDao.java
+++ b/repository/src/org/pentaho/platform/security/policy/rolebased/AbstractJcrBackedRoleBindingDao.java
@@ -129,6 +129,10 @@ public abstract class AbstractJcrBackedRoleBindingDao implements IRoleAuthorizat
           if ( !loaded ) {
             setAuthorizationActions( PentahoSystem.getAll( IAuthorizationAction.class ) );
             updateImmutableRoleBindingNames();
+            // when immutableRoleBindingNames gets updated, we should ensure no stale logical roles remain cached
+            if ( cacheManager.cacheEnabled( LOGICAL_ROLE_BINDINGS_REGION ) ) {
+              cacheManager.removeRegionCache( LOGICAL_ROLE_BINDINGS_REGION );
+            }
             loaded = true;
           }
         }


### PR DESCRIPTION
… not applied in due time to pentaho-server

	- Follow-up to the work done a while back for [BACKLOG-7363] Operation Permissions from plugins are not used in merged server
	- cacheManager gets populated with platform permissions *prior* to a plugin's systemListener.onReload() kicks in ( and while loaded = false )