### PR TITLE
[SP-2822] - Backport of PPP-3536 - Use of vulnerable component org.co…

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -212,7 +212,7 @@
     
     
     <dependency org="com.lowagie" name="itext-rtf" rev="${dependency.itextrtf.revision}" changing="true" transitive="false"/>
-    <dependency org="org.codehaus.groovy"  name="groovy"  rev="2.4.7"  changing="true" transitive="false"/>
+    <dependency org="org.codehaus.groovy"  name="groovy-all"  rev="2.4.7"  changing="true" transitive="false"/>
 
     <!-- olap -->
     <dependency org="pentaho" name="mondrian" rev="${dependency.mondrian.revision}" changing="true">


### PR DESCRIPTION
…dehaus.groovy v.1.8.0 CVE-2015-3253 (5.4 Suite)

 - groovy is replaced by groovy-all

@mbatchelor, @pamval, could you please take a look? 