### PR TITLE
[BACKLOG-10832] - guard against a null MimeTypeCallback throwing an error

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/GeneratorStreamingOutput.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/GeneratorStreamingOutput.java
@@ -194,7 +194,9 @@ public class GeneratorStreamingOutput {
             return;
           } else {
             mimeTrace( "Content generator is setting response mime type to [{0}]", mimeType ); //$NON-NLS-1$
-            callback.setMimeType( mimeType );
+            if ( callback != null ) {
+              callback.setMimeType( mimeType );
+            }
             GeneratorStreamingOutput.this.setMimeType( mimeType );
           }
         } catch ( Throwable th ) {


### PR DESCRIPTION
[BACKLOG-10832] - guard against a null MimeTypeCallback throwing an error