### PR TITLE
[BACKLOG-10623] Update springframework 4.3.2 and spring security to 4…

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -253,6 +253,8 @@
     <exclude org="net.sf.ehcache"  module="ehcache" />
     <!-- CM-241 -->
     <exclude org="cglib"  module="cglib" />
+    <exclude org="org.springframework" module="spring"/>
+    <exclude org="com.sun.xml.ws" module="jaxws-rt"/>
 
 	<!-- Excluding test dependencies for the assembly -->
     <exclude org="org.mockito"          module="mockito-all"/>


### PR DESCRIPTION
….1.3

               - Added an exclude for spring-2.0 and jaxws-rt in
		 assembly/ixy.xml