### PR TITLE
[BACKLOG-9649]-System is not able to delete the karaf folder created in the temporary folder location

### DIFF
--- a/extensions/src/org/pentaho/platform/osgi/KarafBoot.java
+++ b/extensions/src/org/pentaho/platform/osgi/KarafBoot.java
@@ -140,15 +140,7 @@ public class KarafBoot implements IPentahoSystemListener {
           destDir = candidate;
         }
 
-        Runtime.getRuntime().addShutdownHook( new Thread( new Runnable() {
-          @Override public void run() {
-            try {
-              FileUtils.deleteDirectory( destDir );
-            } catch ( IOException e ) {
-              logger.error( "Unable to delete karaf directory " + destDir, e );
-            }
-          }
-        } ) );
+        destDir.deleteOnExit();
       } else if ( rootCopyFolderString != null ) {
         destDir = new File( rootCopyFolderString );
       } else {
@@ -189,8 +181,7 @@ public class KarafBoot implements IPentahoSystemListener {
                 }
               } catch ( IOException e ) {
                 logger
-                    .error(
-                        "Unable to create symlink " + linkFile.getAbsolutePath() + " -> " + file.getAbsolutePath(), e );
+                  .warn( "Unable to create symlink " + linkFile.getAbsolutePath() + " -> " + file.getAbsolutePath() );
               }
             }
             return true;

--- a/extensions/test-src/org/pentaho/platform/osgi/KarafBootTest.java
+++ b/extensions/test-src/org/pentaho/platform/osgi/KarafBootTest.java
@@ -81,7 +81,7 @@ public class KarafBootTest {
   @AfterClass
   public static void cleanUp() throws IOException {
     if ( tmpDir.exists() ) {
-      FileUtils.deleteDirectory( tmpDir );
+      tmpDir.deleteOnExit();
     }
   }
 

--- a/extensions/test-src/org/pentaho/platform/osgi/KarafInstanceTest.java
+++ b/extensions/test-src/org/pentaho/platform/osgi/KarafInstanceTest.java
@@ -55,7 +55,7 @@ public class KarafInstanceTest {
     // clean up
     File folder = new File( TEST_CACHE_FOLDER );
     if ( folder.exists() ) {
-      FileUtils.deleteDirectory( folder );
+      folder.deleteOnExit();
     }
   }
 


### PR DESCRIPTION
* Used io deleteOnExit except of nio FileUtils
* Changed symlinks failure logginf from error to warns (as we still copy that files)