### PR TITLE
[BACKLOG-10623] Upgrade springframework and spring security

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -255,6 +255,7 @@
     <exclude org="cglib"  module="cglib" />
     <exclude org="org.springframework" module="spring"/>
     <exclude org="com.sun.xml.ws" module="jaxws-rt"/>
+    <exclude org="com.sun.xml.stream.buffer" module="streambuffer"/>
 
 	<!-- Excluding test dependencies for the assembly -->
     <exclude org="org.mockito"          module="mockito-all"/>


### PR DESCRIPTION
	- Excluded the dependency streambuffer.jar that is pulled in by
	  jaxws-spring