### PR TITLE
[BISERVER-12730] L10N - Untranslated strings in Blockout time table

### DIFF
--- a/user-console/source/org/pentaho/mantle/MantleApplication.gwt.xml
+++ b/user-console/source/org/pentaho/mantle/MantleApplication.gwt.xml
@@ -5,6 +5,15 @@
   <inherits name='com.google.gwt.gen2.Gen2'/>
   <inherits name='com.google.gwt.gen2.table.ScrollTable'/>
 
+  <!-- If you want to support additional locales you should add them as below. -->
+  <inherits name="com.google.gwt.i18n.I18N"/>
+  <extend-property name="locale" values="en"/>
+  <extend-property name="locale" values="de"/>
+  <extend-property name="locale" values="fr"/>
+  <extend-property name="locale" values="ja"/>
+
+  <set-property-fallback name="locale" value="en"/>
+
   <inherits name='org.pentaho.ui.Xul'/>
   <inherits name='org.pentaho.ui.xul.Gwt'/>
   <inherits name='com.googlecode.gwtx.Java'/>


### PR DESCRIPTION
 - enabled GWT i18n for supported languages