### PR TITLE
[BACKLOG-11273]  ERRORs logged with big-data connections

### DIFF
--- a/core/src/org/pentaho/platform/engine/services/messages/messages.properties
+++ b/core/src/org/pentaho/platform/engine/services/messages/messages.properties
@@ -1,7 +1,7 @@
 #
 # Copyright 2006 - 2010 Pentaho Corporation.  All rights reserved.
 #
-# Copyright 2006 - 2010 Pentaho Corporation.  All rights reserved.
+# Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
 # This program is free software; you can redistribute it and/or modify it under the 
 # terms of the GNU General Public License, version 2 as published by the Free Software 
 # Foundation.
@@ -308,3 +308,5 @@ PooledDatasourceHelper.ERROR_0006_UNABLE_TO_POOL_DATASOURCE_NO_CLASSNAME=Unable 
 PooledDatasourceHelper.ERROR_0007_UNABLE_TO_POOL_DATASOURCE_NO_DRIVER=Unable to pool Data Source [ {0} ]. Unable to get driver information from dialect.
 PooledDatasourceHelper.ERROR_0008_UNABLE_TO_POOL_DATASOURCE_IT_IS_JNDI=Unable to pool Data Source [ {0} ]. IT is JNDI connection.
 PooledDatasourceHelper.ERROR_0009_UNABLE_TO_POOL_DATASOURCE_CANT_INITIALIZE=Unable to pool Data Source [ {0} ]. Cannot initialize {1}.
+
+PooledDatasourceHelper.ERROR_0001_DATASOURCE_CANNOT_LOAD_DIALECT_SVC=Unable to load IDatabaseDialectService from the Pentaho session.


### PR DESCRIPTION
PooledDatasourceHelper.convert calls would fail when initializing big
data drivers due to not being in the caller's CL.
Modified to use the IDriverLocator.initialize where possible,
similar to what had already been done for pooled connections.

http://jira.pentaho.com/browse/BACKLOG-11273