### PR TITLE
[SP-2906][BISERVER-12933] Tooltip and shape visible of buttons "Edit …

### DIFF
--- a/user-console/source/org/pentaho/mantle/public/themes/crystal/mantleCrystal.css
+++ b/user-console/source/org/pentaho/mantle/public/themes/crystal/mantleCrystal.css
@@ -1076,7 +1076,7 @@ a:active, a:hover {
 }
 
 #mainToolbar #editContentButton .toolbar-toggle-button-disabled IMG {
-  background: url('../../../content/common-ui/resources/themes/crystal/images/editContent_32_disabled.png');
+  background: url('../../../content/common-ui/resources/themes/crystal/images/editContent_32.png');
   height: 32px;
   width: 32px;
 }
@@ -1088,7 +1088,7 @@ a:active, a:hover {
 }
 
 #mainToolbar #saveButton .toolbar-button-disabled IMG {
-  background: url('../../../content/common-ui/resources/themes/crystal/images/save_32_disabled.png');
+  background: url('../../../content/common-ui/resources/themes/crystal/images/save_32.png');
   height: 32px;
   width: 32px;
 }
@@ -1100,7 +1100,7 @@ a:active, a:hover {
 }
 
 #mainToolbar #saveAsButton .toolbar-button-disabled IMG {
-  background: url('../../../content/common-ui/resources/themes/crystal/images/saveAs_32_disabled.png');
+  background: url('../../../content/common-ui/resources/themes/crystal/images/saveAs_32.png');
   height: 32px;
   width: 32px;
 }
@@ -1130,7 +1130,7 @@ a:active, a:hover {
 }
 
 #mainToolbar #printButton .toolbar-button-disabled IMG {
-  background: url('../../../content/common-ui/resources/themes/crystal/images/print_32_disabled.png');
+  background: url('../../../content/common-ui/resources/themes/crystal/images/print_32.png');
   height: 32px;
   width: 32px;
 }


### PR DESCRIPTION
…Content", "Save", "Save As"

- set disabled images for main toolabr buttons the asme as enabled in order to make them visible in Crystal theme
- this is probably a temporary fix and disabled images might have to be returned back, but containing something visible at Crystal header