### PR TITLE
[BACKLOG-11242] - Pentaho server will fail to start if a non-pooled c…

### DIFF
--- a/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelper.java
+++ b/core/src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelper.java
@@ -340,11 +340,6 @@ public class PooledDatasourceHelper {
           "PooledDatasourceHelper.ERROR_0001_DATASOURCE_CREATE_ERROR_NO_DIALECT", databaseConnection.getName() ) );
     }
 
-    if ( databaseConnection.getDatabaseType() == null ) {
-      throw new DBDatasourceServiceException( Messages.getInstance().getErrorString(
-          "PooledDatasourceHelper.ERROR_0006_UNABLE_TO_POOL_DATASOURCE_NO_CLASSNAME", databaseConnection.getName() ) );
-    }
-
     if ( databaseConnection.getDatabaseType().getShortName().equals( "GENERIC" ) ) { //$NON-NLS-1$
       String driverClassName =
           databaseConnection.getAttributes().get( GenericDatabaseDialect.ATTRIBUTE_CUSTOM_DRIVER_CLASS );

--- a/core/test-src/org/pentaho/commons/system/PentahoSystemDatabaseDialectProviderTest.java
+++ b/core/test-src/org/pentaho/commons/system/PentahoSystemDatabaseDialectProviderTest.java
@@ -114,5 +114,6 @@ public class PentahoSystemDatabaseDialectProviderTest {
     assertEquals( unusableIDialect,
       pentahoSystemDatabaseDialectProvider.getDialect( false, unusableIDialectType ) );
     assertNull( pentahoSystemDatabaseDialectProvider.getDialect( false, mock( IDatabaseType.class ) ) );
+    assertNull( pentahoSystemDatabaseDialectProvider.getDialect( false, null ) );
   }
 }

--- a/core/test-src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelperTest.java
+++ b/core/test-src/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelperTest.java
@@ -277,17 +277,4 @@ public class PooledDatasourceHelperTest {
       assertThat( e, instanceOf( DBDatasourceServiceException.class ) );
     }
   }
-
-  @Test
-  public void testConnectionWithNoDatabaseType() throws Exception {
-    when( dialectService.getDialect( any( DatabaseConnection.class ) ) ).thenReturn( driverLocatorDialect );
-    when( connection.getDatabaseType() ).thenReturn( null );
-
-    try {
-      PooledDatasourceHelper.convert( connection, () -> dialectService );
-      fail( "Expected exception, database type not specified in connection." );
-    } catch ( Exception e ) {
-      assertThat( e, instanceOf( DBDatasourceServiceException.class ) );
-    }
-  }
 }


### PR DESCRIPTION
…onnection is defined for a dialect that is not present

* Update PentahoSystemDatabaseDialectProvider.getDialect() to return null if specified DatabaseType is null
* Delete previous fix as it is outdated