### PR TITLE
[BACKLOG-11583] Login UI breaks eval login, if wrong user/pass entered

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/jsp/PUCLogin.jsp
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/jsp/PUCLogin.jsp
@@ -341,8 +341,8 @@
   }
 
   function loginAs (username, password) {
-    $("#j_username").attr("value", username);
-    $("#j_password").attr("value", password);
+    $("#j_username").prop("value", username);
+    $("#j_password").prop("value", password);
     doLogin();
   }
 


### PR DESCRIPTION
@pentaho/millenniumfalcon @pamval please review.

This code broke because there was a change to the ".attr()" behaviour in jquery 1.6 when ".prop()" was introduced.

Now ".attr('value', ...)" only changes the attribute's value which specifies the initial value. To change the actual value we need to use ".prop('value', ...) to change the actual property value for a given dom element.