### PR TITLE
[SP-2960] Backport of BISERVER-12718 - L10n - The name of sections ar…

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/solutionbrowser/toolbars/FilesToolbar.java
+++ b/user-console/source/org/pentaho/mantle/client/solutionbrowser/toolbars/FilesToolbar.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.mantle.client.solutionbrowser.toolbars;
@@ -74,7 +74,6 @@ public class FilesToolbar extends Toolbar implements IFileItemListener {
     Label label = new Label( Messages.getString( "files" ) );
     label.setStyleName( "pentaho-titled-toolbar-label" );
     add( label ); //$NON-NLS-1$
-    add( GLUE );
     setEnabled( false );
   }
 


### PR DESCRIPTION
…e cropped for Japanese language in Dashboard (6.1 Suite)

cherry-pick
        [BISERVER-12718] L10n - The name of sections are cropped for Japanese language in Dashboard