### PR TITLE
[BACKLOG-11621] Removes JTDS driver dependency

### DIFF
--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -264,7 +264,6 @@
         <fileset dir="${lib.dir}">
           <include name="jsp-api.jar" />
           <include name="postgres*.jar" />
-          <include name="jtds*.jar" />
         </fileset>
       </copy>
 

--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -272,7 +272,6 @@
 
     <!-- kettle jdbc drivers -->
     <dependency org="infobright" name="infobright-core" rev="3.4" conf="default->default" transitive="false"/>
-    <dependency org="jtds" name="jtds" rev="1.2.5" conf="default->default" transitive="false"/>
     <dependency org="net.sf.jt400" name="jt400" rev="6.1" conf="default->default" transitive="false"/>
     <dependency org="org.xerial" name="sqlite-jdbc" rev="3.7.2" conf="default->default" transitive="false"/>
     <dependency org="org.firebirdsql.jdbc" name="jaybird" rev="2.1.6" conf="default->default" transitive="false"/>


### PR DESCRIPTION
@CodeOnCoffee @rmansoor @mbatchelor @pentaho/rogueone Devci looked good for master, doing 7.0 now. Please review

Related PRs:
https://github.com/pentaho/pentaho-platform/pull/3212
https://github.com/pentaho/pentaho-kettle/pull/3104
https://github.com/pentaho/pentaho-reporting/pull/871
https://github.com/pentaho/pentaho-reportdesigner-ee/pull/54