### PR TITLE
[BACKLOG-11915] Metadata Security

### DIFF
--- a/api/src/org/pentaho/platform/api/engine/IAclEntry.java
+++ b/api/src/org/pentaho/platform/api/engine/IAclEntry.java
@@ -1,0 +1,28 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+import java.io.Serializable;
+
+
+/**
+ * This is a port from spring-security 2.0.8.RELEASE
+ * @see https://github.com/spring-projects/spring-security/blob/2.0.8.RELEASE/core/src/main/java/org/springframework/security/acl/AclEntry.java
+ */
+public interface IAclEntry extends Serializable { }

--- a/api/src/org/pentaho/platform/api/engine/IAclHolder.java
+++ b/api/src/org/pentaho/platform/api/engine/IAclHolder.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.api.engine;
@@ -41,7 +41,7 @@ public interface IAclHolder {
    * 
    * @return List of ACLs for this object only.
    */
-  public List/*<IPentahoAclEntry>*/ getAccessControls();
+  public List<IPentahoAclEntry> getAccessControls();
 
   /**
    * Sets the access controls on this specific object. Currently doesn't check whether the acls are the same as
@@ -49,7 +49,7 @@ public interface IAclHolder {
    * 
    * @param acls
    */
-  public void setAccessControls( List/*<IPentahoAclEntry>*/ acls );
+  public void setAccessControls( List<IPentahoAclEntry> acls );
 
   /**
    * Replaces existing access controls with a new list of access controls. This method should be used in favor of
@@ -57,7 +57,7 @@ public interface IAclHolder {
    * 
    * @param acls
    */
-  public void resetAccessControls( List/*<IPentahoAclEntry>*/ acls );
+  public void resetAccessControls( List<IPentahoAclEntry> acls );
 
   /**
    * Examines whether the existing object has ACLs. If not, it will return the parent's ACLs. All the way up to the
@@ -65,5 +65,5 @@ public interface IAclHolder {
    * 
    * @return List containing all the AclEntry objects
    */
-  public List/*<IPentahoAclEntry>*/ getEffectiveAccessControls();
+  public List<IPentahoAclEntry> getEffectiveAccessControls();
 }

--- a/api/src/org/pentaho/platform/api/engine/IAclSolutionFile.java
+++ b/api/src/org/pentaho/platform/api/engine/IAclSolutionFile.java
@@ -1,0 +1,41 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+import java.util.Set;
+
+/**
+ * This interface makes certain that there is a mechanism to traverse the solution files from root to leaf. Note
+ * that bi-directional traversal is not specified by this interface.
+ *
+ *
+ * mlowery This interface is unrelated to security despite have the word ACL in its name.
+ */
+
+@Deprecated
+public interface IAclSolutionFile extends ISolutionFile, IAclHolder {
+
+  /**
+   * Gets the set children IAclSolutionFiles from this <code>IAclSolutionFile</code>. Each child must be an
+   * instance of IAclSolutionFile.
+   *
+   * @return <tt>Set</tt> of IAclSolutionFile objects
+   */
+  @SuppressWarnings( "rawtypes" )
+  public Set getChildrenFiles();
+}

--- a/api/src/org/pentaho/platform/api/engine/IAclVoter.java
+++ b/api/src/org/pentaho/platform/api/engine/IAclVoter.java
@@ -1,0 +1,94 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+import org.springframework.security.core.GrantedAuthority;
+
+@Deprecated
+public interface IAclVoter {
+
+  /**
+   * Determines whether the user (auth) has the requested authority (mask) based on the list of effective
+   * authorities from the holder.
+   *
+   * @param auth
+   * @param holder
+   * @param mask
+   * @return true if the user has the requested access.
+   */
+  public boolean hasAccess( IPentahoSession session, IAclHolder holder, int mask );
+
+  /**
+   * Returns an array of the authorities from the IAclHolder that apply to the provided authentication object.
+   *
+   * mlowery In practice this method does not do the same thing as EffectiveAclsResolver.
+   *
+   * @param auth
+   * @param holder
+   * @return The array of authorities from the IAclHolder that apply to the person in question
+   */
+  public IAclEntry[] getEffectiveAcls( IPentahoSession session, IAclHolder holder );
+
+  /**
+   * Determines whether the user is a super-manager of Pentaho. Uses the Manager Role.
+   *
+   * @param session
+   * @return <code>true</code> if the user is a super-manager
+   */
+  public boolean isPentahoAdministrator( IPentahoSession session );
+
+  /**
+   * Gets the role used to determine whether someone is the system-manager.
+   *
+   * @return <code>GrantedAuthority</code> of the role someone must be in to be the system manager.
+   */
+  public GrantedAuthority getAdminRole();
+
+  /**
+   * Sets the role used to determine whether someone is the system-manager.
+   *
+   * @param value
+   *          The <code>GrantedAuthority</code> which someone must be a considered a system manager
+   */
+  public void setAdminRole( GrantedAuthority value );
+
+  /**
+   * Returns true if the user is a member of the specified role
+   *
+   * @param session
+   * @param role
+   * @return <code>true</code> if the user is a member of the specified role
+   */
+  public boolean isGranted( IPentahoSession session, GrantedAuthority role );
+
+  /**
+   * This returns the effective ACL for the piece of content for the given user. Ideally, this will look at all the
+   * effective ACLs returned for this user for this piece of content, and return an ACL that encapsulates all the
+   * users' access to that content. The returning PentahoAclEntry will represent the ACL that the user has to the
+   * content.
+   *
+   * This method should NEVER return <code>null</code>. If the user has no access to the object, it needs to return
+   * a PentahoAclEntry with nothing (mask of 0).
+   *
+   * @param session
+   * @param holder
+   * @return PentahoAclEntry holding the access to the object.
+   */
+  public IPentahoAclEntry getEffectiveAcl( IPentahoSession session, IAclHolder holder );
+
+}

--- a/api/src/org/pentaho/platform/api/engine/IPentahoAclEntry.java
+++ b/api/src/org/pentaho/platform/api/engine/IPentahoAclEntry.java
@@ -1,0 +1,105 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+/**
+ * Base Pentaho Access Control entry. Subclassed <tt>BasicAclEntry</tt> from Spring Security. Provides known access
+ * controls.
+ *
+ * @author mbatchel
+ * */
+@Deprecated
+public interface IPentahoAclEntry extends IPentahoBasicAclEntry {
+  /**
+   * No access (0)
+   */
+  public static final int PERM_NOTHING = 0;
+
+  /**
+   * Execute access (1)
+   */
+  public static final int PERM_EXECUTE = 0x01; // Used to turn on/off one bit in a bitmask.
+
+  /**
+   * Subscribe access (2)
+   */
+  public static final int PERM_SUBSCRIBE = 0x02; // Used to turn on/off one bit in a bitmask.
+
+  /**
+   * Create access (4)
+   */
+  public static final int PERM_CREATE = 0x04; // Used to turn on/off one bit in a bitmask.
+
+  /**
+   * Update access (8)
+   */
+  public static final int PERM_UPDATE = 0x08; // Used to turn on/off one bit in a bitmask.
+
+  /**
+   * Delete (16)
+   */
+  public static final int PERM_DELETE = 0x10; // Used to turn on/off one bit in a bitmask.
+
+  /**
+   * Manage perms (32)
+   */
+  public static final int PERM_UPDATE_PERMS = 0x20; // Used to turn on/off one bit in a bitmask.
+
+  /**
+   * Administration access (60)
+   */
+  public static final int PERM_ADMINISTRATION = IPentahoAclEntry.PERM_CREATE | IPentahoAclEntry.PERM_UPDATE
+    | IPentahoAclEntry.PERM_DELETE | IPentahoAclEntry.PERM_UPDATE_PERMS;
+
+  /**
+   * Execute and subscribe (3)
+   */
+  public static final int PERM_EXECUTE_SUBSCRIBE = IPentahoAclEntry.PERM_EXECUTE | IPentahoAclEntry.PERM_SUBSCRIBE;
+
+  /**
+   * @deprecated Do not use this constant; instead use FULL_CONTROL for truly inclusive all access. Old ADMIN_ALL
+   *             (ie, WRITE) combination (31)
+   */
+  @Deprecated
+  public static final int PERM_ADMIN_ALL = IPentahoAclEntry.PERM_CREATE | IPentahoAclEntry.PERM_UPDATE
+    | IPentahoAclEntry.PERM_DELETE | IPentahoAclEntry.PERM_EXECUTE | IPentahoAclEntry.PERM_SUBSCRIBE;
+
+  /**
+   * All possible permissions (all ones; 0xffffffff; a negative number)
+   */
+  public static final int PERM_FULL_CONTROL = 0xffffffff;
+
+  /**
+   * Subscribe and administration (62)
+   */
+  public static final int PERM_SUBSCRIBE_ADMINISTRATION = IPentahoAclEntry.PERM_SUBSCRIBE
+    | IPentahoAclEntry.PERM_ADMINISTRATION;
+
+  /**
+   * Execute and administration (61)
+   */
+  public static final int PERM_EXECUTE_ADMINISTRATION = IPentahoAclEntry.PERM_EXECUTE
+    | IPentahoAclEntry.PERM_ADMINISTRATION;
+
+  public static final String PERMISSIONS_LIST_SOLUTIONS = "solutions"; //$NON-NLS-1$
+
+  public static final String PERMISSIONS_LIST_ALL = "all"; //$NON-NLS-1$
+
+  public static final String PERMISSION_PREFIX = "PERM_"; //$NON-NLS-1$
+
+}

--- a/api/src/org/pentaho/platform/api/engine/IPentahoAclObjectIdentity.java
+++ b/api/src/org/pentaho/platform/api/engine/IPentahoAclObjectIdentity.java
@@ -1,0 +1,47 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+import java.io.Serializable;
+
+
+/**
+ * This is a port from spring-security 2.0.8.RELEASE
+ * @see https://github.com/spring-projects/spring-security/blob/2.0.8.RELEASE/core/src/main/java/org/springframework/security/acl/basic/AclObjectIdentity.java
+ */
+@Deprecated
+public interface IPentahoAclObjectIdentity extends Serializable {
+  //~ Methods ========================================================================================================
+
+  /**
+   * Refer to the <code>java.lang.Object</code> documentation for the interface contract.
+   *
+   * @param obj to be compared
+   *
+   * @return <code>true</code> if the objects are equal, <code>false</code> otherwise
+   */
+  boolean equals( Object obj );
+
+  /**
+   * Refer to the <code>java.lang.Object</code> documentation for the interface contract.
+   *
+   * @return a hash code representation of this object
+   */
+  int hashCode();
+}

--- a/api/src/org/pentaho/platform/api/engine/IPentahoBasicAclEntry.java
+++ b/api/src/org/pentaho/platform/api/engine/IPentahoBasicAclEntry.java
@@ -1,0 +1,114 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+/**
+ * This is a port from spring-security 2.0.8.RELEASE
+ * @see https://github.com/spring-projects/spring-security/blob/2.0.8.RELEASE/core/src/main/java/org/springframework/security/acl/basic/BasicAclEntry.java
+ */
+@Deprecated
+public interface IPentahoBasicAclEntry extends IAclEntry {
+
+  /**
+   * Indicates the domain object instance that is subject of this <code>BasicAclEntry</code>. This
+   * information may be of interest to relying classes (voters and business methods) that wish to know the actual
+   * origination of the ACL entry (so as to distinguish individual ACL entries from others contributed by the
+   * inheritance hierarchy).
+   *
+   * @return the ACL object identity that is subject of this ACL entry (never <code>null</code>)
+   */
+  IPentahoAclObjectIdentity getAclObjectIdentity();
+
+  /**
+   * Indicates any ACL parent of the domain object instance. This is used by <code>BasicAclProvider</code> to
+   * walk the inheritance hierarchy. An domain object instance need <b>not</b> have a parent.
+   *
+   * @return the ACL object identity that is the parent of this ACL entry (may be <code>null</code> if no parent
+   *         should be consulted)
+   */
+  IPentahoAclObjectIdentity getAclObjectParentIdentity();
+
+  /**
+   * Access control lists in this package are based on bit masking. The integer value of the bit mask can be
+   * obtained from this method.
+   *
+   * @return the bit mask applicable to this ACL entry (zero indicates a bit mask where no permissions have been
+   *         granted)
+   */
+  int getMask();
+
+  /**
+   * A domain object instance will usually have multiple <code>BasicAclEntry</code>s. Each separate
+   * <code>BasicAclEntry</code> applies to a particular "recipient". Typical examples of recipients include (but do
+   * not necessarily have to include) usernames, role names, complex granted authorities etc.<P><B>It is
+   * essential that only one <code>BasicAclEntry</code> exists for a given recipient</B>. Otherwise conflicts as to
+   * the mask that should apply to a given recipient will occur.</p>
+   *  <P>This method indicates which recipient this <code>BasicAclEntry</code> applies to. The returned
+   * object type will vary depending on the type of recipient. For instance, it might be a <code>String</code>
+   * containing a username, or a <code>GrantedAuthorityImpl</code> containing a complex granted authority that is
+   * being granted the permissions contained in this access control entry. The {@link EffectiveAclsResolver} and
+   * {@link BasicAclProvider#getAcls(Object,org.springframework.security.Authentication)} can process the different recipient
+   * types and return only those that apply to a specified <code>Authentication</code> object.</p>
+   *
+   * @return the recipient of this access control list entry (never <code>null</code>)
+   */
+  Object getRecipient();
+
+  /**
+   * Determine if the mask of this entry includes this permission or not
+   *
+   * @param permissionToCheck
+   *
+   * @return if the entry's mask includes this permission
+   */
+  boolean isPermitted( int permissionToCheck );
+
+  /**
+   * This setter should <B>only</B> be used by DAO implementations.
+   *
+   * @param aclObjectIdentity an object which can be used to uniquely identify the domain object instance subject of
+   *        this ACL entry
+   */
+  void setAclObjectIdentity( IPentahoAclObjectIdentity aclObjectIdentity );
+
+  /**
+   * This setter should <B>only</B> be used by DAO implementations.
+   *
+   * @param aclObjectParentIdentity an object which represents the parent of the domain object instance subject of
+   *        this ACL entry, or <code>null</code> if either the domain object instance has no parent or its parent
+   *        should be not used to compute an inheritance hierarchy
+   */
+  void setAclObjectParentIdentity( IPentahoAclObjectIdentity aclObjectParentIdentity );
+
+  /**
+   * This setter should <B>only</B> be used by DAO implementations.
+   *
+   * @param mask the integer representing the permissions bit mask
+   */
+  void setMask( int mask );
+
+  /**
+   * This setter should <B>only</B> be used by DAO implementations.
+   *
+   * @param recipient a representation of the recipient of this ACL entry that makes sense to an
+   *        <code>EffectiveAclsResolver</code> implementation
+   */
+  void setRecipient( Object recipient );
+
+}

--- a/api/src/org/pentaho/platform/api/engine/IPermissionMask.java
+++ b/api/src/org/pentaho/platform/api/engine/IPermissionMask.java
@@ -1,0 +1,23 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+@Deprecated
+public interface IPermissionMask {
+  int getMask();
+}

--- a/api/src/org/pentaho/platform/api/engine/IPermissionMgr.java
+++ b/api/src/org/pentaho/platform/api/engine/IPermissionMgr.java
@@ -1,0 +1,51 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+import java.util.Map;
+
+@Deprecated
+public interface IPermissionMgr {
+  /**
+   * TODO mlowery This is really addPermission. Perhaps a method name change?
+   */
+  public void setPermission( IPermissionRecipient permRecipient, IPermissionMask permission, Object domainInstance );
+
+  /**
+   * Returns permission map containing access control entries that are defined directly on this
+   * <code>domainInstance</code>.
+   *
+   * @param domainInstance
+   *          the object for which to fetch permissions
+   * @return a map of permissions
+   */
+  public Map<IPermissionRecipient, IPermissionMask> getPermissions( Object domainInstance );
+
+  /**
+   * Returns permission map containing access control entries that are defined directly on this
+   * <code>domainInstance</code>. If there are no direct entries, then the permission map will be the map of one of
+   * <code>domainInstance</code>'s ancestors.
+   *
+   * @param domainInstance
+   *          the object for which to fetch permissions
+   * @return a map of permissions
+   */
+  public Map<IPermissionRecipient, IPermissionMask> getEffectivePermissions( Object domainInstance );
+
+  public void setPermissions( Map<IPermissionRecipient, IPermissionMask> acl, Object domainInstance );
+}

--- a/api/src/org/pentaho/platform/api/engine/IPermissionRecipient.java
+++ b/api/src/org/pentaho/platform/api/engine/IPermissionRecipient.java
@@ -1,0 +1,23 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.api.engine;
+
+@Deprecated
+public interface IPermissionRecipient {
+  public String getName();
+}

--- a/assembly/package-res/biserver/pentaho-solutions/system/pentahoObjects.spring.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentahoObjects.spring.xml
@@ -47,6 +47,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   <bean id="contentrepo" class="org.pentaho.platform.repository2.unified.fileio.RepositoryContentOutputHandler"
         scope="session"/>
   <bean id="vfs-ftp" class="org.pentaho.platform.plugin.outputs.ApacheVFSOutputHandler" scope="session"/>
+  <bean id="IAclVoter" class="org.pentaho.platform.engine.security.acls.voter.PentahoBasicAclVoter" scope="singleton"/>
   <bean id="IVersionHelper" class="org.pentaho.platform.util.VersionHelper" scope="singleton"/>
   <bean id="ICacheManager" class="org.pentaho.platform.plugin.services.cache.CacheManager" scope="singleton"/>
   <bean id="IScheduler2" class="org.pentaho.platform.scheduler2.quartz.QuartzScheduler" scope="singleton">

--- a/core/src/org/pentaho/platform/engine/security/SecurityHelper.java
+++ b/core/src/org/pentaho/platform/engine/security/SecurityHelper.java
@@ -25,8 +25,10 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.engine.IAclHolder;
+import org.pentaho.platform.api.engine.IAclVoter;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IParameterProvider;
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.ISecurityHelper;
 import org.pentaho.platform.api.engine.IUserRoleListService;
@@ -67,6 +69,7 @@ public class SecurityHelper implements ISecurityHelper {
 
   private ITenantedPrincipleNameResolver tenantedUserNameUtils;
   private IAuthorizationPolicy policy;
+  private IAclVoter aclVoter;
   private UserDetailsService userDetailsService;
   private IUserRoleListService userRoleListService;
 
@@ -277,36 +280,41 @@ public class SecurityHelper implements ISecurityHelper {
 
   @Deprecated
   public boolean hasAccess( IAclHolder aHolder, int actionOperation, IPentahoSession session ) {
-    String aclMask = null; // acl to jcr repositoryAction mask
+    int aclMask = -1;
 
-    // TODO externalize repository action names
     switch ( actionOperation ) {
       case ( IAclHolder.ACCESS_TYPE_READ ): {
-        aclMask = "org.pentaho.repository.read"; // was IPentahoAclEntry.PERM_EXECUTE;
+        aclMask = IPentahoAclEntry.PERM_EXECUTE;
         break;
       }
       case IAclHolder.ACCESS_TYPE_WRITE:
       case IAclHolder.ACCESS_TYPE_UPDATE: {
-        aclMask = "org.pentaho.repository.create"; // was IPentahoAclEntry.PERM_UPDATE;
+        aclMask = IPentahoAclEntry.PERM_UPDATE;
         break;
       }
       case IAclHolder.ACCESS_TYPE_DELETE: {
-        aclMask = "org.pentaho.repository.create"; // was IPentahoAclEntry.PERM_DELETE;
+        aclMask = IPentahoAclEntry.PERM_DELETE;
         break;
       }
       case IAclHolder.ACCESS_TYPE_ADMIN: {
-        aclMask = "org.pentaho.security.administerSecurity"; // was IPentahoAclEntry.PERM_ADMINISTRATION;
+        aclMask = IPentahoAclEntry.PERM_ADMINISTRATION;
         break;
       }
       default: {
-        aclMask = "org.pentaho.repository.read"; // was IPentahoAclEntry.PERM_EXECUTE;
+        aclMask = IPentahoAclEntry.PERM_EXECUTE;
         break;
       }
 
     }
+    return getAclVoter().hasAccess( session, aHolder, aclMask );
+  }
 
-    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
-    return policy.isAllowed( aclMask );
+  @Deprecated
+  public IAclVoter getAclVoter() {
+    if ( aclVoter == null ) {
+      aclVoter = PentahoSystem.get( IAclVoter.class );
+    }
+    return aclVoter;
   }
 
   /**

--- a/core/src/org/pentaho/platform/engine/security/SimplePermissionMask.java
+++ b/core/src/org/pentaho/platform/engine/security/SimplePermissionMask.java
@@ -1,0 +1,77 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security;
+
+import org.pentaho.platform.api.engine.IPermissionMask;
+
+@Deprecated
+public class SimplePermissionMask implements IPermissionMask {
+  int permissionMask;
+
+  public SimplePermissionMask() {
+  }
+
+  public SimplePermissionMask( final int permissionMask ) {
+    this.permissionMask = permissionMask;
+  }
+
+  public void setPermissionMask( final int permissionMask ) {
+    this.permissionMask = permissionMask;
+  }
+
+  public int getMask() {
+    return permissionMask;
+  }
+
+  public void addPermission( final int permissionMask ) {
+    this.permissionMask |= permissionMask;
+  }
+
+  public void addPermissions( final int[] permissionMasks ) {
+    for ( int element : permissionMasks ) {
+      this.permissionMask |= element;
+    }
+  }
+
+  public void deletePermission( int permissionMask ) {
+    this.permissionMask &= ~permissionMask;
+  }
+
+  public void deletePermissions( final int[] permissionMasks ) {
+    for ( int i = 0; i < permissionMasks.length; i++ ) {
+      this.permissionMask &= ~permissionMasks[i];
+    }
+  }
+
+  @Override
+  public boolean equals( final Object obj ) {
+    return ( obj instanceof SimplePermissionMask )
+      && ( permissionMask == ( (SimplePermissionMask) obj ).permissionMask );
+  }
+
+  @Override
+  public int hashCode() {
+    return permissionMask;
+  }
+
+  @Override
+  public String toString() {
+    return String.format( "SimplePermissionMask[permissionMask=%d]", permissionMask ); //$NON-NLS-1$
+  }
+}

--- a/core/src/org/pentaho/platform/engine/security/SimpleRole.java
+++ b/core/src/org/pentaho/platform/engine/security/SimpleRole.java
@@ -1,0 +1,51 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security;
+
+import org.pentaho.platform.api.engine.IPermissionRecipient;
+
+@Deprecated
+public class SimpleRole implements IPermissionRecipient {
+
+  String roleName;
+
+  public SimpleRole( final String roleName ) {
+    this.roleName = roleName;
+  }
+
+  public String getName() {
+    return roleName;
+  }
+
+  @Override
+  public boolean equals( final Object o ) {
+    return ( ( o instanceof SimpleRole ) ? roleName.equals( ( (SimpleRole) o ).getName() ) : false );
+  }
+
+  @Override
+  public int hashCode() {
+    // TODO Auto-generated method stub
+    return roleName.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return String.format( "SimpleRole[roleName=%s]", roleName ); //$NON-NLS-1$
+  }
+}

--- a/core/src/org/pentaho/platform/engine/security/SimpleUser.java
+++ b/core/src/org/pentaho/platform/engine/security/SimpleUser.java
@@ -1,0 +1,51 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security;
+
+import org.pentaho.platform.api.engine.IPermissionRecipient;
+
+@Deprecated
+public class SimpleUser implements IPermissionRecipient {
+
+  String userName;
+
+  public SimpleUser( final String userName ) {
+    this.userName = userName;
+  }
+
+  public String getName() {
+    return userName;
+  }
+
+  @Override
+  public boolean equals( final Object o ) {
+    return ( ( o instanceof SimpleUser ) ? userName.equals( ( (SimpleUser) o ).getName() ) : false );
+  }
+
+  @Override
+  public int hashCode() {
+    // TODO Auto-generated method stub
+    return userName.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return String.format( "SimpleUser[userName=%s]", userName ); //$NON-NLS-1$
+  }
+}

--- a/core/src/org/pentaho/platform/engine/security/SpringSecurityPermissionMgr.java
+++ b/core/src/org/pentaho/platform/engine/security/SpringSecurityPermissionMgr.java
@@ -1,0 +1,130 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security;
+
+import org.pentaho.platform.api.engine.IAclHolder;
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.api.engine.IPermissionMask;
+import org.pentaho.platform.api.engine.IPermissionMgr;
+import org.pentaho.platform.api.engine.IPermissionRecipient;
+import org.pentaho.platform.engine.security.acls.PentahoAclEntry;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+@Deprecated
+public class SpringSecurityPermissionMgr implements IPermissionMgr {
+
+  private static final SpringSecurityPermissionMgr singletonPermMgr = new SpringSecurityPermissionMgr();
+
+  private SpringSecurityPermissionMgr() {
+  }
+
+  public static SpringSecurityPermissionMgr instance() {
+    return SpringSecurityPermissionMgr.singletonPermMgr;
+  }
+
+  public Map<IPermissionRecipient, IPermissionMask> getPermissions( final Object domainInstance ) {
+    IAclHolder aclHolder = (IAclHolder) domainInstance;
+    List<IPentahoAclEntry> aclList = aclHolder.getAccessControls();
+    return transformEntries( aclList );
+  }
+
+  public Map<IPermissionRecipient, IPermissionMask> getEffectivePermissions( Object domainInstance ) {
+    IAclHolder aclHolder = (IAclHolder) domainInstance;
+    List<IPentahoAclEntry> aclList = aclHolder.getEffectiveAccessControls();
+    return transformEntries( aclList );
+  }
+
+  /**
+   * Converts from List&lt;IPentahoAclEntry&gt; to Map&lt;IPermissionRecipient, IPermissionMask&gt;.
+   */
+  @SuppressWarnings( "deprecation" )
+  protected Map<IPermissionRecipient, IPermissionMask> transformEntries( List<IPentahoAclEntry> entriesFromHolder ) {
+    Map<IPermissionRecipient, IPermissionMask> permissionsMap =
+      new LinkedHashMap<IPermissionRecipient, IPermissionMask>();
+    for ( IPentahoAclEntry pentahoAclEntry : entriesFromHolder ) {
+      IPermissionRecipient permissionRecipient = null;
+      if ( pentahoAclEntry.getRecipient() instanceof SimpleGrantedAuthority ) {
+        SimpleGrantedAuthority grantedAuthorityImpl = (SimpleGrantedAuthority) pentahoAclEntry.getRecipient();
+        permissionRecipient = new SimpleRole( grantedAuthorityImpl.toString() );
+      } else if ( pentahoAclEntry.getRecipient() instanceof SimpleRole ) {
+        permissionRecipient = new SimpleRole( (String) pentahoAclEntry.getRecipient() );
+      } else {
+        permissionRecipient = new SimpleUser( (String) pentahoAclEntry.getRecipient() );
+      }
+      IPermissionMask permissionMask = new SimplePermissionMask( pentahoAclEntry.getMask() );
+      permissionsMap.put( permissionRecipient, permissionMask );
+    }
+    return permissionsMap;
+  }
+
+  @SuppressWarnings( "deprecation" )
+  public void setPermission( final IPermissionRecipient permissionRecipient, final IPermissionMask permission,
+                             final Object object ) {
+    if ( object == null || !( object instanceof IAclHolder ) ) {
+      // i would argue that the "object" parameter should be IAclHolder!
+      return;
+    }
+    IAclHolder aclHolder = (IAclHolder) object;
+    PentahoAclEntry entry = new PentahoAclEntry();
+    // TODO mlowery instanceof is undesirable as it doesn't allow new concrete classes.
+    if ( permissionRecipient instanceof SimpleRole ) {
+      entry.setRecipient( new SimpleGrantedAuthority( permissionRecipient.getName() ) );
+    } else {
+      entry.setRecipient( permissionRecipient.getName() );
+    }
+    entry.addPermission( permission.getMask() );
+    // HibernateUtil.beginTransaction(); - This is now handled by the RepositoryFile
+    aclHolder.getAccessControls().add( entry );
+    // HibernateUtil.commitTransaction(); - This should be covered by the exitPoint call
+  }
+
+  @SuppressWarnings( "deprecation" )
+  public void setPermissions( final Map<IPermissionRecipient, IPermissionMask> permissionsMap, final Object object ) {
+    if ( object == null || !( object instanceof IAclHolder ) ) {
+      // i would argue that the "object" parameter should be IAclHolder!
+      return;
+    }
+    IAclHolder aclHolder = (IAclHolder) object;
+    Set<Map.Entry<IPermissionRecipient, IPermissionMask>> mapEntrySet = permissionsMap.entrySet();
+    ArrayList<IPentahoAclEntry> aclList = new ArrayList<IPentahoAclEntry>();
+    for ( Entry<IPermissionRecipient, IPermissionMask> mapEntry : mapEntrySet ) {
+      PentahoAclEntry pentahoAclEntry = new PentahoAclEntry();
+      IPermissionRecipient permissionRecipient = mapEntry.getKey();
+      if ( permissionRecipient instanceof SimpleRole ) {
+        pentahoAclEntry.setRecipient( new SimpleGrantedAuthority( permissionRecipient.getName() ) );
+      } else {
+        pentahoAclEntry.setRecipient( permissionRecipient.getName() );
+      }
+      pentahoAclEntry.addPermission( mapEntry.getValue().getMask() );
+      aclList.add( pentahoAclEntry );
+    }
+    // HibernateUtil.beginTransaction(); - This is now handled in the RepositoryFile
+    aclHolder.resetAccessControls( aclList );
+    // HibernateUtil.commitTransaction(); - This is covered by the exitPoint
+  }
+
+}

--- a/core/src/org/pentaho/platform/engine/security/acls/PentahoAbstractBasicAclEntry.java
+++ b/core/src/org/pentaho/platform/engine/security/acls/PentahoAbstractBasicAclEntry.java
@@ -1,0 +1,252 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security.acls;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.pentaho.platform.api.engine.IPentahoAclObjectIdentity;
+import org.pentaho.platform.api.engine.IPentahoBasicAclEntry;
+
+import java.util.Arrays;
+
+/**
+ * This is a port from spring-security 2.0.8.RELEASE
+ * @see https://github.com/spring-projects/spring-security/blob/2.0.8.RELEASE/core/src/main/java/org/springframework/security/acl/basic/AbstractBasicAclEntry.java
+ */
+public abstract class PentahoAbstractBasicAclEntry implements IPentahoBasicAclEntry {
+  //~ Static fields/initializers =====================================================================================
+
+  private static final Log logger = LogFactory.getLog( PentahoAbstractBasicAclEntry.class );
+
+  //~ Instance fields ================================================================================================
+
+  private IPentahoAclObjectIdentity aclObjectIdentity;
+  private IPentahoAclObjectIdentity aclObjectParentIdentity;
+  private Object recipient;
+  private int[] validPermissions;
+  private int mask = 0; // default means no permissions
+
+  //~ Constructors ===================================================================================================
+
+  public PentahoAbstractBasicAclEntry( Object recipient, IPentahoAclObjectIdentity aclObjectIdentity,
+                               IPentahoAclObjectIdentity aclObjectParentIdentity, int mask ) {
+    assert recipient != null;
+
+    assert aclObjectIdentity != null;
+
+    validPermissions = getValidPermissions();
+    Arrays.sort( validPermissions );
+
+    for ( int i = 0; i < validPermissions.length; i++ ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "Valid permission:   " + printPermissionsBlock( validPermissions[i] ) + " "
+          + printBinary( validPermissions[i] ) + " (" + validPermissions[i] + ")" );
+      }
+    }
+
+    this.recipient = recipient;
+    this.aclObjectIdentity = aclObjectIdentity;
+    this.aclObjectParentIdentity = aclObjectParentIdentity;
+    this.mask = mask;
+  }
+
+  /**
+   * A protected constructor for use by Hibernate.
+   */
+  protected PentahoAbstractBasicAclEntry() {
+    validPermissions = getValidPermissions();
+    Arrays.sort( validPermissions );
+  }
+
+  //~ Methods ========================================================================================================
+
+  public int addPermission( int permissionToAdd ) {
+    return addPermissions( new int[] { permissionToAdd } );
+  }
+
+  public int addPermissions( int[] permissionsToAdd ) {
+    if ( logger.isDebugEnabled() ) {
+      logger.debug( "BEFORE Permissions: " + printPermissionsBlock( mask ) + " " + printBinary( mask ) + " (" + mask
+        + ")" );
+    }
+
+    for ( int i = 0; i < permissionsToAdd.length; i++ ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "Add permission: " + printPermissionsBlock( permissionsToAdd[i] ) + " "
+          + printBinary( permissionsToAdd[i] ) + " (" + permissionsToAdd[i] + ")" );
+      }
+
+      this.mask |= permissionsToAdd[i];
+    }
+
+    if ( Arrays.binarySearch( validPermissions, this.mask ) < 0 ) {
+      throw new IllegalArgumentException( "Resulting permission set will be invalid." );
+    } else {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "AFTER  Permissions: " + printPermissionsBlock( mask ) + " " + printBinary( mask ) + " ("
+          + mask + ")" );
+      }
+
+      return this.mask;
+    }
+  }
+
+  public int deletePermission( int permissionToDelete ) {
+    return deletePermissions( new int[] { permissionToDelete } );
+  }
+
+  public int deletePermissions( int[] permissionsToDelete ) {
+    if ( logger.isDebugEnabled() ) {
+      logger.debug( "BEFORE Permissions: " + printPermissionsBlock( mask ) + " " + printBinary( mask ) + " (" + mask
+        + ")" );
+    }
+
+    for ( int i = 0; i < permissionsToDelete.length; i++ ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "Delete  permission: " + printPermissionsBlock( permissionsToDelete[i] ) + " "
+          + printBinary( permissionsToDelete[i] ) + " (" + permissionsToDelete[i] + ")" );
+      }
+
+      this.mask &= ~permissionsToDelete[i];
+    }
+
+    if ( Arrays.binarySearch( validPermissions, this.mask ) < 0 ) {
+      throw new IllegalArgumentException( "Resulting permission set will be invalid." );
+    } else {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "AFTER  Permissions: " + printPermissionsBlock( mask ) + " " + printBinary( mask ) + " ("
+          + mask + ")" );
+      }
+
+      return this.mask;
+    }
+  }
+
+  public IPentahoAclObjectIdentity getAclObjectIdentity() {
+    return this.aclObjectIdentity;
+  }
+
+  public IPentahoAclObjectIdentity getAclObjectParentIdentity() {
+    return this.aclObjectParentIdentity;
+  }
+
+  public int getMask() {
+    return this.mask;
+  }
+
+  public Object getRecipient() {
+    return this.recipient;
+  }
+
+  /**
+   * Subclasses must indicate the permissions they support. Each base permission should be an integer with a
+   * base 2. ie: the first permission is 2^^0 (1), the second permission is 2^^1 (2), the third permission is 2^^2
+   * (4) etc. Each base permission should be exposed by the subclass as a <code>public static final int</code>. It
+   * is further recommended that valid combinations of permissions are also exposed as <code>public static final
+   * int</code>s.<P>This method returns all permission integers that are allowed to be used together. <B>This
+   * must include any combinations of valid permissions</b>. So if the permissions indicated by 2^^2 (4) and 2^^1
+   * (2) can be used together, one of the integers returned by this method must be 6 (4 + 2). Otherwise attempts to
+   * set the permission will be rejected, as the final resulting mask will be rejected.</p>
+   *  <P>Whilst it may seem unduly time onerous to return every valid permission <B>combination</B>, doing so
+   * delivers maximum flexibility in ensuring ACLs only reflect logical combinations. For example, it would be
+   * inappropriate to grant a "read" and "write" permission along with an "unrestricted" permission, as the latter
+   * implies the former permissions.</p>
+   *
+   * @return <b>every</b> valid combination of permissions
+   */
+  public abstract int[] getValidPermissions();
+
+  public boolean isPermitted( int permissionToCheck ) {
+    return isPermitted( this.mask, permissionToCheck );
+  }
+
+  protected boolean isPermitted( int maskToCheck, int permissionToCheck ) {
+    return ( ( maskToCheck & permissionToCheck ) == permissionToCheck );
+  }
+
+  private String printBinary( int i ) {
+    String s = Integer.toString( i, 2 );
+
+    String pattern = "................................";
+
+    String temp1 = pattern.substring( 0, pattern.length() - s.length() );
+
+    String temp2 = temp1 + s;
+
+    return temp2.replace( '0', '.' );
+  }
+
+  /**
+   * Outputs the permissions in a human-friendly format. For example, this method may return "CR-D" to
+   * indicate the passed integer permits create, permits read, does not permit update, and permits delete.
+   *
+   * @param i the integer containing the mask which should be printed
+   *
+   * @return the human-friend formatted block
+   */
+  public abstract String printPermissionsBlock( int i );
+
+  /**
+   * Outputs the permissions in human-friendly format for the current <code>AbstractBasicAclEntry</code>'s
+   * mask.
+   *
+   * @return the human-friendly formatted block for this instance
+   */
+  public String printPermissionsBlock() {
+    return printPermissionsBlock( this.mask );
+  }
+
+  public void setAclObjectIdentity( IPentahoAclObjectIdentity aclObjectIdentity ) {
+    this.aclObjectIdentity = aclObjectIdentity;
+  }
+
+  public void setAclObjectParentIdentity( IPentahoAclObjectIdentity aclObjectParentIdentity ) {
+    this.aclObjectParentIdentity = aclObjectParentIdentity;
+  }
+
+  public void setMask( int mask ) {
+    this.mask = mask;
+  }
+
+  public void setRecipient( Object recipient ) {
+    this.recipient = recipient;
+  }
+
+  public String toString() {
+    StringBuffer sb = new StringBuffer();
+    sb.append( getClass().getName() );
+    sb.append( "[" ).append( aclObjectIdentity ).append( "," ).append( recipient );
+    sb.append( "=" ).append( printPermissionsBlock( mask ) ).append( " " );
+    sb.append( printBinary( mask ) ).append( " (" );
+    sb.append( mask ).append( ")" ).append( "]" );
+
+    return sb.toString();
+  }
+
+  public int togglePermission( int permissionToToggle ) {
+    this.mask ^= permissionToToggle;
+
+    if ( Arrays.binarySearch( validPermissions, this.mask ) < 0 ) {
+      throw new IllegalArgumentException( "Resulting permission set will be invalid." );
+    } else {
+      return this.mask;
+    }
+  }
+}

--- a/core/src/org/pentaho/platform/engine/security/acls/PentahoAclEntry.java
+++ b/core/src/org/pentaho/platform/engine/security/acls/PentahoAclEntry.java
@@ -1,0 +1,320 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security.acls;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.engine.security.messages.Messages;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base Pentaho Access Control entry. Subclassed <tt>AbstractBasicAclEntry</tt> from Spring Security project.
+ * Provides known access controls.
+ *
+ * @author mbatchel
+ */
+
+@SuppressWarnings( "deprecation" )
+public class PentahoAclEntry extends PentahoAbstractBasicAclEntry implements IPentahoAclEntry {
+
+  private static final Log logger = LogFactory.getLog( PentahoAclEntry.class );
+
+  /**
+   * Populated lazily in getValidPermissions().
+   */
+  private static int[] validPermissions;
+
+  private static final long serialVersionUID = -1123574274303339402L;
+
+  private static final int RECIPIENT_STRING = 0;
+
+  private static final int RECIPIENT_GRANTEDAUTHORITY = 1;
+
+  private static final Map validPermissionsNameMap = new HashMap();
+  public int recipientType = PentahoAclEntry.RECIPIENT_STRING;
+
+  // Prevent breakage downstream by inadvertant or malicious modifications to validPermissions array
+  private int[] lazyPermissionClone;
+
+  static {
+    Map solutionPermissionsMap = new HashMap();
+    Map allPermissionsMap = new HashMap();
+
+    PentahoAclEntry.validPermissionsNameMap.put( PentahoAclEntry.PERMISSIONS_LIST_SOLUTIONS, Collections
+      .unmodifiableMap( solutionPermissionsMap ) );
+    PentahoAclEntry.validPermissionsNameMap.put( PentahoAclEntry.PERMISSIONS_LIST_ALL, Collections
+      .unmodifiableMap( allPermissionsMap ) );
+
+    // TODO gmoran Are two lists really necessary any more?
+    // TODO mlowery Why does PentahoAclEntry know about what permissions are valid for solutions?
+    solutionPermissionsMap
+      .put(
+        Messages.getInstance().getString( "PentahoAclEntry.USER_ADMINISTER" ), new Integer( PentahoAclEntry.PERM_FULL_CONTROL ) ); //$NON-NLS-1$
+    solutionPermissionsMap
+      .put(
+        Messages.getInstance().getString( "PentahoAclEntry.USER_MANAGE_PERMS" ), new Integer( PentahoAclEntry.PERM_UPDATE_PERMS ) ); //$NON-NLS-1$
+    solutionPermissionsMap.put(
+      Messages.getInstance().getString( "PentahoAclEntry.USER_UPDATE" ), new Integer( PentahoAclEntry.PERM_UPDATE ) ); //$NON-NLS-1$
+    solutionPermissionsMap.put(
+      Messages.getInstance().getString( "PentahoAclEntry.USER_CREATE" ), new Integer( PentahoAclEntry.PERM_CREATE ) ); //$NON-NLS-1$
+    solutionPermissionsMap.put(
+      Messages.getInstance().getString( "PentahoAclEntry.USER_DELETE" ), new Integer( PentahoAclEntry.PERM_DELETE ) ); //$NON-NLS-1$
+    solutionPermissionsMap
+      .put(
+        Messages.getInstance().getString( "PentahoAclEntry.USER_EXECUTE" ), new Integer( PentahoAclEntry.PERM_EXECUTE ) ); //$NON-NLS-1$
+    solutionPermissionsMap
+      .put(
+        Messages.getInstance().getString( "PentahoAclEntry.USER_SUBSCRIBE" ), new Integer( PentahoAclEntry.PERM_SUBSCRIBE ) ); //$NON-NLS-1$
+
+    allPermissionsMap.put( Messages.getInstance().getString( "PentahoAclEntry.USER_NONE" ), new Integer( 0 ) ); //$NON-NLS-1$
+    allPermissionsMap
+      .put(
+        Messages.getInstance().getString( "PentahoAclEntry.USER_EXECUTE" ), new Integer( PentahoAclEntry.PERM_EXECUTE ) ); //$NON-NLS-1$
+    allPermissionsMap
+      .put(
+        Messages.getInstance().getString( "PentahoAclEntry.USER_SUBSCRIBE" ), new Integer( PentahoAclEntry.PERM_SUBSCRIBE ) ); //$NON-NLS-1$
+    allPermissionsMap.put(
+      Messages.getInstance().getString( "PentahoAclEntry.USER_CREATE" ), new Integer( PentahoAclEntry.PERM_CREATE ) ); //$NON-NLS-1$
+    allPermissionsMap.put(
+      Messages.getInstance().getString( "PentahoAclEntry.USER_UPDATE" ), new Integer( PentahoAclEntry.PERM_UPDATE ) ); //$NON-NLS-1$
+    allPermissionsMap.put(
+      Messages.getInstance().getString( "PentahoAclEntry.USER_DELETE" ), new Integer( PentahoAclEntry.PERM_DELETE ) ); //$NON-NLS-1$
+    allPermissionsMap
+      .put(
+        Messages.getInstance().getString( "PentahoAclEntry.USER_ALL" ), new Integer( PentahoAclEntry.PERM_FULL_CONTROL ) ); //$NON-NLS-1$
+
+    initializePermissionsArray();
+  }
+
+  private static void initializePermissionsArray() {
+    if ( null == PentahoAclEntry.validPermissions ) {
+      int maxPower = -1;
+      Field[] fields = IPentahoAclEntry.class.getDeclaredFields();
+      for ( Field field : fields ) {
+        // if field is public static final int
+        if ( int.class == field.getType() && Modifier.isPublic( field.getModifiers() )
+          && Modifier.isStatic( field.getModifiers() ) && Modifier.isFinal( field.getModifiers() )
+          && field.getName().startsWith( PERMISSION_PREFIX ) ) {
+          if ( PentahoAclEntry.logger.isDebugEnabled() ) {
+            PentahoAclEntry.logger.debug( "Candidate field: " + field.getName() ); //$NON-NLS-1$
+          }
+
+          // power of two (0-based)
+          double powerOfTwo = -1;
+          try {
+            powerOfTwo = Math.log( field.getInt( null ) ) / Math.log( 2 );
+          } catch ( IllegalArgumentException e ) {
+            //ignore
+          } catch ( IllegalAccessException e ) {
+            //ignore
+          }
+          // if log calculation results in an integer
+          if ( powerOfTwo == (int) powerOfTwo ) {
+            if ( powerOfTwo > maxPower ) {
+              if ( PentahoAclEntry.logger.isDebugEnabled() ) {
+                PentahoAclEntry.logger.debug( "Found new power of two." ); //$NON-NLS-1$
+              }
+              maxPower = (int) powerOfTwo;
+            }
+          }
+        }
+      }
+      if ( PentahoAclEntry.logger.isDebugEnabled() ) {
+        PentahoAclEntry.logger.debug( "Max power of two: " + maxPower ); //$NON-NLS-1$
+      }
+
+      int numberOfPermutations = (int) Math.pow( 2, maxPower + 1 );
+
+      PentahoAclEntry.validPermissions = new int[numberOfPermutations + 1];
+      for ( int i = 0; i < numberOfPermutations; i++ ) {
+        PentahoAclEntry.validPermissions[i] = i;
+      }
+      PentahoAclEntry.validPermissions[PentahoAclEntry.validPermissions.length - 1] = PentahoAclEntry.PERM_FULL_CONTROL;
+    }
+  }
+
+  public PentahoAclEntry() {
+    super();
+  }
+
+  public PentahoAclEntry( final Object recipient, final int mask ) {
+    this();
+    setRecipient( recipient );
+    setMask( mask );
+  }
+
+  protected void setRecipientType( final int value ) {
+    this.recipientType = value;
+  }
+
+  protected int getRecipientType() {
+    return this.recipientType;
+  }
+
+  protected void setRecipientString( final String value ) {
+    if ( this.recipientType == PentahoAclEntry.RECIPIENT_GRANTEDAUTHORITY ) {
+      this.setRecipient( new SimpleGrantedAuthority( value ) );
+    } else {
+      this.setRecipient( value );
+    }
+
+  }
+
+  protected String getRecipientString() {
+    return this.getRecipient().toString();
+  }
+
+  @Override
+  public void setRecipient( final Object value ) {
+    super.setRecipient( value );
+    if ( value instanceof GrantedAuthority ) {
+      this.setRecipientType( PentahoAclEntry.RECIPIENT_GRANTEDAUTHORITY );
+    } else {
+      this.setRecipientType( PentahoAclEntry.RECIPIENT_STRING );
+    }
+  }
+
+  /**
+   * As implemented, this method says that all permission combinations are valid. (Well not all. FULL_CONTROL must
+   * stand alone. It cannot be combined with other bits.)
+   *
+   * <ol>
+   * <li>Find the permission value (call it p) that is the highest power of two.</li>
+   * <li>Find n (0-based) such that 2^n = p. (Uses logarithm with base 2.)</li>
+   * <li>So there are 2^(n+1) permutations of permission bits.</li>
+   * <li>So the valid permission values list consists of those 2^(n+1) permutations plus the FULL_CONTROL perm bit.
+   * (i.e. (2^(n+1))+1</li>
+   * </ol>
+   */
+  @Override
+  public int[] getValidPermissions() {
+    if ( lazyPermissionClone == null ) {
+      lazyPermissionClone = new int[validPermissions.length];
+      System.arraycopy( validPermissions, 0, lazyPermissionClone, 0, validPermissions.length );
+    }
+    return this.lazyPermissionClone;
+  }
+
+  public static void main( final String[] args ) {
+    PentahoAclEntry e = new PentahoAclEntry();
+    System.out.println( Arrays.toString( e.getValidPermissions() ) );
+    System.out.println( Arrays.toString( e.getValidPermissions() ) );
+  }
+
+  @Override
+  public String printPermissionsBlock( final int i ) {
+    StringBuffer sb = new StringBuffer();
+
+    if ( isPermitted( i, PentahoAclEntry.PERM_EXECUTE ) ) {
+      sb.append( 'X' );
+    } else {
+      sb.append( '-' );
+    }
+
+    if ( isPermitted( i, PentahoAclEntry.PERM_SUBSCRIBE ) ) {
+      sb.append( 'S' );
+    } else {
+      sb.append( '-' );
+    }
+
+    if ( isPermitted( i, PentahoAclEntry.PERM_CREATE ) ) {
+      sb.append( 'C' );
+    } else {
+      sb.append( '-' );
+    }
+
+    if ( isPermitted( i, PentahoAclEntry.PERM_UPDATE ) ) {
+      sb.append( 'U' );
+    } else {
+      sb.append( '-' );
+    }
+
+    if ( isPermitted( i, PentahoAclEntry.PERM_DELETE ) ) {
+      sb.append( 'D' );
+    } else {
+      sb.append( '-' );
+    }
+
+    if ( isPermitted( i, PentahoAclEntry.PERM_UPDATE_PERMS ) ) {
+      sb.append( 'P' );
+    } else {
+      sb.append( '-' );
+    }
+
+    return sb.toString();
+  }
+
+  /**
+   * @return Returns the validPermissionsNameMap. This method is generally useful for UI work as it returns a Map
+   *         of Permission atomic values (as Integer objects) keyed by a human readable permission name.
+   */
+  public static Map getValidPermissionsNameMap() {
+    return PentahoAclEntry.getValidPermissionsNameMap( PentahoAclEntry.PERMISSIONS_LIST_SOLUTIONS );
+  }
+
+  /**
+   * @return Returns the validPermissionsNameMap. This method is generally useful for UI work as it returns a Map
+   *         of Permission atomic values (as Integer objects) keyed by a human readable permission name.
+   * @param permissionsListType
+   *          - The permissions list for solutions is different than that for other UIs
+   */
+  public static Map getValidPermissionsNameMap( final String permissionsListType ) {
+    return (Map) PentahoAclEntry.validPermissionsNameMap.get( permissionsListType );
+  }
+
+  public boolean equals( final Object obj ) {
+    if ( obj instanceof PentahoAclEntry == false ) {
+      return false;
+    }
+    if ( this == obj ) {
+      return true;
+    }
+    //
+    // MB - If the instanceof above compares to anything other than
+    // this object, then the static comparison below of getValidPermissions() should
+    // be re-evaluated.
+    //
+    PentahoAclEntry rhs = (PentahoAclEntry) obj;
+    return new EqualsBuilder().append( getRecipient(), rhs.getRecipient() ).append( getRecipientType(),
+      rhs.getRecipientType() ).append( getAclObjectIdentity(), rhs.getAclObjectIdentity() ).append(
+      getAclObjectParentIdentity(), rhs.getAclObjectParentIdentity() )
+      // .append(getValidPermissions(),rhs.getValidPermissions())
+      .append( getMask(), rhs.getMask() ).isEquals();
+  }
+
+  public int hashCode() {
+    return new HashCodeBuilder( 79, 211 ).append( getRecipient() ).append( getRecipientType() ).append(
+      getAclObjectIdentity() ).append( getAclObjectParentIdentity() )
+      // MB - Commented out because it's not relevant
+      // .append(getValidPermissions())
+      .append( getMask() ).toHashCode();
+  }
+
+}

--- a/core/src/org/pentaho/platform/engine/security/acls/PentahoGrantedAuthorityEffectiveAclsResolver.java
+++ b/core/src/org/pentaho/platform/engine/security/acls/PentahoGrantedAuthorityEffectiveAclsResolver.java
@@ -1,0 +1,127 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security.acls;
+
+import java.util.Collection;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.pentaho.platform.api.engine.IAclEntry;
+import org.pentaho.platform.api.engine.IPentahoBasicAclEntry;
+
+import java.util.List;
+import java.util.Vector;
+
+/**
+ * This is a port from spring-security 2.0.8.RELEASE
+ * @see https://github.com/spring-projects/spring-security/blob/2.0.8.RELEASE/core/src/main/java/org/springframework/security/acl/basic/GrantedAuthorityEffectiveAclsResolver.java
+ */
+public class PentahoGrantedAuthorityEffectiveAclsResolver {
+
+  //~ Static fields/initializers =====================================================================================
+
+  private static final Log logger = LogFactory.getLog( PentahoGrantedAuthorityEffectiveAclsResolver.class );
+
+  //~ Methods ========================================================================================================
+
+  public IAclEntry[] resolveEffectiveAcls( IAclEntry[] allAcls, Authentication filteredBy ) {
+    if ( ( allAcls == null ) || ( allAcls.length == 0 ) ) {
+      return null;
+    }
+
+    List list = new Vector();
+
+    if ( logger.isDebugEnabled() ) {
+      logger.debug( "Locating AclEntry[]s (from set of " + ( ( allAcls == null ) ? 0 : allAcls.length )
+        + ") that apply to Authentication: " + filteredBy );
+    }
+
+    for ( int i = 0; i < allAcls.length; i++ ) {
+      if ( !( allAcls[i] instanceof IPentahoBasicAclEntry ) ) {
+        continue;
+      }
+
+      Object recipient = ( (IPentahoBasicAclEntry) allAcls[i] ).getRecipient();
+
+      // Allow the Authentication's getPrincipal to decide whether
+      // the presented recipient is "equal" (allows BasicAclDaos to
+      // return Strings rather than proper objects in simple cases)
+      if ( filteredBy.getPrincipal().equals( recipient ) ) {
+        if ( logger.isDebugEnabled() ) {
+          logger.debug( "Principal matches AclEntry recipient: " + recipient );
+        }
+
+        list.add( allAcls[i] );
+      } else if ( filteredBy.getPrincipal() instanceof UserDetails
+        && ( (UserDetails) filteredBy.getPrincipal() ).getUsername().equals( recipient ) ) {
+        if ( logger.isDebugEnabled() ) {
+          logger.debug( "Principal (from UserDetails) matches AclEntry recipient: " + recipient );
+        }
+
+        list.add( allAcls[i] );
+      } else {
+        // No direct match against principal; try each authority.
+        // As with the principal, allow each of the Authentication's
+        // granted authorities to decide whether the presented
+        // recipient is "equal"
+        Collection<? extends GrantedAuthority> authoritiesCollection = filteredBy.getAuthorities();
+        GrantedAuthority[] authorities = authoritiesCollection.toArray( new GrantedAuthority[]{} );
+
+        if ( ( authorities == null ) || ( authorities.length == 0 ) ) {
+          if ( logger.isDebugEnabled() ) {
+            logger.debug( "Did not match principal and there are no granted authorities, "
+              + "so cannot compare with recipient: " + recipient );
+          }
+
+          continue;
+        }
+
+        for ( int k = 0; k < authorities.length; k++ ) {
+          if ( authorities[k].equals( recipient ) ) {
+            if ( logger.isDebugEnabled() ) {
+              logger.debug( "GrantedAuthority: " + authorities[k] + " matches recipient: " + recipient );
+            }
+
+            list.add( allAcls[i] );
+          }
+        }
+      }
+    }
+
+    // return null if appropriate (as per interface contract)
+    if ( list.size() > 0 ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "Returning effective AclEntry array with " + list.size() + " elements" );
+      }
+
+      return (IPentahoBasicAclEntry[]) list.toArray( new IPentahoBasicAclEntry[] {} );
+    } else {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "Returning null AclEntry array as zero effective AclEntrys found" );
+      }
+
+      return null;
+    }
+  }
+}

--- a/core/src/org/pentaho/platform/engine/security/acls/voter/AbstractPentahoAclVoter.java
+++ b/core/src/org/pentaho/platform/engine/security/acls/voter/AbstractPentahoAclVoter.java
@@ -1,0 +1,74 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security.acls.voter;
+
+import java.util.Collection;
+
+import org.pentaho.platform.api.engine.IAclVoter;
+import org.pentaho.platform.api.engine.IPentahoInitializer;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.ISystemSettings;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public abstract class AbstractPentahoAclVoter implements IAclVoter, IPentahoInitializer {
+  protected GrantedAuthority adminRole;
+
+  public abstract Authentication getAuthentication( IPentahoSession session );
+
+  public GrantedAuthority getAdminRole() {
+    return this.adminRole;
+  }
+
+  public void setAdminRole( final GrantedAuthority value ) {
+    this.adminRole = value;
+  }
+
+  public void init( final IPentahoSession session ) {
+    ISystemSettings settings = PentahoSystem.getSystemSettings();
+    String roleName = settings.getSystemSetting( "acl-voter/admin-role", "Administrator" ); //$NON-NLS-1$ //$NON-NLS-2$
+    adminRole = new SimpleGrantedAuthority( roleName );
+  }
+
+  public boolean isPentahoAdministrator( final IPentahoSession session ) {
+    // A user is considered a manager if they're authenticated,
+    // and a member of the adminRole specified.
+    return isGranted( session, adminRole );
+  }
+
+  public boolean isGranted( final IPentahoSession session, GrantedAuthority role ) {
+    Authentication auth = getAuthentication( session );
+    if ( ( auth != null ) && auth.isAuthenticated() ) {
+      Collection<? extends GrantedAuthority> userAuths = auth.getAuthorities();
+      if ( userAuths == null ) {
+        return false;
+      }
+      for ( GrantedAuthority element : userAuths ) {
+        if ( element.equals( role ) ) {
+          return true;
+        }
+      }
+      return false;
+    } else {
+      return false;
+    }
+  }
+}

--- a/core/src/org/pentaho/platform/engine/security/acls/voter/PentahoAllowAllAclVoter.java
+++ b/core/src/org/pentaho/platform/engine/security/acls/voter/PentahoAllowAllAclVoter.java
@@ -1,0 +1,72 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security.acls.voter;
+
+import org.pentaho.platform.api.engine.IAclEntry;
+import org.pentaho.platform.api.engine.IAclHolder;
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.engine.security.acls.PentahoAclEntry;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.List;
+
+@SuppressWarnings( "deprecation" )
+public class PentahoAllowAllAclVoter extends AbstractPentahoAclVoter {
+
+  public boolean hasAccess( final IPentahoSession session, final IAclHolder holder, final int mask ) {
+    // Return true indicating that there are no access prohibitions.
+    return true;
+  }
+
+  @Override
+  public Authentication getAuthentication( final IPentahoSession session ) {
+    return SecurityHelper.getInstance().getAuthentication();
+  }
+
+  public IAclEntry[] getEffectiveAcls( final IPentahoSession session, final IAclHolder holder ) {
+    // Returns all the ACLs on the object which indicates that the
+    // user has all the necessary acls to access the object.
+    List allAcls = holder.getEffectiveAccessControls();
+    IAclEntry[] acls = new IAclEntry[allAcls.size()];
+    acls = (IAclEntry[]) allAcls.toArray( acls );
+    return acls;
+  }
+
+  public IPentahoAclEntry getEffectiveAcl( final IPentahoSession session, final IAclHolder holder ) {
+    IPentahoAclEntry rtn = new PentahoAclEntry();
+    rtn.setMask( IPentahoAclEntry.PERM_FULL_CONTROL );
+    return rtn;
+  }
+
+  @Override
+  public boolean isPentahoAdministrator( final IPentahoSession session ) {
+    // This system is wide open. All users are managers.
+    return true;
+  }
+
+  @Override
+  public boolean isGranted( final IPentahoSession session, final GrantedAuthority auth ) {
+    // This system is wide open. Everyone is granted everything.
+    return true;
+  }
+
+}

--- a/core/src/org/pentaho/platform/engine/security/acls/voter/PentahoAllowAnonymousAclVoter.java
+++ b/core/src/org/pentaho/platform/engine/security/acls/voter/PentahoAllowAnonymousAclVoter.java
@@ -1,0 +1,41 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security.acls.voter;
+
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Extends the BasicAclVoter, but overrides the getAuthentication() method to allow anonymous sessions. This is the
+ * simplest case to add to other voters.
+ *
+ * @author mbatchel
+ *
+ */
+
+public class PentahoAllowAnonymousAclVoter extends PentahoBasicAclVoter {
+
+  // Allow anonymous users to have possible acls on an entry.
+  @Override
+  public Authentication getAuthentication( final IPentahoSession session ) {
+    return SecurityHelper.getInstance().getAuthentication( session, true );
+  }
+
+}

--- a/core/src/org/pentaho/platform/engine/security/acls/voter/PentahoBasicAclVoter.java
+++ b/core/src/org/pentaho/platform/engine/security/acls/voter/PentahoBasicAclVoter.java
@@ -1,0 +1,149 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security.acls.voter;
+
+import org.pentaho.platform.api.engine.IAclEntry;
+import org.pentaho.platform.api.engine.IAclHolder;
+import org.pentaho.platform.api.engine.IAclVoter;
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.api.engine.IPentahoBasicAclEntry;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.engine.security.acls.PentahoAclEntry;
+import org.springframework.security.core.Authentication;
+import org.pentaho.platform.engine.security.acls.PentahoGrantedAuthorityEffectiveAclsResolver;
+
+import java.util.List;
+
+/**
+ * Standard basic ACL Voter. This voter simply aggregates all the applicable access controls on an object when
+ * asked for the effective ACL.
+ * <p>
+ * For example, if the user (sally) belongs to the following roles:
+ *
+ * <pre>
+ *   <table>
+ *     <tr>
+ *       <th>User Id</th><th>Role</th>
+ *     </tr>
+ *     <tr>
+ *       <td>sally</td><td>dev</td>
+ *     </tr>
+ *     <tr>
+ *       <td></td><td>mgr</td>
+ *     </tr>
+ *   </table>
+ * </pre>
+ *
+ * And the object has the following defined access controls:
+ *
+ * <pre>
+ *   <table>
+ *     <tr>
+ *       <th>Role</th><th>Access</th>
+ *     </tr>
+ *     <tr>
+ *       <td>dev</td><td>Execute</td>
+ *     </tr>
+ *     <tr>
+ *       <td>sales</td><td>Execute and Subscribe</td>
+ *     </tr>
+ *     <tr>
+ *       <td>sally</td><td>Nothing</td>
+ *     </tr>
+ *   </table>
+ * </pre>
+ *
+ * With voter, sally would have Execute permissions on this object because this voter simply aggregates all
+ * applicable access controls.
+ * <p>
+ *
+ * @author mbatchel
+ * @see PentahoUserOverridesVoter
+ *
+ */
+
+@SuppressWarnings( "deprecation" )
+public class PentahoBasicAclVoter extends AbstractPentahoAclVoter implements IAclVoter {
+
+  // Allow overriding of the obtaining of the authentication. This
+  // allows someone to decide whether to create an anonymous authentication
+  // or not.
+  @Override
+  public Authentication getAuthentication( final IPentahoSession session ) {
+    return SecurityHelper.getInstance().getAuthentication();
+  }
+
+  public boolean hasAccess( final IPentahoSession session, final IAclHolder holder, final int mask ) {
+    Authentication auth = getAuthentication( session );
+    // If we're not authenticated, default to no access and return.
+    if ( auth == null ) {
+      return false;
+    }
+    // admins can do anything they want!
+    if ( isPentahoAdministrator( session ) ) {
+      return true;
+    }
+    IAclEntry[] effectiveAcls = getEffectiveAcls( session, holder );
+    if ( ( effectiveAcls == null ) || ( effectiveAcls.length == 0 ) ) {
+      return false;
+    }
+    for ( IAclEntry element : effectiveAcls ) {
+      IPentahoBasicAclEntry acl = (IPentahoBasicAclEntry) element;
+      if ( acl.isPermitted( mask ) ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public IAclEntry[] getEffectiveAcls( final IPentahoSession session, final IAclHolder holder ) {
+    Authentication auth = getAuthentication( session );
+    if ( auth == null ) {
+      return null; // No user, so no ACLs.
+    }
+    List allAcls = holder.getEffectiveAccessControls();
+    IAclEntry[] acls = new IAclEntry[allAcls.size()];
+    acls = (IAclEntry[]) allAcls.toArray( acls );
+    PentahoGrantedAuthorityEffectiveAclsResolver resolver = new PentahoGrantedAuthorityEffectiveAclsResolver();
+    IAclEntry[] resolvedAcls = resolver.resolveEffectiveAcls( acls, auth );
+    return resolvedAcls;
+  }
+
+  public PentahoAclEntry getEffectiveAcl( final IPentahoSession session, final IAclHolder holder ) {
+    // First, get all the ACLs on the object that apply to the user.
+    IAclEntry[] effectiveAcls = getEffectiveAcls( session, holder );
+    PentahoAclEntry entry = new PentahoAclEntry();
+    entry.setMask( IPentahoAclEntry.PERM_NOTHING );
+    // By default, we'll OR together all the acls to create the whole mask
+    // which
+    // indicates their access.
+    if ( ( effectiveAcls != null ) && ( effectiveAcls.length > 0 ) ) {
+      int[] allAcls = new int[effectiveAcls.length];
+      for ( int i = 0; i < effectiveAcls.length; i++ ) {
+        allAcls[i] = ( (IPentahoAclEntry) effectiveAcls[i] ).getMask();
+      }
+      entry.addPermissions( allAcls );
+      return entry;
+    } else {
+      return entry;
+    }
+  }
+
+}

--- a/core/src/org/pentaho/platform/engine/security/acls/voter/PentahoUserOverridesVoter.java
+++ b/core/src/org/pentaho/platform/engine/security/acls/voter/PentahoUserOverridesVoter.java
@@ -1,0 +1,117 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.security.acls.voter;
+
+import org.pentaho.platform.api.engine.IAclEntry;
+import org.pentaho.platform.api.engine.IAclHolder;
+import org.pentaho.platform.api.engine.IPentahoBasicAclEntry;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * Extends the PentahoBasicAclVoter class, and overrides the getEffectiveAcls method to stipulate that if the
+ * current user occurrs in the access control list, that whatever access controls are listed for that user, those
+ * are the only ones returned.
+ * <p>
+ * For example, if the user (sally) belongs to the following roles:
+ *
+ * <pre>
+ *   <table>
+ *     <tr>
+ *       <th>User Id</th><th>Role</th>
+ *     </tr>
+ *     <tr>
+ *       <td>sally</td><td>dev</td>
+ *     </tr>
+ *     <tr>
+ *       <td></td><td>mgr</td>
+ *     </tr>
+ *   </table>
+ * </pre>
+ *
+ * And the object has the following defined access controls:
+ *
+ * <pre>
+ *   <table>
+ *     <tr>
+ *       <th>Role</th><th>Access</th>
+ *     </tr>
+ *     <tr>
+ *       <td>dev</td><td>Execute</td>
+ *     </tr>
+ *     <tr>
+ *       <td>sales</td><td>Execute and Subscribe</td>
+ *     </tr>
+ *     <tr>
+ *       <td>sally</td><td>Nothing</td>
+ *     </tr>
+ *   </table>
+ * </pre>
+ *
+ * With the standard <tt>PentahoBasicAclVoter</tt>, sally would have Execute permissions on this object because
+ * that voter will simply aggregate all applicable access controls. With this voter, the returned access controls
+ * for sally will be <tt>PentahoAclEntry.NOTHING</tt>.
+ *
+ *
+ * @author mbatchel
+ *
+ */
+
+@Deprecated
+public class PentahoUserOverridesVoter extends PentahoBasicAclVoter {
+
+  @Override
+  public IAclEntry[] getEffectiveAcls( final IPentahoSession session, final IAclHolder holder ) {
+    Authentication auth = getAuthentication( session );
+    // User is un-authenticated. Return no access controls.
+    if ( auth == null ) {
+      return null;
+    }
+    IAclEntry[] objectAcls = super.getEffectiveAcls( session, holder );
+    if ( objectAcls == null ) {
+      return null;
+    }
+    Object principal = auth.getPrincipal();
+    String userName = null;
+    if ( principal instanceof UserDetails ) {
+      userName = ( (UserDetails) principal ).getUsername();
+    } else {
+      userName = principal.toString();
+    }
+    for ( IAclEntry element : objectAcls ) {
+      // First, search for the user name in the objectAcls. If it's there,
+      // then that
+      // overrides anything else. It's the only acl returned.
+      IPentahoBasicAclEntry entry = (IPentahoBasicAclEntry) element;
+      String recipient = entry.getRecipient().toString();
+      // Found the user in there - That means that his/her access to the
+      // object
+      // has been spelled out. Therefore, we need to simply return that
+      // ACL.
+      if ( recipient.equals( userName ) ) {
+        return new IAclEntry[] { entry };
+      }
+    }
+    // Wasn't anything specifically on the user. So, return default
+    // settings.
+    return objectAcls;
+  }
+
+}

--- a/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataAclHolder.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/metadata/PentahoMetadataAclHolder.java
@@ -22,6 +22,9 @@ import org.pentaho.metadata.model.concept.IConcept;
 import org.pentaho.metadata.model.concept.security.Security;
 import org.pentaho.metadata.model.concept.security.SecurityOwner;
 import org.pentaho.platform.api.engine.IAclHolder;
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.engine.security.acls.PentahoAclEntry;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +32,7 @@ import java.util.Map;
 
 public class PentahoMetadataAclHolder implements IAclHolder {
 
-  private List /* <IPentahoAclEntry> */ accessControls = new ArrayList /* <IPentahoAclEntry> */();
+  private List<IPentahoAclEntry> accessControls = new ArrayList<IPentahoAclEntry>();
 
   public PentahoMetadataAclHolder( final IConcept aclHolder ) {
     try {
@@ -41,13 +44,13 @@ public class PentahoMetadataAclHolder implements IAclHolder {
           // We now have the SecurityOwner and the Rights in there.
           secOwn = entry.getKey();
           int rights = entry.getValue().intValue();
-          /* TODO
+
           if ( secOwn.getOwnerType() == SecurityOwner.OwnerType.USER ) {
             accessControls.add( new PentahoAclEntry( secOwn.getOwnerName(), rights ) );
           } else {
-            accessControls.add( new PentahoAclEntry( new GrantedAuthorityImpl( secOwn.getOwnerName() ), rights ) );
+            accessControls.add( new PentahoAclEntry( new SimpleGrantedAuthority( secOwn.getOwnerName() ), rights ) );
           }
-          */
+
         }
       }
     } catch ( Throwable th ) {
@@ -56,19 +59,19 @@ public class PentahoMetadataAclHolder implements IAclHolder {
 
   }
 
-  public List /* <IPentahoAclEntry> TODO */ getAccessControls() {
+  public List<IPentahoAclEntry> getAccessControls() {
     return accessControls;
   }
 
-  public List /* <IPentahoAclEntry> TODO */ getEffectiveAccessControls() {
+  public List<IPentahoAclEntry> getEffectiveAccessControls() {
     return accessControls;
   }
 
-  public void resetAccessControls( final List /* <IPentahoAclEntry> TODO */ acls ) {
+  public void resetAccessControls( final List<IPentahoAclEntry> acls ) {
     throw new UnsupportedOperationException( "Cannot set Metadata Acls yet" ); //$NON-NLS-1$
   }
 
-  public void setAccessControls( final List /* <IPentahoAclEntry> TODO */ acls ) {
+  public void setAccessControls( final List<IPentahoAclEntry> acls ) {
     throw new UnsupportedOperationException( "Cannot set Metadata Acls yet" ); //$NON-NLS-1$
   }
 

--- a/repository/src/org/pentaho/platform/repository/legacy/acl/AccessVoterToLegacyAcl.java
+++ b/repository/src/org/pentaho/platform/repository/legacy/acl/AccessVoterToLegacyAcl.java
@@ -1,0 +1,110 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.repository.legacy.acl;
+
+import org.pentaho.platform.api.engine.IAclVoter;
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.repository2.unified.IRepositoryAccessVoter;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAce;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.engine.security.acls.PentahoAclEntry;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Deprecated
+public class AccessVoterToLegacyAcl implements IRepositoryAccessVoter {
+
+  private IAclVoter aclVoter;
+
+  public AccessVoterToLegacyAcl( IAclVoter aclVoter ) {
+    Assert.notNull( aclVoter );
+    this.aclVoter = aclVoter;
+  }
+
+  @Override
+  public boolean hasAccess( RepositoryFile file, RepositoryFilePermission operation, RepositoryFileAcl acl,
+                            IPentahoSession session ) {
+
+    Assert.notNull( file );
+    Assert.notNull( operation );
+    Assert.notNull( acl );
+
+    return aclVoter.hasAccess( session, convert( file, acl ), mask( operation ) );
+  }
+
+  private int mask( RepositoryFilePermission permission ) {
+
+    Assert.notNull( permission );
+
+    if ( RepositoryFilePermission.READ == permission ) {
+      return IPentahoAclEntry.PERM_EXECUTE;
+    } else if ( RepositoryFilePermission.WRITE == permission ) {
+      return IPentahoAclEntry.PERM_CREATE | IPentahoAclEntry.PERM_UPDATE;
+    } else if ( RepositoryFilePermission.DELETE == permission ) {
+      return IPentahoAclEntry.PERM_DELETE;
+    } else if ( RepositoryFilePermission.ACL_MANAGEMENT == permission ) {
+      return IPentahoAclEntry.PERM_UPDATE_PERMS;
+    } else if ( RepositoryFilePermission.ALL == permission ) {
+      return IPentahoAclEntry.PERM_FULL_CONTROL;
+    } else {
+      return IPentahoAclEntry.PERM_NOTHING;
+    }
+  }
+
+  private LegacyRepositoryFile convert( RepositoryFile file, RepositoryFileAcl acl ) {
+
+    LegacyRepositoryFile legacy = new LegacyRepositoryFile( file.getName(), file.getPath(), file.isFolder() );
+
+    legacy.setId( file.getId() );
+
+    if ( file.getLastModifiedDate() != null ) {
+      legacy.setLastModified( file.getLastModifiedDate().getTime() );
+    }
+
+    List<IPentahoAclEntry> legacyAcls = new ArrayList<IPentahoAclEntry>();
+    for ( RepositoryFileAce fileAce : acl.getAces() ) {
+      if ( fileAce != null && fileAce.getSid() != null && fileAce.getPermissions() != null ) {
+        for ( RepositoryFilePermission filePermission : fileAce.getPermissions() ) {
+
+          PentahoAclEntry fileAcl = new PentahoAclEntry();
+
+          if ( RepositoryFileSid.Type.USER == fileAce.getSid().getType() ) {
+            // user
+            fileAcl.setRecipient( fileAce.getSid().getName() );
+          } else {
+            // role
+            fileAcl.setRecipient( new SimpleGrantedAuthority( fileAce.getSid().getName() ) );
+          }
+          fileAcl.setMask( mask( filePermission ) );
+          legacyAcls.add( fileAcl );
+        }
+      }
+    }
+
+    legacy.setAccessControls( legacyAcls );
+    return legacy;
+  }
+}

--- a/repository/src/org/pentaho/platform/repository/legacy/acl/LegacyRepositoryFile.java
+++ b/repository/src/org/pentaho/platform/repository/legacy/acl/LegacyRepositoryFile.java
@@ -1,0 +1,256 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.repository.legacy.acl;
+
+import org.pentaho.platform.api.engine.IAclHolder;
+import org.pentaho.platform.api.engine.IFileFilter;
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.api.engine.ISolutionFile;
+import org.springframework.util.Assert;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+@Deprecated
+public class LegacyRepositoryFile implements ISolutionFile, IAclHolder, Serializable {
+
+  private static final long serialVersionUID = -3181545217413101032L;
+
+  public static final char EXTENSION_CHAR = '.';
+
+  protected Serializable id;
+  private String fileName;
+  private String fullPath;
+  private long lastModified;
+  private boolean root;
+  private boolean directory;
+  private byte[] data;
+  private String solution;
+  private String solutionPath;
+  protected LegacyRepositoryFile parent;
+  private List<IPentahoAclEntry> accessControls = new ArrayList<IPentahoAclEntry>();
+  private Set childrenFiles = new TreeSet();
+
+  public LegacyRepositoryFile( String fileName, String fullPath, boolean directory ) {
+
+    Assert.notNull( fileName );
+    Assert.notNull( fullPath );
+    Assert.notNull( directory );
+
+    this.fileName = fileName;
+    this.fullPath = fullPath;
+    this.directory = directory;
+  }
+
+  @Override
+  public String getFileName() {
+    return fileName;
+  }
+
+  @Override
+  public String getFullPath() {
+    return fullPath;
+  }
+
+  @Override
+  public String getExtension() {
+    return hasExtension() ? fileName.substring( fileName.lastIndexOf( EXTENSION_CHAR ) ) : ""; //$NON-NLS-1$
+  }
+
+  @Override
+  public long getLastModified() {
+    return lastModified;
+  }
+
+  @Override
+  public boolean isDirectory() {
+    return directory;
+  }
+
+  @Override
+  public boolean isRoot() {
+    return root;
+  }
+
+  @Override
+  public byte[] getData() {
+    return data;
+  }
+
+  @Override
+  public String getSolution() {
+    return solution;
+  }
+
+  @Override
+  public String getSolutionPath() {
+    return solutionPath;
+  }
+
+  @Override
+  public List<IPentahoAclEntry> getAccessControls() {
+    return accessControls;
+  }
+
+  @Override
+  public void resetAccessControls( List<IPentahoAclEntry> arg0 ) {
+    this.accessControls = new ArrayList<IPentahoAclEntry>();
+  }
+
+  @Override
+  public void setAccessControls( List<IPentahoAclEntry> arg0 ) {
+    this.accessControls = arg0;
+  }
+
+  /**
+   * Chains up to find the access controls that are in force on this object. Could end up chaining all the way to
+   * the root.
+   *
+   * <p>
+   * Note that (1) defining no access control entries of your own and (2) removing all of your access control
+   * entries is indistiguishable in the current design. In #1, we chain up because we inherit. But in #2, it might
+   * be expected that by explicitly removing all access control entries, the chaining up ends. That is not the case
+   * in the current design.
+   * </p>
+   */
+  @Override
+  public List<IPentahoAclEntry> getEffectiveAccessControls() {
+    List acls = this.getAccessControls();
+    if ( acls.size() == 0 ) {
+      LegacyRepositoryFile chain = this;
+      while ( !chain.isRoot() && ( acls.size() == 0 ) ) {
+        chain = (LegacyRepositoryFile) chain.retrieveParent();
+        acls = chain.getAccessControls();
+      }
+    }
+    return acls;
+  }
+
+  @Override
+  public boolean exists() {
+    return true;
+  }
+
+  @Override
+  public ISolutionFile[] listFiles() {
+    Set<ISolutionFile> files = getChildrenFiles();
+    return files.toArray( new ISolutionFile[] {} );
+  }
+
+  @Override
+  public ISolutionFile[] listFiles( IFileFilter filter ) {
+    List matchedFiles = new ArrayList();
+    Object[] objArray = getChildrenFiles().toArray();
+    for ( Object element : objArray ) {
+      if ( filter.accept( (ISolutionFile) element ) ) {
+        matchedFiles.add( element );
+      }
+    }
+    return (ISolutionFile[]) matchedFiles.toArray( new ISolutionFile[] {} );
+  }
+
+  @Override
+  public ISolutionFile retrieveParent() {
+    return parent;
+  }
+
+  @Override
+  public int hashCode() {
+    return id.hashCode();
+  }
+
+  @Override
+  public boolean equals( final Object other ) {
+    if ( this == other ) {
+      return true;
+    }
+    if ( !( other instanceof LegacyRepositoryFile ) ) {
+      return false;
+    }
+    final LegacyRepositoryFile that = (LegacyRepositoryFile) other;
+    return this.getId().equals( that.getId() );
+  }
+
+  public void setFileName( String fileName ) {
+    this.fileName = fileName;
+  }
+
+  public void setFullPath( String fullPath ) {
+    this.fullPath = fullPath;
+  }
+
+  public void setLastModified( long lastModified ) {
+    this.lastModified = lastModified;
+  }
+
+  public void setRoot( boolean root ) {
+    this.root = root;
+  }
+
+  public void setDirectory( boolean directory ) {
+    this.directory = directory;
+  }
+
+  public void setData( byte[] data ) {
+    this.data = data;
+  }
+
+  public void setSolution( String solution ) {
+    this.solution = solution;
+  }
+
+  public void setSolutionPath( String solutionPath ) {
+    this.solutionPath = solutionPath;
+  }
+
+  public Set getChildrenFiles() {
+    return childrenFiles;
+  }
+
+  public void setChildrenFiles( Set childrenFiles ) {
+    this.childrenFiles = childrenFiles;
+  }
+
+  private boolean hasExtension() {
+    return fileName.lastIndexOf( LegacyRepositoryFile.EXTENSION_CHAR ) != -1;
+  }
+
+  public Serializable getId() {
+    return id;
+  }
+
+  public void setId( String id ) {
+    this.id = id;
+  }
+
+  public LegacyRepositoryFile getParent() {
+    return parent;
+  }
+
+  public void setParent( LegacyRepositoryFile parent ) {
+    this.parent = parent;
+  }
+
+  public void setId( Serializable id ) {
+    this.id = id;
+  }
+}

--- a/repository/test-src/org/pentaho/test/platform/security/acls/TestPentahoAclEntryTest.java
+++ b/repository/test-src/org/pentaho/test/platform/security/acls/TestPentahoAclEntryTest.java
@@ -1,0 +1,106 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 3 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * Copyright 2005 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.test.platform.security.acls;
+
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.engine.security.acls.PentahoAclEntry;
+import org.pentaho.test.platform.engine.core.BaseTest;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+
+import java.io.File;
+
+@SuppressWarnings( "nls" )
+public class TestPentahoAclEntryTest extends BaseTest {
+  private static final String SOLUTION_PATH = "test-src/solution";
+  private static final String ALT_SOLUTION_PATH = "test-src/solution";
+  private static final String PENTAHO_XML_PATH = "/system/pentaho.xml";
+
+  public String getSolutionPath() {
+    File file = new File( SOLUTION_PATH + PENTAHO_XML_PATH );
+    if ( file.exists() ) {
+      return SOLUTION_PATH;
+    } else {
+      return ALT_SOLUTION_PATH;
+    }
+
+  }
+
+  public static void main( String[] args ) {
+    junit.textui.TestRunner.run( TestPentahoAclEntryTest.class );
+    System.exit( 0 );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  public void testAcls() {
+    PentahoAclEntry aclEntry = null;
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_NOTHING ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "------" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_EXECUTE ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "X-----" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_SUBSCRIBE ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "-S----" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_CREATE ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "--C---" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_UPDATE ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "---U--" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_DELETE ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "----D-" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_UPDATE_PERMS ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "-----P" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_ADMINISTRATION ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "--CUDP" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_EXECUTE_SUBSCRIBE ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "XS----" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_ADMIN_ALL ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "XSCUD-" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_SUBSCRIBE_ADMINISTRATION ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "-SCUDP" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_EXECUTE_ADMINISTRATION ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "X-CUDP" ); //$NON-NLS-1$
+
+    aclEntry = new PentahoAclEntry( "admin", IPentahoAclEntry.PERM_FULL_CONTROL ); //$NON-NLS-1$
+    assertEquals( aclEntry.printPermissionsBlock(), "XSCUDP" ); //$NON-NLS-1$
+
+    aclEntry.setRecipient( new SimpleGrantedAuthority( "ROLE_ADMIN" ) ); //$NON-NLS-1$
+    Object recip = aclEntry.getRecipient();
+    if ( !( recip instanceof GrantedAuthority ) ) {
+      fail( "setRecipientString failed - GrantedAuthority." ); //$NON-NLS-1$
+    }
+    aclEntry.setRecipient( "suzy" ); //$NON-NLS-1$
+    recip = aclEntry.getRecipient();
+    if ( !( recip instanceof String ) ) {
+      fail( "setRecipientString failed - User." ); //$NON-NLS-1$
+    }
+
+  }
+
+}

--- a/repository/test-src/org/pentaho/test/platform/security/acls/voter/TestBasicAclVoterTest.java
+++ b/repository/test-src/org/pentaho/test/platform/security/acls/voter/TestBasicAclVoterTest.java
@@ -1,0 +1,145 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 3 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * Copyright 2005 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.test.platform.security.acls.voter;
+
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.IPermissionMask;
+import org.pentaho.platform.api.engine.IPermissionRecipient;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.engine.security.SimplePermissionMask;
+import org.pentaho.platform.engine.security.SimpleRole;
+import org.pentaho.platform.engine.security.SimpleUser;
+import org.pentaho.platform.engine.security.SpringSecurityPermissionMgr;
+import org.pentaho.platform.engine.security.acls.PentahoAclEntry;
+import org.pentaho.platform.engine.security.acls.voter.PentahoBasicAclVoter;
+import org.pentaho.platform.repository.solution.dbbased.RepositoryFile;
+import org.pentaho.test.platform.engine.core.BaseTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+@SuppressWarnings( "nls" )
+public class TestBasicAclVoterTest extends BaseTest {
+  private static final String SOLUTION_PATH = "test-src/solution";
+  private static final String ALT_SOLUTION_PATH = "test-src/solution";
+  private static final String PENTAHO_XML_PATH = "/system/pentaho.xml";
+
+  public String getSolutionPath() {
+    File file = new File( SOLUTION_PATH + PENTAHO_XML_PATH );
+    if ( file.exists() ) {
+      return SOLUTION_PATH;
+    } else {
+      return ALT_SOLUTION_PATH;
+    }
+
+  }
+
+  public static void main( String[] args ) {
+    junit.textui.TestRunner.run( TestBasicAclVoterTest.class );
+    System.exit( 0 );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  public void testVoter() throws Exception {
+    SecurityHelper.getInstance().runAsUser( "suzy", new Callable<Void>() {
+
+      @Override
+      public Void call() throws Exception {
+        RepositoryFile testFile = new RepositoryFile( "Test Folder", null, null ); //$NON-NLS-1$
+        Map<IPermissionRecipient, IPermissionMask> perms = new LinkedHashMap<IPermissionRecipient, IPermissionMask>();
+        perms.put( new SimpleUser( "suzy" ), new SimplePermissionMask( IPentahoAclEntry.PERM_EXECUTE ) );
+        perms.put( new SimpleRole( "ROLE_POWER_USER" ), new SimplePermissionMask( IPentahoAclEntry.PERM_SUBSCRIBE ) );
+        SpringSecurityPermissionMgr.instance().setPermissions( perms, testFile );
+        PentahoBasicAclVoter voter = new PentahoBasicAclVoterForTesting( new MockAuthentication( "suzy", Arrays.asList(
+          new GrantedAuthority[] { new SimpleGrantedAuthority( "ROLE_AUTHENTICATED" ), new SimpleGrantedAuthority( "ROLE_POWER_USER" ) } ) ) );
+        assertTrue( voter.hasAccess( PentahoSessionHolder.getSession(), testFile, IPentahoAclEntry.PERM_EXECUTE ) );
+        assertTrue( voter.hasAccess( PentahoSessionHolder.getSession(), testFile, IPentahoAclEntry.PERM_SUBSCRIBE ) );
+        assertFalse( voter.hasAccess( PentahoSessionHolder.getSession(), testFile, IPentahoAclEntry.PERM_ADMINISTRATION ) );
+        PentahoAclEntry entry = voter.getEffectiveAcl( PentahoSessionHolder.getSession(), testFile );
+        assertNotNull( entry );
+        assertEquals( entry.printPermissionsBlock(), "XS----" ); //$NON-NLS-1$
+        return null;
+      }
+
+    } );
+  }
+
+  private class PentahoBasicAclVoterForTesting extends PentahoBasicAclVoter {
+
+    Authentication authentication;
+
+    public PentahoBasicAclVoterForTesting( Authentication authentication ) {
+      this.authentication = authentication;
+    }
+
+    @Override
+    public Authentication getAuthentication( final IPentahoSession session ) {
+      return authentication;
+    }
+  }
+
+  /**
+   * Mock class used for testing
+   */
+  private class MockAuthentication implements Authentication {
+
+    private String currentUser;
+    private Collection<? extends GrantedAuthority> authorities;
+
+    public MockAuthentication( final String currentUser, Collection<? extends GrantedAuthority> authorities ) {
+      this.currentUser = currentUser;
+      this.authorities = authorities;
+    }
+
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+      return authorities;
+    }
+
+    public Object getCredentials() {
+      return null;
+    }
+
+    public Object getDetails() {
+      return null;
+    }
+
+    public Object getPrincipal() {
+      return currentUser;
+    }
+
+    public boolean isAuthenticated() {
+      return true;
+    }
+
+    public void setAuthenticated( final boolean b ) throws IllegalArgumentException {
+    }
+
+    public String getName() {
+      return currentUser;
+    }
+  }
+}

--- a/repository/test-src/org/pentaho/test/platform/security/acls/voter/TestPentahoAllowAllAclVoterTest.java
+++ b/repository/test-src/org/pentaho/test/platform/security/acls/voter/TestPentahoAllowAllAclVoterTest.java
@@ -1,0 +1,77 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 3 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * Copyright 2005 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.test.platform.security.acls.voter;
+
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.engine.security.acls.PentahoAclEntry;
+import org.pentaho.platform.engine.security.acls.voter.PentahoAllowAllAclVoter;
+import org.pentaho.platform.repository.solution.dbbased.RepositoryFile;
+import org.pentaho.test.platform.engine.core.BaseTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+
+import java.io.File;
+import java.util.concurrent.Callable;
+
+@SuppressWarnings( "nls" )
+public class TestPentahoAllowAllAclVoterTest extends BaseTest {
+
+  private static final String SOLUTION_PATH = "test-src/solution";
+  private static final String ALT_SOLUTION_PATH = "test-src/solution";
+  private static final String PENTAHO_XML_PATH = "/system/pentaho.xml";
+
+  public String getSolutionPath() {
+    File file = new File( SOLUTION_PATH + PENTAHO_XML_PATH );
+    if ( file.exists() ) {
+      return SOLUTION_PATH;
+    } else {
+      return ALT_SOLUTION_PATH;
+    }
+
+  }
+
+  public static void main( String[] args ) {
+    junit.textui.TestRunner.run( TestPentahoAllowAllAclVoterTest.class );
+    System.exit( 0 );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  public void testVoter() throws Exception {
+    SecurityHelper.getInstance().runAsUser( "suzy", new Callable<Void>() {
+
+      @Override
+      public Void call() throws Exception {
+        RepositoryFile testFile = new RepositoryFile( "Test Folder", null, null ); //$NON-NLS-1$
+        // RepositoryFile has no acls on it. Nobody should be able to access it.
+        // But, we're using an allowAll voter.
+        PentahoAllowAllAclVoter voter = new PentahoAllowAllAclVoter();
+        assertTrue( voter.hasAccess( PentahoSessionHolder.getSession(), testFile, IPentahoAclEntry.PERM_EXECUTE ) );
+        IPentahoAclEntry entry = voter.getEffectiveAcl( PentahoSessionHolder.getSession(), testFile );
+        assertEquals( ( (PentahoAclEntry) entry ).getMask(), IPentahoAclEntry.PERM_FULL_CONTROL );
+        assertTrue( voter.isPentahoAdministrator( PentahoSessionHolder.getSession() ) );
+        assertTrue( voter.isGranted( PentahoSessionHolder.getSession(), new SimpleGrantedAuthority( "ROLE_ANYTHING" ) ) ); //$NON-NLS-1$
+
+        return null;
+      }
+
+    } );
+
+  }
+}

--- a/repository/test-src/org/pentaho/test/platform/security/acls/voter/TestPentahoUserOverridesVoterTest.java
+++ b/repository/test-src/org/pentaho/test/platform/security/acls/voter/TestPentahoUserOverridesVoterTest.java
@@ -1,0 +1,79 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 3 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * Copyright 2005 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.test.platform.security.acls.voter;
+
+import org.pentaho.platform.api.engine.IPentahoAclEntry;
+import org.pentaho.platform.api.engine.IPermissionMask;
+import org.pentaho.platform.api.engine.IPermissionRecipient;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.engine.security.SimplePermissionMask;
+import org.pentaho.platform.engine.security.SimpleRole;
+import org.pentaho.platform.engine.security.SimpleUser;
+import org.pentaho.platform.engine.security.SpringSecurityPermissionMgr;
+import org.pentaho.platform.engine.security.acls.voter.PentahoUserOverridesVoter;
+import org.pentaho.platform.repository.solution.dbbased.RepositoryFile;
+import org.pentaho.test.platform.engine.core.BaseTest;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+@SuppressWarnings( "nls" )
+public class TestPentahoUserOverridesVoterTest extends BaseTest {
+
+  private static final String SOLUTION_PATH = "test-src/solution";
+  private static final String ALT_SOLUTION_PATH = "test-src/solution";
+  private static final String PENTAHO_XML_PATH = "/system/pentaho.xml";
+
+  @Override
+  public String getSolutionPath() {
+    File file = new File( SOLUTION_PATH + PENTAHO_XML_PATH );
+    if ( file.exists() ) {
+      return SOLUTION_PATH;
+    } else {
+      return ALT_SOLUTION_PATH;
+    }
+
+  }
+
+  public void testVoter() throws Exception {
+    SecurityHelper.getInstance().runAsUser( "suzy", new Callable<Void>() {
+
+      @Override
+      public Void call() throws Exception {
+        RepositoryFile testFile = new RepositoryFile( "Test Folder", null, null ); //$NON-NLS-1$
+        Map<IPermissionRecipient, IPermissionMask> perms = new LinkedHashMap<IPermissionRecipient, IPermissionMask>();
+        perms.put( new SimpleUser( "suzy" ), new SimplePermissionMask( IPentahoAclEntry.PERM_NOTHING ) );
+        perms.put( new SimpleRole( "ROLE_POWER_USER" ), new SimplePermissionMask(
+          IPentahoAclEntry.PERM_FULL_CONTROL ) );
+        SpringSecurityPermissionMgr.instance().getPermissions( testFile );
+
+        // Now, the stage is set. We should be able to double-check that suzy
+        // has no access to the testFile.
+        PentahoUserOverridesVoter voter = new PentahoUserOverridesVoter();
+        assertNotNull( voter );
+        assertFalse( voter.hasAccess( PentahoSessionHolder.getSession(), testFile, IPentahoAclEntry.PERM_EXECUTE ) );
+        return null;
+      }
+
+    } );
+
+  }
+}


### PR DESCRIPTION
	- Row security metadata still relies on spring security's AclEntry objects; these stopped existing ever since spring 3
	- Brought the interfaces over from spring-security-2.0.8 and made them Pentaho interfaces
	- IAclVoter.hasAccess now once again relies on a PentahoBasicAclVoter
        - [TEST] reinstated ACL unit tests