### PR TITLE
[SP-2953] - Backport of PPP-3560 - Use of vulnerable component taglibs:standard:1.0.6 CVE-2015-0254 (6.1 Suite)

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/tld/c.tld
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/tld/c.tld
@@ -81,7 +81,7 @@
 
   <tag>
     <name>out</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.OutTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.OutTag</tag-class>
     <body-content>JSP</body-content>
     <description>
 	Like &lt;%= ... &gt;, but for expressions.
@@ -105,7 +105,7 @@
 
   <tag>
     <name>if</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.IfTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.IfTag</tag-class>
     <body-content>JSP</body-content>
     <description>
         Simple conditional tag, which evalutes its body if the
@@ -131,7 +131,7 @@
 
   <tag>
     <name>import</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.ImportTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.ImportTag</tag-class>
     <tei-class>org.apache.taglibs.standard.tei.ImportTEI</tei-class>
     <body-content>JSP</body-content>
     <description>
@@ -172,7 +172,7 @@
 
   <tag>
     <name>forEach</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.ForEachTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.ForEachTag</tag-class>
     <tei-class>org.apache.taglibs.standard.tei.ForEachTEI</tei-class>
     <body-content>JSP</body-content>
     <description>
@@ -214,7 +214,7 @@
 
   <tag>
     <name>forTokens</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.ForTokensTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.ForTokensTag</tag-class>
     <body-content>JSP</body-content>
     <description>
 	Iterates over tokens, separated by the supplied delimeters
@@ -269,7 +269,7 @@
 
   <tag>
     <name>param</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.ParamTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.ParamTag</tag-class>
     <body-content>JSP</body-content>
     <description>
 	Adds a parameter to a containing 'import' tag's URL.
@@ -288,7 +288,7 @@
 
   <tag>
     <name>redirect</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.RedirectTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.RedirectTag</tag-class>
     <body-content>JSP</body-content>
     <description>
 	Redirects to a new URL.
@@ -336,7 +336,7 @@
 
   <tag>
     <name>set</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.SetTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.SetTag</tag-class>
     <body-content>JSP</body-content>
     <description>
 	Sets the result of an expression evaluation in a 'scope'
@@ -370,7 +370,7 @@
 
   <tag>
     <name>url</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.UrlTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.UrlTag</tag-class>
     <body-content>JSP</body-content>
     <description>
 	Prints or exposes a URL with optional query parameters
@@ -400,7 +400,7 @@
 
   <tag>
     <name>when</name>
-    <tag-class>org.apache.taglibs.standard.tag.el.core.WhenTag</tag-class>
+    <tag-class>org.apache.taglibs.standard.tag.rt.core.WhenTag</tag-class>
     <body-content>JSP</body-content>
     <description>
         Subtag of &lt;choose&gt; that includes its body if its

--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -144,7 +144,7 @@
     <dependency org="com.sun" name="jai_codec" rev="1.1.2"/>
     <dependency org="com.sun" name="jai_core" rev="1.1.2"/>
     <dependency org="javax.faces" name="jsf-api" rev="1.1"/>
-    <dependency org="jakarta-taglibs" name="standard" rev="1.0.6"/>
+    <dependency org="org.apache.taglibs" name="taglibs-standard-impl" rev="1.2.5" transitive="false"/>
 
     <dependency org="javax.servlet" name="jstl" rev="1.0.5"/>
     <dependency org="javatar" name="javatar" rev="2.5" transitive="false"/>


### PR DESCRIPTION
@mbatchelor, @pamval, @CodeOnCoffee, here is backport of https://github.com/pentaho/pentaho-platform/pull/3112/files to 6.1. Thanks.   