### PR TITLE
[BACKLOG-12001] - Removed elasticsearch as a dependency. 

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -65,9 +65,6 @@
     <!--  The PDI Excel output step depends on this  -->
     <dependency org="org.apache.xmlbeans" name="xmlbeans" rev="2.6.0" transitive="false"/>
 
-    <!--  PDI Elastic search bulk loader -->
-    <dependency org="elasticsearch" name="elasticsearch" rev="0.16.3" transitive="false"/>
-
     <!--  this is a runtime dependency, used sometimes in JavascriptRules (CDF) as well as plugins (XDASH) -->
     <dependency org="org.json" name="json" rev="${dependency.json.revision}" transitive="false" changing="true"/>
 


### PR DESCRIPTION
It was there only to support the Kettle elasticsearch loader which is a separate plugin and has its own version, and the version specific had a known security vulnerability. Since it was bad and not needed, it was removed