### PR TITLE
[BACKLOG-12100]-Bring back refresh data cache endpoint

### DIFF
--- a/user-console/source/org/pentaho/mantle/client/commands/PurgeReportingDataCacheCommand.java
+++ b/user-console/source/org/pentaho/mantle/client/commands/PurgeReportingDataCacheCommand.java
@@ -35,9 +35,9 @@ public class PurgeReportingDataCacheCommand extends AbstractCommand {
   }
 
   protected void performOperation() {
-    final String url = GWT.getHostPageBaseURL() + "plugin/reporting/api/cache/clear"; //$NON-NLS-1$
-    RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.POST, url );
-    requestBuilder.setHeader( "accept", "text/text" );
+    final String url = GWT.getHostPageBaseURL() + "api/system/refresh/reportingDataCache"; //$NON-NLS-1$
+    RequestBuilder requestBuilder = new RequestBuilder( RequestBuilder.GET, url );
+    requestBuilder.setHeader( "accept", "text/plain" );
     requestBuilder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
     try {
       requestBuilder.sendRequest( null, new RequestCallback() {


### PR DESCRIPTION
Our main fix for the cache refresh works like a charm, but we forgot that the old refresh functionality now also uses the plugin endpoint.
So both refresh button and "Tools" work the same way - clean cache for one session :(
The fix is easy - bring back the old url for "Tools".

🙏 

@tmorgner @kcruzada @CodeOnCoffee @pamval 