### PR TITLE
[BACKLOG-12212] - When runing in background or scheduling .prpti and …

### DIFF
--- a/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -89,6 +89,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.channels.IllegalSelectorException;
@@ -2235,7 +2236,8 @@ public class FileResource extends AbstractJaxRSResource {
 
   protected Document parseText( String text ) throws DocumentException {
     SAXReader reader = XMLParserFactoryProducer.getSAXReader( null );
-    return reader.read( text );
+    StringReader stringReader = new StringReader( text );
+    return reader.read( stringReader );
   }
 
   protected Messages getMessagesInstance() {

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
@@ -1480,4 +1480,13 @@ public class FileResourceTest {
     final Response response = fileResource.buildOkResponse( mock );
     final MultivaluedMap<String, Object> metadata = response.getMetadata();
   }
+
+  @Test
+  public void testGenerateDocumentFromXMLString() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<element>" + "true" + "</element>";
+    Document document = fileResource.parseText( xml );
+    assertNotNull( document );
+    assertTrue( document.getRootElement().getStringValue().equals( "true" ) );
+  }
+
 }


### PR DESCRIPTION
[BACKLOG-12212] - When runing in background or scheduling .prpti and prpt reports, output type is locked.