### PR TITLE
[BISERVER-13375] Fixed export of additional parameters

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalog.java
+++ b/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalog.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.action.mondrian.catalog;
@@ -82,6 +82,10 @@ public class MondrianCatalog implements Serializable {
 
   public MondrianCatalogComplementInfo getMondrianCatalogComplementInfo() {
     return mondrianCatalogComplementInfo;
+  }
+
+  public Util.PropertyList getConnectProperties() {
+    return Util.parseConnectString( dataSourceInfo );
   }
 
   @Override

--- a/extensions/src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java
@@ -75,6 +75,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -261,6 +262,11 @@ public class PentahoPlatformExporter extends ZipExportProcessor {
           mondrianParameters.put( "Provider", "mondrian" );
           mondrianParameters.put( "DataSource", catalog.getJndi() );
           mondrianParameters.put( "EnableXmla", Boolean.toString( xmlaEnabled ) );
+
+          StreamSupport.stream( catalog.getConnectProperties().spliterator(), false )
+            .filter( p -> !mondrianParameters.containsKey( p.getKey() ) )
+            .forEach( p -> mondrianParameters.put( p.getKey(), p.getValue() ) );
+
           mondrian.setParameters( mondrianParameters );
         }
 

--- a/extensions/test-src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogTest.java
@@ -1,0 +1,48 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.plugin.action.mondrian.catalog;
+
+import mondrian.olap.Util;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Vadim_Polynkov
+ */
+public class MondrianCatalogTest {
+
+  MondrianCatalog catalog;
+
+  @Test
+  public void testGetConnectProperties() {
+    final String parameterName = "AdditionalParameter";
+    final String parameterValue = "\"TestValue\"";
+    final String expectedParameterValue = "TestValue";
+
+    final String dataSourceInfo = parameterName + "=" + parameterValue;
+    catalog = new MondrianCatalog( "", dataSourceInfo, "", null );
+
+    Util.PropertyList connectProperties = catalog.getConnectProperties();
+    assertNotNull( connectProperties );
+    assertNotNull( connectProperties.get( parameterName ) );
+    assertEquals( connectProperties.get( parameterName ), expectedParameterValue );
+  }
+
+}


### PR DESCRIPTION
@rmansoor , @pamval , @rfellows please review.
BISERVER-13375 (http://jira.pentaho.com/browse/BISERVER-13375)

Ideas of this are: 

1. to get additional parameters from **dataSourceInfo**, and to put in **mondrianParameters** 
(https://github.com/VadimPolynkov/pentaho-platform/blob/ff17302cffffcabd81c9e8ee2ebc39e241659803/extensions/src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java#L266-L268)

2. to move getting of parameters in separate method of **MondrianCatalog** (https://github.com/VadimPolynkov/pentaho-platform/blob/ff17302cffffcabd81c9e8ee2ebc39e241659803/extensions/src/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalog.java#L87-L89)

3. to write unit test where it is checked that parameters were added to exportManifest.
Export execution for specific dataSourceInfo was moved to separate method in test class for reuse.
(https://github.com/VadimPolynkov/pentaho-platform/blob/de1b4e7d27ededbc31700adf13faf8c568bedf34/extensions/test-src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporterTest.java#L328)

I have found that dataSourceInfo contains other parameter "overwrite".  This parameter got on exportManifest.xml after fix. 
What about it?
...
<ExportManifestMondrian file="_datasources/analysis/SampleData/schema.xml">
        <catalogName>SampleData</catalogName>
        <xmlaEnabled>false</xmlaEnabled>
        <parameters>
            <entries>
                <entry key="EnableXmla" value="false"/>
                <entry key="DynamicSchemaProcessor" value="Test"/>
                **<entry key="overwrite" value="true"/>**
                <entry key="Provider" value="mondrian"/>
                <entry key="DataSource" value="SampleData"/>
            </entries>
        </parameters>
    </ExportManifestMondrian>
...