### PR TITLE
[SP-3056][PDI-15689] Log level set for schedules do not preserve after doing a RESTORE using the import-export utility

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/exporter/ScheduleExportUtil.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/exporter/ScheduleExportUtil.java
@@ -35,6 +35,8 @@ import org.pentaho.platform.web.http.api.resources.RepositoryFileStreamProvider;
 
 public class ScheduleExportUtil {
 
+  public static final  String RUN_PARAMETERS_KEY = "parameters";
+
   public ScheduleExportUtil() {
     // to get 100% coverage
   }
@@ -95,24 +97,28 @@ public class ScheduleExportUtil {
 
     for ( String key : jobParams.keySet() ) {
       Serializable serializable = jobParams.get( key );
-      JobScheduleParam param = null;
-      if ( serializable instanceof String ) {
-        String value = (String) serializable;
-        if ( QuartzScheduler.RESERVEDMAPKEY_ACTIONCLASS.equals( key ) ) {
-          schedule.setActionClass( value );
-        } else if ( IBlockoutManager.TIME_ZONE_PARAM.equals( key ) ) {
-          schedule.setTimeZone( value );
+      if ( RUN_PARAMETERS_KEY.equals( key ) ) {
+        schedule.getPdiParameters().putAll( (Map<String, String>) serializable );
+      } else {
+        JobScheduleParam param = null;
+        if ( serializable instanceof String ) {
+          String value = (String) serializable;
+          if ( QuartzScheduler.RESERVEDMAPKEY_ACTIONCLASS.equals( key ) ) {
+            schedule.setActionClass( value );
+          } else if ( IBlockoutManager.TIME_ZONE_PARAM.equals( key ) ) {
+            schedule.setTimeZone( value );
+          }
+          param = new JobScheduleParam( key, (String) serializable );
+        } else if ( serializable instanceof Number ) {
+          param = new JobScheduleParam( key, (Number) serializable );
+        } else if ( serializable instanceof Date ) {
+          param = new JobScheduleParam( key, (Date) serializable );
+        } else if ( serializable instanceof Boolean ) {
+          param = new JobScheduleParam( key, (Boolean) serializable );
         }
-        param = new JobScheduleParam( key, (String) serializable );
-      } else if ( serializable instanceof Number ) {
-        param = new JobScheduleParam( key, (Number) serializable );
-      } else if ( serializable instanceof Date ) {
-        param = new JobScheduleParam( key, (Date) serializable );
-      } else if ( serializable instanceof Boolean ) {
-        param = new JobScheduleParam( key, (Boolean) serializable );
-      }
-      if ( param != null ) {
-        schedule.getJobParameters().add( param );
+        if ( param != null ) {
+          schedule.getJobParameters().add( param );
+        }
       }
     }
 

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/JobScheduleRequest.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/JobScheduleRequest.java
@@ -19,6 +19,8 @@ package org.pentaho.platform.web.http.api.resources;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -91,6 +93,8 @@ public class JobScheduleRequest implements Serializable {
 
   ArrayList<JobScheduleParam> jobParameters = new ArrayList<JobScheduleParam>();
 
+  Map<String, String> pdiParameters = new HashMap<>();
+
   long duration;
 
   String timeZone;
@@ -158,6 +162,14 @@ public class JobScheduleRequest implements Serializable {
         this.jobParameters.addAll( jobParameters );
       }
     }
+  }
+
+  public Map<String, String> getPdiParameters() {
+    return pdiParameters;
+  }
+
+  public void setPdiParameters( Map<String, String> pdiParameters ) {
+    this.pdiParameters = pdiParameters;
   }
 
   public String getJobName() {

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/services/SchedulerService.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/services/SchedulerService.java
@@ -62,7 +62,6 @@ import org.pentaho.platform.web.http.api.resources.SchedulerOutputPathResolver;
 import org.pentaho.platform.web.http.api.resources.SchedulerResourceUtil;
 import org.pentaho.platform.web.http.api.resources.SessionResource;
 import org.pentaho.platform.web.http.api.resources.proxies.BlockStatusProxy;
-import org.pentaho.platform.web.http.api.resources.utils.SystemUtils;
 
 public class SchedulerService {
 
@@ -135,7 +134,7 @@ public class SchedulerService {
     }
 
     if ( isPdiFile( file ) ) {
-      parameterMap = handlePDIScheduling( file, parameterMap );
+      parameterMap = handlePDIScheduling( file, parameterMap, scheduleRequest.getPdiParameters() );
     }
 
     parameterMap.put( LocaleHelper.USER_LOCALE_PARAM, LocaleHelper.getLocale() );
@@ -481,8 +480,8 @@ public class SchedulerService {
   }
 
   protected HashMap<String, Serializable> handlePDIScheduling( RepositoryFile file,
-                                                               HashMap<String, Serializable> parameterMap ) {
-    return SchedulerResourceUtil.handlePDIScheduling( file, parameterMap );
+                                                               HashMap<String, Serializable> parameterMap, Map<String, String> pdiParameters ) {
+    return SchedulerResourceUtil.handlePDIScheduling( file, parameterMap, pdiParameters );
   }
 
   public boolean getAutoCreateUniqueFilename( final JobScheduleRequest scheduleRequest ) {

--- a/extensions/test-src/org/pentaho/platform/plugin/services/exporter/ScheduleExportUtilTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/exporter/ScheduleExportUtilTest.java
@@ -1,3 +1,20 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
 package org.pentaho.platform.plugin.services.exporter;
 
 import org.junit.Before;
@@ -76,6 +93,11 @@ public class ScheduleExportUtilTest {
     Map<String, Serializable> params = new HashMap<>();
     params.put( "directory", "/home/admin" );
     params.put( "transformation", "myTransform" );
+
+    HashMap<String, String> pdiParams = new HashMap<>();
+    pdiParams.put( "pdiParam", "pdiParamValue" );
+    params.put( ScheduleExportUtil.RUN_PARAMETERS_KEY, pdiParams );
+
     when( job.getJobParams() ).thenReturn( params );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
@@ -85,6 +107,7 @@ public class ScheduleExportUtilTest {
     assertEquals( trigger, jobScheduleRequest.getSimpleJobTrigger() );
     assertEquals( "/home/admin/myTransform.ktr", jobScheduleRequest.getInputFile() );
     assertEquals( "/home/admin/myTransform*", jobScheduleRequest.getOutputFile() );
+    assertEquals( "pdiParamValue", jobScheduleRequest.getPdiParameters().get( "pdiParam" ) );
   }
 
   @Test
@@ -248,9 +271,9 @@ public class ScheduleExportUtilTest {
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
     for ( JobScheduleParam jobScheduleParam : jobScheduleRequest.getJobParameters() ) {
-      assertTrue( jobScheduleParam.getValue().equals( l ) ||
-        jobScheduleParam.getValue().equals( d ) ||
-        jobScheduleParam.getValue().equals( b ) );
+      assertTrue( jobScheduleParam.getValue().equals( l )
+              || jobScheduleParam.getValue().equals( d )
+              || jobScheduleParam.getValue().equals( b ) );
     }
   }
 

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtilTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtilTest.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  * ******************************************************************************
  *
@@ -33,6 +33,7 @@ import org.pentaho.platform.api.scheduler2.CronJobTrigger;
 import org.pentaho.platform.api.scheduler2.IJobTrigger;
 import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
 import org.pentaho.platform.api.scheduler2.recur.ITimeRecurrence;
+import org.pentaho.platform.plugin.services.exporter.ScheduleExportUtil;
 import org.pentaho.platform.scheduler2.quartz.QuartzScheduler;
 import org.pentaho.platform.scheduler2.recur.QualifiedDayOfWeek;
 import org.pentaho.platform.scheduler2.recur.RecurrenceList;
@@ -311,12 +312,14 @@ public class SchedulerResourceUtilTest {
     params.put( "test", "value" );
     when( repo.getName() ).thenReturn( "transform.ktr" );
     when( repo.getPath() ).thenReturn( "/home/me/transform.ktr" );
+    HashMap<String, String> pdiParams = new HashMap<>();
+    pdiParams.put( "pdiParam", "pdiParamValue" );
 
-    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params );
-    assertEquals( params.size() + 2, result.size() );
+    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params, pdiParams );
+    assertEquals( params.size() + 3, result.size() );
     assertEquals( "transform", result.get( "transformation" ) );
     assertEquals( "home/me", result.get( "directory" ) );
-    assertEquals( "value", ( (HashMap) result.get( "parameters" ) ).get( "test" ) );
+    assertEquals( "pdiParamValue", ( (HashMap) result.get( ScheduleExportUtil.RUN_PARAMETERS_KEY ) ).get( "pdiParam" ) );
   }
 
   @Test
@@ -325,12 +328,14 @@ public class SchedulerResourceUtilTest {
     params.put( "test", "value" );
     when( repo.getName() ).thenReturn( "job.kjb" );
     when( repo.getPath() ).thenReturn( "/home/me/job.kjb" );
+    HashMap<String, String> pdiParams = new HashMap<>();
+    pdiParams.put( "pdiParam", "pdiParamValue" );
 
-    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params );
-    assertEquals( params.size() + 2, result.size() );
+    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params, pdiParams );
+    assertEquals( params.size() + 3, result.size() );
     assertEquals( "job", result.get( "job" ) );
     assertEquals( "home/me", result.get( "directory" ) );
-    assertEquals( "value", ( (HashMap) result.get( "parameters" ) ).get( "test" ) );
+    assertEquals( "pdiParamValue", ( (HashMap) result.get( ScheduleExportUtil.RUN_PARAMETERS_KEY ) ).get( "pdiParam" ) );
   }
 
   @Test
@@ -338,8 +343,10 @@ public class SchedulerResourceUtilTest {
     HashMap<String, Serializable> params = new HashMap<>();
     params.put( "test", "value" );
     when( repo.getName() ).thenReturn( "readme.txt" );
+    HashMap<String, String> pdiParams = new HashMap<>();
+    pdiParams.put( "pdiParam", "pdiParamValue" );
 
-    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params );
-    assertEquals( params, result );
+    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params, pdiParams );
+    assertEquals( params.size() + pdiParams.size(), result.size() );
   }
 }

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
@@ -155,7 +155,7 @@ public class SchedulerServiceTest {
     verify( scheduleRequest, times( 5 ) ).getActionClass();
     verify( schedulerService.repository, times( 2 ) ).getFileMetadata( anyString() );
     verify( schedulerService, times( 3 ) ).isPdiFile( any( RepositoryFile.class ) );
-    verify( schedulerService, times( 3 ) ).handlePDIScheduling( any( RepositoryFile.class ), any( HashMap.class ) );
+    verify( schedulerService, times( 3 ) ).handlePDIScheduling( any( RepositoryFile.class ), any( HashMap.class ), any( HashMap.class ) );
     verify( schedulerService, times( 2 ) ).getSchedulerOutputPathResolver( any( JobScheduleRequest.class ) );
     verify( schedulerService, times( 2 ) ).getExtension( anyString() );
     verify( scheduleRequest, times( 5 ) ).getActionClass();
@@ -259,7 +259,7 @@ public class SchedulerServiceTest {
     verify( scheduleRequest, times( 7 ) ).getActionClass();
     verify( schedulerService.repository, times( 1 ) ).getFileMetadata( anyString() );
     verify( schedulerService, times( 1 ) ).isPdiFile( any( RepositoryFile.class ) );
-    verify( schedulerService, times( 1 ) ).handlePDIScheduling( any( RepositoryFile.class ), any( HashMap.class ) );
+    verify( schedulerService, times( 1 ) ).handlePDIScheduling( any( RepositoryFile.class ), any( HashMap.class ), any( HashMap.class ) );
     verify( scheduleRequest, times( 7 ) ).getActionClass();
     verify( schedulerService ).getAction( anyString() );
   }


### PR DESCRIPTION
[SP-3056][PDI-15689] Log level set for schedules do not preserve after doing a RESTORE using the import-export utility

- fixed problem restoring job parameters as pdi parameters
- added backup pdi parameters
- added restoring pdi parameters