### PR TITLE
[SP-3057][PDI-15689] Log level set for schedules do not preserve after doing a RESTORE using the import-export utility

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/exporter/ScheduleExportUtil.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/exporter/ScheduleExportUtil.java
@@ -35,6 +35,8 @@ import org.pentaho.platform.web.http.api.resources.RepositoryFileStreamProvider;
 
 public class ScheduleExportUtil {
 
+  public static final  String RUN_PARAMETERS_KEY = "parameters";
+
   public ScheduleExportUtil() {
     // to get 100% coverage
   }
@@ -95,24 +97,28 @@ public class ScheduleExportUtil {
 
     for ( String key : jobParams.keySet() ) {
       Serializable serializable = jobParams.get( key );
-      JobScheduleParam param = null;
-      if ( serializable instanceof String ) {
-        String value = (String) serializable;
-        if ( QuartzScheduler.RESERVEDMAPKEY_ACTIONCLASS.equals( key ) ) {
-          schedule.setActionClass( value );
-        } else if ( IBlockoutManager.TIME_ZONE_PARAM.equals( key ) ) {
-          schedule.setTimeZone( value );
+      if ( RUN_PARAMETERS_KEY.equals( key ) ) {
+        schedule.getPdiParameters().putAll( (Map<String, String>) serializable );
+      } else {
+        JobScheduleParam param = null;
+        if ( serializable instanceof String ) {
+          String value = (String) serializable;
+          if ( QuartzScheduler.RESERVEDMAPKEY_ACTIONCLASS.equals( key ) ) {
+            schedule.setActionClass( value );
+          } else if ( IBlockoutManager.TIME_ZONE_PARAM.equals( key ) ) {
+            schedule.setTimeZone( value );
+          }
+          param = new JobScheduleParam( key, (String) serializable );
+        } else if ( serializable instanceof Number ) {
+          param = new JobScheduleParam( key, (Number) serializable );
+        } else if ( serializable instanceof Date ) {
+          param = new JobScheduleParam( key, (Date) serializable );
+        } else if ( serializable instanceof Boolean ) {
+          param = new JobScheduleParam( key, (Boolean) serializable );
         }
-        param = new JobScheduleParam( key, (String) serializable );
-      } else if ( serializable instanceof Number ) {
-        param = new JobScheduleParam( key, (Number) serializable );
-      } else if ( serializable instanceof Date ) {
-        param = new JobScheduleParam( key, (Date) serializable );
-      } else if ( serializable instanceof Boolean ) {
-        param = new JobScheduleParam( key, (Boolean) serializable );
-      }
-      if ( param != null ) {
-        schedule.getJobParameters().add( param );
+        if ( param != null ) {
+          schedule.getJobParameters().add( param );
+        }
       }
     }
 

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/JobScheduleRequest.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/JobScheduleRequest.java
@@ -19,6 +19,8 @@ package org.pentaho.platform.web.http.api.resources;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -91,6 +93,8 @@ public class JobScheduleRequest implements Serializable {
 
   ArrayList<JobScheduleParam> jobParameters = new ArrayList<JobScheduleParam>();
 
+  Map<String, String> pdiParameters = new HashMap<>();
+
   long duration;
 
   String timeZone;
@@ -158,6 +162,14 @@ public class JobScheduleRequest implements Serializable {
         this.jobParameters.addAll( jobParameters );
       }
     }
+  }
+
+  public Map<String, String> getPdiParameters() {
+    return pdiParameters;
+  }
+
+  public void setPdiParameters( Map<String, String> pdiParameters ) {
+    this.pdiParameters = pdiParameters;
   }
 
   public String getJobName() {

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/services/SchedulerService.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/services/SchedulerService.java
@@ -135,7 +135,7 @@ public class SchedulerService {
     }
 
     if ( isPdiFile( file ) ) {
-      parameterMap = handlePDIScheduling( file, parameterMap );
+      parameterMap = handlePDIScheduling( file, parameterMap, scheduleRequest.getPdiParameters() );
     }
 
     parameterMap.put( LocaleHelper.USER_LOCALE_PARAM, LocaleHelper.getLocale() );
@@ -482,8 +482,8 @@ public class SchedulerService {
   }
 
   protected HashMap<String, Serializable> handlePDIScheduling( RepositoryFile file,
-                                                               HashMap<String, Serializable> parameterMap ) {
-    return SchedulerResourceUtil.handlePDIScheduling( file, parameterMap );
+                                                               HashMap<String, Serializable> parameterMap, Map<String, String> pdiParameters ) {
+    return SchedulerResourceUtil.handlePDIScheduling( file, parameterMap, pdiParameters );
   }
 
   public boolean getAutoCreateUniqueFilename( final JobScheduleRequest scheduleRequest ) {

--- a/extensions/test-src/org/pentaho/platform/plugin/services/exporter/ScheduleExportUtilTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/exporter/ScheduleExportUtilTest.java
@@ -1,7 +1,26 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
 package org.pentaho.platform.plugin.services.exporter;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.pentaho.platform.api.scheduler2.ComplexJobTrigger;
 import org.pentaho.platform.api.scheduler2.CronJobTrigger;
 import org.pentaho.platform.api.scheduler2.IBlockoutManager;
@@ -17,10 +36,6 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ScheduleExportUtilTest {
 
@@ -38,10 +53,10 @@ public class ScheduleExportUtilTest {
   public void testCreateJobScheduleRequest_unknownTrigger() throws Exception {
     String jobName = "JOB";
 
-    Job job = mock( Job.class );
-    JobTrigger trigger = mock( JobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    JobTrigger trigger = Mockito.mock( JobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
 
@@ -51,62 +66,68 @@ public class ScheduleExportUtilTest {
   public void testCreateJobScheduleRequest_SimpleJobTrigger() throws Exception {
     String jobName = "JOB";
 
-    Job job = mock( Job.class );
-    SimpleJobTrigger trigger = mock( SimpleJobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    SimpleJobTrigger trigger = Mockito.mock( SimpleJobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
-    when( job.getJobName() ).thenReturn( jobName );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobName() ).thenReturn( jobName );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
 
-    assertNotNull( jobScheduleRequest );
-    assertEquals( jobName, jobScheduleRequest.getJobName() );
-    assertEquals( trigger, jobScheduleRequest.getSimpleJobTrigger() );
+    Assert.assertNotNull( jobScheduleRequest );
+    Assert.assertEquals( jobName, jobScheduleRequest.getJobName() );
+    Assert.assertEquals( trigger, jobScheduleRequest.getSimpleJobTrigger() );
   }
 
   @Test
   public void testCreateJobScheduleRequest_NoStreamProvider() throws Exception {
     String jobName = "JOB";
 
-    Job job = mock( Job.class );
-    SimpleJobTrigger trigger = mock( SimpleJobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    SimpleJobTrigger trigger = Mockito.mock( SimpleJobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
-    when( job.getJobName() ).thenReturn( jobName );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobName() ).thenReturn( jobName );
     Map<String, Serializable> params = new HashMap<>();
     params.put( "directory", "/home/admin" );
     params.put( "transformation", "myTransform" );
-    when( job.getJobParams() ).thenReturn( params );
+
+    HashMap<String, String> pdiParams = new HashMap<>();
+    pdiParams.put( "pdiParam", "pdiParamValue" );
+    params.put( ScheduleExportUtil.RUN_PARAMETERS_KEY, pdiParams );
+
+    Mockito.when( job.getJobParams() ).thenReturn( params );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
 
-    assertNotNull( jobScheduleRequest );
-    assertEquals( jobName, jobScheduleRequest.getJobName() );
-    assertEquals( trigger, jobScheduleRequest.getSimpleJobTrigger() );
-    assertEquals( "/home/admin/myTransform.ktr", jobScheduleRequest.getInputFile() );
-    assertEquals( "/home/admin/myTransform*", jobScheduleRequest.getOutputFile() );
+    Assert.assertNotNull( jobScheduleRequest );
+    Assert.assertEquals( jobName, jobScheduleRequest.getJobName() );
+    Assert.assertEquals( trigger, jobScheduleRequest.getSimpleJobTrigger() );
+    Assert.assertEquals( "/home/admin/myTransform.ktr", jobScheduleRequest.getInputFile() );
+    Assert.assertEquals( "/home/admin/myTransform*", jobScheduleRequest.getOutputFile() );
+    Assert.assertEquals( "pdiParamValue", jobScheduleRequest.getPdiParameters().get( "pdiParam" ) );
   }
 
   @Test
   public void testCreateJobScheduleRequest_StringStreamProvider() throws Exception {
     String jobName = "JOB";
 
-    Job job = mock( Job.class );
-    SimpleJobTrigger trigger = mock( SimpleJobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    SimpleJobTrigger trigger = Mockito.mock( SimpleJobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
-    when( job.getJobName() ).thenReturn( jobName );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobName() ).thenReturn( jobName );
     Map<String, Serializable> params = new HashMap<>();
     params.put( QuartzScheduler.RESERVEDMAPKEY_STREAMPROVIDER, "import file = /home/admin/myJob.kjb:output file=/home/admin/myJob*" );
-    when( job.getJobParams() ).thenReturn( params );
+    Mockito.when( job.getJobParams() ).thenReturn( params );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
 
-    assertNotNull( jobScheduleRequest );
-    assertEquals( jobName, jobScheduleRequest.getJobName() );
-    assertEquals( trigger, jobScheduleRequest.getSimpleJobTrigger() );
-    assertEquals( "/home/admin/myJob.kjb", jobScheduleRequest.getInputFile() );
-    assertEquals( "/home/admin/myJob*", jobScheduleRequest.getOutputFile() );
+    Assert.assertNotNull( jobScheduleRequest );
+    Assert.assertEquals( jobName, jobScheduleRequest.getJobName() );
+    Assert.assertEquals( trigger, jobScheduleRequest.getSimpleJobTrigger() );
+    Assert.assertEquals( "/home/admin/myJob.kjb", jobScheduleRequest.getInputFile() );
+    Assert.assertEquals( "/home/admin/myJob*", jobScheduleRequest.getOutputFile() );
   }
 
   @Test
@@ -114,50 +135,50 @@ public class ScheduleExportUtilTest {
     String jobName = "JOB";
     Date now = new Date();
 
-    Job job = mock( Job.class );
-    ComplexJobTrigger trigger = mock( ComplexJobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    ComplexJobTrigger trigger = Mockito.mock( ComplexJobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
-    when( job.getJobName() ).thenReturn( jobName );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobName() ).thenReturn( jobName );
 
-    when( trigger.getCronString() ).thenReturn( "0 30 13 ? * 2,3,4,5,6 *" );
-    when( trigger.getDuration() ).thenReturn( -1L );
-    when( trigger.getStartTime() ).thenReturn( now );
-    when( trigger.getEndTime() ).thenReturn( now );
-    when( trigger.getUiPassParam() ).thenReturn( "uiPassParm" );
+    Mockito.when( trigger.getCronString() ).thenReturn( "0 30 13 ? * 2,3,4,5,6 *" );
+    Mockito.when( trigger.getDuration() ).thenReturn( -1L );
+    Mockito.when( trigger.getStartTime() ).thenReturn( now );
+    Mockito.when( trigger.getEndTime() ).thenReturn( now );
+    Mockito.when( trigger.getUiPassParam() ).thenReturn( "uiPassParm" );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
 
-    assertNotNull( jobScheduleRequest );
-    assertEquals( jobName, jobScheduleRequest.getJobName() );
+    Assert.assertNotNull( jobScheduleRequest );
+    Assert.assertEquals( jobName, jobScheduleRequest.getJobName() );
 
     // we should be getting back a cron trigger, not a complex trigger.
-    assertNull( jobScheduleRequest.getSimpleJobTrigger() );
-    assertNull( jobScheduleRequest.getComplexJobTrigger() );
-    assertNotNull( jobScheduleRequest.getCronJobTrigger() );
+    Assert.assertNull( jobScheduleRequest.getSimpleJobTrigger() );
+    Assert.assertNull( jobScheduleRequest.getComplexJobTrigger() );
+    Assert.assertNotNull( jobScheduleRequest.getCronJobTrigger() );
 
-    assertEquals( trigger.getCronString(), jobScheduleRequest.getCronJobTrigger().getCronString() );
-    assertEquals( trigger.getDuration(), jobScheduleRequest.getCronJobTrigger().getDuration() );
-    assertEquals( trigger.getEndTime(), jobScheduleRequest.getCronJobTrigger().getEndTime() );
-    assertEquals( trigger.getStartTime(), jobScheduleRequest.getCronJobTrigger().getStartTime() );
-    assertEquals( trigger.getUiPassParam(), jobScheduleRequest.getCronJobTrigger().getUiPassParam() );
+    Assert.assertEquals( trigger.getCronString(), jobScheduleRequest.getCronJobTrigger().getCronString() );
+    Assert.assertEquals( trigger.getDuration(), jobScheduleRequest.getCronJobTrigger().getDuration() );
+    Assert.assertEquals( trigger.getEndTime(), jobScheduleRequest.getCronJobTrigger().getEndTime() );
+    Assert.assertEquals( trigger.getStartTime(), jobScheduleRequest.getCronJobTrigger().getStartTime() );
+    Assert.assertEquals( trigger.getUiPassParam(), jobScheduleRequest.getCronJobTrigger().getUiPassParam() );
   }
 
   @Test
   public void testCreateJobScheduleRequest_CronJobTrigger() throws Exception {
     String jobName = "JOB";
 
-    Job job = mock( Job.class );
-    CronJobTrigger trigger = mock( CronJobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    CronJobTrigger trigger = Mockito.mock( CronJobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
-    when( job.getJobName() ).thenReturn( jobName );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobName() ).thenReturn( jobName );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
 
-    assertNotNull( jobScheduleRequest );
-    assertEquals( jobName, jobScheduleRequest.getJobName() );
-    assertEquals( trigger, jobScheduleRequest.getCronJobTrigger() );
+    Assert.assertNotNull( jobScheduleRequest );
+    Assert.assertEquals( jobName, jobScheduleRequest.getJobName() );
+    Assert.assertEquals( trigger, jobScheduleRequest.getCronJobTrigger() );
   }
 
   @Test
@@ -168,22 +189,22 @@ public class ScheduleExportUtilTest {
 
     Map<String, Serializable> params = new HashMap<>();
 
-    RepositoryFileStreamProvider streamProvider = mock( RepositoryFileStreamProvider.class );
+    RepositoryFileStreamProvider streamProvider = Mockito.mock( RepositoryFileStreamProvider.class );
     params.put( QuartzScheduler.RESERVEDMAPKEY_STREAMPROVIDER, streamProvider );
 
-    Job job = mock( Job.class );
-    CronJobTrigger trigger = mock( CronJobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    CronJobTrigger trigger = Mockito.mock( CronJobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
-    when( job.getJobName() ).thenReturn( jobName );
-    when( job.getJobParams() ).thenReturn( params );
-    when( streamProvider.getInputFilePath() ).thenReturn( inputPath );
-    when( streamProvider.getOutputFilePath() ).thenReturn( outputPath );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobName() ).thenReturn( jobName );
+    Mockito.when( job.getJobParams() ).thenReturn( params );
+    Mockito.when( streamProvider.getInputFilePath() ).thenReturn( inputPath );
+    Mockito.when( streamProvider.getOutputFilePath() ).thenReturn( outputPath );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
-    assertEquals( inputPath, jobScheduleRequest.getInputFile() );
-    assertEquals( outputPath, jobScheduleRequest.getOutputFile() );
-    assertEquals( 0, jobScheduleRequest.getJobParameters().size() );
+    Assert.assertEquals( inputPath, jobScheduleRequest.getInputFile() );
+    Assert.assertEquals( outputPath, jobScheduleRequest.getOutputFile() );
+    Assert.assertEquals( 0, jobScheduleRequest.getJobParameters().size() );
   }
 
   @Test
@@ -194,16 +215,16 @@ public class ScheduleExportUtilTest {
 
     params.put( QuartzScheduler.RESERVEDMAPKEY_ACTIONCLASS, actionClass );
 
-    Job job = mock( Job.class );
-    CronJobTrigger trigger = mock( CronJobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    CronJobTrigger trigger = Mockito.mock( CronJobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
-    when( job.getJobName() ).thenReturn( jobName );
-    when( job.getJobParams() ).thenReturn( params );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobName() ).thenReturn( jobName );
+    Mockito.when( job.getJobParams() ).thenReturn( params );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
-    assertEquals( actionClass, jobScheduleRequest.getActionClass() );
-    assertEquals( actionClass, jobScheduleRequest.getJobParameters().get( 0 ).getValue() );
+    Assert.assertEquals( actionClass, jobScheduleRequest.getActionClass() );
+    Assert.assertEquals( actionClass, jobScheduleRequest.getJobParameters().get( 0 ).getValue() );
   }
 
   @Test
@@ -214,16 +235,16 @@ public class ScheduleExportUtilTest {
 
     params.put( IBlockoutManager.TIME_ZONE_PARAM, timeZone );
 
-    Job job = mock( Job.class );
-    CronJobTrigger trigger = mock( CronJobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    CronJobTrigger trigger = Mockito.mock( CronJobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
-    when( job.getJobName() ).thenReturn( jobName );
-    when( job.getJobParams() ).thenReturn( params );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobName() ).thenReturn( jobName );
+    Mockito.when( job.getJobParams() ).thenReturn( params );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
-    assertEquals( timeZone, jobScheduleRequest.getTimeZone() );
-    assertEquals( timeZone, jobScheduleRequest.getJobParameters().get( 0 ).getValue() );
+    Assert.assertEquals( timeZone, jobScheduleRequest.getTimeZone() );
+    Assert.assertEquals( timeZone, jobScheduleRequest.getJobParameters().get( 0 ).getValue() );
   }
 
   @Test
@@ -239,24 +260,24 @@ public class ScheduleExportUtilTest {
     params.put( "DateValue", d );
     params.put( "BooleanValue", b );
 
-    Job job = mock( Job.class );
-    CronJobTrigger trigger = mock( CronJobTrigger.class );
+    Job job = Mockito.mock( Job.class );
+    CronJobTrigger trigger = Mockito.mock( CronJobTrigger.class );
 
-    when( job.getJobTrigger() ).thenReturn( trigger );
-    when( job.getJobName() ).thenReturn( jobName );
-    when( job.getJobParams() ).thenReturn( params );
+    Mockito.when( job.getJobTrigger() ).thenReturn( trigger );
+    Mockito.when( job.getJobName() ).thenReturn( jobName );
+    Mockito.when( job.getJobParams() ).thenReturn( params );
 
     JobScheduleRequest jobScheduleRequest = ScheduleExportUtil.createJobScheduleRequest( job );
     for ( JobScheduleParam jobScheduleParam : jobScheduleRequest.getJobParameters() ) {
-      assertTrue( jobScheduleParam.getValue().equals( l ) ||
-        jobScheduleParam.getValue().equals( d ) ||
-        jobScheduleParam.getValue().equals( b ) );
+      Assert.assertTrue( jobScheduleParam.getValue().equals( l )
+              || jobScheduleParam.getValue().equals( d )
+              || jobScheduleParam.getValue().equals( b ) );
     }
   }
 
   @Test
   public void testConstructor() throws Exception {
     // only needed to get 100% code coverage
-    assertNotNull( new ScheduleExportUtil() );
+    Assert.assertNotNull( new ScheduleExportUtil() );
   }
 }

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtilTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtilTest.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  * ******************************************************************************
  *
@@ -22,10 +22,13 @@
 package org.pentaho.platform.web.http.api.resources;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.scheduler2.ComplexJobTrigger;
@@ -33,6 +36,7 @@ import org.pentaho.platform.api.scheduler2.CronJobTrigger;
 import org.pentaho.platform.api.scheduler2.IJobTrigger;
 import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
 import org.pentaho.platform.api.scheduler2.recur.ITimeRecurrence;
+import org.pentaho.platform.plugin.services.exporter.ScheduleExportUtil;
 import org.pentaho.platform.scheduler2.quartz.QuartzScheduler;
 import org.pentaho.platform.scheduler2.recur.QualifiedDayOfWeek;
 import org.pentaho.platform.scheduler2.recur.RecurrenceList;
@@ -42,11 +46,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
-
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Created by rfellows on 11/9/15.
@@ -85,90 +84,90 @@ public class SchedulerResourceUtilTest {
   @Test
   public void testConvertScheduleRequestToJobTrigger_SimpleJobTrigger() throws Exception {
     IJobTrigger trigger = SchedulerResourceUtil.convertScheduleRequestToJobTrigger( scheduleRequest, scheduler );
-    assertNotNull( trigger );
-    assertTrue( trigger instanceof SimpleJobTrigger );
-    assertTrue( trigger.getStartTime().getTime() > System.currentTimeMillis() );
+    Assert.assertNotNull( trigger );
+    Assert.assertTrue( trigger instanceof SimpleJobTrigger );
+    Assert.assertTrue( trigger.getStartTime().getTime() > System.currentTimeMillis() );
   }
 
   @Test
   public void testConvertScheduleRequestToJobTrigger_SimpleJobTrigger_basedOnExisting() throws Exception {
-    when( scheduleRequest.getSimpleJobTrigger() ).thenReturn( simple );
+    Mockito.when( scheduleRequest.getSimpleJobTrigger() ).thenReturn( simple );
     IJobTrigger trigger = SchedulerResourceUtil.convertScheduleRequestToJobTrigger( scheduleRequest, scheduler );
-    assertNotNull( trigger );
-    assertEquals( simple, trigger );
-    verify( simple ).setStartTime( any( Date.class ) );
+    Assert.assertNotNull( trigger );
+    Assert.assertEquals( simple, trigger );
+    Mockito.verify( simple ).setStartTime( Matchers.any( Date.class ) );
   }
 
   @Test
   public void testConvertScheduleRequestToJobTrigger_ComplexJobTrigger_daysOfMonth() throws Exception {
     complex.setDaysOfMonth( new int[] { 1, 25 } );
 
-    when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
+    Mockito.when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
     IJobTrigger trigger = SchedulerResourceUtil.convertScheduleRequestToJobTrigger( scheduleRequest, scheduler );
-    assertNotNull( trigger );
-    assertTrue( trigger instanceof ComplexJobTrigger );
+    Assert.assertNotNull( trigger );
+    Assert.assertTrue( trigger instanceof ComplexJobTrigger );
 
     ComplexJobTrigger trig = (ComplexJobTrigger) trigger;
     List<ITimeRecurrence> recurrences = trig.getDayOfMonthRecurrences().getRecurrences();
-    assertEquals( 2, recurrences.size() );
+    Assert.assertEquals( 2, recurrences.size() );
     RecurrenceList rec = (RecurrenceList) recurrences.get( 0 );
-    assertEquals( 1, rec.getValues().get( 0 ).intValue() );
+    Assert.assertEquals( 1, rec.getValues().get( 0 ).intValue() );
     rec = (RecurrenceList) recurrences.get( 1 );
-    assertEquals( 25, rec.getValues().get( 0 ).intValue() );
+    Assert.assertEquals( 25, rec.getValues().get( 0 ).intValue() );
   }
 
   @Test
   public void testConvertScheduleRequestToJobTrigger_ComplexJobTrigger_monthsOfYear() throws Exception {
     complex.setMonthsOfYear( new int[] { 1, 8 } );
 
-    when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
+    Mockito.when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
     IJobTrigger trigger = SchedulerResourceUtil.convertScheduleRequestToJobTrigger( scheduleRequest, scheduler );
-    assertNotNull( trigger );
-    assertTrue( trigger instanceof ComplexJobTrigger );
+    Assert.assertNotNull( trigger );
+    Assert.assertTrue( trigger instanceof ComplexJobTrigger );
 
     ComplexJobTrigger trig = (ComplexJobTrigger) trigger;
     List<ITimeRecurrence> recurrences = trig.getMonthlyRecurrences().getRecurrences();
-    assertEquals( 2, recurrences.size() );
+    Assert.assertEquals( 2, recurrences.size() );
     RecurrenceList rec = (RecurrenceList) recurrences.get( 0 );
-    assertEquals( 2, rec.getValues().get( 0 ).intValue() );
+    Assert.assertEquals( 2, rec.getValues().get( 0 ).intValue() );
     rec = (RecurrenceList) recurrences.get( 1 );
-    assertEquals( 9, rec.getValues().get( 0 ).intValue() );
+    Assert.assertEquals( 9, rec.getValues().get( 0 ).intValue() );
   }
 
   @Test
   public void testConvertScheduleRequestToJobTrigger_ComplexJobTrigger_years() throws Exception {
     complex.setYears( new int[] { 2016, 2020 } );
 
-    when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
+    Mockito.when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
     IJobTrigger trigger = SchedulerResourceUtil.convertScheduleRequestToJobTrigger( scheduleRequest, scheduler );
-    assertNotNull( trigger );
-    assertTrue( trigger instanceof ComplexJobTrigger );
+    Assert.assertNotNull( trigger );
+    Assert.assertTrue( trigger instanceof ComplexJobTrigger );
 
     ComplexJobTrigger trig = (ComplexJobTrigger) trigger;
     List<ITimeRecurrence> recurrences = trig.getYearlyRecurrences().getRecurrences();
-    assertEquals( 2, recurrences.size() );
+    Assert.assertEquals( 2, recurrences.size() );
     RecurrenceList rec = (RecurrenceList) recurrences.get( 0 );
-    assertEquals( 2016, rec.getValues().get( 0 ).intValue() );
+    Assert.assertEquals( 2016, rec.getValues().get( 0 ).intValue() );
     rec = (RecurrenceList) recurrences.get( 1 );
-    assertEquals( 2020, rec.getValues().get( 0 ).intValue() );
+    Assert.assertEquals( 2020, rec.getValues().get( 0 ).intValue() );
   }
 
   @Test
   public void testConvertScheduleRequestToJobTrigger_ComplexJobTrigger_daysOfWeek() throws Exception {
     complex.setDaysOfWeek( new int[] { 1, 5 } );
 
-    when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
+    Mockito.when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
     IJobTrigger trigger = SchedulerResourceUtil.convertScheduleRequestToJobTrigger( scheduleRequest, scheduler );
-    assertNotNull( trigger );
-    assertTrue( trigger instanceof ComplexJobTrigger );
+    Assert.assertNotNull( trigger );
+    Assert.assertTrue( trigger instanceof ComplexJobTrigger );
 
     ComplexJobTrigger trig = (ComplexJobTrigger) trigger;
     List<ITimeRecurrence> recurrences = trig.getDayOfWeekRecurrences().getRecurrences();
-    assertEquals( 2, recurrences.size() );
+    Assert.assertEquals( 2, recurrences.size() );
     RecurrenceList rec = (RecurrenceList) recurrences.get( 0 );
-    assertEquals( 2, rec.getValues().get( 0 ).intValue() );
+    Assert.assertEquals( 2, rec.getValues().get( 0 ).intValue() );
     rec = (RecurrenceList) recurrences.get( 1 );
-    assertEquals( 6, rec.getValues().get( 0 ).intValue() );
+    Assert.assertEquals( 6, rec.getValues().get( 0 ).intValue() );
   }
 
   @Test
@@ -176,30 +175,30 @@ public class SchedulerResourceUtilTest {
     complex.setDaysOfWeek( new int[] { 1, 5 } );
     complex.setWeeksOfMonth( new int[] { 3, 4 } );
 
-    when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
+    Mockito.when( scheduleRequest.getComplexJobTrigger() ).thenReturn( complex );
     IJobTrigger trigger = SchedulerResourceUtil.convertScheduleRequestToJobTrigger( scheduleRequest, scheduler );
-    assertNotNull( trigger );
-    assertTrue( trigger instanceof ComplexJobTrigger );
+    Assert.assertNotNull( trigger );
+    Assert.assertTrue( trigger instanceof ComplexJobTrigger );
 
     ComplexJobTrigger trig = (ComplexJobTrigger) trigger;
     List<ITimeRecurrence> recurrences = trig.getDayOfWeekRecurrences().getRecurrences();
-    assertEquals( 4, recurrences.size() );
+    Assert.assertEquals( 4, recurrences.size() );
 
     QualifiedDayOfWeek rec = (QualifiedDayOfWeek) recurrences.get( 0 );
-    assertEquals( "MON", rec.getDayOfWeek().toString() );
-    assertEquals( "FOURTH", rec.getQualifier().toString() );
+    Assert.assertEquals( "MON", rec.getDayOfWeek().toString() );
+    Assert.assertEquals( "FOURTH", rec.getQualifier().toString() );
 
     rec = (QualifiedDayOfWeek) recurrences.get( 1 );
-    assertEquals( "MON", rec.getDayOfWeek().toString() );
-    assertEquals( "LAST", rec.getQualifier().toString() );
+    Assert.assertEquals( "MON", rec.getDayOfWeek().toString() );
+    Assert.assertEquals( "LAST", rec.getQualifier().toString() );
 
     rec = (QualifiedDayOfWeek) recurrences.get( 2 );
-    assertEquals( "FRI", rec.getDayOfWeek().toString() );
-    assertEquals( "FOURTH", rec.getQualifier().toString() );
+    Assert.assertEquals( "FRI", rec.getDayOfWeek().toString() );
+    Assert.assertEquals( "FOURTH", rec.getQualifier().toString() );
 
     rec = (QualifiedDayOfWeek) recurrences.get( 3 );
-    assertEquals( "FRI", rec.getDayOfWeek().toString() );
-    assertEquals( "LAST", rec.getQualifier().toString() );
+    Assert.assertEquals( "FRI", rec.getDayOfWeek().toString() );
+    Assert.assertEquals( "LAST", rec.getQualifier().toString() );
   }
 
   @Test
@@ -211,35 +210,35 @@ public class SchedulerResourceUtilTest {
     cron.setUiPassParam( "param" );
     cron.setEndTime( now );
 
-    when( scheduleRequest.getCronJobTrigger() ).thenReturn( cron );
+    Mockito.when( scheduleRequest.getCronJobTrigger() ).thenReturn( cron );
 
     IJobTrigger trigger = SchedulerResourceUtil.convertScheduleRequestToJobTrigger( scheduleRequest, scheduler );
-    assertTrue( trigger instanceof ComplexJobTrigger );
+    Assert.assertTrue( trigger instanceof ComplexJobTrigger );
 
     ComplexJobTrigger trig = (ComplexJobTrigger) trigger;
-    assertEquals( now, trig.getStartTime() );
-    assertEquals( now, trig.getEndTime() );
-    assertEquals( 200000, trig.getDuration() );
-    assertEquals( "param", trig.getUiPassParam() );
+    Assert.assertEquals( now, trig.getStartTime() );
+    Assert.assertEquals( now, trig.getEndTime() );
+    Assert.assertEquals( 200000, trig.getDuration() );
+    Assert.assertEquals( "param", trig.getUiPassParam() );
 
     List<ITimeRecurrence> recurrences = trig.getDayOfWeekRecurrences().getRecurrences();
-    assertEquals( 4, recurrences.size() );
+    Assert.assertEquals( 4, recurrences.size() );
 
     QualifiedDayOfWeek rec = (QualifiedDayOfWeek) recurrences.get( 0 );
-    assertEquals( "MON", rec.getDayOfWeek().toString() );
-    assertEquals( "FOURTH", rec.getQualifier().toString() );
+    Assert.assertEquals( "MON", rec.getDayOfWeek().toString() );
+    Assert.assertEquals( "FOURTH", rec.getQualifier().toString() );
 
     rec = (QualifiedDayOfWeek) recurrences.get( 1 );
-    assertEquals( "MON", rec.getDayOfWeek().toString() );
-    assertEquals( "LAST", rec.getQualifier().toString() );
+    Assert.assertEquals( "MON", rec.getDayOfWeek().toString() );
+    Assert.assertEquals( "LAST", rec.getQualifier().toString() );
 
     rec = (QualifiedDayOfWeek) recurrences.get( 2 );
-    assertEquals( "FRI", rec.getDayOfWeek().toString() );
-    assertEquals( "FOURTH", rec.getQualifier().toString() );
+    Assert.assertEquals( "FRI", rec.getDayOfWeek().toString() );
+    Assert.assertEquals( "FOURTH", rec.getQualifier().toString() );
 
     rec = (QualifiedDayOfWeek) recurrences.get( 3 );
-    assertEquals( "FRI", rec.getDayOfWeek().toString() );
-    assertEquals( "LAST", rec.getQualifier().toString() );
+    Assert.assertEquals( "FRI", rec.getDayOfWeek().toString() );
+    Assert.assertEquals( "LAST", rec.getQualifier().toString() );
 
   }
 
@@ -247,99 +246,105 @@ public class SchedulerResourceUtilTest {
   public void testUpdateStartDateForTimeZone_simple() throws Exception {
     SimpleJobTrigger sjt = new SimpleJobTrigger();
     sjt.setStartTime( now );
-    when( scheduleRequest.getSimpleJobTrigger() ).thenReturn( sjt );
-    when( scheduleRequest.getTimeZone() ).thenReturn( "GMT" );
+    Mockito.when( scheduleRequest.getSimpleJobTrigger() ).thenReturn( sjt );
+    Mockito.when( scheduleRequest.getTimeZone() ).thenReturn( "GMT" );
 
     long gmtTime = now.getTime() + TimeZone.getTimeZone( "EST" ).getRawOffset();
 
     SchedulerResourceUtil.updateStartDateForTimeZone( scheduleRequest );
-    assertEquals( gmtTime, scheduleRequest.getSimpleJobTrigger().getStartTime().getTime() );
+    Assert.assertEquals( gmtTime, scheduleRequest.getSimpleJobTrigger().getStartTime().getTime() );
   }
 
   @Test
   public void testUpdateStartDateForTimeZone_complex() throws Exception {
     ComplexJobTriggerProxy t = new ComplexJobTriggerProxy();
     t.setStartTime( now );
-    when( scheduleRequest.getComplexJobTrigger() ).thenReturn( t );
-    when( scheduleRequest.getTimeZone() ).thenReturn( "GMT" );
+    Mockito.when( scheduleRequest.getComplexJobTrigger() ).thenReturn( t );
+    Mockito.when( scheduleRequest.getTimeZone() ).thenReturn( "GMT" );
 
     long gmtTime = now.getTime() + TimeZone.getTimeZone( "EST" ).getRawOffset();
 
     SchedulerResourceUtil.updateStartDateForTimeZone( scheduleRequest );
-    assertEquals( gmtTime, scheduleRequest.getComplexJobTrigger().getStartTime().getTime() );
+    Assert.assertEquals( gmtTime, scheduleRequest.getComplexJobTrigger().getStartTime().getTime() );
   }
 
   @Test
   public void testUpdateStartDateForTimeZone_cron() throws Exception {
     CronJobTrigger t = new CronJobTrigger();
     t.setStartTime( now );
-    when( scheduleRequest.getCronJobTrigger() ).thenReturn( t );
-    when( scheduleRequest.getTimeZone() ).thenReturn( "GMT" );
+    Mockito.when( scheduleRequest.getCronJobTrigger() ).thenReturn( t );
+    Mockito.when( scheduleRequest.getTimeZone() ).thenReturn( "GMT" );
 
     long gmtTime = now.getTime() + TimeZone.getTimeZone( "EST" ).getRawOffset();
 
     SchedulerResourceUtil.updateStartDateForTimeZone( scheduleRequest );
-    assertEquals( gmtTime, scheduleRequest.getCronJobTrigger().getStartTime().getTime() );
+    Assert.assertEquals( gmtTime, scheduleRequest.getCronJobTrigger().getStartTime().getTime() );
   }
 
   @Test
   public void testIsPdiFile_ktr() throws Exception {
-    when( repo.getName() ).thenReturn( "transform.ktr" );
-    assertTrue( SchedulerResourceUtil.isPdiFile( repo ) );
+    Mockito.when( repo.getName() ).thenReturn( "transform.ktr" );
+    Assert.assertTrue( SchedulerResourceUtil.isPdiFile( repo ) );
   }
 
   @Test
   public void testIsPdiFile_kjb() throws Exception {
-    when( repo.getName() ).thenReturn( "job.kjb" );
-    assertTrue( SchedulerResourceUtil.isPdiFile( repo ) );
+    Mockito.when( repo.getName() ).thenReturn( "job.kjb" );
+    Assert.assertTrue( SchedulerResourceUtil.isPdiFile( repo ) );
   }
 
   @Test
   public void testIsPdiFile_txt() throws Exception {
-    when( repo.getName() ).thenReturn( "readme.txt" );
-    assertFalse( SchedulerResourceUtil.isPdiFile( repo ) );
+    Mockito.when( repo.getName() ).thenReturn( "readme.txt" );
+    Assert.assertFalse( SchedulerResourceUtil.isPdiFile( repo ) );
   }
 
   @Test
   public void testIsPdiFile_null() throws Exception {
-    assertFalse( SchedulerResourceUtil.isPdiFile( null ) );
+    Assert.assertFalse( SchedulerResourceUtil.isPdiFile( null ) );
   }
 
   @Test
   public void testHandlePdiScheduling_ktr() throws Exception {
     HashMap<String, Serializable> params = new HashMap<>();
     params.put( "test", "value" );
-    when( repo.getName() ).thenReturn( "transform.ktr" );
-    when( repo.getPath() ).thenReturn( "/home/me/transform.ktr" );
+    Mockito.when( repo.getName() ).thenReturn( "transform.ktr" );
+    Mockito.when( repo.getPath() ).thenReturn( "/home/me/transform.ktr" );
+    HashMap<String, String> pdiParams = new HashMap<>();
+    pdiParams.put( "pdiParam", "pdiParamValue" );
 
-    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params );
-    assertEquals( params.size() + 2, result.size() );
-    assertEquals( "transform", result.get( "transformation" ) );
-    assertEquals( "home/me", result.get( "directory" ) );
-    assertEquals( "value", ( (HashMap) result.get( "parameters" ) ).get( "test" ) );
+    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params, pdiParams );
+    Assert.assertEquals( params.size() + 3, result.size() );
+    Assert.assertEquals( "transform", result.get( "transformation" ) );
+    Assert.assertEquals( "home/me", result.get( "directory" ) );
+    Assert.assertEquals( "pdiParamValue", ( (HashMap) result.get( ScheduleExportUtil.RUN_PARAMETERS_KEY ) ).get( "pdiParam" ) );
   }
 
   @Test
   public void testHandlePdiScheduling_job() throws Exception {
     HashMap<String, Serializable> params = new HashMap<>();
     params.put( "test", "value" );
-    when( repo.getName() ).thenReturn( "job.kjb" );
-    when( repo.getPath() ).thenReturn( "/home/me/job.kjb" );
+    Mockito.when( repo.getName() ).thenReturn( "job.kjb" );
+    Mockito.when( repo.getPath() ).thenReturn( "/home/me/job.kjb" );
+    HashMap<String, String> pdiParams = new HashMap<>();
+    pdiParams.put( "pdiParam", "pdiParamValue" );
 
-    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params );
-    assertEquals( params.size() + 2, result.size() );
-    assertEquals( "job", result.get( "job" ) );
-    assertEquals( "home/me", result.get( "directory" ) );
-    assertEquals( "value", ( (HashMap) result.get( "parameters" ) ).get( "test" ) );
+    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params, pdiParams );
+    Assert.assertEquals( params.size() + 3, result.size() );
+    Assert.assertEquals( "job", result.get( "job" ) );
+    Assert.assertEquals( "home/me", result.get( "directory" ) );
+    Assert.assertEquals( "pdiParamValue", ( (HashMap) result.get( ScheduleExportUtil.RUN_PARAMETERS_KEY ) ).get( "pdiParam" ) );
   }
 
   @Test
   public void testHandlePdiScheduling_notPdiFile() throws Exception {
     HashMap<String, Serializable> params = new HashMap<>();
     params.put( "test", "value" );
-    when( repo.getName() ).thenReturn( "readme.txt" );
+    Mockito.when( repo.getName() ).thenReturn( "readme.txt" );
+    HashMap<String, String> pdiParams = new HashMap<>();
+    pdiParams.put( "pdiParam", "pdiParamValue" );
 
-    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params );
-    assertEquals( params, result );
+    HashMap<String, Serializable> result = SchedulerResourceUtil.handlePDIScheduling( repo, params, pdiParams );
+    Assert.assertEquals( params.size() + pdiParams.size(), result.size() );
   }
 }

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/services/SchedulerServiceTest.java
@@ -154,7 +154,7 @@ public class SchedulerServiceTest extends Assert {
     Mockito.verify( schedulerService.repository, Mockito.times( 2 ) ).getFileMetadata( Mockito.anyString() );
     Mockito.verify( schedulerService, Mockito.times( 3 ) ).isPdiFile( Mockito.any( RepositoryFile.class ) );
     Mockito.verify( schedulerService, Mockito.times( 3 ) ).handlePDIScheduling( Mockito.any( RepositoryFile.class ),
-        Mockito.any( HashMap.class ) );
+        Mockito.any( HashMap.class ), Mockito.any( HashMap.class ) );
     Mockito.verify( schedulerService, Mockito.times( 2 ) ).getSchedulerOutputPathResolver( Mockito.any(
         JobScheduleRequest.class ) );
     Mockito.verify( schedulerService, Mockito.times( 2 ) ).getExtension( Mockito.anyString() );
@@ -260,7 +260,7 @@ public class SchedulerServiceTest extends Assert {
     Mockito.verify( schedulerService.repository, Mockito.times( 1 ) ).getFileMetadata( Mockito.anyString() );
     Mockito.verify( schedulerService, Mockito.times( 1 ) ).isPdiFile( Mockito.any( RepositoryFile.class ) );
     Mockito.verify( schedulerService, Mockito.times( 1 ) ).handlePDIScheduling( Mockito.any( RepositoryFile.class ),
-        Mockito.any( HashMap.class ) );
+        Mockito.any( HashMap.class ), Mockito.any( HashMap.class ) );
     Mockito.verify( scheduleRequest, Mockito.times( 7 ) ).getActionClass();
     Mockito.verify( schedulerService ).getAction( Mockito.anyString() );
   }


### PR DESCRIPTION
[SP-3057][PDI-15689] Log level set for schedules do not preserve after doing a RESTORE using the import-export utility

- fixed problem restoring job parameters as pdi parameters
- added backup pdi parameters
- added restoring pdi parameters