### PR TITLE
[BISERVER-13375] Added parse-safe escaping

### DIFF
--- a/extensions/src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java
@@ -18,6 +18,7 @@
 package org.pentaho.platform.plugin.services.exporter;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.di.core.exception.KettleException;
@@ -260,12 +261,15 @@ public class PentahoPlatformExporter extends ZipExportProcessor {
           mondrian.setFile( path );
           Parameters mondrianParameters = new Parameters();
           mondrianParameters.put( "Provider", "mondrian" );
-          mondrianParameters.put( "DataSource", catalog.getJndi() );
+          //DataSource can be escaped
+          mondrianParameters.put( "DataSource", StringEscapeUtils.unescapeXml( catalog.getJndi() ) );
           mondrianParameters.put( "EnableXmla", Boolean.toString( xmlaEnabled ) );
 
           StreamSupport.stream( catalog.getConnectProperties().spliterator(), false )
             .filter( p -> !mondrianParameters.containsKey( p.getKey() ) )
-            .forEach( p -> mondrianParameters.put( p.getKey(), p.getValue() ) );
+            //if value is escaped it should be unescaped to avoid double escape after export in xml file, because
+            //marshaller executes escaping as well
+            .forEach( p -> mondrianParameters.put( p.getKey(), StringEscapeUtils.unescapeXml( p.getValue() ) ) );
 
           mondrian.setParameters( mondrianParameters );
         }

--- a/extensions/src/org/pentaho/platform/plugin/services/importer/MondrianImportHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/services/importer/MondrianImportHandler.java
@@ -35,6 +35,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import mondrian.util.Pair;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.pentaho.metadata.repository.DomainAlreadyExistsException;
 import org.pentaho.metadata.repository.DomainIdNullException;
 import org.pentaho.metadata.repository.DomainStorageException;
@@ -190,20 +191,29 @@ public class MondrianImportHandler implements IPlatformImportHandler {
     StringBuilder sb = new StringBuilder();
 
     if ( dsName != null ) {
-      sb.append( "DataSource=" + dsName + ";" );
+      sb.append( "DataSource=\"" )
+        .append( StringEscapeUtils.escapeXml( dsName.replaceAll( "&quot;", "\"" ) ) )
+        .append( "\";" );
     }
     if ( !parameters.containsKey( "EnableXmla" ) ) {
-      sb.append( "EnableXmla=" + xmlaEnabled + ";" );
+      sb.append( "EnableXmla=" )
+        .append( xmlaEnabled )
+        .append( ";" );
     }
-    sb.append( "Provider=" + provider );
+    sb.append("Provider=\"")
+      .append( StringEscapeUtils.escapeXml( provider.replaceAll( "&quot;", "\"" ) ) )
+      .append( "\"" );
 
     // Build a list of the remaining properties
     for ( Entry<String, String> parameter : parameters.entrySet() ) {
       if ( !parameter.getKey().equals( DATA_SOURCE ) && !parameter.getKey().equals( PROVIDER ) ) {
+        //value contains custom-escaped quotes.
+        //It needs custom unescape and standard escapeXml for following mondrian parsing
+        String parseSafeValue = StringEscapeUtils.escapeXml( parameter.getValue().replaceAll( "&quot;", "\"" ) );
         sb.append( ";" );
         sb.append( parameter.getKey() );
         sb.append( "=\"" );
-        sb.append( parameter.getValue() );
+        sb.append( parseSafeValue );
         sb.append( "\"" );
       }
     }

--- a/extensions/test-src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporterTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporterTest.java
@@ -313,7 +313,7 @@ public class PentahoPlatformExporterTest {
   @Test
   public void testExportMondrianSchemas_AdditionalParametersSaved() throws Exception {
     final String parameterName = "AdditionalParameter";
-    final String parameterValue = "\"TestValue\"";
+    final String parameterValue = "TestValue";
     final String expectedParameterValue = "TestValue";
     final String dataSourceInfo = "EnableXmla=\"true\";" + parameterName + "=" + parameterValue;
     String catalogName = "test";
@@ -323,6 +323,27 @@ public class PentahoPlatformExporterTest {
     String returnedParameterValue = exportManifest.getMondrianList().get( 0 ).getParameters().get( parameterName );
     assertNotNull( returnedParameterValue );
     assertEquals( returnedParameterValue, expectedParameterValue );
+  }
+
+  @Test
+  public void testPerformExportMondrianSchemas_XmlUnsafeDataSourceInfoSaved() throws IOException {
+
+    final String dataSourceInfo = "DataSource=\"&quot;DS &quot;Test&apos;s&quot; &amp; &lt;Fun&gt;&quot;\";" +
+      "DynamicSchemaProcessor=\"&quot;DSP&apos;s &amp; &quot;Other&quot; &lt;stuff&gt;&quot;\";";
+
+    final String dataSourceExpectedValue = "\"DS \"Test's\" & <Fun>\"";
+    final String dynamicSchemaProcessorExpectedValue = "\"DSP's & \"Other\" <stuff>\"";
+
+    executeExportMondrianSchemasForDataSourceInfo( "", dataSourceInfo );
+
+    String returnedParameterValue = exportManifest.getMondrianList().get( 0 ).getParameters().get( "DataSource" );
+    assertNotNull( returnedParameterValue );
+    assertEquals( returnedParameterValue, dataSourceExpectedValue );
+
+    returnedParameterValue = exportManifest.getMondrianList().get( 0 ).getParameters().get( "DynamicSchemaProcessor" );
+    assertNotNull( returnedParameterValue );
+    assertEquals( returnedParameterValue, dynamicSchemaProcessorExpectedValue );
+
   }
 
   private void executeExportMondrianSchemasForDataSourceInfo( String catalogName, String dataSourceInfo ) throws IOException {

--- a/extensions/test-src/org/pentaho/platform/plugin/services/importer/MondrianImportHandlerTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/importer/MondrianImportHandlerTest.java
@@ -173,4 +173,29 @@ public class MondrianImportHandlerTest {
     assertTrue( mondrianCatalog.getValue().getDataSourceInfo().contains( OTHER_PARAMETR ) );
   }
 
+  @Test
+  public void testCreateCatalogObject_SpecificSymbolsInBundle() throws Exception {
+    //createCatalogObject method has input parameters with custom-escaped only quotes
+    //should unescape it and escape all symbols by standard escapeXml
+
+    IPlatformImportBundle customBundle = mock( IPlatformImportBundle.class );
+    parameters = MondrianImportHandler.PROVIDER + "=provider;" +
+      MondrianImportHandler.DATA_SOURCE + "=\"DS &quot;Test's&quot; & <Fun>\";" +
+      "DynamicSchemaProcessor=\"DSP's & &quot;Other&quot; <stuff>\"";
+
+    String expectedValue = new StringBuilder()
+      .append( "DataSource=\"DS &quot;Test&apos;s&quot; &amp; &lt;Fun&gt;\";" )
+      .append( "EnableXmla=true;" )
+      .append( "Provider=\"provider\";" )
+      .append( "DynamicSchemaProcessor=\"DSP&apos;s &amp; &quot;Other&quot; &lt;stuff&gt;\"" )
+      .toString();
+
+    when( customBundle.getProperty( eq( MondrianImportHandler.ENABLE_XMLA ) ) ).thenReturn( "true" );
+    when( customBundle.getProperty( eq( MondrianImportHandler.DATA_SOURCE ) ) ).thenReturn( "DS &quot;Test's&quot; & <Fun>" );
+    when( customBundle.getProperty( eq( MondrianImportHandler.PARAMETERS ) ) ).thenReturn( parameters );
+    MondrianImportHandler mondrianImportHandler = new MondrianImportHandler( mimeTypes, mondrianImporter );
+    MondrianCatalog catalog = mondrianImportHandler.createCatalogObject( "catalog", true, customBundle );
+
+    assertEquals( catalog.getDataSourceInfo(), expectedValue );
+  }
 }

--- a/extensions/test-src/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifestTest.java
+++ b/extensions/test-src/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifestTest.java
@@ -19,6 +19,9 @@
 package org.pentaho.platform.plugin.services.importexport.exportManifest;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -238,6 +241,117 @@ public class ExportManifestTest extends TestCase {
             false, "lockOwner", "lockMessage", lockDate, "en_US", "title", "description",
             "/original/parent/folder/path", deletedDate, 4096, "creatorId", null );
     return mockRepositoryFile;
+  }
+
+  @Test
+  public void testToXml_XmlUnsafeManifestParameters() {
+    final String keyFirst = "DataSource";
+    final String keySecond = "DynamicSchemaProcessor";
+    final String valueFirst = "\"DS \"Test's\" & <Fun>\"";
+    final String valueSecond = "\"DSP's & \"Other\" <stuff>\"";
+
+    ExportManifestMondrian mondrian = new ExportManifestMondrian();
+    Parameters mondrianParameters = new Parameters();
+
+    mondrianParameters.put( keyFirst , valueFirst );
+    mondrianParameters.put( keySecond , valueSecond );
+    mondrian.setParameters( mondrianParameters );
+    mondrian.setCatalogName( "mondrian" );
+    mondrian.setXmlaEnabled( false );
+
+    exportManifest.addMondrian( mondrian );
+    try ( ByteArrayOutputStream out = new ByteArrayOutputStream() ) {
+      try {
+        exportManifest.toXml( out );
+      } catch ( Exception e ) {
+        fail( "Could not marshal to XML " + e );
+      }
+      try (ByteArrayInputStream inputStream = new ByteArrayInputStream( out.toByteArray() ) ) {
+        ExportManifest ex = null;
+        try {
+          ex = ExportManifest.fromXml( inputStream );
+        } catch ( Exception e ) {
+          fail( "Could not un-marshal from XML " + e );
+        }
+        List<ExportManifestMondrian> catalogs = ex.getMondrianList();
+        assertNotNull( catalogs );
+        assertTrue( !catalogs.isEmpty() );
+
+        ExportManifestMondrian mondrianCatalog = null;
+
+        for ( ExportManifestMondrian catalog : catalogs ) {
+          if ( "mondrian".equals( catalog.getCatalogName() ) ) {
+            mondrianCatalog = catalog;
+            break;
+          }
+        }
+        assertNotNull( mondrianCatalog );
+        Parameters parameters = mondrianCatalog.getParameters();
+        assertNotNull( parameters );
+        assertTrue( !parameters.isEmpty() );
+
+        String parameter = parameters.get( keyFirst );
+        assertNotNull( parameter );
+        assertTrue( valueFirst.equals(parameter) );
+
+        parameter = parameters.get( keySecond );
+        assertNotNull( parameter );
+        assertTrue( valueSecond.equals(parameter) );
+      }
+    } catch ( Exception e ) {
+      fail( e.toString() );
+    }
+  }
+
+  @Test
+  public void testToXml_XmlUnsafeEscaped() {
+    final String keyFirst = "DataSource";
+    final String keySecond = "DynamicSchemaProcessor";
+    final String valueFirst = "\"DS \"Test's\" & <Fun>\"";
+    final String valueSecond = "\"DSP's & \"Other\" <stuff>\"";
+
+    final String expectedValueFirst = "&quot;DS &quot;Test's&quot; &amp; &lt;Fun&gt;&quot;";
+    final String expectedValueSecond = "&quot;DSP's &amp; &quot;Other&quot; &lt;stuff&gt;&quot;";
+
+    ExportManifestMondrian mondrian = new ExportManifestMondrian();
+    Parameters mondrianParameters = new Parameters();
+
+    mondrianParameters.put( keyFirst , valueFirst );
+    mondrianParameters.put( keySecond , valueSecond );
+    mondrian.setParameters( mondrianParameters );
+    mondrian.setCatalogName( "mondrian" );
+    mondrian.setXmlaEnabled( false );
+
+    String lineParamFirst = null;
+    String lineParamSecond = null;
+
+    exportManifest.addMondrian( mondrian );
+
+    try ( ByteArrayOutputStream out = new ByteArrayOutputStream() ) {
+      exportManifest.toXml( out );
+      try (ByteArrayInputStream inputStream = new ByteArrayInputStream( out.toByteArray() );
+           BufferedReader reader = new BufferedReader( new InputStreamReader ( inputStream ) )
+      ) {
+        String line;
+        while ( ( line = reader.readLine() ) != null ) {
+          if ( line.contains( keyFirst ) ) {
+            lineParamFirst = line;
+          }
+          if ( line.contains( keySecond ) ) {
+            lineParamSecond = line;
+          }
+          if ( lineParamFirst != null && lineParamSecond != null) {
+            break;
+          }
+        }
+      }
+    } catch ( Exception e ) {
+      fail( "Could not marshal to XML " + e );
+    }
+    assertNotNull( lineParamFirst );
+    assertTrue( lineParamFirst.contains( "value=\"" + expectedValueFirst + "\"" ) );
+    assertNotNull( lineParamSecond );
+    assertTrue( lineParamSecond.contains( "value=\"" + expectedValueSecond + "\"" ) );
   }
 
   private RepositoryFileAcl createMockRepositoryAcl( Serializable id, String owner, boolean entriesInheriting,


### PR DESCRIPTION
@rmansoor , @pamval , @rfellows please review.

This PR is related to [PR](https://github.com/pentaho/data-access/pull/819) in data-access.
[jira issue](http://jira.pentaho.com/browse/BISERVER-13375), [previous PR](https://github.com/pentaho/pentaho-platform/pull/3270)

This PR contains following changes:

1. ExportManifestTest has tests which check special characters is successfully processed through replacing by XML-escaped substitutes. Marshall and unmarshall methods work correctly. Sequential methods calls (toXml(), fromXml()) return original string. ([link](https://github.com/pentaho/pentaho-platform/compare/master...VadimPolynkov:BISERVER-13375-parameters?expand=1#diff-4144b3cdf3be937fedc42ba05c6dd1afR247)).
In addition, output stream contains XML-escaped characters ([link](https://github.com/pentaho/pentaho-platform/compare/master...VadimPolynkov:BISERVER-13375-parameters?expand=1#diff-4144b3cdf3be937fedc42ba05c6dd1afR307)).

2. PentahoPlatformExporter.exportMondrianSchemas() executes unescapeXml for DataSource and additional parameters ([link](https://github.com/VadimPolynkov/pentaho-platform/blob/19a8c507eea350b768553eb20cdf0273dec2fdb8/extensions/src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java#L265-L272)).
It is necessary because DataSourceInfo can contain escaped values. It avoids double escaping when export to xml is executed.
Marshaller executes escaping as well.

3. PentahoPlatformExporterTest has tests which check exportMondrianSchemas unescapes special characters([link](https://github.com/VadimPolynkov/pentaho-platform/blob/19a8c507eea350b768553eb20cdf0273dec2fdb8/extensions/test-src/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporterTest.java#L329)).

4. MondrianImportHandler.createCatalogObject method executes custom unescape for quotes and standart escapeXml for all specific characters([link](https://github.com/VadimPolynkov/pentaho-platform/blob/19a8c507eea350b768553eb20cdf0273dec2fdb8/extensions/src/org/pentaho/platform/plugin/services/importer/MondrianImportHandler.java#L191-L219)).
It is necessary because values extraction is based on quotes too ([mondrian.olap.Util.parseConnectString](https://github.com/pentaho/mondrian/blob/master/mondrian/src/main/java/mondrian/olap/Util.java#L2827)).
Custom unescape is used for replacing only quotes. Other specific symbols are in original representation.

5. Custom unescape is used in pentaho-platform and data-access plugin for parameters transfer as string ([data-access_1](https://github.com/VadimPolynkov/data-access/blob/3d3da2acb23e053ea2972d4e65ef75e5cb07f8ba/src/org/pentaho/platform/dataaccess/datasource/utils/DataSourceInfoUtil.java#L28-L35), [data-access_2](https://github.com/VadimPolynkov/data-access/blob/3d3da2acb23e053ea2972d4e65ef75e5cb07f8ba/src/org/pentaho/platform/dataaccess/datasource/ui/importing/AnalysisImportDialogModel.java#L124)).

