### PR TITLE
[PPP-3581] CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to P…

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -46,7 +46,7 @@
     <!-- Misc -->
     <dependency org="org.owasp.encoder"  name="encoder"  rev="1.2"   transitive="false"/>
     <dependency org="org.apache.axis" name="axis" rev="1.4" />
-    <dependency org="org.apache.xmlgraphics" name="batik-bridge" rev="1.7" transitive="false"/>
+    <dependency org="org.apache.xmlgraphics" name="batik-bridge" rev="1.8" transitive="false"/>
     <dependency org="bsf" name="bsf" rev="2.4.0" transitive="false" />   <!-- we don't want bsf's commons_logging -->
     <dependency org="org.netbeans" name="mdrjdbc" rev="1.4.2" />
     <dependency org="org.beanshell" name="bsh" rev="1.3.0" />


### PR DESCRIPTION
[PPP-3581] CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes - update assembly