### PR TITLE
[BISERVER-13379] Xaction Output Destination File throws error on PUC …

### DIFF
--- a/scheduler/src/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
+++ b/scheduler/src/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
@@ -284,7 +284,7 @@ public class ActionAdapterQuartzJob implements Job {
             repo.setFileMetadata( sourceFile.getId(), metadata );
           } else {
             String fileName = getFSFileNameSafe( contentItem );
-            log.warn( Messages.getInstance().getString( "XactionUtil.SKIP_REMOVING_OUTPUT_FILE", fileName ) );
+            log.warn( Messages.getInstance().getString( "ActionAdapterQuartzJob.WARN_0001_SKIP_REMOVING_OUTPUT_FILE", fileName ) );
           }
         }
       }


### PR DESCRIPTION
…it fails on / (slash) Separator but writes files folder