### PR TITLE
[BISERVER-13463] - White screen displayed forever when Pentaho accessed with wrong URL having double slash

### DIFF
--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/jsp/PUCLogin.jsp
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/jsp/PUCLogin.jsp
@@ -149,6 +149,12 @@
 </style>
 
 <script language="javascript" type="text/javascript" src="webcontext.js"></script>
+<script type="text/javascript">
+  var targetUrl = window.location.pathname.replace(new RegExp("(/){2,}"), "/");
+  if (history && history.pushState){
+    history.pushState(null, null, targetUrl);
+  }
+</script>
 
 </head>
 

--- a/core/src/org/pentaho/platform/engine/core/system/BasePentahoRequestContext.java
+++ b/core/src/org/pentaho/platform/engine/core/system/BasePentahoRequestContext.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2013 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.engine.core.system;
@@ -29,7 +29,8 @@ public class BasePentahoRequestContext implements IPentahoRequestContext {
   public BasePentahoRequestContext( String contextPath ) {
     super();
     if ( contextPath != null ) {
-      this.contextPath = contextPath + ( contextPath.endsWith( SLASH ) ? EMPTY : SLASH );
+      String draftPath = contextPath + ( contextPath.endsWith( SLASH ) ? EMPTY : SLASH );
+      this.contextPath = draftPath.replaceAll( "(/){2,}", SLASH );
     } else {
       String path = PentahoSystem.getApplicationContext().getFullyQualifiedServerURL();
       this.contextPath = path + ( path != null && path.endsWith( SLASH ) ? EMPTY : SLASH );

--- a/core/test-src/org/pentaho/platform/engine/core/system/BasePentahoRequestContextTest.java
+++ b/core/test-src/org/pentaho/platform/engine/core/system/BasePentahoRequestContextTest.java
@@ -1,0 +1,57 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.core.system;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Created by Yury_Bakhmutski on 12/27/2016.
+ */
+@RunWith( Parameterized.class )
+public class BasePentahoRequestContextTest {
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList( new Object[][]{
+        { "//pentaho/Login", "/pentaho/Login/" },
+        { "/pentaho/Login", "/pentaho/Login/" },
+        { "localhost:8080//pentaho/Login", "localhost:8080/pentaho/Login/" },
+        { "localhost:8080///pentaho/Login", "localhost:8080/pentaho/Login/" }
+    } );
+  }
+
+  @Parameterized.Parameter( value = 0 )
+  public String input;
+
+  @Parameterized.Parameter( value = 1 )
+  public String expected;
+
+  @Test
+  public void basePentahoRequestContextTest() throws Exception {
+    BasePentahoRequestContext basePentahoRequestContext = new BasePentahoRequestContext( input );
+    String actual = basePentahoRequestContext.getContextPath();
+    Assert.assertEquals( expected, actual );
+  }
+}


### PR DESCRIPTION
@pamval, @mbatchelor, @duarteteixeira, here is fix for both server and client sides. Server side fix is done in order to prevent server from being hanged off in case of js will be turned off in browser. Thanks.