### PR TITLE
[SP-3190] Backport of BISERVER-13379 - Xaction Output Destination Fil…

### DIFF
--- a/core/src/org/pentaho/platform/engine/core/output/FileContentItem.java
+++ b/core/src/org/pentaho/platform/engine/core/output/FileContentItem.java
@@ -1,0 +1,38 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.core.output;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+
+public class FileContentItem extends SimpleContentItem {
+
+  private File file;
+
+  public FileContentItem( File file ) throws FileNotFoundException {
+    super( new FileOutputStream( file ) );
+    this.file = file;
+  }
+
+  public File getFile() {
+    return file;
+  }
+
+}

--- a/core/src/org/pentaho/platform/engine/core/output/FileContentItem.java
+++ b/core/src/org/pentaho/platform/engine/core/output/FileContentItem.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.engine.core.output;

--- a/core/test-src/org/pentaho/platform/engine/core/output/FileContentItemTest.java
+++ b/core/test-src/org/pentaho/platform/engine/core/output/FileContentItemTest.java
@@ -1,0 +1,88 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+
+package org.pentaho.platform.engine.core.output;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class FileContentItemTest {
+  static File tempOutFile;
+  FileContentItem fci;
+
+  @BeforeClass
+  public static void beforeClass() throws IOException {
+    tempOutFile = File.createTempFile( "FileContentItemTest", "out" );
+    tempOutFile.delete();
+  }
+
+  @Before
+  public void setup() {
+    Assert.assertFalse( "tempOutFile exists", tempOutFile.exists() );
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if ( fci != null ) {
+      fci.closeOutputStream();
+      fci = null;
+    }
+    tempOutFile.delete();
+  }
+
+  @Test
+  public void testInitProperties() throws IOException {
+    fci = new FileContentItem( tempOutFile );
+    Assert.assertNull( "mimeType", fci.getMimeType() );
+    Assert.assertNull( "dataSource", fci.getDataSource() );
+    Assert.assertNull( "inputStream", fci.getInputStream() );
+    Assert.assertNotNull( "outputStream", fci.getOutputStream( null ) );
+    Assert.assertEquals( "file", tempOutFile, fci.getFile() );
+  }
+
+  @Test
+  public void testInitOutputStream() throws IOException {
+    fci = new FileContentItem( tempOutFile );
+    writeStringToOutputStream( fci.getOutputStream( null ), "asdf" );
+    Assert.assertEquals( "content-after", "asdf", FileUtils.readFileToString( tempOutFile ) );
+  }
+
+  private void writeStringToOutputStream( OutputStream os, String str ) throws IOException {
+    Writer w = null;
+    try {
+      w = new OutputStreamWriter( os );
+      w.write( str );
+    } finally {
+      if ( w != null ) {
+        w.close();
+      }
+    }
+  }
+
+}

--- a/core/test-src/org/pentaho/platform/engine/core/output/FileContentItemTest.java
+++ b/core/test-src/org/pentaho/platform/engine/core/output/FileContentItemTest.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 

--- a/extensions/src/org/pentaho/platform/plugin/outputs/FileOutputHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/outputs/FileOutputHandler.java
@@ -12,20 +12,20 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.outputs;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.repository.IContentItem;
+import org.pentaho.platform.engine.core.output.FileContentItem;
 import org.pentaho.platform.engine.core.output.SimpleContentItem;
 import org.pentaho.platform.engine.services.outputhandler.BaseOutputHandler;
 import org.pentaho.platform.plugin.services.messages.Messages;
@@ -53,8 +53,7 @@ public class FileOutputHandler extends BaseOutputHandler {
       }
     }
     try {
-      FileOutputStream outputStream = new FileOutputStream( file );
-      SimpleContentItem content = new SimpleContentItem( outputStream );
+      SimpleContentItem content = new FileContentItem( file );
       return content;
     } catch ( FileNotFoundException e ) {
       logger.error( Messages.getInstance().getErrorString(

--- a/extensions/src/org/pentaho/platform/plugin/outputs/FileOutputHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/outputs/FileOutputHandler.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.outputs;

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/XactionUtil.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/XactionUtil.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;

--- a/extensions/src/org/pentaho/platform/web/http/messages/messages.properties
+++ b/extensions/src/org/pentaho/platform/web/http/messages/messages.properties
@@ -140,6 +140,8 @@ PluginFileResource.COULD_NOT_READ_FILE=Could not read file {0}
 PluginFileResource.UNDETERMINED_MIME_TYPE=Can't determine mime type for {0}, using *
 XactionUtil.HTML_OUTPUT_NOT_SUPPORTED=Unable to execute xaction as an html output
 XactionUtil.XML_OUTPUT_NOT_SUPPORTED=Unable to execute xaction as an xml output
+XactionUtil.CANNOT_REMOVE_OUTPUT_FILE=Unable to remove XAction output file {0}
+XactionUtil.SKIP_REMOVING_OUTPUT_FILE=File written by XActions must be cleaned up by external means: {0}
 
 SystemResource.GENERAL_ERROR=Error getting system resource
 

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/XActionUtilTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/XActionUtilTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;

--- a/scheduler/src/org/pentaho/platform/scheduler2/messsages/messages.properties
+++ b/scheduler/src/org/pentaho/platform/scheduler2/messsages/messages.properties
@@ -3,6 +3,7 @@ ActionAdapterQuartzJob.ERROR_0001_REQUIRED_PARAM_MISSING=Property "{0}" or "{1}"
 ActionAdapterQuartzJob.ERROR_0002_FAILED_TO_CREATE_ACTION=Failed to create an instance of action "{0}"
 ActionAdapterQuartzJob.ERROR_0003_ACTION_WRONG_TYPE=class {0} must be an instance of "{1}"
 ActionAdapterQuartzJob.ERROR_0004_ACTION_FAILED=Action "{0}" failed to run as a quartz job
+ActionAdapterQuartzJob.WARN_0001_SKIP_REMOVING_OUTPUT_FILE=File written by XActions must be cleaned up by external means: {0}
 
 QuartzJobKey.ERROR_0000=Cannot generate job key, jobName is missing
 QuartzJobKey.ERROR_0001=Cannot generate job key, username is missing

--- a/scheduler/src/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
+++ b/scheduler/src/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.scheduler2.quartz;


### PR DESCRIPTION
…e throws error on PUC it fails on / (slash) Separator but writes files folder (7.0 Suite)

cherry-pick:
        [BISERVER-13379] Xaction Output Destination File throws error on PUC it fails on / (slash) Separator but writes files folder
cherry-pick:
        [BISERVER-13379] Xaction Output Destination File throws error on PUC it fails on / (slash) Separator but writes files folder