### PR TITLE
[SP-3189] Backport of BISERVER-13379 - Xaction Output Destination Fil…

### DIFF
--- a/core/src/org/pentaho/platform/engine/core/output/FileContentItem.java
+++ b/core/src/org/pentaho/platform/engine/core/output/FileContentItem.java
@@ -1,0 +1,38 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.platform.engine.core.output;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+
+public class FileContentItem extends SimpleContentItem {
+
+  private File file;
+
+  public FileContentItem( File file ) throws FileNotFoundException {
+    super( new FileOutputStream( file ) );
+    this.file = file;
+  }
+
+  public File getFile() {
+    return file;
+  }
+
+}

--- a/core/src/org/pentaho/platform/engine/core/output/FileContentItem.java
+++ b/core/src/org/pentaho/platform/engine/core/output/FileContentItem.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.engine.core.output;

--- a/core/test-src/org/pentaho/platform/engine/core/output/FileContentItemTest.java
+++ b/core/test-src/org/pentaho/platform/engine/core/output/FileContentItemTest.java
@@ -1,0 +1,88 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+
+package org.pentaho.platform.engine.core.output;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class FileContentItemTest {
+  static File tempOutFile;
+  FileContentItem fci;
+
+  @BeforeClass
+  public static void beforeClass() throws IOException {
+    tempOutFile = File.createTempFile( "FileContentItemTest", "out" );
+    tempOutFile.delete();
+  }
+
+  @Before
+  public void setup() {
+    Assert.assertFalse( "tempOutFile exists", tempOutFile.exists() );
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if ( fci != null ) {
+      fci.closeOutputStream();
+      fci = null;
+    }
+    tempOutFile.delete();
+  }
+
+  @Test
+  public void testInitProperties() throws IOException {
+    fci = new FileContentItem( tempOutFile );
+    Assert.assertNull( "mimeType", fci.getMimeType() );
+    Assert.assertNull( "dataSource", fci.getDataSource() );
+    Assert.assertNull( "inputStream", fci.getInputStream() );
+    Assert.assertNotNull( "outputStream", fci.getOutputStream( null ) );
+    Assert.assertEquals( "file", tempOutFile, fci.getFile() );
+  }
+
+  @Test
+  public void testInitOutputStream() throws IOException {
+    fci = new FileContentItem( tempOutFile );
+    writeStringToOutputStream( fci.getOutputStream( null ), "asdf" );
+    Assert.assertEquals( "content-after", "asdf", FileUtils.readFileToString( tempOutFile ) );
+  }
+
+  private void writeStringToOutputStream( OutputStream os, String str ) throws IOException {
+    Writer w = null;
+    try {
+      w = new OutputStreamWriter( os );
+      w.write( str );
+    } finally {
+      if ( w != null ) {
+        w.close();
+      }
+    }
+  }
+
+}

--- a/core/test-src/org/pentaho/platform/engine/core/output/FileContentItemTest.java
+++ b/core/test-src/org/pentaho/platform/engine/core/output/FileContentItemTest.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 

--- a/extensions/src/org/pentaho/platform/plugin/outputs/FileOutputHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/outputs/FileOutputHandler.java
@@ -12,20 +12,20 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.outputs;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.repository.IContentItem;
+import org.pentaho.platform.engine.core.output.FileContentItem;
 import org.pentaho.platform.engine.core.output.SimpleContentItem;
 import org.pentaho.platform.engine.services.outputhandler.BaseOutputHandler;
 import org.pentaho.platform.plugin.services.messages.Messages;
@@ -53,8 +53,7 @@ public class FileOutputHandler extends BaseOutputHandler {
       }
     }
     try {
-      FileOutputStream outputStream = new FileOutputStream( file );
-      SimpleContentItem content = new SimpleContentItem( outputStream );
+      SimpleContentItem content = new FileContentItem( file );
       return content;
     } catch ( FileNotFoundException e ) {
       logger.error( Messages.getInstance().getErrorString(

--- a/extensions/src/org/pentaho/platform/plugin/outputs/FileOutputHandler.java
+++ b/extensions/src/org/pentaho/platform/plugin/outputs/FileOutputHandler.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.outputs;

--- a/extensions/src/org/pentaho/platform/web/http/api/resources/XactionUtil.java
+++ b/extensions/src/org/pentaho/platform/web/http/api/resources/XactionUtil.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;

--- a/extensions/src/org/pentaho/platform/web/http/messages/messages.properties
+++ b/extensions/src/org/pentaho/platform/web/http/messages/messages.properties
@@ -140,6 +140,8 @@ PluginFileResource.COULD_NOT_READ_FILE=Could not read file {0}
 PluginFileResource.UNDETERMINED_MIME_TYPE=Can't determine mime type for {0}, using *
 XactionUtil.HTML_OUTPUT_NOT_SUPPORTED=Unable to execute xaction as an html output
 XactionUtil.XML_OUTPUT_NOT_SUPPORTED=Unable to execute xaction as an xml output
+XactionUtil.CANNOT_REMOVE_OUTPUT_FILE=Unable to remove XAction output file {0}
+XactionUtil.SKIP_REMOVING_OUTPUT_FILE=File written by XActions must be cleaned up by external means: {0}
 
 SystemResource.GENERAL_ERROR=Error getting system resource
 

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/XActionUtilTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/XActionUtilTest.java
@@ -17,8 +17,6 @@
 
 package org.pentaho.platform.web.http.api.resources;
 
-import static org.mockito.Mockito.*;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -35,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -87,22 +86,22 @@ public class XActionUtilTest {
   @SuppressWarnings( "unchecked" )
   public void setUp() throws ObjectFactoryException {
     MockitoAnnotations.initMocks( this );
-    Map<String, String[]> map = mock( Map.class );
-    when( httpServletRequest.getParameterMap() ).thenReturn( map );
-    when( httpServletRequest.getParameter( anyString() ) ).thenReturn( null );
+    Map<String, String[]> map = Mockito.mock( Map.class );
+    Mockito.when( httpServletRequest.getParameterMap() ).thenReturn( map );
+    Mockito.when( httpServletRequest.getParameter( Mockito.anyString() ) ).thenReturn( null );
 
-    when( repository.getFile( anyString() ) ).thenReturn( generatedFile );
+    Mockito.when( repository.getFile( Mockito.anyString() ) ).thenReturn( generatedFile );
 
-    List<IContentItem> items = Arrays.asList( (IContentItem) mock( RepositoryFileContentItem.class ) );
-    IRuntimeContext context = mock( IRuntimeContext.class );
-    when( context.getOutputContentItems() ).thenReturn( items );
+    List<IContentItem> items = Arrays.asList( (IContentItem) Mockito.mock( RepositoryFileContentItem.class ) );
+    IRuntimeContext context = Mockito.mock( IRuntimeContext.class );
+    Mockito.when( context.getOutputContentItems() ).thenReturn( items );
 
-    when( engine.execute( anyString(), anyString(), anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyMap(),
-        any( IOutputHandler.class ), any( IActionCompleteListener.class ), any( IPentahoUrlFactory.class ),
-        anyList() ) ).thenReturn( context );
-    pentahoObjectFactoryUnified = mock( IPentahoObjectFactory.class );
-    when( pentahoObjectFactoryUnified.objectDefined( anyString() ) ).thenReturn( true );
-    when( pentahoObjectFactoryUnified.get( this.anyClass(), anyString(), any( IPentahoSession.class ) ) ).thenAnswer( new Answer<Object>() {
+    Mockito.when( engine.execute( Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap(),
+        Mockito.any( IOutputHandler.class ), Mockito.any( IActionCompleteListener.class ), Mockito.any( IPentahoUrlFactory.class ),
+        Mockito.anyList() ) ).thenReturn( context );
+    pentahoObjectFactoryUnified = Mockito.mock( IPentahoObjectFactory.class );
+    Mockito.when( pentahoObjectFactoryUnified.objectDefined( Mockito.anyString() ) ).thenReturn( true );
+    Mockito.when( pentahoObjectFactoryUnified.get( this.anyClass(), Mockito.anyString(), Mockito.any( IPentahoSession.class ) ) ).thenAnswer( new Answer<Object>() {
         @Override
         public Object answer( InvocationOnMock invocation ) throws Throwable {
           if ( IUnifiedRepository.class.toString().equals( invocation.getArguments()[0].toString() ) ) {
@@ -118,8 +117,8 @@ public class XActionUtilTest {
       } );
     PentahoSystem.registerObjectFactory( pentahoObjectFactoryUnified );
 
-    ISystemSettings systemSettingsService = mock( ISystemSettings.class );
-    when( systemSettingsService.getSystemSetting( anyString(), anyString() ) ).thenAnswer( new Answer<String>() {
+    ISystemSettings systemSettingsService = Mockito.mock( ISystemSettings.class );
+    Mockito.when( systemSettingsService.getSystemSetting( Mockito.anyString(), Mockito.anyString() ) ).thenAnswer( new Answer<String>() {
       @Override
       public String answer( InvocationOnMock invocation ) throws Throwable {
         return invocation.getArguments()[0].toString();
@@ -138,43 +137,43 @@ public class XActionUtilTest {
   @Test
   public void executeXActionSequence() throws Exception {
     XactionUtil.execute( MediaType.TEXT_HTML, xactionFile, httpServletRequest, httpServletResponse, userSession, mimeTypeListener );
-    verify( repository, times( 1 ) ).deleteFile( anyString(), anyBoolean(), anyString() );
+    Mockito.verify( repository, Mockito.times( 1 ) ).deleteFile( Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyString() );
   }
 
   @Test
   public void testDeleteContentItem_null() throws Exception {
     XactionUtil.deleteContentItem( null, null ); // No exception
-    XactionUtil.deleteContentItem( null, mock( IUnifiedRepository.class ) ); // No exception
-    verify( repository, times( 0 ) ).deleteFile( anyString(), anyBoolean(), anyString() );
+    XactionUtil.deleteContentItem( null, Mockito.mock( IUnifiedRepository.class ) ); // No exception
+    Mockito.verify( repository, Mockito.times( 0 ) ).deleteFile( Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyString() );
   }
 
   @Test
   public void testDeleteContentItem_simple() throws Exception {
-    final IContentItem contentItem = mock( SimpleContentItem.class );
-    doReturn( mock( OutputStream.class ) ).when( contentItem ).getOutputStream( anyString() );
+    final IContentItem contentItem = Mockito.mock( SimpleContentItem.class );
+    Mockito.doReturn( Mockito.mock( OutputStream.class ) ).when( contentItem ).getOutputStream( Mockito.anyString() );
     try {
       XactionUtil.deleteContentItem( contentItem, null );
     } finally {
       contentItem.getOutputStream( null ).close();
     }
-    verify( repository, times( 0 ) ).deleteFile( anyString(), anyBoolean(), anyString() );
+    Mockito.verify( repository, Mockito.times( 0 ) ).deleteFile( Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyString() );
   }
 
   @Test
   public void testDeleteContentItem_repo() throws Exception {
-    IContentItem item = mock( RepositoryFileContentItem.class );
-    doReturn( mock( OutputStream.class ) ).when( item ).getOutputStream( anyString() );
+    IContentItem item = Mockito.mock( RepositoryFileContentItem.class );
+    Mockito.doReturn( Mockito.mock( OutputStream.class ) ).when( item ).getOutputStream( Mockito.anyString() );
     XactionUtil.deleteContentItem( item, repository );
-    verify( repository, times( 1 ) ).deleteFile( anyString(), anyBoolean(), anyString() );
+    Mockito.verify( repository, Mockito.times( 1 ) ).deleteFile( Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyString() );
   }
 
   @Test
   public void testDeleteContentItem_repoNoFile() throws Exception {
-    doReturn( null ).when( repository ).getFile( anyString() );
-    IContentItem item = mock( RepositoryFileContentItem.class );
-    doReturn( mock( OutputStream.class ) ).when( item ).getOutputStream( anyString() );
+    Mockito.doReturn( null ).when( repository ).getFile( Mockito.anyString() );
+    IContentItem item = Mockito.mock( RepositoryFileContentItem.class );
+    Mockito.doReturn( Mockito.mock( OutputStream.class ) ).when( item ).getOutputStream( Mockito.anyString() );
     XactionUtil.deleteContentItem( item, repository );
-    verify( repository, times( 0 ) ).deleteFile( anyString(), anyBoolean(), anyString() );
+    Mockito.verify( repository, Mockito.times( 0 ) ).deleteFile( Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyString() );
   }
 
   @After
@@ -185,7 +184,7 @@ public class XActionUtilTest {
   }
 
   private Class<?> anyClass() {
-    return argThat( new AnyClassMatcher() );
+    return Mockito.argThat( new AnyClassMatcher() );
   }
 
   private class AnyClassMatcher extends ArgumentMatcher<Class<?>> {

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/XActionUtilTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/XActionUtilTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;

--- a/extensions/test-src/org/pentaho/platform/web/http/api/resources/XActionUtilTest.java
+++ b/extensions/test-src/org/pentaho/platform/web/http/api/resources/XActionUtilTest.java
@@ -93,7 +93,7 @@ public class XActionUtilTest {
 
     when( repository.getFile( anyString() ) ).thenReturn( generatedFile );
 
-    List<IContentItem> items = Arrays.asList( mock( RepositoryFileContentItem.class ) );
+    List<IContentItem> items = Arrays.asList( (IContentItem) mock( RepositoryFileContentItem.class ) );
     IRuntimeContext context = mock( IRuntimeContext.class );
     when( context.getOutputContentItems() ).thenReturn( items );
 
@@ -151,7 +151,7 @@ public class XActionUtilTest {
   @Test
   public void testDeleteContentItem_simple() throws Exception {
     final IContentItem contentItem = mock( SimpleContentItem.class );
-    doReturn( mock( OutputStream.class ) ).when( contentItem ).getOutputStream( anyObject() );
+    doReturn( mock( OutputStream.class ) ).when( contentItem ).getOutputStream( anyString() );
     try {
       XactionUtil.deleteContentItem( contentItem, null );
     } finally {
@@ -163,7 +163,7 @@ public class XActionUtilTest {
   @Test
   public void testDeleteContentItem_repo() throws Exception {
     IContentItem item = mock( RepositoryFileContentItem.class );
-    doReturn( mock( OutputStream.class ) ).when( item ).getOutputStream( anyObject() );
+    doReturn( mock( OutputStream.class ) ).when( item ).getOutputStream( anyString() );
     XactionUtil.deleteContentItem( item, repository );
     verify( repository, times( 1 ) ).deleteFile( anyString(), anyBoolean(), anyString() );
   }
@@ -172,7 +172,7 @@ public class XActionUtilTest {
   public void testDeleteContentItem_repoNoFile() throws Exception {
     doReturn( null ).when( repository ).getFile( anyString() );
     IContentItem item = mock( RepositoryFileContentItem.class );
-    doReturn( mock( OutputStream.class ) ).when( item ).getOutputStream( anyObject() );
+    doReturn( mock( OutputStream.class ) ).when( item ).getOutputStream( anyString() );
     XactionUtil.deleteContentItem( item, repository );
     verify( repository, times( 0 ) ).deleteFile( anyString(), anyBoolean(), anyString() );
   }

--- a/scheduler/src/org/pentaho/platform/scheduler2/messsages/messages.properties
+++ b/scheduler/src/org/pentaho/platform/scheduler2/messsages/messages.properties
@@ -3,6 +3,7 @@ ActionAdapterQuartzJob.ERROR_0001_REQUIRED_PARAM_MISSING=Property "{0}" or "{1}"
 ActionAdapterQuartzJob.ERROR_0002_FAILED_TO_CREATE_ACTION=Failed to create an instance of action "{0}"
 ActionAdapterQuartzJob.ERROR_0003_ACTION_WRONG_TYPE=class {0} must be an instance of "{1}"
 ActionAdapterQuartzJob.ERROR_0004_ACTION_FAILED=Action "{0}" failed to run as a quartz job
+ActionAdapterQuartzJob.WARN_0001_SKIP_REMOVING_OUTPUT_FILE=File written by XActions must be cleaned up by external means: {0}
 
 QuartzJobKey.ERROR_0000=Cannot generate job key, jobName is missing
 QuartzJobKey.ERROR_0001=Cannot generate job key, username is missing

--- a/scheduler/src/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
+++ b/scheduler/src/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.scheduler2.quartz;


### PR DESCRIPTION
…e throws error on PUC it fails on / (slash) Separator but writes files folder (6.1 Suite)

cherry-pick:
        [BISERVER-13379] Xaction Output Destination File throws error on PUC it fails on / (slash) Separator but writes files folder
cherry-pick:
        [BISERVER-13379] Xaction Output Destination File throws error on PUC it fails on / (slash) Separator but writes files folder