### PR TITLE
[SP-3096] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnera…

### DIFF
--- a/assembly/ivy.xml
+++ b/assembly/ivy.xml
@@ -46,7 +46,7 @@
     <!-- Misc -->
     <dependency org="org.owasp.esapi" name="esapi" rev="2.0.1" transitive="false" />
     <dependency org="org.apache.axis" name="axis" rev="1.4" />
-    <dependency org="org.apache.xmlgraphics" name="batik-bridge" rev="1.7" transitive="false"/>
+    <dependency org="org.apache.xmlgraphics" name="batik-bridge" rev="1.7.1" transitive="false"/>
     <dependency org="bsf" name="bsf" rev="2.4.0" transitive="false" />   <!-- we don't want bsf's commons_logging -->
     <dependency org="org.netbeans" name="mdrjdbc" rev="1.4.2" />
     <dependency org="org.beanshell" name="bsh" rev="1.3.0" />

--- a/core/build.properties
+++ b/core/build.properties
@@ -15,5 +15,6 @@ dependency.spring.framework.revision=4.3.2.RELEASE
 dependency.spring.security.revision=4.1.3.RELEASE
 dependency.spring.ldap.revision=2.1.0.RELEASE
 dependency.spring.mock.revision=2.0.8
+dependency.batik.revision=1.7.1
 
 tests.publish=true

--- a/core/ivy.xml
+++ b/core/ivy.xml
@@ -15,9 +15,9 @@
     
 	<dependencies defaultconf="default->default">
 		<!--  external dependencies -->
-		<dependency org="org.apache.xmlgraphics" name="batik-awt-util" rev="1.7"    transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-dom"      rev="1.7"    transitive="false"/>
-		<dependency org="org.apache.xmlgraphics" name="batik-svggen"   rev="1.7"    transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-awt-util" rev="${dependency.batik.revision}"    transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-dom"      rev="${dependency.batik.revision}"    transitive="false"/>
+		<dependency org="org.apache.xmlgraphics" name="batik-svggen"   rev="${dependency.batik.revision}"    transitive="false"/>
 		<dependency org="commons-beanutils"    name="commons-beanutils" rev="1.8.0" transitive="false"/>
 		<dependency org="commons-codec"       name="commons-codec"       rev="1.9"   transitive="false"/>
 		<dependency org="commons-collections" name="commons-collections" rev="3.2.2"   transitive="false"/>

--- a/extensions/build.properties
+++ b/extensions/build.properties
@@ -26,6 +26,7 @@ dependency.spring.security.tests.revision=2.0.5.RELEASE
 dependency.spring.ldap.revision=2.1.0.RELEASE
 dependency.spring.mock.revision=2.0.8
 dependency.spring.extensions.jcr.revision=0.9
+dependency.batik.revision=1.7.1
 
 library.group=pentaho-library
 dependency.reporting-library.revision=7.0-SNAPSHOT

--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -37,9 +37,9 @@
     <dependency org="org.slf4j" name="jcl-over-slf4j" rev="1.6.1"/>
 
     <!--  compile time batik -->
-    <dependency org="org.apache.xmlgraphics" name="batik-awt-util" rev="1.7" transitive="false"/>
-    <dependency org="org.apache.xmlgraphics" name="batik-dom" rev="1.7" transitive="false"/>
-    <dependency org="org.apache.xmlgraphics" name="batik-svggen" rev="1.7" transitive="false"/>
+    <dependency org="org.apache.xmlgraphics" name="batik-awt-util" rev="${dependency.batik.revision}" transitive="false"/>
+    <dependency org="org.apache.xmlgraphics" name="batik-dom" rev="${dependency.batik.revision}" transitive="false"/>
+    <dependency org="org.apache.xmlgraphics" name="batik-svggen" rev="${dependency.batik.revision}" transitive="false"/>
 
     <dependency org="org.springframework"   name="spring-beans"     rev="${dependency.spring.framework.revision}"   transitive="false"/>
     <dependency org="org.springframework"   name="spring-context"   rev="${dependency.spring.framework.revision}"   transitive="false"/>


### PR DESCRIPTION
[SP-3096] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes (7.0 Suite)