### PR TITLE
[BACKLOG-14709] - 7.1-QAT-187:It's impossible to connect to Pentaho Server in PUC, Spoon

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2822,9 +2822,27 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.jackrabbit</groupId>
+			<artifactId>jackrabbit-api</artifactId>
+			<version>${jackrabbit.version}</version>
+			<scope>compile</scope>
+		    <exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.jackrabbit</groupId>
 			<artifactId>jackrabbit-core</artifactId>
 			<version>${jackrabbit.version}</version>
 			<scope>compile</scope>
+		    <exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.jackrabbit</groupId>


### PR DESCRIPTION
@pamval , @mbatchelor , @mchen-len-son, @bmorrise
please review. These changes removes jackrabbit-data test-jar from build. Thus they should fix the (ivy-related) issue with platform-ee build. (see the similar issue: https://issues.apache.org/jira/browse/JCR-3876)