### PR TITLE
[PDI-15929] Salesforce Input step throws a Incompatible class exception when run on server in 7.0

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -234,7 +234,6 @@
     <dependency org="pentaho-kettle" name="kettle-ui-swt" rev="${dependency.kettle.revision}" changing="true"/>
 
     <dependency org="org.snmp4j" name="snmp4j" rev="1.9.3d" conf="default->default" transitive="false"/>
-    <dependency org="pentaho" name="salesforce-partner" rev="24.0" conf="default->default" transitive="false"/>
     <dependency org="rome" name="rome" rev="1.0" conf="default->default" transitive="false"/>
     <dependency org="georss-rome" name="georss-rome" rev="0.9.8" conf="default->default" transitive="false"/>
     <dependency org="feed4j" name="feed4j" rev="1.0" conf="default->default" transitive="false"/>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -1375,18 +1375,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>pentaho</groupId>
-			<artifactId>salesforce-partner</artifactId>
-			<version>${salesforce-partner.version}</version>
-			<scope>compile</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>*</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>rome</groupId>
 			<artifactId>rome</artifactId>
 			<version>${rome.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,6 @@
   <rsyntaxtextarea.version>1.3.2</rsyntaxtextarea.version>
   <sac.version>1.3</sac.version>
   <saaj.version>1.3</saaj.version>
-  <salesforce-partner.version>24.0</salesforce-partner.version>
   <sapdbc.version>7.4.4</sapdbc.version>
   <sassyreader.version>0.5</sassyreader.version>
   <saxon.version>9.1.0.8</saxon.version>


### PR DESCRIPTION
[PDI-15929] Salesforce Input step throws a Incompatible class exception when run on server in 7.0

-old jar removed from the server platform
force-partner-api.jar from plugins contains necessary classes

@mdamour1976 @matthewtckr  Could you please review and merge it?