### PR TITLE
[BISERVER-12916]-Add a filter to handle MS Office pre-flight requests

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
@@ -154,4 +154,7 @@
 
    </file-upload-defaults>
   <default-theme>sapphire</default-theme>
+
+  <!-- Excel pre-flight request filter pattern -->
+  <pre-flight-pattern>^.*(reporting/api/jobs|api/repos/.*\\.prpt).*$</pre-flight-pattern>
 </pentaho-system>

--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/web.xml
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/web.xml
@@ -97,6 +97,11 @@
     <filter-class>org.pentaho.platform.web.http.filters.PentahoWebContextFilter</filter-class>
   </filter>
 
+  <filter>
+    <filter-name>Pre Flight Reporting Filter</filter-name>
+    <filter-class>org.pentaho.platform.web.http.filters.PreFlightReportingFilter</filter-class>
+  </filter>
+
   <!-- insert additional filters -->
 
   <filter-mapping>
@@ -106,6 +111,11 @@
 
 	<filter-mapping>
     <filter-name>WEBAPP_ROOT URL rewrite filter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter-mapping>
+    <filter-name>Pre Flight Reporting Filter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 

--- a/extensions/src/main/java/org/pentaho/platform/web/http/filters/PreFlightReportingFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/filters/PreFlightReportingFilter.java
@@ -1,0 +1,72 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.filters;
+
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.HttpMethod;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+public class PreFlightReportingFilter implements Filter {
+
+
+  private static final String DEFAULT_PATTERN = "^.*(reporting/api/jobs|api/repos/.*\\.prpt).*$";
+  private static final String PRE_FLIGHT_PATTERN = "pre-flight-pattern";
+  private final Pattern preFlightPattern;
+
+
+  public PreFlightReportingFilter() {
+    final String regex = PentahoSystem.getSystemSetting( PRE_FLIGHT_PATTERN, DEFAULT_PATTERN );
+    preFlightPattern = Pattern.compile( regex );
+  }
+
+  public void init( FilterConfig filterConfig ) throws ServletException {
+  }
+
+  public void destroy() {
+  }
+
+  public void doFilter( ServletRequest request, ServletResponse response, FilterChain chain ) throws IOException,
+    ServletException {
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+    if ( isReportingPreFlight( httpRequest ) ) {
+      final HttpServletResponse servletResponse = (HttpServletResponse) response;
+      servletResponse.setStatus( HttpServletResponse.SC_OK );
+    } else {
+      chain.doFilter( request, response );
+    }
+  }
+
+  boolean isReportingPreFlight( final HttpServletRequest request ) {
+    return ( HttpMethod.OPTIONS.equals( request.getMethod() )
+      || HttpMethod.HEAD.equals( request.getMethod() ) ) && preFlightPattern
+      .matcher( request.getRequestURI() )
+      .matches();
+  }
+
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/http/filters/PreFlightReportingFilterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/filters/PreFlightReportingFilterTest.java
@@ -1,0 +1,113 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.filters;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.platform.api.engine.ISystemSettings;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.HttpMethod;
+import java.io.IOException;
+
+public class PreFlightReportingFilterTest {
+
+  private static final String PENTAHO_API_NOTMATCHING = "/pentaho/api/notmatching";
+
+  private static final String SYNC_URL =
+    "/pentaho/api/repos/%3Apublic%3ASteel%20Wheels%3AInventory%20List%20(report).prpt/";
+
+  private static final String ASYNC_URL =
+    "/pentaho/plugin/reporting/api/jobs/5a41f746-55f4-4acf-a804-f7f5348d59bb/";
+
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+  private FilterChain chain;
+  private static ISystemSettings systemSettings;
+
+  @BeforeClass
+  public static void setUpClass() {
+    systemSettings = PentahoSystem.getSystemSettings();
+  }
+
+  @Before
+  public void setUp() {
+    request = Mockito.mock( HttpServletRequest.class );
+    response = Mockito.mock( HttpServletResponse.class );
+    chain = Mockito.mock( FilterChain.class );
+    PentahoSystem.setSystemSettingsService( systemSettings );
+  }
+
+
+  @Test
+  public void notPreFlight() throws Exception {
+    Mockito.when( request.getMethod() ).thenReturn( HttpMethod.POST );
+    new PreFlightReportingFilter().doFilter( request, response, chain );
+    Mockito.verify( chain, Mockito.times( 1 ) ).doFilter( request, response );
+  }
+
+  @Test
+  public void notMatchingUrl() throws Exception {
+    Mockito.when( request.getMethod() ).thenReturn( HttpMethod.OPTIONS );
+    Mockito.when( request.getRequestURI() ).thenReturn( PENTAHO_API_NOTMATCHING );
+    new PreFlightReportingFilter().doFilter( request, response, chain );
+    Mockito.verify( chain, Mockito.times( 1 ) ).doFilter( request, response );
+  }
+
+  @Test
+  public void syncPreFlight() throws Exception {
+    testMethodAndURI( HttpMethod.OPTIONS, SYNC_URL, request, response, chain );
+  }
+
+
+  @Test
+  public void asyncPreFlight() throws Exception {
+    testMethodAndURI( HttpMethod.OPTIONS, ASYNC_URL, request, response, chain );
+  }
+
+  @Test
+  public void asyncPreFlightHead() throws Exception {
+    testMethodAndURI( HttpMethod.HEAD, ASYNC_URL, request, response, chain );
+  }
+
+  @Test
+  public void nonDefaultPattern() throws Exception {
+    final ISystemSettings mockSystemSettings = Mockito.mock( ISystemSettings.class );
+    Mockito.when( mockSystemSettings.getSystemSetting( Mockito.eq( "pre-flight-pattern" ), Mockito.anyString() ) )
+      .thenReturn( "^.*excel.*$" );
+    PentahoSystem.setSystemSettingsService( mockSystemSettings );
+    testMethodAndURI( HttpMethod.OPTIONS, "/pentaho/anotherexcelurl", request, response, chain );
+  }
+
+  private void testMethodAndURI( final String method, final String uri, final HttpServletRequest request,
+                                 final HttpServletResponse response, final FilterChain chain )
+    throws IOException, ServletException {
+    Mockito.when( request.getMethod() ).thenReturn( method );
+    Mockito.when( request.getRequestURI() ).thenReturn( uri );
+    new PreFlightReportingFilter().doFilter( request, response, chain );
+    Mockito.verify( chain, Mockito.never() ).doFilter( Mockito.any(), Mockito.any() );
+    Mockito.verify( response, Mockito.times( 1 ) ).setStatus( HttpServletResponse.SC_OK );
+  }
+
+}


### PR DESCRIPTION
MS Excel behaves wierd, when opening a file from IE. It sends OPTION requests ( OPTION+HEAD requests in case of XHR ) before opening a file. Pentaho responds with 401 and the file is not opened.
Also, sometimes Excel thinks that the file is broken. In such case it tries to load the content one more time ( another GET ) and repair it. When failed,  it will prompt you a warning message but will open the file anyway. We can't do anything with this particular case without setting a session cookie. And we definitely don't want to do so.

The fix is in returning 200 status for OPTION and HEAD requests for the report content urls.
It adds not so big overhead ( 2 string equals in most cases ).
Unfortunately we won't be able to use it as is in SP cases. We can't change a web.xml. I made the method static and package private to be able to use it in another filter ( most likely WebappRootForwardingFilter ).

I know it looks like a hack, but it tends to match a general developement aproach for MS products :)