### PR TITLE
[BISERVER-13484] 7.0 Manual install on Tomcat 8.0.39- Browse files is not working

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 define([
   "./browser.fileButtons",
@@ -541,7 +541,7 @@ define([
      * Path has already been converted to colons
      */
     getFileTreeRequest: function (path) {
-      return CONTEXT_PATH + "api/repo/files/" + path + "/tree?depth=-1&showHidden=" + this.get("showHiddenFiles") + "&filter=*|FOLDERS";
+      return CONTEXT_PATH + "api/repo/files/" + path + "/tree?depth=-1&showHidden=" + this.get("showHiddenFiles") + "&filter=*%7CFOLDERS";
     }
   });
 
@@ -710,7 +710,7 @@ define([
       }
       else {
         //request = CONTEXT_PATH + "api/repo/files/" + path + "/tree?depth=-1&showHidden=" + this.get("showHiddenFiles") + "&filter=*|FILES";
-        request = CONTEXT_PATH + "api/repo/files/" + path + "/children?showHidden=" + this.get("showHiddenFiles") + "&filter=*|FILES";
+        request = CONTEXT_PATH + "api/repo/files/" + path + "/children?showHidden=" + this.get("showHiddenFiles") + "&filter=*%7CFILES";
       }
       return request;
     }


### PR DESCRIPTION
Unsafe character - pipe line "|" replaced with "%7C".