### PR TITLE
[BISERVER-12916]-Refactored a PreFlightFilter

### DIFF
--- a/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/applicationContext-spring-security.xml
@@ -3,7 +3,7 @@
 <!--+
   | Application context containing FilterChainProxy.
   +-->
-<beans xmlns="http://www.springframework.org/schema/beans" 
+<beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:sec="http://www.springframework.org/schema/security"
@@ -11,7 +11,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
                            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
                            http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.1.xsd
-                           http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd" 
+                           http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd"
        default-lazy-init="true">
 
   <!-- ======================== FILTER CHAIN ======================= -->
@@ -23,7 +23,9 @@
     <constructor-arg>
       <util:list>
         <sec:filter-chain pattern="/webservices/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS" />
+        <sec:filter-chain pattern="/api/repos/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS,preFlightFilter" />
         <sec:filter-chain pattern="/api/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS" />
+        <sec:filter-chain pattern="/plugin/reporting/api/jobs/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS,preFlightFilter" />
         <sec:filter-chain pattern="/plugin/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS" />
         <sec:filter-chain pattern="/**" filters="securityContextHolderAwareRequestFilter,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,httpSessionReuseDetectionFilter,logoutFilter,authenticationProcessingFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilter,filterInvocationInterceptor" />
       </util:list>
@@ -131,13 +133,15 @@
         class="org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter" />
 
   <bean id="securityContextHolderAwareRequestFilterForWS" class="org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter">
-    <!-- SecurityContextHolderAwareRequestFilter in latest spring security has 2 behaviours, for pre and post servlet 3: in pre-servlet 3, 
+    <!-- SecurityContextHolderAwareRequestFilter in latest spring security has 2 behaviours, for pre and post servlet 3: in pre-servlet 3,
       the wrapper class used by default is SecurityContextHolderAwareRequestWrapper; this means we no longer need to set it as a 'wrapperClass'
       property ( this property no longer exists, anyway ) -->
     <!-- hhttps://github.com/spring-projects/spring-security/blob/4.1.3.RELEASE/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestFilter.java#L45-L47 -->
     <!-- <property name="wrapperClass" value="org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper" /> -->
   </bean>
 
+  <!-- Excel pre-flight filter -->
+  <bean id="preFlightFilter" class="org.pentaho.platform.web.http.filters.PreFlightReportingFilter" />
 
 
   <!--
@@ -156,9 +160,9 @@
       <bean class="org.springframework.security.web.access.AccessDeniedHandlerImpl" />
     </property>
   </bean>
-  
+
   <bean id="sas" class="org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy" />
-  
+
   <bean id="authenticationProcessingFilter"
         class="org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter">
     <property name="authenticationManager">
@@ -267,6 +271,10 @@
         <sec:intercept-url pattern=".*system.*smtp-email/.*" access="Nobody" />
         <sec:intercept-url pattern=".*system.*ui/.*" access="Nobody" />
         <sec:intercept-url pattern=".*system.*\.\./.*" access="Nobody" />
+        <sec:intercept-url pattern="\A/plugin/reporting/api/jobs/.*\Z" access="Anonymous,Authenticated" method="OPTIONS" />
+        <sec:intercept-url pattern="\A/plugin/reporting/api/jobs/.*\Z" access="Anonymous,Authenticated" method="HEAD" />
+        <sec:intercept-url pattern="\A/api/repos/.*\Z" access="Anonymous,Authenticated" method="OPTIONS" />
+        <sec:intercept-url pattern="\A/api/repos/.*\Z" access="Anonymous,Authenticated" method="HEAD" />
         <sec:intercept-url pattern="\A/.*\Z" access="Authenticated" />
       </sec:filter-security-metadata-source>
     </property>
@@ -290,6 +298,10 @@
         <sec:intercept-url pattern="\A/webservices/repositorysync\?wsdl.*\Z" access="Anonymous,Authenticated" />
         <sec:intercept-url pattern="\A/webservices/datasourcemgmtservice\?wsdl.*\Z" access="Anonymous,Authenticated" />
         <sec:intercept-url pattern="\A/webservices/.*\Z" access="Authenticated" />
+        <sec:intercept-url pattern="\A/plugin/reporting/api/jobs/.*\Z" access="Anonymous,Authenticated" method="OPTIONS" />
+        <sec:intercept-url pattern="\A/plugin/reporting/api/jobs/.*\Z" access="Anonymous,Authenticated" method="HEAD" />
+        <sec:intercept-url pattern="\A/api/repos/.*\Z" access="Anonymous,Authenticated" method="OPTIONS" />
+        <sec:intercept-url pattern="\A/api/repos/.*\Z" access="Anonymous,Authenticated" method="HEAD" />
         <sec:intercept-url pattern="\A/api/.*require-cfg.js.*\Z" access="Anonymous,Authenticated" />
         <sec:intercept-url pattern="\A/api/.*require-js-cfg.js.*\Z" access="Anonymous,Authenticated" />
         <sec:intercept-url pattern="\A/api/.*\Z" access="Authenticated" />

--- a/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
+++ b/assembly/package-res/biserver/pentaho-solutions/system/pentaho.xml
@@ -154,7 +154,4 @@
 
    </file-upload-defaults>
   <default-theme>sapphire</default-theme>
-
-  <!-- Excel pre-flight request filter pattern -->
-  <pre-flight-pattern>^.*(reporting/api/jobs|api/repos/.*\\.prpt).*$</pre-flight-pattern>
 </pentaho-system>

--- a/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/web.xml
+++ b/assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/web.xml
@@ -97,11 +97,6 @@
     <filter-class>org.pentaho.platform.web.http.filters.PentahoWebContextFilter</filter-class>
   </filter>
 
-  <filter>
-    <filter-name>Pre Flight Reporting Filter</filter-name>
-    <filter-class>org.pentaho.platform.web.http.filters.PreFlightReportingFilter</filter-class>
-  </filter>
-
   <!-- insert additional filters -->
 
   <filter-mapping>
@@ -111,11 +106,6 @@
 
 	<filter-mapping>
     <filter-name>WEBAPP_ROOT URL rewrite filter</filter-name>
-    <url-pattern>/*</url-pattern>
-  </filter-mapping>
-
-  <filter-mapping>
-    <filter-name>Pre Flight Reporting Filter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 

--- a/extensions/src/main/java/org/pentaho/platform/web/http/filters/PreFlightReportingFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/filters/PreFlightReportingFilter.java
@@ -17,8 +17,6 @@
 
 package org.pentaho.platform.web.http.filters;
 
-import org.pentaho.platform.engine.core.system.PentahoSystem;
-
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -29,20 +27,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.HttpMethod;
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 public class PreFlightReportingFilter implements Filter {
-
-
-  private static final String DEFAULT_PATTERN = "^.*(reporting/api/jobs|api/repos/.*\\.prpt).*$";
-  private static final String PRE_FLIGHT_PATTERN = "pre-flight-pattern";
-  private final Pattern preFlightPattern;
-
-
-  public PreFlightReportingFilter() {
-    final String regex = PentahoSystem.getSystemSetting( PRE_FLIGHT_PATTERN, DEFAULT_PATTERN );
-    preFlightPattern = Pattern.compile( regex );
-  }
 
   public void init( FilterConfig filterConfig ) throws ServletException {
   }
@@ -54,19 +40,16 @@ public class PreFlightReportingFilter implements Filter {
     ServletException {
     HttpServletRequest httpRequest = (HttpServletRequest) request;
 
-    if ( isReportingPreFlight( httpRequest ) ) {
+    if ( isPreFlight( httpRequest ) ) {
       final HttpServletResponse servletResponse = (HttpServletResponse) response;
-      servletResponse.setStatus( HttpServletResponse.SC_OK );
+      servletResponse.setStatus( HttpServletResponse.SC_METHOD_NOT_ALLOWED );
     } else {
       chain.doFilter( request, response );
     }
   }
 
-  boolean isReportingPreFlight( final HttpServletRequest request ) {
-    return ( HttpMethod.OPTIONS.equals( request.getMethod() )
-      || HttpMethod.HEAD.equals( request.getMethod() ) ) && preFlightPattern
-      .matcher( request.getRequestURI() )
-      .matches();
+  private boolean isPreFlight( final HttpServletRequest request ) {
+    return ( HttpMethod.OPTIONS.equals( request.getMethod() ) || HttpMethod.HEAD.equals( request.getMethod() ) );
   }
 
 }

--- a/extensions/src/test/java/org/pentaho/platform/web/http/filters/PreFlightReportingFilterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/filters/PreFlightReportingFilterTest.java
@@ -33,13 +33,6 @@ import java.io.IOException;
 
 public class PreFlightReportingFilterTest {
 
-  private static final String PENTAHO_API_NOTMATCHING = "/pentaho/api/notmatching";
-
-  private static final String SYNC_URL =
-    "/pentaho/api/repos/%3Apublic%3ASteel%20Wheels%3AInventory%20List%20(report).prpt/";
-
-  private static final String ASYNC_URL =
-    "/pentaho/plugin/reporting/api/jobs/5a41f746-55f4-4acf-a804-f7f5348d59bb/";
 
   private HttpServletRequest request;
   private HttpServletResponse response;
@@ -68,46 +61,22 @@ public class PreFlightReportingFilterTest {
   }
 
   @Test
-  public void notMatchingUrl() throws Exception {
-    Mockito.when( request.getMethod() ).thenReturn( HttpMethod.OPTIONS );
-    Mockito.when( request.getRequestURI() ).thenReturn( PENTAHO_API_NOTMATCHING );
-    new PreFlightReportingFilter().doFilter( request, response, chain );
-    Mockito.verify( chain, Mockito.times( 1 ) ).doFilter( request, response );
+  public void preFlightOptions() throws Exception {
+    testMethodAndURI( HttpMethod.OPTIONS, request, response, chain );
   }
 
   @Test
-  public void syncPreFlight() throws Exception {
-    testMethodAndURI( HttpMethod.OPTIONS, SYNC_URL, request, response, chain );
+  public void preFlightHead() throws Exception {
+    testMethodAndURI( HttpMethod.HEAD, request, response, chain );
   }
 
-
-  @Test
-  public void asyncPreFlight() throws Exception {
-    testMethodAndURI( HttpMethod.OPTIONS, ASYNC_URL, request, response, chain );
-  }
-
-  @Test
-  public void asyncPreFlightHead() throws Exception {
-    testMethodAndURI( HttpMethod.HEAD, ASYNC_URL, request, response, chain );
-  }
-
-  @Test
-  public void nonDefaultPattern() throws Exception {
-    final ISystemSettings mockSystemSettings = Mockito.mock( ISystemSettings.class );
-    Mockito.when( mockSystemSettings.getSystemSetting( Mockito.eq( "pre-flight-pattern" ), Mockito.anyString() ) )
-      .thenReturn( "^.*excel.*$" );
-    PentahoSystem.setSystemSettingsService( mockSystemSettings );
-    testMethodAndURI( HttpMethod.OPTIONS, "/pentaho/anotherexcelurl", request, response, chain );
-  }
-
-  private void testMethodAndURI( final String method, final String uri, final HttpServletRequest request,
+  private void testMethodAndURI( final String method, final HttpServletRequest request,
                                  final HttpServletResponse response, final FilterChain chain )
     throws IOException, ServletException {
     Mockito.when( request.getMethod() ).thenReturn( method );
-    Mockito.when( request.getRequestURI() ).thenReturn( uri );
     new PreFlightReportingFilter().doFilter( request, response, chain );
     Mockito.verify( chain, Mockito.never() ).doFilter( Mockito.any(), Mockito.any() );
-    Mockito.verify( response, Mockito.times( 1 ) ).setStatus( HttpServletResponse.SC_OK );
+    Mockito.verify( response, Mockito.times( 1 ) ).setStatus( HttpServletResponse.SC_METHOD_NOT_ALLOWED );
   }
 
 }


### PR DESCRIPTION
- moved the filter registration to a Spring config
- the filter is now applied only to affected urls not to /**
- only HEAD and OPTIONS http methods are anonymously accessible
- removed a URL pattern configuration from a pentaho.xml
- sending a 405 code instead of 200 for a valid semantics, Excell understands it
- reverted changes in the web.xml
- the test is updated respectively

Verified for sync/async prpt reports and analyzer.