### PR TITLE
[ENGOPS-2897] Add org.apache.jackrabbit.spi.* test dependencies

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2834,6 +2834,22 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.jackrabbit</groupId>
+			<artifactId>jackrabbit-spi</artifactId>
+			<version>${jackrabbit.version}</version>
+			<scope>test</scope>
+			<exclusions>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.jackrabbit</groupId>
+			<artifactId>jackrabbit-spi-commons</artifactId>
+			<version>${jackrabbit.version}</version>
+			<scope>test</scope>
+			<exclusions>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.jackrabbit</groupId>
 			<artifactId>jackrabbit-data</artifactId>
 			<version>${jackrabbit.version}</version>
 			<scope>test</scope>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2837,24 +2837,18 @@
 			<artifactId>jackrabbit-spi</artifactId>
 			<version>${jackrabbit.version}</version>
 			<scope>test</scope>
-			<exclusions>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.jackrabbit</groupId>
 			<artifactId>jackrabbit-spi-commons</artifactId>
 			<version>${jackrabbit.version}</version>
 			<scope>test</scope>
-			<exclusions>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.jackrabbit</groupId>
 			<artifactId>jackrabbit-data</artifactId>
 			<version>${jackrabbit.version}</version>
 			<scope>test</scope>
-			<exclusions>
-			</exclusions>
 		</dependency>
         <dependency>
             <groupId>pentaho</groupId>


### PR DESCRIPTION
Missing jackrabbit test dependencies were causing tests to fail.

http://cerberus.pentaho.com/job/master-snapshot/job/platform-base/44/consoleFull