### PR TITLE
[BACKLOG-11933][PDB-1938] Encode URI for the tab name when user input contains special characters

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/commands/SaveCommand.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/commands/SaveCommand.java
@@ -310,6 +310,11 @@ public class SaveCommand extends AbstractCommand {
   private void doTabRename() {
     if ( tabName != null ) { // Save-As does not modify the name of the tab.
       PentahoTab tab = SolutionBrowserPanel.getInstance().getContentTabPanel().getSelectedTab();
+      if ( tabName.indexOf( "\"" ) != -1 ) {
+        //BACKLOG-11933, double quote ( " ) need special handling, could have done encodeUri, yet %22 brings UX issue.
+        //For now, replace double quote with 2 single quote as a fallback solution.
+        tabName = tabName.replaceAll( "\"", "''" );
+      }
       tab.setLabelText( tabName );
       tab.setLabelTooltip( tabName );
     }


### PR DESCRIPTION
@pentaho/rogueone 
Please review. 
The fix is to do a URI encoding on file name user entered. So that special characters won't break succeeding JSON response.