### PR TITLE
[BACKLOG-14990] Fix OSGi 'and' filter invalid syntax

### DIFF
--- a/core/src/main/java/org/pentaho/platform/engine/core/system/osgi/OSGIUtils.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/osgi/OSGIUtils.java
@@ -7,15 +7,26 @@ import java.util.Map;
  */
 public class OSGIUtils {
   public static String createFilter( Map<String, String> props ) {
-    if ( props == null || props.size() == 0 ) {
+    int numberOfProperties = props != null ? props.size() : 0;
+
+    if ( numberOfProperties == 0 ) {
       return null;
     }
+
     StringBuilder sb = new StringBuilder();
-    sb.append( "(" );
-    for ( Map.Entry<String, String> entry : props.entrySet() ) {
-      sb.append( "&(" ).append( entry.getKey() ).append( "=" ).append( entry.getValue() ).append( ")" );
+
+    if ( numberOfProperties > 1 ) {
+      sb.append( "(&" );
     }
-    sb.append( ")" );
+
+    for ( Map.Entry<String, String> entry : props.entrySet() ) {
+      sb.append( "(" ).append( entry.getKey() ).append( "=" ).append( entry.getValue() ).append( ")" );
+    }
+
+    if ( numberOfProperties > 1 ) {
+      sb.append( ")" );
+    }
+
     return sb.toString();
   }
 

--- a/core/src/main/java/org/pentaho/platform/engine/core/system/osgi/OSGIUtils.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/osgi/OSGIUtils.java
@@ -1,3 +1,19 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright 2015-2017 Pentaho Corporation. All rights reserved.
+ */
 package org.pentaho.platform.engine.core.system.osgi;
 
 import java.util.Map;

--- a/core/src/test/java/org/pentaho/platform/engine/core/system/objfac/OSGIObjectFactoryTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/core/system/objfac/OSGIObjectFactoryTest.java
@@ -242,10 +242,10 @@ public class OSGIObjectFactoryTest {
     ServiceReference<String> ref = Mockito.mock( ServiceReference.class );
     ServiceReference<String> ref2 = Mockito.mock( ServiceReference.class );
 
-    when( mockContext.getServiceReferences( String.class, "(&(name=foo))" ) )
+    when( mockContext.getServiceReferences( String.class, "(name=foo)" ) )
       .thenReturn( Collections.singletonList( ref ) );
     when( mockContext.getServiceReferences( String.class, null ) ).thenReturn( Collections.singletonList( ref ) );
-    when( mockContext.getServiceReferences( String.class, "(&(emptyPriority=true))" ) )
+    when( mockContext.getServiceReferences( String.class, "(emptyPriority=true)" ) )
       .thenReturn( Collections.singletonList( ref2 ) );
 
     when( mockContext.getService( ref ) ).thenReturn( "SomeString" );
@@ -268,8 +268,8 @@ public class OSGIObjectFactoryTest {
 
     assertNull( objectReference );
 
-    verify( mockContext ).getServiceReferences( String.class, "(&(name=foo))" );
-    verify( mockContext ).getServiceReferences( String.class, "(&(name=foobar))" );
+    verify( mockContext ).getServiceReferences( String.class, "(name=foo)" );
+    verify( mockContext ).getServiceReferences( String.class, "(name=foobar)" );
 
     objectReference = factory.getObjectReference( String.class, session, Collections.singletonMap( "name", "foo(" ) );
     assertNull( objectReference );
@@ -373,7 +373,7 @@ public class OSGIObjectFactoryTest {
     ServiceReference<String> ref = (ServiceReference<String>) Mockito.mock( ServiceReference.class );
     ServiceReference<String> ref2 = Mockito.mock( ServiceReference.class );
 
-    when( mockContext.getServiceReferences( String.class, "(&(name=foo))" ) ).thenReturn( Arrays.asList( ref, ref2 ) );
+    when( mockContext.getServiceReferences( String.class, "(name=foo)" ) ).thenReturn( Arrays.asList( ref, ref2 ) );
     when( mockContext.getServiceReferences( Integer.class, null ) )
       .thenThrow( new InvalidSyntaxException( "bad", "call" ) );
 
@@ -399,7 +399,7 @@ public class OSGIObjectFactoryTest {
     objectReferences = factory.getObjectReferences( String.class, session, Collections.singletonMap( "name", "bar" ) );
     assertTrue( objectReferences.isEmpty() );
 
-    verify( mockContext ).getServiceReferences( String.class, "(&(name=foo))" );
+    verify( mockContext ).getServiceReferences( String.class, "(name=foo)" );
 
 
   }

--- a/core/src/test/java/org/pentaho/platform/engine/core/system/objfac/OSGIObjectFactoryTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/core/system/objfac/OSGIObjectFactoryTest.java
@@ -12,9 +12,8 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright 2013 Pentaho Corporation. All rights reserved.
+ * Copyright 2013-2017 Pentaho Corporation. All rights reserved.
  */
-
 package org.pentaho.platform.engine.core.system.objfac;
 
 import static junit.framework.Assert.assertEquals;


### PR DESCRIPTION
The 'and' filter syntax only has a `&` at the begining, not between operands. Was causing `InvalidSyntaxException`.

Also changed the util function so it returns a simple filter if only one property exists.

@pentaho/millenniumfalcon and @pentaho-nbaker please review.