### PR TITLE
[CLEANUP] removing unnecessary jsp-api-2.1.jar from tomcat/lib folder

### DIFF
--- a/assemblies/pentaho-server/src/assembly/assembly.xml
+++ b/assemblies/pentaho-server/src/assembly/assembly.xml
@@ -129,7 +129,6 @@
         <include>org.hsqldb:hsqldb</include>
         <include>mysql:mysql-connector-java</include>
         <include>com.h2database:h2</include>
-        <include>javax.servlet.jsp:jsp-api</include>
         <include>org.postgresql:postgresql</include>
       </includes>
       <outputDirectory>tomcat/lib</outputDirectory>


### PR DESCRIPTION
@pentaho/2-1b pls review
removed jsp-api-2.1.jar from tomcat/lib, the jsp-api.jar is already present in a standard tomcat installation, but on linux it fails to startup PUC correctly if it loads that jar specifically.