### PR TITLE
[SP-3302] Backport of PPP-3619 - Schedules shows wrong "Next run" time/date after schedule was edited. (7.0 Suite)

### DIFF
--- a/scheduler/src/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/scheduler/src/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -475,7 +475,7 @@ public class QuartzScheduler implements IScheduler {
             job.setJobId( jobId );
             setJobTrigger( scheduler, job, trigger );
             job.setJobName( QuartzJobKey.parse( jobId ).getJobName() );
-            job.setNextRun( trigger.getNextFireTime() );
+            job.setNextRun( trigger.getFireTimeAfter( new Date() ) );
             job.setLastRun( trigger.getPreviousFireTime() );
             if ( ( filter == null ) || filter.accept( job ) ) {
               jobs.add( job );


### PR DESCRIPTION
Backport of #3455