### PR TITLE
[SP-3324][PDI-15929] Salesforce Input step throws a Incompatible class exception when run on server in 7.0

### DIFF
--- a/extensions/ivy.xml
+++ b/extensions/ivy.xml
@@ -234,7 +234,6 @@
     <dependency org="pentaho-kettle" name="kettle-ui-swt" rev="${dependency.kettle.revision}" changing="true"/>
 
     <dependency org="org.snmp4j" name="snmp4j" rev="1.9.3d" conf="default->default" transitive="false"/>
-    <dependency org="pentaho" name="salesforce-partner" rev="24.0" conf="default->default" transitive="false"/>
     <dependency org="rome" name="rome" rev="1.0" conf="default->default" transitive="false"/>
     <dependency org="georss-rome" name="georss-rome" rev="0.9.8" conf="default->default" transitive="false"/>
     <dependency org="feed4j" name="feed4j" rev="1.0" conf="default->default" transitive="false"/>


### PR DESCRIPTION
-old jar removed from the server platform
force-partner-api.jar from plugins contains necessary classes

@mdamour1976 @matthewtckr Could you please review and merge it?