### PR TITLE
[BISERVER-13473] JMS Connection for destination 'snmpQueue' error after switching to LDAP authentication on Pentaho 7

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
@@ -12,7 +12,7 @@
        						http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd
        						http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.3.xsd" default-lazy-init="true">
 
-  <bean class="org.pentaho.platform.plugin.services.security.userrole.ldap.DefaultLdapAuthenticationProvider">
+  <bean id="ldapAuthenticationProvider" class="org.pentaho.platform.plugin.services.security.userrole.ldap.DefaultLdapAuthenticationProvider">
     <constructor-arg>
       <ref bean="authenticator" />
     </constructor-arg>
@@ -22,6 +22,19 @@
     <constructor-arg>
       <ref bean="ldapRoleMapper" />
     </constructor-arg>
+  </bean>
+
+  <bean id="classloaderSwitcherInterceptor" class="org.pentaho.platform.plugin.services.security.userrole.ClassloaderSwitcherInterceptor">
+  </bean>
+
+  <bean id="proxyForClassloaderSwitcher" class="org.springframework.aop.framework.ProxyFactoryBean">
+    <property name="proxyInterfaces" value="org.springframework.security.authentication.AuthenticationProvider"/>
+    <property name="target" ref="ldapAuthenticationProvider"/>
+    <property name="interceptorNames">
+      <list>
+        <value>classloaderSwitcherInterceptor</value>
+      </list>
+    </property>
     <pen:publish as-type="org.springframework.security.authentication.AuthenticationProvider">
       <pen:attributes>
         <pen:attr key="providerName" value="ldap"/>

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ClassloaderSwitcherInterceptor.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ClassloaderSwitcherInterceptor.java
@@ -1,0 +1,39 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.platform.plugin.services.security.userrole;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * @author Andrei Abramov
+ */
+public class ClassloaderSwitcherInterceptor implements MethodInterceptor {
+
+  public Object invoke( MethodInvocation invocation ) throws Throwable {
+    Object ret = null;
+    ClassLoader currentThreadContextClassLoader = null;
+    try {
+      currentThreadContextClassLoader = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread().setContextClassLoader( this.getClass().getClassLoader() );
+      ret = invocation.proceed();
+    } finally {
+      Thread.currentThread().setContextClassLoader( currentThreadContextClassLoader );
+    }
+    return ret;
+  }
+}


### PR DESCRIPTION
Fixed regression which was caused by switching to the spring-ldap-2.1.0