### PR TITLE
[BISERVER-13473] JMS Connection for destination 'snmpQueue' error after switching to LDAP authentication on Pentaho 7

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
@@ -12,7 +12,7 @@
        						http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd
        						http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.3.xsd" default-lazy-init="true">
 
-  <bean class="org.pentaho.platform.plugin.services.security.userrole.ldap.DefaultLdapAuthenticationProvider">
+  <bean id="ldapAuthenticationProvider" class="org.pentaho.platform.plugin.services.security.userrole.ldap.DefaultLdapAuthenticationProvider">
     <constructor-arg>
       <ref bean="authenticator" />
     </constructor-arg>
@@ -22,6 +22,26 @@
     <constructor-arg>
       <ref bean="ldapRoleMapper" />
     </constructor-arg>
+  </bean>
+
+  <!--
+    Interceptor which changes the thread context classloader to the class' current classloader.
+  -->
+  <bean id="classloaderSwitcherInterceptor" class="org.pentaho.platform.plugin.services.security.userrole.ClassloaderSwitcherInterceptor">
+  </bean>
+
+  <!--
+    This proxy bean is used to change the thread context classloader in order to escape ClassCastException in
+    org.springframework.ldap.odm.typeconversion.impl.ConversionServiceConverterManager
+  -->
+  <bean id="ldapAuthenticationProviderProxy" class="org.springframework.aop.framework.ProxyFactoryBean">
+    <property name="proxyInterfaces" value="org.springframework.security.authentication.AuthenticationProvider"/>
+    <property name="target" ref="ldapAuthenticationProvider"/>
+    <property name="interceptorNames">
+      <list>
+        <value>classloaderSwitcherInterceptor</value>
+      </list>
+    </property>
     <pen:publish as-type="org.springframework.security.authentication.AuthenticationProvider">
       <pen:attributes>
         <pen:attr key="providerName" value="ldap"/>
@@ -81,6 +101,20 @@
     <constructor-arg ref="tenantedUserNameUtils"/>
   </bean>
 
+  <!--
+    This proxy bean is used to change the thread context classloader in order to escape ClassCastException in
+    org.springframework.ldap.odm.typeconversion.impl.ConversionServiceConverterManager
+  -->
+  <bean id="ldapUserDetailsServiceProxy" class="org.springframework.aop.framework.ProxyFactoryBean">
+    <property name="proxyInterfaces" value="org.springframework.security.core.userdetails.UserDetailsService"/>
+    <property name="target" ref="ldapUserDetailsService0"/>
+    <property name="interceptorNames">
+      <list>
+        <value>classloaderSwitcherInterceptor</value>
+      </list>
+    </property>
+  </bean>
+
     <!-- map ldap role to pentaho security role -->
     <util:map id="ldapRoleMap">
         <entry key="${ldap.adminRole}" value="Administrator"/>
@@ -103,7 +137,7 @@
     In that file, userRoleListService uses this bean for fetching roles for a user (e.g. during scheduled jobs). 
   -->
   <bean id="ldapUserDetailsService" class="org.pentaho.platform.engine.security.DefaultRoleUserDetailsServiceDecorator">
-    <property name="userDetailsService" ref="ldapUserDetailsService0" />
+    <property name="userDetailsService" ref="ldapUserDetailsServiceProxy" />
     <property name="defaultRole" ref="defaultRole" />
     <property name="roleMapper" ref="ldapRoleMapper" />
     <pen:publish as-type="INTERFACES">

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ClassloaderSwitcherInterceptor.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ClassloaderSwitcherInterceptor.java
@@ -1,0 +1,61 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.platform.plugin.services.security.userrole;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * <p>This interceptor changes the thread context classloader to the class' current classloader.
+ *
+ * <p>We need this because of the
+ * {@link org.springframework.ldap.odm.typeconversion.impl.ConversionServiceConverterManager} which was introduced
+ * in spring-security-2.0.0.
+ *
+ * <p>This manager uses {@link org.springframework.util.ClassUtils#getDefaultClassLoader()} which creates
+ * new class instance using thread context classloader which differs from the current classloader of the caller class:
+ * <ul>
+ * <li> thread context classloader is the {@code org.apache.activemq.activemq-osgi}
+ * <li> current classloader is the spring's {@code WebappClassLoader}
+ * </ul>
+ *
+ * When {@code ConversionServiceConverterManager} tries to cast {@code clazz.newInstance()} to the
+ * {@code GenericConversionService} it throws {@code ClassCastException} if the context classloader hadn't changed.
+ *
+ * <p>That's why we need to proxy all classes which might use the {@code ConversionServiceConverterManager}.
+ *
+ * @author Andrei Abramov
+ */
+public class ClassloaderSwitcherInterceptor implements MethodInterceptor {
+
+  public Object invoke( MethodInvocation invocation ) throws Throwable {
+    Object ret;
+    ClassLoader currentThreadContextClassLoader = null;
+    boolean classLoaderWasSet = false;
+    try {
+      currentThreadContextClassLoader = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread().setContextClassLoader( this.getClass().getClassLoader() );
+      classLoaderWasSet = true;
+      ret = invocation.proceed();
+    } finally {
+      if ( classLoaderWasSet ) {
+        Thread.currentThread().setContextClassLoader( currentThreadContextClassLoader );
+      }
+    }
+    return ret;
+  }
+}


### PR DESCRIPTION
- Fixed regression which was caused by switching to the spring-ldap-2.1.0