### PR TITLE
[BACKLOG-15653] In KarafBoot, while looking for etc folder based on c…

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/osgi/KarafBoot.java
+++ b/extensions/src/main/java/org/pentaho/platform/osgi/KarafBoot.java
@@ -345,8 +345,9 @@ public class KarafBoot implements IPentahoSystemListener {
     // the particular execution needs (Carte, Spoon, Pan, Kitchen)
     KettleClientEnvironment.ClientType clientType = getClientType();
     String extraKettleEtc = translateToExtraKettleEtc( clientType );
-
-    if ( extraKettleEtc != null ) {
+    // If clientType is null, the extraKettleEtc will return 'etc-default'
+    // Added a check to see if the folder exist before setting the system property
+    if ( extraKettleEtc != null && new File( root + extraKettleEtc ).exists() ) {
       System.setProperty( "felix.fileinstall.dir", root + "/etc" + "," + root + extraKettleEtc );
     } else {
       System.setProperty( "felix.fileinstall.dir", root + "/etc" );


### PR DESCRIPTION
…lientType, if the

clientType is null, the folder is getting defaulted to etc-default. Since this
folder does not exist in PentahoServer, added a check to ensure the folder
exist, before using it to set the path in system property.