### PR TITLE
[BISERVER-12677]-Session-expiry cookie an logic

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/pentaho.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/pentaho.xml
@@ -154,4 +154,5 @@
 
    </file-upload-defaults>
   <default-theme>sapphire</default-theme>
+  <session-expired-dialog>true</session-expired-dialog>
 </pentaho-system>

--- a/extensions/src/test/java/org/pentaho/platform/web/http/filters/CasAuthenticationProvider.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/filters/CasAuthenticationProvider.java
@@ -1,0 +1,36 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.filters;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * Is needed in {@link HttpSessionPentahoSessionIntegrationFilterTest}
+ */
+class CasAuthenticationProvider implements AuthenticationProvider {
+
+  @Override public Authentication authenticate( Authentication authentication ) throws AuthenticationException {
+    return null;
+  }
+
+  @Override public boolean supports( Class<?> authentication ) {
+    return false;
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/http/filters/HttpSessionPentahoSessionIntegrationFilterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/filters/HttpSessionPentahoSessionIntegrationFilterTest.java
@@ -1,0 +1,137 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.filters;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.ISystemSettings;
+import org.pentaho.platform.api.engine.ObjectFactoryException;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.springframework.security.authentication.AuthenticationProvider;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+public class HttpSessionPentahoSessionIntegrationFilterTest {
+
+  private HttpServletResponse servletResponse;
+  private HttpSession httpSession;
+  private IPentahoSession pentahoSession;
+
+  @Before
+  public void setUp() {
+    servletResponse = Mockito.mock( HttpServletResponse.class );
+    httpSession = Mockito.mock( HttpSession.class );
+    pentahoSession = Mockito.mock( IPentahoSession.class );
+    PentahoSystem.clearObjectFactory();
+  }
+
+  @Test
+  public void testSessionCookieNoHttpSession() {
+    new HttpSessionPentahoSessionIntegrationFilter()
+      .setSessionExpirationCookies( null, pentahoSession, servletResponse );
+    Mockito.verify( servletResponse, Mockito.never() ).addCookie( Mockito.any() );
+  }
+
+  @Test
+  public void testSessionCookieNoPentahoSession() {
+    new HttpSessionPentahoSessionIntegrationFilter().setSessionExpirationCookies( httpSession, null, servletResponse );
+    Mockito.verify( servletResponse, Mockito.never() ).addCookie( Mockito.any() );
+  }
+
+  @Test
+  public void testSessionCookieDisabledInSettings() {
+    final ISystemSettings systemSettings = PentahoSystem.getSystemSettings();
+    try {
+      final ISystemSettings mockSettings = Mockito.mock( ISystemSettings.class );
+      Mockito.when( mockSettings.getSystemSetting( "session-expired-dialog", "true" ) ).thenReturn( "false" );
+      PentahoSystem.setSystemSettingsService( mockSettings );
+      new HttpSessionPentahoSessionIntegrationFilter()
+        .setSessionExpirationCookies( httpSession, pentahoSession, servletResponse );
+      Mockito.verify( servletResponse, Mockito.never() ).addCookie( Mockito.any() );
+    } finally {
+      PentahoSystem.setSystemSettingsService( systemSettings );
+    }
+  }
+
+  @Test
+  public void testSessionCookieNoAuthenticationProviders() {
+    final ISystemSettings systemSettings = PentahoSystem.getSystemSettings();
+    try {
+      final ISystemSettings mockSettings = Mockito.mock( ISystemSettings.class );
+      Mockito.when( mockSettings.getSystemSetting( "session-expired-dialog", "true" ) ).thenReturn( "true" );
+      PentahoSystem.setSystemSettingsService( mockSettings );
+      new HttpSessionPentahoSessionIntegrationFilter()
+        .setSessionExpirationCookies( httpSession, pentahoSession, servletResponse );
+      Mockito.verify( servletResponse, Mockito.never() ).addCookie( Mockito.any() );
+    } finally {
+      PentahoSystem.setSystemSettingsService( systemSettings );
+    }
+  }
+
+  @Test
+  public void testSessionCookieCASEnabled() throws ObjectFactoryException {
+
+    final ISystemSettings systemSettings = PentahoSystem.getSystemSettings();
+    try {
+      final ISystemSettings mockSettings = Mockito.mock( ISystemSettings.class );
+      Mockito.when( mockSettings.getSystemSetting( "session-expired-dialog", "true" ) ).thenReturn( "true" );
+      PentahoSystem.setSystemSettingsService( mockSettings );
+      final CasAuthenticationProvider mockObj = Mockito.mock( CasAuthenticationProvider.class );
+      PentahoSystem.registerObject( mockObj, AuthenticationProvider.class );
+      new HttpSessionPentahoSessionIntegrationFilter()
+        .setSessionExpirationCookies( httpSession, pentahoSession, servletResponse );
+      Mockito.verify( servletResponse, Mockito.never() ).addCookie( Mockito.any() );
+    } finally {
+      PentahoSystem.setSystemSettingsService( systemSettings );
+    }
+  }
+
+  @Test
+  public void testSessionCookieNoSettings() throws ObjectFactoryException {
+    final AuthenticationProvider mockObj = Mockito.mock( AuthenticationProvider.class );
+    PentahoSystem.registerObject( mockObj, AuthenticationProvider.class );
+
+    new HttpSessionPentahoSessionIntegrationFilter()
+      .setSessionExpirationCookies( httpSession, pentahoSession, servletResponse );
+    Mockito.verify( servletResponse, Mockito.times( 1 ) ).addCookie( Mockito.any() );
+  }
+
+  @Test
+  public void testSessionCookieSettingsEnabled() throws ObjectFactoryException {
+
+    final ISystemSettings systemSettings = PentahoSystem.getSystemSettings();
+    try {
+      final ISystemSettings mockSettings = Mockito.mock( ISystemSettings.class );
+      Mockito.when( mockSettings.getSystemSetting( "session-expired-dialog", "true" ) ).thenReturn( "true" );
+      PentahoSystem.setSystemSettingsService( mockSettings );
+      final AuthenticationProvider mockObj = Mockito.mock( AuthenticationProvider.class );
+      PentahoSystem.registerObject( mockObj, AuthenticationProvider.class );
+      new HttpSessionPentahoSessionIntegrationFilter()
+        .setSessionExpirationCookies( httpSession, pentahoSession, servletResponse );
+      Mockito.verify( servletResponse, Mockito.times( 1 ) ).addCookie( Mockito.any() );
+    } finally {
+      PentahoSystem.setSystemSettingsService( systemSettings );
+    }
+  }
+
+
+}

--- a/user-console/src/main/java/org/pentaho/mantle/client/commands/SessionExpiredCommand.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/commands/SessionExpiredCommand.java
@@ -1,0 +1,81 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.mantle.client.commands;
+
+import com.google.gwt.user.client.Cookies;
+import com.google.gwt.user.client.Timer;
+import org.pentaho.gwt.widgets.client.dialogs.SessionExpiredDialog;
+
+/**
+ * Shows a session expired dialog in a top frame.
+ * Won't work on the screens missing the mantle application.
+ */
+public class SessionExpiredCommand extends AbstractCommand {
+
+  //10 seconds by default
+  private Integer pollingInterval = 10000;
+  private static final String SESSION_EXPIRY = "session-expiry";
+  private static Timer timer;
+
+  @Override protected void performOperation() {
+    this.performOperation( true );
+  }
+
+  @Override protected void performOperation( boolean feedback ) {
+    checkCookie();
+    //Only one timer at a time
+    if ( timer == null ) {
+      timer = new Timer() {
+        @Override public void run() {
+          checkCookie();
+        }
+      };
+      timer.scheduleRepeating( getPollingInterval() );
+    }
+  }
+
+  public Integer getPollingInterval() {
+    return pollingInterval;
+  }
+
+  public void setPollingInterval( final Integer pollingInterval ) {
+    this.pollingInterval = pollingInterval;
+  }
+
+  /**
+   * Checks the cookie set in {@link org.pentaho.platform.web.http.filters
+   * .HttpSessionPentahoSessionIntegrationFilter#setSessionExpirationCookies(HttpSession,
+   * HttpServletResponse)}
+   */
+  private void checkCookie() {
+    final String sessionExpiry = Cookies.getCookie( SESSION_EXPIRY );
+    //A cookie is not set
+    if ( sessionExpiry != null ) {
+      try {
+        if ( System.currentTimeMillis() > Long.parseLong( sessionExpiry ) ) {
+          //Session expired
+          new SessionExpiredDialog().center();
+          timer.cancel();
+          timer = null;
+        }
+      } catch ( final NumberFormatException e ) {
+        //Wrong value in the header
+      }
+    }
+  }
+}


### PR DESCRIPTION
Will fail due to unmerged gwt https://github.com/pentaho/pentaho-commons-gwt-modules/pull/559
The command is started by a script included globally https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1009

A cookie usage allows us to cover both regular and asynchronous requests without modifications in spring-security.
Checked with JCR/LDAP/CAS - works as expected.
The settings file will not be backported, the feature is enabled by default.