### PR TITLE
[BACKLOG-15987] Add check to disable inherits check box in root folders

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
@@ -45,6 +45,7 @@ import org.pentaho.gwt.widgets.client.dialogs.PromptDialogBox;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFile;
 import org.pentaho.mantle.client.messages.Messages;
 import org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel;
+import org.pentaho.platform.web.http.api.resources.utils.FileUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -304,7 +305,11 @@ public class PermissionsPanel extends FlexTable implements IFileModifier {
     } );
 
     // home folders ( i.e. folders below /home ) will not have the 'inherits folder permission' action available
-    boolean inheritsCheckBoxDisabled = this.fileSummary.isFolder() && this.fileSummary.getPath().toLowerCase().startsWith( "/home/" );
+    final String HOME_FOLDER = FileUtils.PATH_SEPARATOR + "home" + FileUtils.PATH_SEPARATOR;
+    String lowercasePath = this.fileSummary.getPath().toLowerCase();
+
+    boolean inheritsCheckBoxDisabled = this.fileSummary.isFolder()
+      && ( isPathAtRootLevel( lowercasePath ) || lowercasePath.startsWith( HOME_FOLDER ) );
     inheritsCheckBox.setEnabled( !inheritsCheckBoxDisabled );
 
     int row = 0;
@@ -334,6 +339,17 @@ public class PermissionsPanel extends FlexTable implements IFileModifier {
     permissionsTable.setHeight( "100%" ); //$NON-NLS-1$
 
     init();
+  }
+
+  private boolean isPathAtRootLevel( String path ) {
+    int matches = Integer.MAX_VALUE;
+    if ( path != null ) {
+      matches = path.length() - path.replace( FileUtils.PATH_SEPARATOR, "" ).length();
+      if ( path.endsWith( FileUtils.PATH_SEPARATOR ) ) {
+        matches--;
+      }
+    }
+    return matches == 1;
   }
 
   private void setManageCheckBox( boolean value ) {


### PR DESCRIPTION
This PR is a complement to https://github.com/pentaho/pentaho-platform/pull/3531

Inherits checkbox is disabled if:
 - It's a folder at root level
 - It's a folder under home folder