### PR TITLE
[BISERVER-13579]- REST API /userrolelist/getRolesForUser and /userrolelist/getUsersInRole don't return JSON

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RolesWrapper.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RolesWrapper.java
@@ -1,0 +1,48 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017-2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlRootElement( name = "roles" )
+public class RolesWrapper {
+
+  List<String> roles = new ArrayList<String>();
+
+  public RolesWrapper() {
+  }
+
+  public RolesWrapper( List<String> roles ) {
+    this.roles.addAll( roles );
+  }
+
+  @XmlElement( name = "role" )
+  public List<String> getRoles() {
+    return roles;
+  }
+
+  public void setRoles( List<String> roles ) {
+    if ( roles != this.roles ) {
+      this.roles.clear();
+      this.roles.addAll( roles );
+    }
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserRoleListResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserRoleListResource.java
@@ -12,24 +12,16 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import java.util.ArrayList;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import org.codehaus.enunciate.jaxrs.ResponseCode;
 import org.codehaus.enunciate.jaxrs.StatusCodes;
@@ -38,7 +30,11 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.security.DefaultRoleComparator;
 import org.pentaho.platform.engine.security.DefaultUsernameComparator;
 import org.pentaho.platform.web.http.api.resources.services.UserRoleListService;
-import org.pentaho.platform.web.http.api.resources.services.UserRoleListService.UnauthorizedException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 /**
  * The UserRoleListResource service lists roles, permissions, and users. Provides a list of users per role and roles per
@@ -296,15 +292,8 @@ public class UserRoleListResource extends AbstractJaxRSResource {
   @Produces( { APPLICATION_XML, APPLICATION_JSON } )
   @StatusCodes( { @ResponseCode( code = 200, condition = "Successfully retrieved the list of Role objects." ),
     @ResponseCode( code = 500, condition = "Invalid user parameter." ) } )
-  public Response getRolesForUser( @QueryParam( "user" ) String user ) throws Exception {
-    try {
-      String roles = userRoleListService.doGetRolesForUser( user );
-      return buildOkResponse( roles, MediaType.APPLICATION_XML );
-    } catch ( UnauthorizedException t ) {
-      return buildStatusResponse( UNAUTHORIZED );
-    } catch ( Throwable t ) {
-      throw new WebApplicationException( t );
-    }
+  public RolesWrapper getRolesForUser( @QueryParam( "user" ) String user ) throws Exception {
+    return new RolesWrapper( userRoleListService.doGetRolesForUser( user ) );
   }
 
   /**
@@ -334,22 +323,8 @@ public class UserRoleListResource extends AbstractJaxRSResource {
   @Produces( { APPLICATION_XML, APPLICATION_JSON } )
   @StatusCodes( { @ResponseCode( code = 200, condition = "Successfully retrieved the list of User objects." ),
     @ResponseCode( code = 500, condition = "Missing the role parameter." ) } )
-  public Response getUsersInRole( @QueryParam( "role" ) String role ) throws Exception {
-    try {
-      String roles = userRoleListService.doGetUsersInRole( role );
-      return buildOkResponse( roles, MediaType.APPLICATION_XML );
-    } catch ( UnauthorizedException t ) {
-      return buildStatusResponse( UNAUTHORIZED );
-    } catch ( Throwable t ) {
-      throw new WebApplicationException( t );
-    }
+  public UsersWrapper getUsersInRole( @QueryParam( "role" ) String role ) throws Exception {
+    return new UsersWrapper( userRoleListService.doGetUsersInRole( role ) );
   }
 
-  protected Response buildOkResponse( Object entity, String type ) {
-    return Response.ok( entity ).type( type ).build();
-  }
-
-  protected Response buildStatusResponse( Response.Status status ) {
-    return Response.status( status ).build();
-  }
 }

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UsersWrapper.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UsersWrapper.java
@@ -1,0 +1,48 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017-2017 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+@XmlRootElement( name = "users" )
+public class UsersWrapper {
+
+  List<String> users = new ArrayList<String>();
+
+  public UsersWrapper() {
+  }
+
+  public UsersWrapper( List<String> users ) {
+    this.users.addAll( users );
+  }
+
+  @XmlElement( name = "user" )
+  public List<String> getUsers() {
+    return users;
+  }
+
+  public void setUsers( List<String> users ) {
+    if ( users != this.users ) {
+      this.users.clear();
+      this.users.addAll( users );
+    }
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/SystemService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/SystemService.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources.services;
@@ -96,41 +96,19 @@ public class SystemService {
   }
 
   /**
-   * Returns XML for list of Roles for a given User.
+   * Returns a list of Roles for a given User.
    */
-  public Document getRolesForUser( String user ) throws ServletException, IOException {
+  public List<String> getRolesForUser( String user ) {
     IUserRoleListService service = PentahoSystem.get( IUserRoleListService.class );
-    Element rootElement = new DefaultElement( "roles" ); //$NON-NLS-1$
-    Document doc = DocumentHelper.createDocument( rootElement );
-    if ( service != null ) {
-      List<String> roles = service.getRolesForUser( null, user );
-      for ( Iterator<String> rolesIterator = roles.iterator(); rolesIterator.hasNext(); ) {
-        String roleName = rolesIterator.next().toString();
-        if ( ( null != roleName ) && ( roleName.length() > 0 ) ) {
-          rootElement.addElement( "role" ).setText( roleName ); //$NON-NLS-1$
-        }
-      }
-    }
-    return doc;
+    return service.getRolesForUser( null, user );
   }
 
   /**
-   * Returns XML for list of Users for a given Role.
+   * Returns a list of Users for a given Role.
    */
-  public Document getUsersInRole( String role ) throws ServletException, IOException {
+  public List<String> getUsersInRole( String role ) {
     IUserRoleListService service = PentahoSystem.get( IUserRoleListService.class );
-    Element rootElement = new DefaultElement( "users" ); //$NON-NLS-1$
-    Document doc = DocumentHelper.createDocument( rootElement );
-    if ( service != null ) {
-      List<String> users = service.getUsersInRole( null, role );
-      for ( Iterator<String> usersIterator = users.iterator(); usersIterator.hasNext(); ) {
-        String username = usersIterator.next().toString();
-        if ( ( null != username ) && ( username.length() > 0 ) ) {
-          rootElement.addElement( "user" ).setText( username ); //$NON-NLS-1$
-        }
-      }
-    }
-    return doc;
+    return service.getUsersInRole( null, role );
   }
 
   /**

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources.services;
@@ -45,7 +45,7 @@ public class UserRoleListService {
 
   private Comparator<String> userComparator;
 
-  public String doGetRolesForUser( String user ) throws Exception {
+  public List<String> doGetRolesForUser( String user ) throws UnauthorizedException {
     if ( canAdminister() ) {
       return getRolesForUser( user );
     } else {
@@ -53,7 +53,7 @@ public class UserRoleListService {
     }
   }
 
-  public String doGetUsersInRole( String role ) throws Exception {
+  public List<String> doGetUsersInRole( String role ) throws UnauthorizedException {
     if ( canAdminister() ) {
       return getUsersInRole( role );
     } else {
@@ -147,12 +147,12 @@ public class UserRoleListService {
     return userRoleListService;
   }
 
-  protected String getRolesForUser( String user ) throws Exception {
-    return SystemService.getSystemService().getRolesForUser( user ).asXML();
+  protected List<String> getRolesForUser( String user ) {
+    return SystemService.getSystemService().getRolesForUser( user );
   }
 
-  protected String getUsersInRole( String role ) throws Exception {
-    return SystemService.getSystemService().getUsersInRole( role ).asXML();
+  protected List<String> getUsersInRole( String role )  {
+    return SystemService.getSystemService().getUsersInRole( role );
   }
 
   public void setExtraRoles( ArrayList<String> extraRoles ) {

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/UserRoleListResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/UserRoleListResourceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
@@ -22,13 +22,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.platform.web.http.api.resources.services.UserRoleListService;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
 
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
 
 public class UserRoleListResourceTest {
 
@@ -48,49 +50,21 @@ public class UserRoleListResourceTest {
   @Test
   public void testGetRolesForUser() throws Exception {
     String user = "user";
+    String role1 = "role_1";
+    String role2 = "role_2";
 
-    String roles = "roles";
-    doReturn( roles ).when( userRoleListResource.userRoleListService ).doGetRolesForUser( user );
+    List<String> listRoles = new ArrayList<>();
+    listRoles.add( role1 );
+    listRoles.add( role2 );
+    doReturn( listRoles ).when( userRoleListResource.userRoleListService ).doGetRolesForUser( user );
 
-    Response mockResponse = mock( Response.class );
-    doReturn( mockResponse ).when( userRoleListResource ).buildOkResponse( roles, MediaType.APPLICATION_XML );
+    RolesWrapper rolesWrapper = userRoleListResource.getRolesForUser( user );
 
-    Response testResponse = userRoleListResource.getRolesForUser( user );
-    assertEquals( mockResponse, testResponse );
+    assertEquals( listRoles.size(), rolesWrapper.getRoles().size() );
+    assertEquals( listRoles.get( 0 ), rolesWrapper.getRoles().get( 0 ) );
+    assertEquals( listRoles.get( 1 ), rolesWrapper.getRoles().get( 1 ) );
 
     verify( userRoleListResource.userRoleListService, times( 1 ) ).doGetRolesForUser( user );
-    verify( userRoleListResource, times( 1 ) ).buildOkResponse( roles, MediaType.APPLICATION_XML );
-  }
-
-  @Test
-  public void testGetRolesForUserError() throws Exception {
-    String user = "user";
-
-    Response mockResponse = mock( Response.class );
-    doReturn( mockResponse ).when( userRoleListResource ).buildStatusResponse( Response.Status.UNAUTHORIZED );
-
-
-    // Test 1
-    UserRoleListService.UnauthorizedException mockUnauthorizedException =
-        mock( UserRoleListService.UnauthorizedException.class );
-    doThrow( mockUnauthorizedException ).when( userRoleListResource.userRoleListService ).doGetRolesForUser( user );
-
-    Response testResponse = userRoleListResource.getRolesForUser( user );
-    assertEquals( mockResponse, testResponse );
-
-    // Test 2
-    Throwable mockThrowable = mock( RuntimeException.class );
-    doThrow( mockThrowable ).when( userRoleListResource.userRoleListService ).doGetRolesForUser( user );
-
-    try {
-      userRoleListResource.getRolesForUser( user );
-      fail();
-    } catch ( WebApplicationException e ) {
-      // expected
-    }
-
-    verify( userRoleListResource, times( 1 ) ).buildStatusResponse( Response.Status.UNAUTHORIZED );
-    verify( userRoleListResource.userRoleListService, times( 2 ) ).doGetRolesForUser( user );
   }
 
   @Test
@@ -118,45 +92,21 @@ public class UserRoleListResourceTest {
   @Test
   public void testGetUsersInRole() throws Exception {
     String role = "role";
+    String user1 = "user_1";
+    String user2 = "user_2";
 
-    String roles = "roles";
-    doReturn( roles ).when( userRoleListResource.userRoleListService ).doGetUsersInRole( role );
+    List<String> listUsers = new ArrayList<>();
+    listUsers.add( user1 );
+    listUsers.add( user2 );
+    doReturn( listUsers ).when( userRoleListResource.userRoleListService ).doGetUsersInRole( role );
 
-    Response mockResponse = mock( Response.class );
-    doReturn( mockResponse ).when( userRoleListResource ).buildOkResponse( roles, MediaType.APPLICATION_XML );
+    UsersWrapper usersWrapper = userRoleListResource.getUsersInRole( role );
 
-    Response testResponse = userRoleListResource.getUsersInRole( role );
-    assertEquals( mockResponse, testResponse );
+    assertEquals( listUsers.size(), usersWrapper.getUsers().size() );
+    assertEquals( listUsers.get( 0 ), usersWrapper.getUsers().get( 0 ) );
+    assertEquals( listUsers.get( 1 ), usersWrapper.getUsers().get( 1 ) );
 
     verify( userRoleListResource.userRoleListService, times( 1 ) ).doGetUsersInRole( role );
-    verify( userRoleListResource, times( 1 ) ).buildOkResponse( roles, MediaType.APPLICATION_XML );
-  }
-
-  @Test
-  public void testGetUsersInRoleError() throws Exception {
-    String role = "role";
-
-    Response mockResponse = mock( Response.class );
-    doReturn( mockResponse ).when( userRoleListResource ).buildStatusResponse( UNAUTHORIZED );
-
-    // Test 1
-    UserRoleListService.UnauthorizedException mockUnauthorizedException =
-        mock( UserRoleListService.UnauthorizedException.class );
-    doThrow( mockUnauthorizedException ).when( userRoleListResource.userRoleListService ).doGetUsersInRole( role );
-
-    Response testResponse = userRoleListResource.getUsersInRole( role );
-    assertEquals( mockResponse, testResponse );
-
-    // Test 2
-    Throwable mockThrowabe = mock( RuntimeException.class );
-    doThrow( mockThrowabe ).when( userRoleListResource.userRoleListService ).doGetUsersInRole( role );
-
-    try {
-      userRoleListResource.getUsersInRole( role );
-      fail();
-    } catch ( WebApplicationException e ) {
-      // expected
-    }
   }
 
   @Test

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/UserRoleListServiceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/UserRoleListServiceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources.services;
@@ -50,14 +50,20 @@ public class UserRoleListServiceTest {
 
   @Test
   public void testDoGetRolesForUser() throws Exception {
+    String user = "TestUser";
     doReturn( true ).when( userRoleListService ).canAdminister();
-    doReturn( "admin, guest" ).when( userRoleListService ).getRolesForUser( "Administrator" );
-    String roles = userRoleListService.doGetRolesForUser( "Administrator" );
-    assertTrue( roles.length() > 0 );
+    List<String> testRoles = new ArrayList<>();
+    testRoles.add( "Role_1" );
+    testRoles.add( "Role_2" );
+    doReturn( testRoles ).when( userRoleListService ).getRolesForUser( user );
+    List<String> receivedRoles = userRoleListService.doGetRolesForUser( user );
+    assertTrue( receivedRoles.size() == 2 );
+    assertEquals( testRoles.get( 0 ), receivedRoles.get( 0 ) );
+    assertEquals( testRoles.get( 1 ), receivedRoles.get( 1 ) );
 
     try {
       doReturn( false ).when( userRoleListService ).canAdminister();
-      userRoleListService.doGetRolesForUser( "unauthorized" );
+      userRoleListService.doGetRolesForUser( user );
     } catch ( Exception e ) {
       assertTrue( e instanceof UserRoleListService.UnauthorizedException );
     }
@@ -65,14 +71,20 @@ public class UserRoleListServiceTest {
 
   @Test
   public void testDoGetUsersInRole() throws Exception {
+    String role = "TestRole";
     doReturn( true ).when( userRoleListService ).canAdminister();
-    doReturn( "Administrator, Guest" ).when( userRoleListService ).getUsersInRole( "admin" );
-    String users = userRoleListService.doGetUsersInRole( "admin" );
-    assertTrue( users.length() > 0 );
+    List<String> testUsers = new ArrayList<>();
+    testUsers.add( "User_1" );
+    testUsers.add( "User_2" );
+    doReturn( testUsers ).when( userRoleListService ).getUsersInRole( role );
+    List<String> receivedUsers = userRoleListService.getUsersInRole( role );
+    assertTrue( receivedUsers.size() == 2 );
+    assertEquals( testUsers.get( 0 ), receivedUsers.get( 0 ) );
+    assertEquals( testUsers.get( 1 ), receivedUsers.get( 1 ) );
 
     try {
       doReturn( false ).when( userRoleListService ).canAdminister();
-      userRoleListService.doGetUsersInRole( "unauthorized" );
+      userRoleListService.doGetUsersInRole( role );
     } catch ( Exception e ) {
       assertTrue( e instanceof UserRoleListService.UnauthorizedException );
     }


### PR DESCRIPTION
-XML hard-coded response is removed.  Now the answer type (XML or JSON) depends on Accept header.
-The previous type of xml aswer (as in pentaho documentation) is  retained