### PR TITLE
[BACKLOG-15986] Added the call to setInheritsAcls() in cancel handler…

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
@@ -249,7 +249,8 @@ public class PermissionsPanel extends FlexTable implements IFileModifier {
               permissionsOverwriteConfirm.hide();
               inheritsCheckBox.setValue( false );
               dirty = false;
-              // Set the button state to value before the confirmation dialog
+              // BACKLOG-15986 Set the button state to value before the confirmation dialog
+              setInheritsAcls( inheritsCheckBox.getValue(), fileInfo );
               addButton.setEnabled( currAddButtonState );
               removeButton.setEnabled( currRemoveButtonState );
             }


### PR DESCRIPTION
… of the

confirmation dialog. This was to avoid any side effects as
refreshPermissions are being called from lots of places.