### PR TITLE
[BACKLOG-15986] Added the call to setInheritsAcls() in cancel handler…

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
@@ -246,7 +246,10 @@ public class PermissionsPanel extends FlexTable implements IFileModifier {
               permissionsOverwriteConfirm.hide();
               inheritsCheckBox.setValue( false );
               dirty = false;
-              refreshPermission();
+              // BACKLOG-15986 Set the button state to value before the confirmation dialog
+              setInheritsAcls( inheritsCheckBox.getValue(), fileInfo );
+              addButton.setEnabled( currAddButtonState );
+              removeButton.setEnabled( currRemoveButtonState );
             }
 
             public void okPressed() {


### PR DESCRIPTION
… of the

confirmation dialog. This was to avoid any side effects as
refreshPermissions are being called from lots of places.
Removed refreshPermission() and setthe state of add and remove button to
state before the confirmation dialog opened