### PR TITLE
[BACKLOG-15986] Reset the state of add and remove button to the value

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/PermissionsPanel.java
@@ -236,6 +236,9 @@ public class PermissionsPanel extends FlexTable implements IFileModifier {
         if ( inheritsCheckBox.getValue() ) {
           VerticalPanel vp = new VerticalPanel();
           vp.add( new Label( Messages.getString( "permissionsWillBeLostQuestion" ) ) ); //$NON-NLS-1$
+          // Get the state of add and remove button
+          final boolean currRemoveButtonState = removeButton.isEnabled();
+          final boolean currAddButtonState = addButton.isEnabled();
           final PromptDialogBox permissionsOverwriteConfirm =
               new PromptDialogBox(
                   Messages.getString( "permissionsWillBeLostConfirmMessage" ), Messages.getString( "ok" ), Messages.getString( "cancel" ), false, true, vp ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -248,6 +251,7 @@ public class PermissionsPanel extends FlexTable implements IFileModifier {
               dirty = false;
               // BACKLOG-15986 Set the button state to value before the confirmation dialog
               setInheritsAcls( inheritsCheckBox.getValue(), fileInfo );
+              // Set the button state to value before the confirmation dialog
               addButton.setEnabled( currAddButtonState );
               removeButton.setEnabled( currRemoveButtonState );
             }


### PR DESCRIPTION
before the confirmation dialog, if the user cancel in the "Inherit folder
permission" dialog.