### PR TITLE
[BACKLOG-11933][REVERT] Encode URI for the tab name when user input c…

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/commands/SaveCommand.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/commands/SaveCommand.java
@@ -310,11 +310,6 @@ public class SaveCommand extends AbstractCommand {
   private void doTabRename() {
     if ( tabName != null ) { // Save-As does not modify the name of the tab.
       PentahoTab tab = SolutionBrowserPanel.getInstance().getContentTabPanel().getSelectedTab();
-      if ( tabName.indexOf( "\"" ) != -1 ) {
-        //BACKLOG-11933, double quote ( " ) need special handling, could have done encodeUri, yet %22 brings UX issue.
-        //For now, replace double quote with 2 single quote as a fallback solution.
-        tabName = tabName.replaceAll( "\"", "''" );
-      }
       tab.setLabelText( tabName );
       tab.setLabelTooltip( tabName );
     }


### PR DESCRIPTION
…ontains special characters

- [REVERT] https://github.com/pentaho/pentaho-platform/pull/3460/commits/20117fcba1a625243a39644fafa590514fd4478d
- Focus will be on actually allowing a double-quote on the first save