### PR TITLE
[BISERVER-13575] - DynamicallyPooledDatasourceSystemListener causing startup issues when driver can not be initialized

### DIFF
--- a/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DriverNotInitializedException.java
+++ b/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DriverNotInitializedException.java
@@ -1,0 +1,38 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2017 - 2017 Pentaho Corporation.  All rights reserved.
+ */
+package org.pentaho.platform.engine.services.connection.datasource.dbcp;
+
+public class DriverNotInitializedException extends RuntimeException {
+
+  public DriverNotInitializedException() {
+  }
+
+  public DriverNotInitializedException( String message ) {
+    super( message );
+  }
+
+
+  public DriverNotInitializedException( String message, Throwable reas ) {
+    super( message, reas );
+  }
+
+  public DriverNotInitializedException( Throwable reas ) {
+    super( reas );
+  }
+
+}

--- a/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DynamicallyPooledDatasourceSystemListener.java
+++ b/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DynamicallyPooledDatasourceSystemListener.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2014 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 package org.pentaho.platform.engine.services.connection.datasource.dbcp;
 
@@ -42,7 +42,7 @@ public class DynamicallyPooledDatasourceSystemListener extends PooledDatasourceS
     DataSource ds = null;
     try {
       ds = getDatasourceService().getDataSource( connection.getName() );
-    } catch ( DBDatasourceServiceException e ) {
+    } catch ( DBDatasourceServiceException | DriverNotInitializedException e ) {
       Logger.error( this, Messages.getInstance()
           .getErrorString( "DatasourceSystemListener.ERROR_0003_UNABLE_TO_POOL_DATASOURCE", connection.getName(), e.getMessage() ) ); //$NON-NLS-1$
     }

--- a/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelper.java
+++ b/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelper.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.engine.services.connection.datasource.dbcp;
@@ -163,7 +163,7 @@ public class PooledDatasourceHelper {
       poolingDataSource = new PoolingDataSource();
       if ( dialect instanceof IDriverLocator ) {
         if ( !( (IDriverLocator) dialect ).initialize( driverClass ) ) {
-          throw new RuntimeException( Messages.getInstance()
+          throw new DriverNotInitializedException( Messages.getInstance()
             .getErrorString( "PooledDatasourceHelper.ERROR_0009_UNABLE_TO_POOL_DATASOURCE_CANT_INITIALIZE",
               databaseConnection.getName(), driverClass ) );
         }
@@ -382,7 +382,7 @@ public class PooledDatasourceHelper {
                                        String databaseConnectionName ) throws DBDatasourceServiceException {
     if ( dialect instanceof IDriverLocator ) {
       if ( !( (IDriverLocator) dialect ).initialize( driverClassName ) ) {
-        throw new RuntimeException( Messages.getInstance()
+        throw new DriverNotInitializedException( Messages.getInstance()
           .getErrorString( "PooledDatasourceHelper.ERROR_0009_UNABLE_TO_POOL_DATASOURCE_CANT_INITIALIZE",
             databaseConnectionName, driverClassName ) );
       }

--- a/core/src/test/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DynamicallyPooledDatasourceSystemListenerTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DynamicallyPooledDatasourceSystemListenerTest.java
@@ -13,34 +13,69 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2014 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 package org.pentaho.platform.engine.services.connection.datasource.dbcp;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 import javax.sql.DataSource;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.database.model.IDatabaseConnection;
+import org.pentaho.platform.api.data.DBDatasourceServiceException;
+import org.pentaho.platform.api.data.IDBDatasourceService;
 import org.pentaho.platform.engine.services.MockDataSourceService;
 
+@RunWith( MockitoJUnitRunner.class )
 public class DynamicallyPooledDatasourceSystemListenerTest {
 
   private static final String CONNECTION_NAME = "TEST CONNECTION";
 
+  @Mock
+  IDBDatasourceService datasourceService;
+  @Mock
+  IDatabaseConnection connection;
+  @Spy
+  DynamicallyPooledDatasourceSystemListener listener;
+
+
+  @Before
+  public void before() {
+    when( connection.getName() ).thenReturn( CONNECTION_NAME );
+  }
+
   @Test
   public void testGetDataSource() {
-    IDatabaseConnection connection = mock( IDatabaseConnection.class );
-    when( connection.getName() ).thenReturn( CONNECTION_NAME );
-
-    DynamicallyPooledDatasourceSystemListener listener = spy( new DynamicallyPooledDatasourceSystemListener() );
     when( listener.getDatasourceService() ).thenReturn( new MockDataSourceService( false ) );
     DataSource ds = listener.getDataSource( connection );
     assertNotNull( ds );
   }
 
+  @Test
+  public void testGetDataSourceHandleDBDatasourceServiceException() throws Exception {
+
+    when( listener.getDatasourceService() ).thenReturn( datasourceService );
+    when( datasourceService.getDataSource( CONNECTION_NAME ) ).thenThrow( new DBDatasourceServiceException() );
+
+    DataSource ds = listener.getDataSource( connection );
+    assertNull( ds );
+  }
+
+  @Test
+  public void testGetDataSourceHanldeDriverNotInitializedException() throws Exception {
+
+    when( listener.getDatasourceService() ).thenReturn( datasourceService );
+    when( datasourceService.getDataSource( CONNECTION_NAME ) ).thenThrow( new DriverNotInitializedException() );
+
+    DataSource ds = listener.getDataSource( connection );
+    assertNull( ds );
+  }
 }

--- a/core/src/test/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelperTest.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.engine.services.connection.datasource.dbcp;
@@ -289,6 +289,13 @@ public class PooledDatasourceHelperTest {
     } catch ( Exception e ) {
       assertThat( e, instanceOf( DBDatasourceServiceException.class ) );
     }
+  }
+
+  @Test( expected = DriverNotInitializedException.class )
+  public void testDriverNotInitialized() throws DBDatasourceServiceException {
+    when( dialectService.getDialect( connection ) ).thenReturn( driverLocatorDialect );
+    when( ( (IDriverLocator) driverLocatorDialect ).initialize( nativeDriverName ) ).thenReturn( false );
+    PooledDatasourceHelper.convert( connection, () -> dialectService );
   }
 
   @After


### PR DESCRIPTION
The issue was caused by throwing and not handling unchecked RuntimeException. Added add a new unchecked exception, which would be catched and logged in DynamicallyPooledDatasourceSystemListener only. By doing this we won't affect other places