### PR TITLE
[BACKLOG-11933] Add correction to a specific case where the tab would…

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
@@ -546,7 +546,7 @@ public class MantleTabPanel extends org.pentaho.gwt.widgets.client.tabs.PentahoT
       // is called due to conversion to JSON. Ex. for tab name a"b:
       //    #a"b1494409287116 need to be escaped to #a\"b1494409287116.
       if ( frameId.indexOf( "\"" ) != -1 ) {
-        frameId = frameId.replaceAll( "\"", "\\\\\"" );
+        frameId = frameId.replaceAll( "\"", "" );
         frameElement.setAttribute( "id", frameId );
       }
       final String finalFrameId = frameId;


### PR DESCRIPTION
…n't close if a pir/paz was created, closed and opened from the browse files for the first time

This PR is a complement of https://github.com/pentaho/pentaho-platform/pull/3579