### PR TITLE
[BACKLOG-16489] Pentaho Server CE - Folder 'plugin-samples' is hidden

### DIFF
--- a/assemblies/pentaho-plugin-samples/src/main/resources/plugin-samples/exportManifest.xml
+++ b/assemblies/pentaho-plugin-samples/src/main/resources/plugin-samples/exportManifest.xml
@@ -23,7 +23,7 @@
 	
     <ExportManifestEntity path="public/plugin-samples">
         <ExportManifestProperty>
-            <EntityMetaData name="plugin-samples" createdDate="2015-02-17T15:03:21.570-03:00" isFolder="true" path="public/plugin-samples" isHidden="true" locale="en_US" description="plugin-samples-ddd" title="plugin-samples-nnn"/>
+            <EntityMetaData name="plugin-samples" createdDate="2015-02-17T15:03:21.570-03:00" isFolder="true" path="public/plugin-samples" isHidden="false" locale="en_US" description="plugin-samples-ddd" title="plugin-samples-nnn"/>
         </ExportManifestProperty>
         <ExportManifestProperty>
             <EntityAcl>


### PR DESCRIPTION
- CE plugin-samples's exportManifest.xml has the 'isHidden' flag set to 'true'
  - https://github.com/pentaho/pentaho-platform/blob/7.1.0.0/assemblies/pentaho-plugin-samples/src/main/resources/plugin-samples/exportManifest.xml#L26 

- EE also holds a plugin-samples's exportManifest.xml, that also has the 'isHidden' flag set to 'true'
  - https://github.com/pentaho/pentaho-platform-ee/blob/7.1.0.0/assemblies/pentaho-solutions-ee/src/main/resources/pentaho-solutions/plugin-samples/exportManifest.xml#L26


We switch CE plugin-samples's 'isHidden' flag to 'false', leaving EE's the way it is.