### PR TITLE
[BACKLOG-16489] Pentaho Server CE - Folder 'plugin-samples' is hidden

### DIFF
--- a/assemblies/pentaho-plugin-samples/src/main/resources/plugin-samples/exportManifest.xml
+++ b/assemblies/pentaho-plugin-samples/src/main/resources/plugin-samples/exportManifest.xml
@@ -23,7 +23,7 @@
 	
     <ExportManifestEntity path="public/plugin-samples">
         <ExportManifestProperty>
-            <EntityMetaData name="plugin-samples" createdDate="2015-02-17T15:03:21.570-03:00" isFolder="true" path="public/plugin-samples" isHidden="true" locale="en_US" description="plugin-samples-ddd" title="plugin-samples-nnn"/>
+            <EntityMetaData name="plugin-samples" createdDate="2015-02-17T15:03:21.570-03:00" isFolder="true" path="public/plugin-samples" isHidden="false" locale="en_US" description="plugin-samples-ddd" title="plugin-samples-nnn"/>
         </ExportManifestProperty>
         <ExportManifestProperty>
             <EntityAcl>


### PR DESCRIPTION
- dev-validated in 8.0-SNAPSHOT
  - CE-8.0-SNAPSHOT has the plugin-samples showing by default
  - EE-8.0-SNAPSHOT has the plugin-samples hidden by default
- [CHERRY-PICK] bf912d7