### PR TITLE
Revert "[BACKLOG-16489] Pentaho Server CE - Folder 'plugin-samples' is hidden"

### DIFF
--- a/assemblies/pentaho-plugin-samples/src/main/resources/plugin-samples/exportManifest.xml
+++ b/assemblies/pentaho-plugin-samples/src/main/resources/plugin-samples/exportManifest.xml
@@ -23,7 +23,7 @@
 	
     <ExportManifestEntity path="public/plugin-samples">
         <ExportManifestProperty>
-            <EntityMetaData name="plugin-samples" createdDate="2015-02-17T15:03:21.570-03:00" isFolder="true" path="public/plugin-samples" isHidden="false" locale="en_US" description="plugin-samples-ddd" title="plugin-samples-nnn"/>
+            <EntityMetaData name="plugin-samples" createdDate="2015-02-17T15:03:21.570-03:00" isFolder="true" path="public/plugin-samples" isHidden="true" locale="en_US" description="plugin-samples-ddd" title="plugin-samples-nnn"/>
         </ExportManifestProperty>
         <ExportManifestProperty>
             <EntityAcl>


### PR DESCRIPTION
Reverts pentaho/pentaho-platform#3594

- @pamval, @pentaho/rogueone the EE-8.0-SNAPSHOT under which this was tested / validated gave a "false positive". A more recent EE SNAPSHOT build show that now the "plugin-samples" folder appears **visible** by default, with this change. Issuing a PR to revert this change.

Will re-open this issue and continue looking into it.