### PR TITLE
[PPP-3734] Use of vulnerable component webservices-rt-2.1- CVE-2013-5…

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -739,7 +739,7 @@
     <dependency>
       <groupId>org.glassfish.metro</groupId>
       <artifactId>webservices-api</artifactId>
-      <version>${webservices-api.version}</version>
+      <version>${webservices.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -751,7 +751,7 @@
     <dependency>
       <groupId>org.glassfish.metro</groupId>
       <artifactId>webservices-rt</artifactId>
-      <version>${webservices-rt.version}</version>
+      <version>${webservices.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestMondrian.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestMondrian.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2013 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 //
@@ -30,6 +30,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * <p>
@@ -64,6 +65,7 @@ public class ExportManifestMondrian {
   protected String catalogName;
   protected boolean xmlaEnabled;
   @XmlElement( type = org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.Parameters.class )
+  @XmlJavaTypeAdapter( MapAdapter.class )
   protected org.pentaho.platform.plugin.services.importexport.exportManifest.Parameters parameters;
   @XmlAttribute( name = "file" )
   protected String file;

--- a/extensions/src/test/java/org/pentaho/platform/plugin/action/kettle/KettleSystemListenerTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/action/kettle/KettleSystemListenerTest.java
@@ -12,12 +12,11 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.action.kettle;
 
-import com.sun.xml.bind.StringInputStream;
 import org.apache.log4j.FileAppender;
 import org.junit.After;
 import org.junit.Before;
@@ -29,6 +28,7 @@ import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
+import java.io.StringBufferInputStream;
 
 import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -82,7 +82,7 @@ public class KettleSystemListenerTest {
   public void shouldNotFailAndReturnNullWhenMaliciousXmlIsGiven() throws IOException, ParserConfigurationException, SAXException {
     KettleSystemListener ksl = new KettleSystemListener();
 
-    ksl.getSlaveServerConfigNode( new StringInputStream( XmlTestConstants.MALICIOUS_XML ) );
+    ksl.getSlaveServerConfigNode( new StringBufferInputStream( XmlTestConstants.MALICIOUS_XML ) );
     fail();
   }
 
@@ -93,6 +93,6 @@ public class KettleSystemListenerTest {
       + "</slave_config>";
     KettleSystemListener ksl = new KettleSystemListener();
 
-    assertNotNull( ksl.getSlaveServerConfigNode( new StringInputStream( xml ) ) );
+    assertNotNull( ksl.getSlaveServerConfigNode( new StringBufferInputStream( xml ) ) );
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperTest.java
@@ -12,15 +12,15 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.action.mondrian.catalog;
 
 import java.io.IOException;
+import java.io.StringBufferInputStream;
 import java.util.Map;
 
-import com.sun.xml.bind.StringInputStream;
 import org.junit.Assert;
 import org.junit.Test;
 import org.pentaho.platform.api.engine.ICacheManager;
@@ -106,7 +106,7 @@ public class MondrianCatalogHelperTest {
 
   @Test( timeout = 2000, expected = SAXException.class )
   public void shouldNotFailAndReturnNullWhenMaliciousXmlIsGiven() throws IOException, ParserConfigurationException, SAXException {
-    mch.getMondrianXmlDocument( new StringInputStream( XmlTestConstants.MALICIOUS_XML ) );
+    mch.getMondrianXmlDocument( new StringBufferInputStream( XmlTestConstants.MALICIOUS_XML ) );
     fail();
   }
 
@@ -116,6 +116,6 @@ public class MondrianCatalogHelperTest {
       + "<slave_config>"
       + "</slave_config>";
 
-    assertNotNull( mch.getMondrianXmlDocument( new StringInputStream( xml ) ) );
+    assertNotNull( mch.getMondrianXmlDocument( new StringBufferInputStream( xml ) ) );
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/LocaleImportHandlerTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/LocaleImportHandlerTest.java
@@ -13,12 +13,11 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.services.importer;
 
-import com.sun.xml.bind.StringInputStream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.junit.Before;
@@ -40,6 +39,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringBufferInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -219,7 +219,7 @@ public class LocaleImportHandlerTest {
   public void shouldNotFailAndReturnNullWhenMaliciousXmlIsGiven() throws IOException, ParserConfigurationException, SAXException {
     LocaleImportHandler lih = new LocaleImportHandler( Collections.emptyList(), null );
 
-    lih.getLocalBundleDocument( new StringInputStream( XmlTestConstants.MALICIOUS_XML ) );
+    lih.getLocalBundleDocument( new StringBufferInputStream( XmlTestConstants.MALICIOUS_XML ) );
     fail();
   }
 
@@ -230,6 +230,6 @@ public class LocaleImportHandlerTest {
       + "</slave_config>";
     LocaleImportHandler lih = new LocaleImportHandler( Collections.emptyList(), null );
 
-    assertNotNull( lih.getLocalBundleDocument( new StringInputStream( xml ) ) );
+    assertNotNull( lih.getLocalBundleDocument( new StringBufferInputStream( xml ) ) );
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/XActionImportHandlerTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/XActionImportHandlerTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.services.importer;
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringBufferInputStream;
 import java.util.Arrays;
 import java.util.List;
 
@@ -37,8 +38,6 @@ import org.pentaho.platform.api.mimetype.IMimeType;
 import org.pentaho.platform.api.repository2.unified.IPlatformImportBundle;
 import org.pentaho.platform.util.XmlTestConstants;
 import org.xml.sax.SAXException;
-
-import com.sun.xml.bind.StringInputStream;
 
 /**
  * This unit test focuses on validating XActionImportHandler logic, which, according to the class' javadoc, quote:
@@ -85,7 +84,7 @@ public class XActionImportHandlerTest {
 
   @Test( timeout = 2000, expected = SAXException.class )
   public void shouldNotFailAndReturnNullWhenMaliciousXmlIsGiven() throws IOException, ParserConfigurationException, SAXException {
-    handler.getImportBundleDocument( new StringInputStream( XmlTestConstants.MALICIOUS_XML ) );
+    handler.getImportBundleDocument( new StringBufferInputStream( XmlTestConstants.MALICIOUS_XML ) );
     fail();
   }
 
@@ -95,7 +94,7 @@ public class XActionImportHandlerTest {
       + "<slave_config>"
       + "</slave_config>";
 
-    assertNotNull( handler.getImportBundleDocument( new StringInputStream( xml ) ) );
+    assertNotNull( handler.getImportBundleDocument( new StringBufferInputStream( xml ) ) );
   }
 
   private InputStream getXactionAsInputStream( String xactionTestFilePath ) {

--- a/extensions/src/test/java/org/pentaho/platform/web/http/context/PentahoSolutionSpringApplicationContextTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/context/PentahoSolutionSpringApplicationContextTest.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  * ******************************************************************************
  *
@@ -21,7 +21,6 @@
 
 package org.pentaho.platform.web.http.context;
 
-import com.sun.xml.bind.StringInputStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +35,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.StringBufferInputStream;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -71,7 +71,7 @@ public class PentahoSolutionSpringApplicationContextTest {
 
   @Test( timeout = 2000, expected = SAXException.class )
   public void shouldNotFailAndReturnNullWhenMaliciousXmlIsGiven() throws IOException, ParserConfigurationException, SAXException {
-    appContext.getResourceDocument( new StringInputStream( XmlTestConstants.MALICIOUS_XML ) );
+    appContext.getResourceDocument( new StringBufferInputStream( XmlTestConstants.MALICIOUS_XML ) );
     fail();
   }
 
@@ -81,6 +81,6 @@ public class PentahoSolutionSpringApplicationContextTest {
       + "<slave_config>"
       + "</slave_config>";
 
-    assertNotNull( appContext.getResourceDocument( new StringInputStream( xml ) ) );
+    assertNotNull( appContext.getResourceDocument( new StringBufferInputStream( xml ) ) );
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
     <bsf.version>2.4.0</bsf.version>
     <lucene-core.version>3.6.0</lucene-core.version>
     <georss-rome.version>0.9.8</georss-rome.version>
-    <webservices-api.version>2.1</webservices-api.version>
     <jmock-junit4.version>2.5.1</jmock-junit4.version>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
@@ -131,7 +130,6 @@
     <trilead-ssh2.version>build213</trilead-ssh2.version>
     <spring-ldap-core.version>2.1.0.RELEASE</spring-ldap-core.version>
     <xmlbeans.version>2.6.0</xmlbeans.version>
-    <webservices-rt.version>2.1</webservices-rt.version>
     <org.apache.felix.utils.version>1.8.0</org.apache.felix.utils.version>
     <saaj.version>1.3</saaj.version>
     <jcl-over-slf4j.version>1.7.7</jcl-over-slf4j.version>
@@ -162,7 +160,7 @@
     <jsr311-api.version>1.1.1</jsr311-api.version>
     <rsyntaxtextarea.version>1.3.2</rsyntaxtextarea.version>
     <license.fail.if.missing>false</license.fail.if.missing>
-    <webservices.version>2.1</webservices.version>
+    <webservices.version>2.3.1</webservices.version>
     <wadl-resourcedoc-doclet.version>1.19.1</wadl-resourcedoc-doclet.version>
     <gwt-servlet.version>2.5.1</gwt-servlet.version>
     <asm.version>3.1</asm.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -423,7 +423,7 @@
     <dependency>
       <groupId>org.glassfish.metro</groupId>
       <artifactId>webservices-api</artifactId>
-      <version>${webservices-api.version}</version>
+      <version>${webservices.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -434,7 +434,7 @@
     <dependency>
       <groupId>org.glassfish.metro</groupId>
       <artifactId>webservices-rt</artifactId>
-      <version>${webservices-rt.version}</version>
+      <version>${webservices.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.glassfish.metro</groupId>
       <artifactId>webservices-api</artifactId>
-      <version>${webservices-api.version}</version>
+      <version>${webservices.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.glassfish.metro</groupId>
       <artifactId>webservices-rt</artifactId>
-      <version>${webservices-rt.version}</version>
+      <version>${webservices.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
[PPP-3734] Use of vulnerable component webservices-rt-2.1- CVE-2013-5816 and CVE-2013-2172

  - StringInputStream was removed in 2.3.1, replace with StringBufferInputStream
  - @XmlJavaTypeAdapter shouldn't be used against class since 2.3.1