### PR TITLE
[BACKLOG-16728] - Using relative context path in WebContext

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/filters/PentahoWebContextFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/filters/PentahoWebContextFilter.java
@@ -197,15 +197,16 @@ public class PentahoWebContextFilter implements Filter {
     }
   }
 
+
   private boolean shouldUseFullyQualifiedUrl( HttpServletRequest httpRequest ) {
     final String useFullyQualifiedUrlParameter = httpRequest.getParameter( "fullyQualifiedUrl" );
     if ( useFullyQualifiedUrlParameter != null ) {
       return "true".equals( useFullyQualifiedUrlParameter );
     } else {
-      final String referer = httpRequest.getHeader( "referer" );
-      final String serverAddress = httpRequest.getScheme() + "://" + httpRequest.getServerName() + ":" + httpRequest.getServerPort();
-
-      return referer != null && !referer.startsWith( serverAddress );
+      // Returning false for now. The smart way of determining whether we should use the fully
+      // qualified url did not work behind the proxy server and this case
+      // http://jira.pentaho.com/browse/BACKLOG-16728 was created.
+      return false;
     }
   }
 

--- a/extensions/src/test/java/org/pentaho/platform/web/http/filters/PentahoWebContextFilterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/filters/PentahoWebContextFilterTest.java
@@ -122,7 +122,7 @@ public class PentahoWebContextFilterTest {
     PentahoWebContextFilter.cache = cacheManager;
 
     when( cacheManager.getFromGlobalCache( PentahoSystem.WAIT_SECONDS ) ).thenReturn( null )
-        .thenReturn( new Integer( 30 ) );
+      .thenReturn( new Integer( 30 ) );
 
     filter.printRequireJsCfgStart( new ByteArrayOutputStream() );
     filter.printRequireJsCfgStart( new ByteArrayOutputStream() );
@@ -194,7 +194,7 @@ public class PentahoWebContextFilterTest {
 
     final String response = this.mockResponseOutputStream.toString( "UTF-8" );
 
-    assertTrue( this.responseSetsContextPathGlobal( response, this.fullyQualifiedServerURL ) );
+    assertTrue( this.responseSetsContextPathGlobal( response, this.contextRoot ) );
     assertTrue( this.requirejsManagerInitIsCalled( response, null ) );
   }
 
@@ -218,7 +218,7 @@ public class PentahoWebContextFilterTest {
     final boolean containsScript = response.contains( "requirejs-manager/js/require-init.js?requirejs=false" );
 
     final boolean containsFullyQualifiedUrlParameter = response.contains(
-        "&fullyQualifiedUrl=" + ( useFullyQualifiedUrlParameter != null ? useFullyQualifiedUrlParameter : "" )
+      "&fullyQualifiedUrl=" + ( useFullyQualifiedUrlParameter != null ? useFullyQualifiedUrlParameter : "" )
     );
 
     return containsScript && containsFullyQualifiedUrlParameter == ( useFullyQualifiedUrlParameter != null );


### PR DESCRIPTION
- Return false to shouldUseFullyQualifiedUrl to make sure CONTEXT_PATH is relative