### PR TITLE
[BACKLOG-16711,BACKLOG-15332,BISERVER-13266] Changed filtering of system folders from FileService …

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/repository2/unified/RepositoryRequest.java
+++ b/api/src/main/java/org/pentaho/platform/api/repository2/unified/RepositoryRequest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.api.repository2.unified;
@@ -35,6 +35,7 @@ public class RepositoryRequest {
   private String path;
   private boolean showHidden = false;
   private boolean includeAcls = false;
+  private boolean includeSystemFolders = true; // default
   private Integer depth = -1;
   private FILES_TYPE_FILTER types = FILES_TYPE_FILTER.FILES_FOLDERS;
   private Set<String> includeMemberSet = null;
@@ -178,6 +179,14 @@ public class RepositoryRequest {
 
   public boolean isShowHidden() {
     return showHidden;
+  }
+
+  public boolean isIncludeSystemFolders() {
+    return includeSystemFolders;
+  }
+
+  public void setIncludeSystemFolders( boolean includeSystemFolders ) {
+    this.includeSystemFolders = includeSystemFolders;
   }
 
   /**

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryRequestTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryRequestTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2015 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.api.repository2.unified;
@@ -24,10 +24,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Created by bgroves on 10/28/15.
@@ -36,6 +33,7 @@ public class RepositoryRequestTest {
 
   private static final String PATH = "path";
   private static final boolean SHOW_HIDE = true;
+  private static final boolean INCLUDE_SYSTEM_FOLDERS = false;
   private static final Integer DEPTH = 2;
   private static final String LEGACY_FILTER = "FILES||ODD_FILTER";
   private static final String INLCUDE_ONE = "includeOne";
@@ -57,6 +55,7 @@ public class RepositoryRequestTest {
     request.setExcludeMemberSet( EXCLUDE_SET );
     request.setIncludeAcls( INCLUDE_ACLS );
     request.setChildNodeFilter( CHILD_FILTER );
+    request.setIncludeSystemFolders( INCLUDE_SYSTEM_FOLDERS );
   }
 
   @Test
@@ -71,11 +70,13 @@ public class RepositoryRequestTest {
     assertNull( defaultRequest.getPath() );
     assertFalse( defaultRequest.isIncludeAcls() );
     assertNull( defaultRequest.getChildNodeFilter() );
+    assertTrue( defaultRequest.isIncludeSystemFolders() );
 
     // Test constructor with nulls
     RepositoryRequest nullRequest = new RepositoryRequest( null, null, null, null );
     assertFalse( nullRequest.isShowHidden() );
     assertEquals( new Integer( -1 ), nullRequest.getDepth() );
+    assertTrue( nullRequest.isIncludeSystemFolders() );
 
     // Test constructor with values
     assertEquals( SHOW_HIDE, request.isShowHidden() );
@@ -86,10 +87,15 @@ public class RepositoryRequestTest {
     assertEquals( PATH, request.getPath() );
     assertEquals( INCLUDE_ACLS, request.isIncludeAcls() );
     assertEquals( CHILD_FILTER, request.getChildNodeFilter() );
+    assertEquals( INCLUDE_SYSTEM_FOLDERS, request.isIncludeSystemFolders() );
 
     boolean newShowHide = !SHOW_HIDE;
     request.setShowHidden( newShowHide );
     assertEquals( newShowHide, request.isShowHidden() );
+
+    boolean newIncludeSystemFolders = !INCLUDE_SYSTEM_FOLDERS;
+    request.setShowHidden( newIncludeSystemFolders );
+    assertEquals( newIncludeSystemFolders, request.isIncludeSystemFolders() );
 
     String newPath = "newPath";
     request.setPath( newPath );

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
@@ -1691,8 +1691,9 @@ public class FileResource extends AbstractJaxRSResource {
     @ResponseCode ( code = 500, condition = "Server Error." ) } )
   public RepositoryFileTreeDto doGetTree( @PathParam ( "pathId" ) String pathId, @QueryParam ( "depth" ) Integer depth,
                                           @QueryParam ( "filter" ) String filter, @QueryParam ( "showHidden" ) Boolean showHidden,
-                                          @DefaultValue ( "false" ) @QueryParam ( "includeAcls" ) Boolean includeAcls ) {
-    return fileService.doGetTree( pathId, depth, filter, showHidden, includeAcls );
+                                          @DefaultValue ( "false" ) @QueryParam ( "includeAcls" ) Boolean includeAcls,
+                                          @DefaultValue ( "false" ) @QueryParam ( "includeSysDirs" ) Boolean includeSystemFolders ) {
+    return fileService.doGetTree( pathId, depth, filter, showHidden, includeAcls, includeSystemFolders );
   }
 
   /**

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources.services;
@@ -1334,6 +1334,11 @@ public class FileService {
 
   public RepositoryFileTreeDto doGetTree( String pathId, Integer depth, String filter, Boolean showHidden,
                                           Boolean includeAcls ) {
+    return doGetTree( pathId, depth, filter, showHidden, includeAcls, false /* default */ );
+  }
+
+  public RepositoryFileTreeDto doGetTree( String pathId, Integer depth, String filter, Boolean showHidden,
+                                          Boolean includeAcls, Boolean includeSystemFolders ) {
     String path = null;
     if ( pathId == null || pathId.equals( FileUtils.PATH_SEPARATOR ) ) {
       path = FileUtils.PATH_SEPARATOR;
@@ -1343,9 +1348,10 @@ public class FileService {
 
     RepositoryRequest repositoryRequest = getRepositoryRequest( path, showHidden, depth, filter );
     repositoryRequest.setIncludeAcls( includeAcls );
+    repositoryRequest.setIncludeSystemFolders( includeSystemFolders );
 
     RepositoryFileTreeDto tree = getRepoWs().getTreeFromRequest( repositoryRequest );
-    List<RepositoryFileTreeDto> filteredChildren = new ArrayList<RepositoryFileTreeDto>();
+
 
     // BISERVER-9599 - Use special sort order
     if ( isShowingTitle( repositoryRequest ) ) {
@@ -1354,17 +1360,12 @@ public class FileService {
       sortByLocaleTitle( collator, tree );
     }
 
+    List<RepositoryFileTreeDto> childrenList = new ArrayList<RepositoryFileTreeDto>();
     for ( RepositoryFileTreeDto child : tree.getChildren() ) {
-      RepositoryFileDto file = child.getFile();
-      Map<String, Serializable> fileMeta = getRepository().getFileMetadata( file.getId() );
-      boolean isSystemFolder =
-        fileMeta.containsKey( IUnifiedRepository.SYSTEM_FOLDER ) ? (Boolean) fileMeta
-          .get( IUnifiedRepository.SYSTEM_FOLDER ) : false;
-      if ( !isSystemFolder ) {
-        filteredChildren.add( child );
-      }
+      childrenList.add( child );
     }
-    tree.setChildren( filteredChildren );
+
+    tree.setChildren( childrenList );
 
     return tree;
   }

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2002 - 2017 Pentaho Corporation.  All rights reserved.
  *
  * This software was developed by Pentaho Corporation and is provided under the terms
  * of the Mozilla Public License, Version 1.1, or any later version. You may not use
@@ -1288,16 +1288,17 @@ public class FileResourceTest {
     String filter = "filter";
     Boolean showHidden = Boolean.TRUE;
     Boolean includeAcls = Boolean.TRUE;
+    Boolean includeSysDirs = Boolean.FALSE;
 
     RepositoryFileTreeDto mockRepositoryFileTreeDto = mock( RepositoryFileTreeDto.class );
     doReturn( mockRepositoryFileTreeDto ).when( fileResource.fileService )
       .doGetTree( PATH_ID, depth, filter, showHidden,
-        includeAcls );
+        includeAcls, includeSysDirs );
 
-    RepositoryFileTreeDto testDto = fileResource.doGetTree( PATH_ID, depth, filter, showHidden, includeAcls );
+    RepositoryFileTreeDto testDto = fileResource.doGetTree( PATH_ID, depth, filter, showHidden, includeAcls, includeSysDirs );
     assertEquals( mockRepositoryFileTreeDto, testDto );
 
-    verify( fileResource.fileService ).doGetTree( PATH_ID, depth, filter, showHidden, includeAcls );
+    verify( fileResource.fileService ).doGetTree( PATH_ID, depth, filter, showHidden, includeAcls, includeSysDirs );
   }
 
   @Test

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources.services;
@@ -1932,6 +1932,7 @@ public class FileServiceTest {
     verify( fileService ).addAdminRole( fileAcl );
   }
 
+  @Test
   public void testDoGetTree() {
     String pathId = ":path:to:file:file1.ext";
     int depth = 1;
@@ -1991,6 +1992,10 @@ public class FileServiceTest {
 
     verify( fileService, times( 2 ) )
       .getRepositoryRequest( eq( FileUtils.PATH_SEPARATOR ), anyBoolean(), anyInt(), anyString() );
+
+    // Test 3 - includeSystemFolders is false
+    mockRequest.setIncludeSystemFolders( false );
+    doReturn( mockTreeDto ).when( fileService.defaultUnifiedRepositoryWebService ).getTreeFromRequest( mockRequest );
   }
 
   @Test

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/DefaultUnifiedRepository.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/DefaultUnifiedRepository.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2013 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.repository2.unified;
@@ -263,7 +263,7 @@ public class DefaultUnifiedRepository implements IUnifiedRepository {
       final Class<T> dataClass ) {
     return getDataForReadInBatch( files, dataClass );
   }
-  
+
   @Override
   public List<RepositoryFile> getChildren( RepositoryRequest repositoryRequest ) {
     return repositoryFileDao.getChildren( repositoryRequest );
@@ -273,13 +273,13 @@ public class DefaultUnifiedRepository implements IUnifiedRepository {
    * {@inheritDoc}
    */
   public List<RepositoryFile> getChildren( final Serializable folderId ) {
-    return getChildren( folderId, null, null);
+    return getChildren( folderId, null, null );
   }
 
   /**
    * {@inheritDoc}
    */
-  public List<RepositoryFile> getChildren( final Serializable folderId, final String filter) {
+  public List<RepositoryFile> getChildren( final Serializable folderId, final String filter ) {
     return getChildren( folderId, filter, null );
   }
 
@@ -459,8 +459,7 @@ public class DefaultUnifiedRepository implements IUnifiedRepository {
   /**
    * {@inheritDoc}
    */
-  public void
-  restoreFileAtVersion( final Serializable fileId, final Serializable versionId, final String versionMessage ) {
+  public void restoreFileAtVersion( final Serializable fileId, final Serializable versionId, final String versionMessage ) {
     Assert.notNull( fileId );
     Assert.notNull( versionId );
     repositoryFileDao.restoreFileAtVersion( fileId, versionId, versionMessage );
@@ -473,12 +472,12 @@ public class DefaultUnifiedRepository implements IUnifiedRepository {
     Assert.notNull( fileId );
     return repositoryFileDao.canUnlockFile( fileId );
   }
-  
+
   /**
    * {@inheritDoc}
    */
   @Override
-  public RepositoryFileTree getTree( RepositoryRequest repositoryRequest ) {
+  public RepositoryFileTree  getTree( RepositoryRequest repositoryRequest ) {
     return repositoryFileDao.getTree( repositoryRequest );
   }
 
@@ -493,8 +492,8 @@ public class DefaultUnifiedRepository implements IUnifiedRepository {
     Assert.hasText( path );
     return getTree( new RepositoryRequest( path, showHidden, depth, filter ) );
   }
-  
-    private RepositoryFile internalCreateFile( final Serializable parentFolderId, final RepositoryFile file,
+
+  private RepositoryFile internalCreateFile( final Serializable parentFolderId, final RepositoryFile file,
       final IRepositoryFileData data, final RepositoryFileAcl acl, final String versionMessage ) {
     Assert.notNull( file );
     Assert.notNull( data );

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/RepositoryFileProxy.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/RepositoryFileProxy.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 package org.pentaho.platform.repository2.unified.jcr;
 
@@ -37,6 +37,9 @@ import org.apache.commons.lang.StringUtils;
 import org.pentaho.platform.api.locale.IPentahoLocale;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.repository2.unified.webservices.RepositoryFileAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.extensions.jcr.JcrCallback;
 import org.springframework.extensions.jcr.JcrTemplate;
 
@@ -46,6 +49,7 @@ import org.springframework.extensions.jcr.JcrTemplate;
 public class RepositoryFileProxy extends RepositoryFile {
 
   private static final long serialVersionUID = 5244310953843118329L;
+  private static Logger logger = LoggerFactory.getLogger( RepositoryFileAdapter.class );
 
   private Node node;
   private PentahoJcrConstants constants;
@@ -86,10 +90,14 @@ public class RepositoryFileProxy extends RepositoryFile {
     try {
       this.absPath = node.getPath();
     } catch ( RepositoryException e ) {
-      e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+      getLogger().error( "RepositoryException was found: ", e );
     }
     this.template = template;
     this.lockHelper = PentahoSystem.get( ILockHelper.class );
+  }
+
+  public static Logger getLogger() {
+    return logger;
   }
 
   private PentahoJcrConstants getPentahoJcrConstants() {
@@ -159,7 +167,6 @@ public class RepositoryFileProxy extends RepositoryFile {
       return false;
     }
     return true;
-//    return super.equals( obj ); // To change body of overridden methods use File | Settings | File Templates.
   }
 
   @Override
@@ -177,11 +184,11 @@ public class RepositoryFileProxy extends RepositoryFile {
               }
             }
           } catch ( PathNotFoundException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( null, e );
           } catch ( ValueFormatException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( null, e );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( null, e );
           }
         }
       } );
@@ -197,7 +204,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           try {
             metadata = JcrRepositoryFileUtils.getFileMetadata( session, getId() );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -215,7 +222,7 @@ public class RepositoryFileProxy extends RepositoryFile {
         }
       }
     } catch ( RepositoryException e ) {
-      e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+      getLogger().error( "RepositoryException was found: ", e );
     }
     return creatorId;
   }
@@ -266,7 +273,7 @@ public class RepositoryFileProxy extends RepositoryFile {
 
             }
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -297,7 +304,7 @@ public class RepositoryFileProxy extends RepositoryFile {
               fileSize = node.getProperty( getPentahoJcrConstants().getPHO_FILESIZE() ).getLong();
             }
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -315,7 +322,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           try {
             id = JcrRepositoryFileUtils.getNodeId( session, getPentahoJcrConstants(), node );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -340,7 +347,7 @@ public class RepositoryFileProxy extends RepositoryFile {
               }
             }
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -369,7 +376,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           } catch ( javax.jcr.PathNotFoundException e ) {
             // Do not throw a stack trace if the locale file is missing.
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -386,7 +393,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           try {
             lock = session.getWorkspace().getLockManager().getLock( node.getPath() );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -403,7 +410,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           try {
             lockDate = lockHelper.getLockDate( session, getPentahoJcrConstants(), getLock() );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -420,7 +427,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           try {
             lockMessage = lockHelper.getLockMessage( session, getPentahoJcrConstants(), getLock() );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -437,7 +444,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           try {
             lockOwner = lockHelper.getLockOwner( session, getPentahoJcrConstants(), getLock() );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -456,7 +463,7 @@ public class RepositoryFileProxy extends RepositoryFile {
                 RepositoryFile.SEPARATOR.equals( getPath() )
                     ? "" : JcrRepositoryFileUtils.getNodeName( session, getPentahoJcrConstants(), node ); //$NON-NLS-1$
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -481,7 +488,7 @@ public class RepositoryFileProxy extends RepositoryFile {
                 new DefaultPathConversionHelper().absToRel( ( JcrRepositoryFileUtils.getAbsolutePath( session,
                     getPentahoJcrConstants(), node ) ) );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -505,7 +512,7 @@ public class RepositoryFileProxy extends RepositoryFile {
             try {
               versionId = JcrRepositoryFileUtils.getVersionId( session, getPentahoJcrConstants(), node );
             } catch ( RepositoryException e ) {
-              e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+              getLogger().error( "RepositoryException was found: ", e );
             }
           }
         } );
@@ -534,7 +541,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           try {
             folder = JcrRepositoryFileUtils.isPentahoFolder( getPentahoJcrConstants(), node );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -554,7 +561,7 @@ public class RepositoryFileProxy extends RepositoryFile {
               hidden = node.getProperty( getPentahoJcrConstants().getPHO_HIDDEN() ).getBoolean();
             }
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -593,7 +600,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           try {
             locked = JcrRepositoryFileUtils.isLocked( getPentahoJcrConstants(), node );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -610,7 +617,7 @@ public class RepositoryFileProxy extends RepositoryFile {
           try {
             versioned = JcrRepositoryFileUtils.isVersioned( session, getPentahoJcrConstants(), node );
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -629,7 +636,7 @@ public class RepositoryFileProxy extends RepositoryFile {
               aclNode = node.getProperty( getPentahoJcrConstants().getPHO_ACLNODE() ).getBoolean();
             }
           } catch ( RepositoryException e ) {
-            e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+            getLogger().error( "RepositoryException was found: ", e );
           }
         }
       } );
@@ -658,7 +665,7 @@ public class RepositoryFileProxy extends RepositoryFile {
         } );
       }
     } catch ( RepositoryException e ) {
-      e.printStackTrace(); // To change body of catch statement use File | Settings | File Templates.
+      getLogger().error( "RepositoryException was found: ", e );
     }
   }
 

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAdapter.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/RepositoryFileAdapter.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.repository2.unified.webservices;
@@ -33,6 +33,8 @@ import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileTree;
 import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
 import org.pentaho.platform.repository2.unified.jcr.JcrRepositoryFileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Converts {@code RepositoryFile} into JAXB-safe object and vice-versa.
@@ -40,6 +42,9 @@ import org.pentaho.platform.repository2.unified.jcr.JcrRepositoryFileUtils;
  * @author mlowery
  */
 public class RepositoryFileAdapter extends XmlAdapter<RepositoryFileDto, RepositoryFile> {
+
+  private static Logger logger = LoggerFactory.getLogger( RepositoryFileAdapter.class );
+
   private static DefaultUnifiedRepositoryWebService repoWs;
   private Set<String> membersSet;
   private boolean exclude;
@@ -60,6 +65,10 @@ public class RepositoryFileAdapter extends XmlAdapter<RepositoryFileDto, Reposit
       this.membersSet = repositoryRequest.getIncludeMemberSet();
     }
     this.includeAcls = repositoryRequest.isIncludeAcls();
+  }
+
+  public static Logger getLogger() {
+    return logger;
   }
 
   @Override
@@ -91,72 +100,80 @@ public class RepositoryFileAdapter extends XmlAdapter<RepositoryFileDto, Reposit
       return null;
     }
     RepositoryFileDto f = new RepositoryFileDto();
-    if ( include( "name", memberSet, exclude ) ) {
-      f.name = v.getName();
-    }
-    if ( include( "path", memberSet, exclude ) ) {
-      f.path = v.getPath();
-    }
-    if ( include( "hidden", memberSet, exclude ) ) {
-      f.hidden = v.isHidden();
-    }
-    if ( include( "aclNode", memberSet, exclude ) ) {
-      f.aclNode = v.isAclNode();
-    }
-    if ( include( "createDate", memberSet, exclude ) ) {
-      f.createdDate = v.getCreatedDate();
-    }
-    if ( include( "creatorId", memberSet, exclude ) ) {
-      f.creatorId = v.getCreatorId();
-    }
-    if ( include( "fileSize", memberSet, exclude ) ) {
-      f.fileSize = v.getFileSize();
-    }
-    if ( include( "description", memberSet, exclude ) ) {
-      f.description = v.getDescription();
-    }
-    if ( include( "folder", memberSet, exclude ) ) {
-      f.folder = v.isFolder();
-    }
-    //The include check is intentionally omitted on the Id field because
-    //it must be present or the tree rest service call will error
-    if ( v.getId() != null ) {
-      f.id = v.getId().toString();
-    }
-    if ( include( "lastModifiedDate", memberSet, exclude ) ) {
-      f.lastModifiedDate = v.getLastModifiedDate();
-    }
-    if ( include( "locale", memberSet, exclude ) ) {
-      f.locale = v.getLocale();
-    }
-    if ( include( "originalParentFolderPath", memberSet, exclude ) ) {
-      f.originalParentFolderPath = v.getOriginalParentFolderPath();
-    }
-    if ( include( "deletedDate", memberSet, exclude ) ) {
-      f.deletedDate = v.getDeletedDate();
-    }
-    if ( include( "lockDate", memberSet, exclude ) ) {
-      f.lockDate = v.getLockDate();
-    }
-    if ( include( "locked", memberSet, exclude ) ) {
-      f.locked = v.isLocked();
-    }
-    if ( include( "lockMessage", memberSet, exclude ) ) {
-      f.lockMessage = v.getLockMessage();
-    }
-    if ( include( "lockOwner", memberSet, exclude ) ) {
-      f.lockOwner = v.getLockOwner();
-    }
-    if ( include( "title", memberSet, exclude ) ) {
-      f.title = v.getTitle();
-    }
-    if ( include( "versioned", memberSet, exclude ) ) {
-      f.versioned = v.isVersioned();
-    }
-    if ( include( "versionId", memberSet, exclude ) ) {
-      if ( v.getVersionId() != null ) {
-        f.versionId = v.getVersionId().toString();
+    // Will try to read the repository file parameters from the repository, in case it returns NPE, means that the file
+    // no longer exists, so it returns null
+    try {
+      if ( include( "name", memberSet, exclude ) ) {
+        f.name = v.getName();
       }
+      if ( include( "path", memberSet, exclude ) ) {
+        f.path = v.getPath();
+      }
+      if ( include( "hidden", memberSet, exclude ) ) {
+        f.hidden = v.isHidden();
+      }
+      if ( include( "aclNode", memberSet, exclude ) ) {
+        f.aclNode = v.isAclNode();
+      }
+      if ( include( "createDate", memberSet, exclude ) ) {
+        f.createdDate = v.getCreatedDate();
+      }
+      if ( include( "creatorId", memberSet, exclude ) ) {
+        f.creatorId = v.getCreatorId();
+      }
+      if ( include( "fileSize", memberSet, exclude ) ) {
+        f.fileSize = v.getFileSize();
+      }
+      if ( include( "description", memberSet, exclude ) ) {
+        f.description = v.getDescription();
+      }
+      if ( include( "folder", memberSet, exclude ) ) {
+        f.folder = v.isFolder();
+      }
+      //The include check is intentionally omitted on the Id field because
+      //it must be present or the tree rest service call will error
+      if ( v.getId() != null ) {
+        f.id = v.getId().toString();
+      }
+      if ( include( "lastModifiedDate", memberSet, exclude ) ) {
+        f.lastModifiedDate = v.getLastModifiedDate();
+      }
+      if ( include( "locale", memberSet, exclude ) ) {
+        f.locale = v.getLocale();
+      }
+      if ( include( "originalParentFolderPath", memberSet, exclude ) ) {
+        f.originalParentFolderPath = v.getOriginalParentFolderPath();
+      }
+      if ( include( "deletedDate", memberSet, exclude ) ) {
+        f.deletedDate = v.getDeletedDate();
+      }
+      if ( include( "lockDate", memberSet, exclude ) ) {
+        f.lockDate = v.getLockDate();
+      }
+      if ( include( "locked", memberSet, exclude ) ) {
+        f.locked = v.isLocked();
+      }
+      if ( include( "lockMessage", memberSet, exclude ) ) {
+        f.lockMessage = v.getLockMessage();
+      }
+      if ( include( "lockOwner", memberSet, exclude ) ) {
+        f.lockOwner = v.getLockOwner();
+      }
+      if ( include( "title", memberSet, exclude ) ) {
+        f.title = v.getTitle();
+      }
+      if ( include( "versioned", memberSet, exclude ) ) {
+        f.versioned = v.isVersioned();
+      }
+      if ( include( "versionId", memberSet, exclude ) ) {
+        if ( v.getVersionId() != null ) {
+          f.versionId = v.getVersionId().toString();
+        }
+      }
+    } catch ( NullPointerException e ) {
+      getLogger().warn( "NullPointerException while reading file attributes, returning null. Probable cause: File does not"
+        + "exist anymore: " );
+      return null;
     }
 
     if ( includeAcls ) {

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/RepositoryFileTreeAdapter.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/RepositoryFileTreeAdapter.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2013 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.repository2.unified.webservices;
@@ -56,19 +56,27 @@ public class RepositoryFileTreeAdapter extends XmlAdapter<RepositoryFileTreeDto,
   @Override
   public RepositoryFileTreeDto marshal( final RepositoryFileTree v ) {
     RepositoryFileTreeDto treeDto = new RepositoryFileTreeDto();
-    treeDto.setFile( RepositoryFileAdapter.toFileDto( v, membersSet, exclude, includeAcls ) );
 
-    List<RepositoryFileTreeDto> children = null;
-    if ( v.getChildren() != null ) {
-      children = new ArrayList<RepositoryFileTreeDto>();
-      for ( RepositoryFileTree child : v.getChildren() ) {
-        children.add( marshal( child ) );
+    RepositoryFileDto file = RepositoryFileAdapter.toFileDto( v, membersSet, exclude, includeAcls );
+    if ( file != null ) {
+      treeDto.setFile( RepositoryFileAdapter.toFileDto( v, membersSet, exclude, includeAcls ) );
+      List<RepositoryFileTreeDto> children = null;
+      if ( v.getChildren() != null ) {
+        children = new ArrayList<RepositoryFileTreeDto>();
+        for ( RepositoryFileTree child : v.getChildren() ) {
+          RepositoryFileTreeDto childTreeDto = marshal( child );
+          if ( childTreeDto != null ) {
+            children.add( childTreeDto );
+          }
+        }
       }
+
+      treeDto.setChildren( children );
+
+      return treeDto;
+    } else {
+      return null;
     }
-
-    treeDto.setChildren( children );
-
-    return treeDto;
   }
 
   @Override
@@ -82,10 +90,10 @@ public class RepositoryFileTreeAdapter extends XmlAdapter<RepositoryFileTreeDto,
     }
 
     RepositoryFileTree repositoryFileTree = new RepositoryFileTree( RepositoryFileAdapter.toFile( v.file ), children );
-    if (v.file.getVersioningEnabled() != null) {
+    if ( v.file.getVersioningEnabled() != null ) {
       repositoryFileTree.setVersioningEnabled( v.file.getVersioningEnabled() );
     }
-    if (v.file.getVersionCommentEnabled() != null) {
+    if ( v.file.getVersionCommentEnabled() != null ) {
       repositoryFileTree.setVersionCommentEnabled( v.file.getVersionCommentEnabled() );
     }
     return repositoryFileTree;

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/webservices/RepositoryFileTreeAdapterTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/webservices/RepositoryFileTreeAdapterTest.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2013 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.repository2.unified.webservices;
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -34,6 +35,8 @@ import javax.xml.bind.Unmarshaller;
 import junit.framework.TestCase;
 
 import org.junit.Test;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.platform.api.repository2.unified.IRepositoryVersionManager;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
@@ -41,6 +44,7 @@ import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileTree;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.repository2.unified.jcr.JcrRepositoryFileUtils;
+import org.pentaho.platform.repository2.unified.jcr.RepositoryFileProxy;
 
 public class RepositoryFileTreeAdapterTest extends TestCase {
 
@@ -85,6 +89,27 @@ public class RepositoryFileTreeAdapterTest extends TestCase {
     RepositoryFileTree rootDir2 = adapter.unmarshal( dtoBackAgain );
     assertNotNull( rootDir2.getChildren().get( 0 ).getChildren() );
     assertEquals( rootDir, rootDir2 );
+  }
+
+  @Test
+  public void testWhenChildrenIsDeleted() throws Exception {
+    // mock RepositoryFile to return null
+    RepositoryFile mockFile = mock( RepositoryFileProxy.class );
+    when( mockFile.isHidden() ).thenReturn( null );
+
+    // create tree with the mockFile
+    RepositoryFileTree nullValueDir = new RepositoryFileTree( mockFile, Collections.<RepositoryFileTree>emptyList() );
+    RepositoryFile root = new RepositoryFile.Builder( "rootDir" ).build();
+    ArrayList<RepositoryFileTree> children = new ArrayList<RepositoryFileTree>( 1 );
+    children.add( nullValueDir );
+    RepositoryFileTree rootDir = new RepositoryFileTree( root, children );
+
+    // to DTO
+    RepositoryFileTreeAdapter adapter = new RepositoryFileTreeAdapter();
+    RepositoryFileTreeDto dtoThere = adapter.marshal( rootDir );
+
+    // as isHidden() returns null, it's expected that null was returned, so root has no children
+    assertTrue( dtoThere.getChildren().isEmpty() );
   }
 
 }


### PR DESCRIPTION
[BACKLOG-16711,BACKLOG-15332] Changed filtering of system folders from FileService & DefaultUnifiedRepositoryWebService to JcrRepositoryUtils. Added includeSysDirs parameter to the getTree rest call

[BACKLOG-15332,BISERVER-13266] Protect RepositoryFileAdapter.toFileDto() against NullPointerException while reading file attributes. When Exception is found, returns null