### PR TITLE
[BISERVER-13633] Schema cache refresh takes too long

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/action/olap/impl/OlapServiceImpl.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/action/olap/impl/OlapServiceImpl.java
@@ -17,25 +17,6 @@
 */
 package org.pentaho.platform.plugin.action.olap.impl;
 
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Properties;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import mondrian.olap.MondrianServer;
@@ -46,7 +27,6 @@ import mondrian.server.DynamicContentFinder;
 import mondrian.server.MondrianServerRegistry;
 import mondrian.spi.CatalogLocator;
 import mondrian.util.LockBox.Entry;
-
 import mondrian.xmla.XmlaHandler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -76,6 +56,25 @@ import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogR
 import org.pentaho.platform.repository.solution.filebased.MondrianVfs;
 import org.pentaho.platform.util.messages.LocaleHelper;
 import org.springframework.security.core.userdetails.UserDetailsService;
+
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of the IOlapService which uses the
@@ -503,15 +502,8 @@ public class OlapServiceImpl implements IOlapService {
       // Start by flushing the local cache.
       resetCache( session );
 
-      flushHostedAndRemote( session );
-
-      if ( server != null ) {
-        // clean cache for all mondrian schemas used by current mondrian server
-        server.getAggregationManager().getCacheControl( null, null ).flushSchemaCache();
-      }
-
-      // clean cache for all mondrian schemas used by mondrian default "static" server
-      MondrianServer.forId( null ).getAggregationManager().getCacheControl( null, null ).flushSchemaCache();
+      flushHostedCatalogs( session );
+      flushRemoteCatalogs( session );
     } catch ( Exception e ) {
       throw new IOlapServiceException( e );
     } finally {
@@ -519,21 +511,24 @@ public class OlapServiceImpl implements IOlapService {
     }
   }
 
-  private void flushHostedAndRemote( final IPentahoSession session )
-      throws SQLException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-    flushCatalogs( getHostedCatalogNames( session ), session );
-    flushCatalogs( getRemoteCatalogNames( session ), session );
+  /**
+   * Flushes all hosted catalogs.
+   */
+  private void flushHostedCatalogs( IPentahoSession session ) throws SQLException {
+    // clean cache for all mondrian schemas used by current mondrian server
+    getServer().getAggregationManager().getCacheControl( null, null ).flushSchemaCache();
+    // clean cache for all mondrian schemas used by mondrian default "static" server
+    MondrianServer.forId( null ).getAggregationManager().getCacheControl( null, null ).flushSchemaCache();
   }
 
   /**
-   * Flushes all catalogs in the catalogNames collection.  If hosted=true
-   * the method breaks after the first successful schemaCacheFlush, since we
-   * know that all schemas will be flushed by the operation.
-   * For remote we assume that each needs to be flushed separately, since
-   * there are possibly multiple servers.
+   * Flushes all remote catalogs accessible to session.
+   * Unlike Hosted Catalogs, remote catalogs need to be
+   * flushed individually since they each may be running
+   * in separate instances.
    */
-  private void flushCatalogs( Collection<String> catalogNames, IPentahoSession session ) throws SQLException {
-    for ( String name : catalogNames ) {
+  private void flushRemoteCatalogs( IPentahoSession session ) throws SQLException {
+    for ( String name : getRemoteCatalogNames( session ) ) {
       OlapConnection connection = null;
       try {
         connection = getConnection( name, session );
@@ -600,18 +595,9 @@ public class OlapServiceImpl implements IOlapService {
     try {
       readLock.lock();
 
-      final List<IOlapService.Catalog> catalogs =
-        new ArrayList<IOlapService.Catalog>();
-      for ( Catalog catalog : cache ) {
-        if ( hasAccess( catalog.name, EnumSet.of( RepositoryFilePermission.READ ), session ) ) {
-          catalogs.add( catalog );
-        }
-      }
-
-      // Do not leak the cache list.
-      // Do not allow modifications on the list.
-      return Collections.unmodifiableList(
-        new ArrayList<IOlapService.Catalog>( cache ) );
+      return cache.stream()
+        .filter( catalog -> hasAccess( catalog.name, EnumSet.of( RepositoryFilePermission.READ ), session ) )
+        .collect( Collectors.toList() );
 
     } finally {
       readLock.unlock();

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/olap/OlapServiceImplTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/olap/OlapServiceImplTest.java
@@ -13,18 +13,7 @@
 
 package org.pentaho.platform.plugin.services.olap;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.io.PrintWriter;
-import java.sql.SQLException;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Properties;
-
 import mondrian.olap.CacheControl;
-import mondrian.olap.Connection;
 import mondrian.olap.MondrianServer;
 import mondrian.rolap.RolapConnection;
 import mondrian.rolap.RolapConnectionProperties;
@@ -33,6 +22,9 @@ import mondrian.xmla.XmlaHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.olap4j.OlapConnection;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
@@ -46,20 +38,36 @@ import org.pentaho.platform.plugin.action.olap.impl.OlapServiceImpl;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
 import org.pentaho.platform.util.messages.LocaleHelper;
 
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.pentaho.platform.repository2.unified.UnifiedRepositoryTestUtils.*;
 
+@RunWith ( MockitoJUnitRunner.class )
 public class OlapServiceImplTest {
 
-  IUnifiedRepository repository;
   String mondrianFolderPath;
   String olapFolderPath;
   IPentahoSession session;
   IOlapService olapService;
-  private MondrianServer server;
-  private XmlaHandler.XmlaExtra mockXmlaExtra;
+
+  @Mock IUnifiedRepository repository;
+  @Mock private MondrianServer server;
+  @Mock private XmlaHandler.XmlaExtra mockXmlaExtra;
+  @Mock AggregationManager aggManager;
+  @Mock CacheControl cacheControl;
 
   /**
    * Default implementation of the hook which grants all access.
@@ -84,8 +92,6 @@ public class OlapServiceImplTest {
   @Before
   public void setUp() throws Exception {
 
-    repository = mock( IUnifiedRepository.class );
-
     // Stub /etc/mondrian
     mondrianFolderPath =
       ClientRepositoryPaths.getEtcFolderPath()
@@ -103,15 +109,9 @@ public class OlapServiceImplTest {
     // Create a session as admin.
     session = new StandaloneSession( "admin" );
 
-    server = mock( MondrianServer.class );
-
-    AggregationManager aggManagerMock = mock( AggregationManager.class );
-    CacheControl cacheControlMock = mock( CacheControl.class );
-    doReturn( aggManagerMock ).when( server ).getAggregationManager();
-    doReturn( cacheControlMock ).when( aggManagerMock ).getCacheControl(
+    doReturn( aggManager ).when( server ).getAggregationManager();
+    doReturn( cacheControl ).when( aggManager ).getCacheControl(
       any( RolapConnection .class ), any( PrintWriter.class ) );
-
-    mockXmlaExtra = mock( XmlaHandler.XmlaExtra.class );
 
     // Create the olap service. Make sure to override hasAccess with the
     // mock version.
@@ -194,7 +194,7 @@ public class OlapServiceImplTest {
     final String metadataPath = testFolderPath + RepositoryFile.SEPARATOR + "metadata";
     stubCreateFile( repository, metadataPath );
 
-    final InputStream is = this.getClass().getResourceAsStream("/solution/security/steelwheels.mondrian.xml" );
+    final InputStream is = this.getClass().getResourceAsStream( "/solution/security/steelwheels.mondrian.xml" );
 
 
     olapService.addHostedCatalog(
@@ -644,7 +644,7 @@ public class OlapServiceImplTest {
         pathPropertyPair( "/catalog/definition", "mondrian:/SteelWheels" ),
         pathPropertyPair( "/catalog/datasourceInfo", "Provider=mondrian;DataSource=SteelWheels;" ) );
 
-    final InputStream is = this.getClass().getResourceAsStream("/solution/security/steelwheels.mondrian.xml" );
+    final InputStream is = this.getClass().getResourceAsStream( "/solution/security/steelwheels.mondrian.xml" );
 
 
     // Try to save it without the overwrite flag. We expect it to fail.
@@ -761,26 +761,10 @@ public class OlapServiceImplTest {
   }
 
   @Test
-  public void testFlushesAllConnections() throws Exception {
-    stubHostedServer();
-    final Properties properties = new Properties();
-    properties.put( RolapConnectionProperties.Locale.name(), getLocale().toString() );
-    OlapConnection conn = mock( OlapConnection.class );
-    when( server.getConnection( "Pentaho", "myHostedServer", null, properties ) ).thenReturn( conn );
-    olapService.flushAll( session );
-    verify( mockXmlaExtra ).flushSchemaCache( conn );
-  }
-
-  @Test
-  public void testFlushStopsAfterFirstHosted() throws Exception {
+  public void flushAllFlushesSchemaCache() throws Exception {
     stubHostedServers( "myHostedServer", "myHostedServer2" );
-
-    final Properties properties = new Properties();
-    properties.put( RolapConnectionProperties.Locale.name(), getLocale().toString() );
-    OlapConnection conn = mock( OlapConnection.class );
-    when( server.getConnection( "Pentaho", "myHostedServer", null, properties ) ).thenReturn( conn );
     olapService.flushAll( session );
-    verify( mockXmlaExtra, times( 1 ) ).flushSchemaCache( conn );
+    verify( cacheControl, times( 1 ) ).flushSchemaCache();
   }
 
   @Test


### PR DESCRIPTION
Removing the logic which iterates each hosted catalog,
creating a connection and flushing individually.  That had
the effect of loading each schema, flushing it out, and
then loading again.  Big perf hit, and unnecessary, since
we were also invoking CacheControl.flushSchemaCache

http://jira.pentaho.com/browse/BISERVER-13633
http://jira.pentaho.com/browse/BISERVER-13631