### PR TITLE
[BISERVER-13621] All the command line parameters for import-export.sh/.bat are showing the localized parameters names.

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessor.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessor.java
@@ -96,6 +96,57 @@ public class CommandLineProcessor {
 
   private IUnifiedRepository repository;
 
+  private static final String INFO_OPTION_HELP_KEY = "h";
+  private static final String INFO_OPTION_HELP_NAME = "help";
+  private static final String INFO_OPTION_IMPORT_KEY = "i";
+  private static final String INFO_OPTION_IMPORT_NAME = "import";
+  private static final String INFO_OPTION_EXPORT_KEY = "e";
+  private static final String INFO_OPTION_EXPORT_NAME = "export";
+  private static final String INFO_OPTION_BACKUP_KEY = "backup";
+  private static final String INFO_OPTION_BACKUP_NAME = "backup";
+  private static final String INFO_OPTION_RESTORE_KEY = "restore";
+  private static final String INFO_OPTION_RESTORE_NAME = "restore";
+  private static final String INFO_OPTION_USERNAME_KEY = "u";
+  private static final String INFO_OPTION_USERNAME_NAME = "username";
+  private static final String INFO_OPTION_PASSWORD_KEY = "p";
+  private static final String INFO_OPTION_PASSWORD_NAME = "password";
+  private static final String INFO_OPTION_URL_KEY = "a";
+  private static final String INFO_OPTION_URL_NAME = "url";
+  private static final String INFO_OPTION_FILEPATH_KEY = "fp";
+  private static final String INFO_OPTION_FILEPATH_NAME = "file-path";
+  private static final String INFO_OPTION_CHARSET_KEY = "c";
+  private static final String INFO_OPTION_CHARSET_NAME = "charset";
+  private static final String INFO_OPTION_LOGFILE_KEY = "l";
+  private static final String INFO_OPTION_LOGFILE_NAME = "logfile";
+  private static final String INFO_OPTION_PATH_KEY = "f";
+  private static final String INFO_OPTION_PATH_NAME = "path";
+  private static final String INFO_OPTION_OVERWRITE_KEY = "o";
+  private static final String INFO_OPTION_OVERWRITE_NAME = "overwrite";
+  private static final String INFO_OPTION_PERMISSION_KEY = "m";
+  private static final String INFO_OPTION_PERMISSION_NAME = "permission";
+  private static final String INFO_OPTION_RETAIN_OWNERSHIP_KEY = "r";
+  private static final String INFO_OPTION_RETAIN_OWNERSHIP_NAME = "retainOwnership";
+  private static final String INFO_OPTION_WITH_MANIFEST_KEY = "w";
+  private static final String INFO_OPTION_WITH_MANIFEST_NAME = "withManifest";
+  private static final String INFO_OPTION_REST_KEY = "rest";
+  private static final String INFO_OPTION_REST_NAME = "rest";
+  private static final String INFO_OPTION_SERVICE_KEY = "v";
+  private static final String INFO_OPTION_SERVICE_NAME = "service";
+  private static final String INFO_OPTION_PARAMS_KEY = "params";
+  private static final String INFO_OPTION_PARAMS_NAME = "params";
+  private static final String INFO_OPTION_RESOURCE_TYPE_KEY = "res";
+  private static final String INFO_OPTION_RESOURCE_TYPE_NAME = "resource-type";
+  private static final String INFO_OPTION_DATASOURCE_TYPE_KEY = "ds";
+  private static final String INFO_OPTION_DATASOURCE_TYPE_NAME = "datasource-type";
+  private static final String INFO_OPTION_ANALYSIS_CATALOG_KEY = "cat";
+  private static final String INFO_OPTION_ANALYSIS_CATALOG_NAME = "catalog";
+  private static final String INFO_OPTION_ANALYSIS_DATASOURCE_KEY = "a_ds";
+  private static final String INFO_OPTION_ANALYSIS_DATASOURCE_NAME = "analysis-datasource";
+  private static final String INFO_OPTION_ANALYSIS_XMLA_ENABLED_KEY = "a_xmla";
+  private static final String INFO_OPTION_ANALYSIS_XMLA_ENABLED_NAME = "xmla-enabled";
+  private static final String INFO_OPTION_METADATA_DOMAIN_ID_KEY = "m_id";
+  private static final String INFO_OPTION_METADATA_DOMAIN_ID_NAME = "metadata-domain-id";
+
   public static enum RequestType {
     HELP, IMPORT, EXPORT, REST, BACKUP, RESTORE
   }
@@ -112,109 +163,84 @@ public class CommandLineProcessor {
 
   static {
     // create the Options
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_HELP_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_HELP_NAME" ), false, Messages.getInstance()
+    options.addOption( INFO_OPTION_HELP_KEY, INFO_OPTION_HELP_NAME, false, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_HELP_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_IMPORT_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_IMPORT_NAME" ), false, Messages.getInstance()
+    options.addOption( INFO_OPTION_IMPORT_KEY, INFO_OPTION_IMPORT_NAME, false, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_IMPORT_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_EXPORT_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_EXPORT_NAME" ), false, Messages.getInstance()
+    options.addOption( INFO_OPTION_EXPORT_KEY, INFO_OPTION_EXPORT_NAME, false, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_EXPORT_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_USERNAME_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_USERNAME_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_USERNAME_KEY, INFO_OPTION_USERNAME_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_USERNAME_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PASSWORD_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_PASSWORD_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_PASSWORD_KEY, INFO_OPTION_PASSWORD_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_PASSWORD_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_URL_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_URL_NAME" ), true, Messages.getInstance().getString(
-            "CommandLineProcessor.INFO_OPTION_URL_DESCRIPTION" ) );
+    options.addOption( INFO_OPTION_URL_KEY, INFO_OPTION_URL_NAME, true, Messages.getInstance()
+            .getString( "CommandLineProcessor.INFO_OPTION_URL_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_FILEPATH_KEY, INFO_OPTION_FILEPATH_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_CHARSET_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_CHARSET_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_CHARSET_KEY, INFO_OPTION_CHARSET_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_CHARSET_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_LOGFILE_KEY, INFO_OPTION_LOGFILE_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PATH_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_PATH_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_PATH_KEY, INFO_OPTION_PATH_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_PATH_DESCRIPTION" ) );
 
     // import only ACL additions
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_OVERWRITE_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_OVERWRITE_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_OVERWRITE_KEY, INFO_OPTION_OVERWRITE_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_OVERWRITE_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PERMISSION_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_PERMISSION_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_PERMISSION_KEY, INFO_OPTION_PERMISSION_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_PERMISSION_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_KEY" ),
-        Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_NAME" ), true, Messages
-            .getInstance().getString( "CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_DESCRIPTION" ) );
+    options.addOption( INFO_OPTION_RETAIN_OWNERSHIP_KEY, INFO_OPTION_RETAIN_OWNERSHIP_NAME, true, Messages.getInstance()
+            .getString( "CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_KEY" ),
-        Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_NAME" ), true, Messages
-            .getInstance().getString( "CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_DESCRIPTION" ) );
+    options.addOption( INFO_OPTION_WITH_MANIFEST_KEY, INFO_OPTION_WITH_MANIFEST_NAME, true, Messages.getInstance()
+            .getString( "CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_DESCRIPTION" ) );
 
     // rest services
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_REST_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_REST_NAME" ), false, Messages.getInstance()
+    options.addOption( INFO_OPTION_REST_KEY, INFO_OPTION_REST_NAME, false, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_REST_DESCRIPTION" ) );
 
     // backup
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_BACKUP_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_BACKUP_NAME" ), false, Messages.getInstance()
+    options.addOption( INFO_OPTION_BACKUP_KEY, INFO_OPTION_BACKUP_NAME, false, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_BACKUP_DESCRIPTION" ) );
 
     // restore
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_RESTORE_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_RESTORE_NAME" ), false, Messages.getInstance()
+    options.addOption( INFO_OPTION_RESTORE_KEY, INFO_OPTION_RESTORE_NAME, false, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_RESTORE_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_SERVICE_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_SERVICE_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_SERVICE_KEY, INFO_OPTION_SERVICE_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_SERVICE_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PARAMS_KEY" ), Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_PARAMS_NAME" ), true, Messages.getInstance()
+    options.addOption( INFO_OPTION_PARAMS_KEY, INFO_OPTION_PARAMS_NAME, true, Messages.getInstance()
             .getString( "CommandLineProcessor.INFO_OPTION_PARAMS_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_KEY" ),
-        Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_NAME" ), true, Messages
-            .getInstance().getString( "CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION" ) );
+    options.addOption( INFO_OPTION_RESOURCE_TYPE_KEY, INFO_OPTION_RESOURCE_TYPE_NAME, true, Messages.getInstance()
+            .getString( "CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_KEY" ),
-        Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_NAME" ), true, Messages
-            .getInstance().getString( "CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION" ) );
+    options.addOption( INFO_OPTION_DATASOURCE_TYPE_KEY, INFO_OPTION_DATASOURCE_TYPE_NAME, true, Messages.getInstance()
+            .getString( "CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_KEY" ),
-        Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_NAME" ), true, Messages
-            .getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_DESCRIPTION" ) );
+    options.addOption( INFO_OPTION_ANALYSIS_CATALOG_KEY, INFO_OPTION_ANALYSIS_CATALOG_NAME, true, Messages.getInstance()
+            .getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_KEY" ),
-        Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_NAME" ), true, Messages
-            .getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_DESCRIPTION" ) );
+    options.addOption( INFO_OPTION_ANALYSIS_DATASOURCE_KEY, INFO_OPTION_ANALYSIS_DATASOURCE_NAME, true, Messages.getInstance()
+            .getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_KEY" ),
-        Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_NAME" ), true,
-        Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_DESCRIPTION" ) );
+    options.addOption( INFO_OPTION_ANALYSIS_XMLA_ENABLED_KEY, INFO_OPTION_ANALYSIS_XMLA_ENABLED_NAME, true, Messages.getInstance()
+            .getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_DESCRIPTION" ) );
 
-    options.addOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_KEY" ),
-        Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_NAME" ), true, Messages
-            .getInstance().getString( "CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_DESCRIPTION" ) );
+    options.addOption( INFO_OPTION_METADATA_DOMAIN_ID_KEY, INFO_OPTION_METADATA_DOMAIN_ID_NAME, true, Messages.getInstance()
+            .getString( "CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_DESCRIPTION" ) );
   }
 
   /**
@@ -273,21 +299,16 @@ public class CommandLineProcessor {
    */
   private void performREST() throws ParseException, InitializationException {
 
-    String contextURL = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_URL_NAME" ),
-      true, false );
-    String path = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PATH_NAME" ),
-      true, false );
-    String logFile = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_NAME" ),
-      false, true );
+    String contextURL = getOptionValue( INFO_OPTION_URL_NAME, true, false );
+    String path = getOptionValue( INFO_OPTION_PATH_NAME, true, false );
+    String logFile = getOptionValue( INFO_OPTION_LOGFILE_NAME, false, true );
     String exportURL = contextURL + "/api/repo/files/";
     if ( path != null ) {
       String effPath = RepositoryPathEncoder.encodeRepositoryPath( path );
       exportURL += effPath;
     }
-    String service = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_SERVICE_NAME" ),
-      true, false );
-    String params = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PARAMS_NAME" ),
-      false, true );
+    String service = getOptionValue( INFO_OPTION_SERVICE_NAME, true, false );
+    String params = getOptionValue( INFO_OPTION_PARAMS_NAME, false, true );
     exportURL += "/" + service;
     if ( params != null ) {
       exportURL += "?params=" + params;
@@ -323,10 +344,8 @@ public class CommandLineProcessor {
    */
   private void initRestService() throws ParseException, InitializationException {
     // get information about the remote connection
-    String username = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_USERNAME_NAME" ),
-      true, false );
-    String password = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PASSWORD_NAME" ),
-      true, false );
+    String username = getOptionValue( INFO_OPTION_USERNAME_NAME, true, false );
+    String password = getOptionValue( INFO_OPTION_PASSWORD_NAME, true, false );
     password = KettleTwoWayPasswordEncoder.decryptPasswordOptionallyEncrypted( password );
     ClientConfig clientConfig = new DefaultClientConfig();
     clientConfig.getFeatures().put( JSONConfiguration.FEATURE_POJO_MAPPING, Boolean.TRUE );
@@ -355,25 +374,20 @@ public class CommandLineProcessor {
   protected CommandLineProcessor( String[] args ) throws ParseException {
     // parse the command line arguments
     commandLine = new CmdParser().parse( options, args );
-    if ( commandLine.hasOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_HELP_NAME" ) )
-        || commandLine.hasOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_HELP_KEY" ) ) ) {
+    if ( commandLine.hasOption( INFO_OPTION_HELP_NAME ) || commandLine.hasOption( INFO_OPTION_HELP_KEY ) ) {
       requestType = RequestType.HELP;
     } else {
-      if ( commandLine.hasOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_REST_NAME" ) )
-          || commandLine.hasOption( Messages.getInstance().getString(
-              "CommandLineProcessor.INFO_OPTION_REST_KEY" ) ) ) {
+      if ( commandLine.hasOption( INFO_OPTION_REST_NAME ) || commandLine.hasOption( INFO_OPTION_REST_KEY ) ) {
         requestType = RequestType.REST;
-      } else if ( commandLine.hasOption( Messages.getInstance().getString(
-          "CommandLineProcessor.INFO_OPTION_BACKUP_KEY" ) ) ) {
+      } else if ( commandLine.hasOption( INFO_OPTION_BACKUP_KEY ) ) {
         requestType = RequestType.BACKUP;
-      } else if ( commandLine.hasOption( Messages.getInstance().getString(
-          "CommandLineProcessor.INFO_OPTION_RESTORE_KEY" ) ) ) {
+      } else if ( commandLine.hasOption( INFO_OPTION_RESTORE_KEY ) ) {
         requestType = RequestType.RESTORE;
       } else {
         final boolean importRequest =
-            commandLine.hasOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_IMPORT_KEY" ) );
+            commandLine.hasOption( INFO_OPTION_IMPORT_KEY );
         final boolean exportRequest =
-            commandLine.hasOption( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_EXPORT_KEY" ) );
+            commandLine.hasOption( INFO_OPTION_EXPORT_KEY );
 
         if ( importRequest == exportRequest ) {
           throw new ParseException( Messages.getInstance().getErrorString(
@@ -408,9 +422,7 @@ public class CommandLineProcessor {
 
     String metadataImportURL = contextURL + METADATA_DATASOURCE_IMPORT;
 
-    String domainId =
-      getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_NAME" ),
-      true, false );
+    String domainId = getOptionValue( INFO_OPTION_METADATA_DOMAIN_ID_NAME, true, false );
 
     WebResource resource = client.resource( metadataImportURL );
 
@@ -505,15 +517,9 @@ public class CommandLineProcessor {
     throws ParseException, IOException {
     String analysisImportURL = contextURL + ANALYSIS_DATASOURCE_IMPORT;
 
-    String catalogName =
-      getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_NAME" ),
-        false, true );
-    String datasourceName =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_NAME" ),
-          false, true );
-    String xmlaEnabledFlag =
-      getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_NAME" ),
-        false, true );
+    String catalogName = getOptionValue( INFO_OPTION_ANALYSIS_CATALOG_NAME, false, true );
+    String datasourceName = getOptionValue( INFO_OPTION_ANALYSIS_DATASOURCE_NAME, false, true );
+    String xmlaEnabledFlag = getOptionValue( INFO_OPTION_ANALYSIS_XMLA_ENABLED_NAME, false, true );
 
     WebResource resource = client.resource( analysisImportURL );
     FileInputStream inputStream = new FileInputStream( analysisDatasourceFile );
@@ -555,16 +561,10 @@ public class CommandLineProcessor {
    * @throws IOException
    */
   private void performDatasourceImport() throws ParseException, IOException {
-    String contextURL = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_URL_NAME" ),
-      true, false );
-    String filePath =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_NAME" ),
-          true, false );
-    String datasourceType =
-      getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_NAME" ),
-        true, false );
-    String overwrite = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_OVERWRITE_NAME" ),
-      false, true );
+    String contextURL = getOptionValue( INFO_OPTION_URL_NAME, true, false );
+    String filePath = getOptionValue( INFO_OPTION_FILEPATH_NAME, true, false );
+    String datasourceType = getOptionValue( INFO_OPTION_DATASOURCE_TYPE_NAME, true, false );
+    String overwrite = getOptionValue( INFO_OPTION_OVERWRITE_NAME, false, true );
 
     /*
      * wrap in a try/finally to ensure input stream is closed properly
@@ -595,23 +595,16 @@ public class CommandLineProcessor {
    */
 
   private void performImport() throws ParseException, IOException {
-    String contextURL = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_URL_NAME" ),
-      true, false );
-    String filePath = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_NAME" ),
-      true, false );
-    String resourceType =
-      getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_NAME" ),
-        false, true );
+    String contextURL = getOptionValue( INFO_OPTION_URL_NAME, true, false );
+    String filePath = getOptionValue( INFO_OPTION_FILEPATH_NAME, true, false );
+    String resourceType = getOptionValue( INFO_OPTION_RESOURCE_TYPE_NAME, false, true );
     // We are importing datasources
     if ( resourceType != null && resourceType.equals( ResourceType.DATASOURCE.name() ) ) {
       performDatasourceImport();
     } else {
-      String charSet = getOptionValue(  Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_CHARSET_NAME" ),
-        false, true );
-      String logFile = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_NAME" ),
-        false, true );
-      String path = getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PATH_NAME" ),
-        true, false );
+      String charSet = getOptionValue( INFO_OPTION_CHARSET_NAME, false, true );
+      String logFile = getOptionValue( INFO_OPTION_LOGFILE_NAME, false, true );
+      String path = getOptionValue( INFO_OPTION_PATH_NAME, true, false );
 
       String importURL = contextURL + API_REPO_FILES_IMPORT;
       File fileIS = new File( filePath );
@@ -625,15 +618,9 @@ public class CommandLineProcessor {
         initRestService();
         WebResource resource = client.resource( importURL );
 
-        String overwrite =
-            getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_OVERWRITE_NAME" ),
-              false, true );
-        String retainOwnership =
-            getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_NAME" ),
-              false, true );
-        String permission =
-            getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PERMISSION_NAME" ),
-              false, true );
+        String overwrite = getOptionValue( INFO_OPTION_OVERWRITE_NAME, false, true );
+        String retainOwnership = getOptionValue( INFO_OPTION_RETAIN_OWNERSHIP_NAME, false, true );
+        String permission = getOptionValue( INFO_OPTION_PERMISSION_NAME, false, true );
 
         part.field( "importDir", path, MediaType.MULTIPART_FORM_DATA_TYPE );
         part.field( "overwriteAclPermissions", "true".equals( overwrite ) ? "true" : "false",
@@ -698,12 +685,8 @@ public class CommandLineProcessor {
    * @throws java.io.IOException
    */
   private void performBackup() throws ParseException, InitializationException, IOException {
-    String contextURL =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_URL_NAME" ),
-          true, false );
-    String logFile =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_NAME" ),
-          false, true );
+    String contextURL = getOptionValue( INFO_OPTION_URL_NAME, true, false );
+    String logFile = getOptionValue( INFO_OPTION_LOGFILE_NAME, false, true );
     String backupURL = contextURL + "/api/repo/files/backup";
 
     initRestService();
@@ -722,9 +705,7 @@ public class CommandLineProcessor {
     Builder builder = resource.type( MediaType.MULTIPART_FORM_DATA ).accept( MediaType.TEXT_HTML_TYPE );
     ClientResponse response = builder.get( ClientResponse.class );
     if ( response != null && response.getStatus() == 200 ) {
-      String filename =
-          getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_NAME" ),
-            true, false );
+      String filename = getOptionValue( INFO_OPTION_FILEPATH_NAME, true, false );
       final InputStream input = response.getEntityInputStream();
       createZipFile( filename, input );
       input.close();
@@ -750,16 +731,9 @@ public class CommandLineProcessor {
    * @throws java.io.IOException
    */
   private void performRestore() throws ParseException, IOException {
-    String contextURL =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_URL_NAME" ),
-          true, false );
-    String filePath =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_NAME" ),
-          true, false );
-
-    String logFile =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_NAME" ),
-          false, true );
+    String contextURL = getOptionValue( INFO_OPTION_URL_NAME, true, false );
+    String filePath = getOptionValue( INFO_OPTION_FILEPATH_NAME, true, false );
+    String logFile = getOptionValue( INFO_OPTION_LOGFILE_NAME, false, true );
 
     String importURL = contextURL + "/api/repo/files/systemRestore";
     File fileIS = new File( filePath );
@@ -779,9 +753,7 @@ public class CommandLineProcessor {
 
       WebResource resource = client.resource( importURL );
 
-      String overwrite =
-          getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_OVERWRITE_NAME" ),
-            true, false );
+      String overwrite = getOptionValue( INFO_OPTION_OVERWRITE_NAME, true, false );
       part.field( "overwriteFile", "true".equals( overwrite ) ? "true" : "false", MediaType.MULTIPART_FORM_DATA_TYPE );
 
       // Response response
@@ -817,31 +789,21 @@ public class CommandLineProcessor {
    * @throws java.io.IOException
    */
   private void performExport() throws ParseException, IOException, InitializationException {
-    String contextURL =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_URL_NAME" ),
-          true, false );
-    String path =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_PATH_NAME" ),
-          true, false );
-    String withManifest =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_NAME" ),
-          false, true );
+    String contextURL = getOptionValue( INFO_OPTION_URL_NAME, true, false );
+    String path = getOptionValue( INFO_OPTION_PATH_NAME, true, false );
+    String withManifest = getOptionValue( INFO_OPTION_WITH_MANIFEST_NAME, false, true );
     String effPath = RepositoryPathEncoder.encodeURIComponent( RepositoryPathEncoder.encodeRepositoryPath( path ) );
     if ( effPath.lastIndexOf( ":" ) == effPath.length() - 1 // remove trailing slash
         && effPath.length() > 1 ) { // allow user to enter "--path=/"
       effPath = effPath.substring( 0, effPath.length() - 1 );
     }
-    String logFile =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_LOGFILE_NAME" ),
-          false, true );
+    String logFile = getOptionValue( INFO_OPTION_LOGFILE_NAME, false, true );
     String exportURL =
         contextURL + "/api/repo/files/" + effPath + "/download?withManifest=" + ( "false".equals( withManifest )
             ? "false" : "true" );
 
     // path is validated before executing
-    String filepath =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_NAME" ),
-          true, false );
+    String filepath = getOptionValue( INFO_OPTION_FILEPATH_NAME, true, false );
 
     if ( !isValidExportPath( filepath, logFile ) ) {
       throw new ParseException( Messages.getInstance().getString( "CommandLineProcessor.ERROR_0005_INVALID_FILE_PATH",
@@ -855,9 +817,7 @@ public class CommandLineProcessor {
     Builder builder = resource.type( MediaType.MULTIPART_FORM_DATA ).accept( MediaType.TEXT_HTML_TYPE );
     ClientResponse response = builder.get( ClientResponse.class );
     if ( response != null && response.getStatus() == 200 ) {
-      String filename =
-          getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_FILEPATH_NAME" ),
-            true, false );
+      String filename = getOptionValue( INFO_OPTION_FILEPATH_NAME, true, false );
       final InputStream input = response.getEntityInputStream();
       createZipFile( filename, input );
       input.close();
@@ -968,9 +928,7 @@ public class CommandLineProcessor {
     final String NAMESPACE_URI = "http://www.pentaho.org/ws/1.0"; //$NON-NLS-1$
     final String SERVICE_NAME = "unifiedRepository"; //$NON-NLS-1$
 
-    String urlString =
-        getOptionValue( Messages.getInstance().getString( "CommandLineProcessor.INFO_OPTION_URL_NAME" ),
-          true, false ).trim();
+    String urlString = getOptionValue( INFO_OPTION_URL_NAME, true, false ).trim();
     if ( urlString.endsWith( "/" ) ) {
       urlString = urlString.substring( 0, urlString.length() - 1 );
     }
@@ -986,10 +944,10 @@ public class CommandLineProcessor {
     Service service = Service.create( url, new QName( NAMESPACE_URI, SERVICE_NAME ) );
     IUnifiedRepositoryJaxwsWebService port = service.getPort( IUnifiedRepositoryJaxwsWebService.class );
     // http basic authentication
-    ( (BindingProvider) port ).getRequestContext().put( BindingProvider.USERNAME_PROPERTY, getOptionValue( Messages.
-      getInstance().getString( "CommandLineProcessor.INFO_OPTION_USERNAME_NAME" ), true, false ) );
-    ( (BindingProvider) port ).getRequestContext().put( BindingProvider.PASSWORD_PROPERTY, getOptionValue( Messages
-        .getInstance().getString( "CommandLineProcessor.INFO_OPTION_PASSWORD_NAME" ), true, true ) );
+    ( (BindingProvider) port ).getRequestContext().put( BindingProvider.USERNAME_PROPERTY,
+        getOptionValue( INFO_OPTION_USERNAME_NAME, true, false ) );
+    ( (BindingProvider) port ).getRequestContext().put( BindingProvider.PASSWORD_PROPERTY,
+        getOptionValue( INFO_OPTION_PASSWORD_NAME, true, true ) );
     // accept cookies to maintain session on server
     ( (BindingProvider) port ).getRequestContext().put( BindingProvider.SESSION_MAINTAIN_PROPERTY, true );
     // support streaming binary data

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages.properties
@@ -208,82 +208,25 @@ CommandLineProcessor.ERROR_0006_NON_ADMIN_CREDENTIALS=Non admin credentials ente
 CommandLineProcessor.ERROR_0007_FORBIDDEN=User is not allowed to perform this operation: {0}
 CommandLineProcessor.ERROR_0008_INVALID_PARAMETER=Invalid parameter syntax: "{0}"
 
-CommandLineProcessor.INFO_OPTION_HELP_KEY=h
-CommandLineProcessor.INFO_OPTION_HELP_NAME=help
 CommandLineProcessor.INFO_OPTION_HELP_DESCRIPTION=print this message
-
-CommandLineProcessor.INFO_OPTION_IMPORT_KEY=i
-CommandLineProcessor.INFO_OPTION_IMPORT_NAME=import
 CommandLineProcessor.INFO_OPTION_IMPORT_DESCRIPTION=import
-
-CommandLineProcessor.INFO_OPTION_EXPORT_KEY=e
-CommandLineProcessor.INFO_OPTION_EXPORT_NAME=export
 CommandLineProcessor.INFO_OPTION_EXPORT_DESCRIPTION=export
-
-CommandLineProcessor.INFO_OPTION_BACKUP_KEY=backup
-CommandLineProcessor.INFO_OPTION_BACKUP_NAME=backup
 CommandLineProcessor.INFO_OPTION_BACKUP_DESCRIPTION=Generates full system backup file to be used with the system restore service.
-
-CommandLineProcessor.INFO_OPTION_RESTORE_KEY=restore
-CommandLineProcessor.INFO_OPTION_RESTORE_NAME=restore
 CommandLineProcessor.INFO_OPTION_RESTORE_DESCRIPTION=Performs a system restore off of a given backup file.
-
-CommandLineProcessor.INFO_OPTION_USERNAME_KEY=u
-CommandLineProcessor.INFO_OPTION_USERNAME_NAME=username
 CommandLineProcessor.INFO_OPTION_USERNAME_DESCRIPTION=repository username
-
-CommandLineProcessor.INFO_OPTION_PASSWORD_KEY=p
-CommandLineProcessor.INFO_OPTION_PASSWORD_NAME=password
 CommandLineProcessor.INFO_OPTION_PASSWORD_DESCRIPTION=repository password
-
-CommandLineProcessor.INFO_OPTION_URL_KEY=a
-CommandLineProcessor.INFO_OPTION_URL_NAME=url
 CommandLineProcessor.INFO_OPTION_URL_DESCRIPTION=url of repository (e.g. http://localhost:8080/pentaho)
-
-CommandLineProcessor.INFO_OPTION_FILEPATH_KEY=fp
-CommandLineProcessor.INFO_OPTION_FILEPATH_NAME=file-path
 CommandLineProcessor.INFO_OPTION_FILEPATH_DESCRIPTION=Path to directory of files for import, or path to .zip file for export
-
-CommandLineProcessor.INFO_OPTION_CHARSET_KEY=c
-CommandLineProcessor.INFO_OPTION_CHARSET_NAME=charset
 CommandLineProcessor.INFO_OPTION_CHARSET_DESCRIPTION=charset to use for the repository (characters from external systems converted to this charset)
-
-CommandLineProcessor.INFO_OPTION_LOGFILE_KEY=l
-CommandLineProcessor.INFO_OPTION_LOGFILE_NAME=logfile
 CommandLineProcessor.INFO_OPTION_LOGFILE_DESCRIPTION=full path and filename of logfile messages
-
-CommandLineProcessor.INFO_OPTION_PATH_KEY=f
-CommandLineProcessor.INFO_OPTION_PATH_NAME=path
 CommandLineProcessor.INFO_OPTION_PATH_DESCRIPTION=repository path to which to add imported files, or to export from (e.g. /public)
-
-CommandLineProcessor.INFO_OPTION_OVERWRITE_KEY=o
-CommandLineProcessor.INFO_OPTION_OVERWRITE_NAME=overwrite
 CommandLineProcessor.INFO_OPTION_OVERWRITE_DESCRIPTION=overwrite files (import only)
-
-CommandLineProcessor.INFO_OPTION_PERMISSION_KEY=m
-CommandLineProcessor.INFO_OPTION_PERMISSION_NAME=permission
 CommandLineProcessor.INFO_OPTION_PERMISSION_DESCRIPTION=apply ACL manifest permissions to files and folders  (import only)
-
-CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_KEY=r
-CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_NAME=retainOwnership
 CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_DESCRIPTION=Retain ownership information  (import only)
-
-CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_KEY=w
-CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_NAME=withManifest
 CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_DESCRIPTION=Export Manifest ACL file included  (export only)
-
-CommandLineProcessor.INFO_OPTION_REST_KEY=rest
-CommandLineProcessor.INFO_OPTION_REST_NAME=rest
 CommandLineProcessor.INFO_OPTION_REST_DESCRIPTION=Use the REST (Default) version (not local to Pentaho Server)
-
-CommandLineProcessor.INFO_OPTION_SERVICE_KEY=v
-CommandLineProcessor.INFO_OPTION_SERVICE_NAME=service
 CommandLineProcessor.INFO_OPTION_SERVICE_DESCRIPTION=this is the REST service call e.g. acl, children, properties
-
-CommandLineProcessor.INFO_OPTION_PARAMS_KEY=params
-CommandLineProcessor.INFO_OPTION_PARAMS_NAME=params
 CommandLineProcessor.INFO_OPTION_PARAMS_DESCRIPTION=parameters to pass to REST service call
-
 CommandLineProcessor.INFO_REST_COMPLETED=REST Completed
 CommandLineProcessor.INFO_REST_RESPONSE_STATUS=Response status:
 CommandLineProcessor.INFO_REST_FILE_WRITTEN=REST File written to:
@@ -335,23 +278,11 @@ Example arguments for running REST services:\n\
   --path=/public/pentaho-solutions/steel-wheels/reports\n\
   --logfile=c:/temp/logfile.log --service=acl\n
 
-CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_KEY=res
-CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_NAME=resource-type
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=Import resource type (eg DATASOURCE)
-CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_KEY=ds
-CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_NAME=datasource-type
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=datasource type
-CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_KEY=cat
-CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_NAME=catalog
 CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_DESCRIPTION=catalog description
-CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_KEY=a_ds
-CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_NAME=analysis-datasource
 CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_DESCRIPTION=Analysis datasource description
-CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_KEY=a_xmla
-CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_NAME=xmla-enabled
 CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_DESCRIPTION=Analysis XMLA enabled flag
-CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_KEY=m_id
-CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_NAME=metadata-domain-id
 CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_DESCRIPTION=Metadata domain ID
 
 

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_de.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_de.properties
@@ -207,80 +207,42 @@ CommandLineProcessor.ERROR_0005_INVALID_FILE_PATH=Ung\u00fcltiger Dateipfad: {0}
 CommandLineProcessor.ERROR_0006_NON_ADMIN_CREDENTIALS=Anmeldeinfos f\u00fcr Benutzer ohne Administratorrechte eingegeben
 CommandLineProcessor.ERROR_0007_FORBIDDEN=Der Benutzer darf diesen Vorgang nicht ausf\u00fchren: {0}
 
-CommandLineProcessor.INFO_OPTION_HELP_KEY=h
-CommandLineProcessor.INFO_OPTION_HELP_NAME=Hilfe
 CommandLineProcessor.INFO_OPTION_HELP_DESCRIPTION=diese Nachricht drucken
 
-CommandLineProcessor.INFO_OPTION_IMPORT_KEY=i
-CommandLineProcessor.INFO_OPTION_IMPORT_NAME=Importieren
 CommandLineProcessor.INFO_OPTION_IMPORT_DESCRIPTION=Importieren
 
-CommandLineProcessor.INFO_OPTION_EXPORT_KEY=e
-CommandLineProcessor.INFO_OPTION_EXPORT_NAME=Exportieren
 CommandLineProcessor.INFO_OPTION_EXPORT_DESCRIPTION=Exportieren
 
-CommandLineProcessor.INFO_OPTION_BACKUP_KEY=Backup
-CommandLineProcessor.INFO_OPTION_BACKUP_NAME=Backup
 CommandLineProcessor.INFO_OPTION_BACKUP_DESCRIPTION=Erstellt eine vollst\u00e4ndige System-Backup-Datei zur Verwendung mit dem System-Wiederherstellungsger\u00e4t.
 
-CommandLineProcessor.INFO_OPTION_RESTORE_KEY=wiederherstellen
-CommandLineProcessor.INFO_OPTION_RESTORE_NAME=wiederherstellen
 CommandLineProcessor.INFO_OPTION_RESTORE_DESCRIPTION=F\u00fchrt eine Systemwiederherstellung ausgehend von einer bestimmten Backup-Datei durch.
 
-CommandLineProcessor.INFO_OPTION_USERNAME_KEY=u
-CommandLineProcessor.INFO_OPTION_USERNAME_NAME=Benutzername
 CommandLineProcessor.INFO_OPTION_USERNAME_DESCRIPTION=Repository-Benutzername
 
-CommandLineProcessor.INFO_OPTION_PASSWORD_KEY=p
-CommandLineProcessor.INFO_OPTION_PASSWORD_NAME=Kennwort
 CommandLineProcessor.INFO_OPTION_PASSWORD_DESCRIPTION=Repository-Kennwort
 
-CommandLineProcessor.INFO_OPTION_URL_KEY=a
-CommandLineProcessor.INFO_OPTION_URL_NAME=url
 CommandLineProcessor.INFO_OPTION_URL_DESCRIPTION=url des Repository (z. B. http://localhost:8080/pentaho)
 
-CommandLineProcessor.INFO_OPTION_FILEPATH_KEY=fp
-CommandLineProcessor.INFO_OPTION_FILEPATH_NAME=Dateipfad
 CommandLineProcessor.INFO_OPTION_FILEPATH_DESCRIPTION=Pfad zum Verzeichnis von Dateien f\u00fcr den Import oder Pfad zu .zip-Datei f\u00fcr den Export
 
-CommandLineProcessor.INFO_OPTION_CHARSET_KEY=c
-CommandLineProcessor.INFO_OPTION_CHARSET_NAME=Zeichensatz
 CommandLineProcessor.INFO_OPTION_CHARSET_DESCRIPTION=Zeichensatz zur Verwendung im Repository (Zeichen externer Systeme werden in diesen Zeichensatz konvertiert)
 
-CommandLineProcessor.INFO_OPTION_LOGFILE_KEY=l
-CommandLineProcessor.INFO_OPTION_LOGFILE_NAME=Protokolldatei
 CommandLineProcessor.INFO_OPTION_LOGFILE_DESCRIPTION=voller Pfad- und Dateiname der Protokolldateinachrichten
 
-CommandLineProcessor.INFO_OPTION_PATH_KEY=f
-CommandLineProcessor.INFO_OPTION_PATH_NAME=Pfad
 CommandLineProcessor.INFO_OPTION_PATH_DESCRIPTION=Repository-Pfad, zu dem importierte Dateien hinzugef\u00fcgt werden k\u00f6nnen und von dem Dateien exportiert werden k\u00f6nnen (z. B. /public)
 
-CommandLineProcessor.INFO_OPTION_OVERWRITE_KEY=o
-CommandLineProcessor.INFO_OPTION_OVERWRITE_NAME=\u00fcberschreiben
 CommandLineProcessor.INFO_OPTION_OVERWRITE_DESCRIPTION=Dateien \u00fcberschreiben (nur Import)
 
-CommandLineProcessor.INFO_OPTION_PERMISSION_KEY=m
-CommandLineProcessor.INFO_OPTION_PERMISSION_NAME=Berechtigung
 CommandLineProcessor.INFO_OPTION_PERMISSION_DESCRIPTION=ACL-Manifestberechtigung auf Dateien und Ordner anwenden (nur Import)
 
-CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_KEY=r
-CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_NAME=retainOwnership
 CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_DESCRIPTION=Besitzrechtinformation beibehalten  (nur Import)
 
-CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_KEY=w
-CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_NAME=withManifest
 CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_DESCRIPTION=Beinhaltet ACL-Manifestdateiexport (nur Export)
 
-CommandLineProcessor.INFO_OPTION_REST_KEY=Rest
-CommandLineProcessor.INFO_OPTION_REST_NAME=Rest
 CommandLineProcessor.INFO_OPTION_REST_DESCRIPTION=Verwenden Sie die REST-(Standard) Version (nicht lokal f\u00fcr BI-Server)
 
-CommandLineProcessor.INFO_OPTION_SERVICE_KEY=v
-CommandLineProcessor.INFO_OPTION_SERVICE_NAME=Dienst
 CommandLineProcessor.INFO_OPTION_SERVICE_DESCRIPTION=dies ist der REST-Dienstanruf, z. B. acl, Unterelemente, Eigenschaften
 
-CommandLineProcessor.INFO_OPTION_PARAMS_KEY=Parameter
-CommandLineProcessor.INFO_OPTION_PARAMS_NAME=Parameter
 CommandLineProcessor.INFO_OPTION_PARAMS_DESCRIPTION=Parameter f\u00fcr den REST-Dienstanruf
 
 CommandLineProcessor.INFO_REST_COMPLETED=REST abgeschlossen
@@ -296,23 +258,11 @@ CommandLineProcessor.INFO_PRINTHELP_CMDLINE=importexport
 CommandLineProcessor.INFO_PRINTHELP_HEADER=Vereinheitlichtes Repository-Import-/Exportwerkzeug in der Befehlszeile
 CommandLineProcessor.INFO_PRINTHELP_FOOTER=Allgemeine Optionen f\u00fcr Import und Export unter Verwendung von Beispielargumenten des REST-Dienstes f\u00fcr Import:\n--import --url=http://localhost:8080/pentaho --username=admin\n--password=password --charset=UTF-8 --path=/public\n--file-path=c:/temp/steel-wheels\n--logfile=c:/temp/logfile.log\n--permission=true\n&quot; + &quot;--overwrite=true\n--retainOwnership=true\n\n\n\nBeispielargumente f\u00fcr Export:\n--export --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --charset=UTF-8 --path=/public\n --withManifest=true--logfile=c:/temp/logfile.log\n\n\nBeispielargumente f\u00fcr Backup:\n--backup --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\n\nExample arguments for restore:\n--restore --url=http://localhost:8080/pentaho --username=admin --password=password \n--overwrite=true --file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\nBeispielargumente f\u00fcr das Ausf\u00fchren von REST-Diensten:\n--rest --url=http://localhost:8080/pentaho --username=admin --password=password \n-path=/public/pentaho-solutions/steel-wheels/reports\n--logfile=c:/temp/logfile.log --service=acl\n
 
-CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_KEY=res
-CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_NAME=Ressourcentyp
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=Import/Export-Ressourcentyp
-CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_KEY=ds
-CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_NAME=Datenquellentyp
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=Datenquellentyp
-CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_KEY=cat
-CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_NAME=Katalog
 CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_DESCRIPTION=Katalogbeschreibung
-CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_KEY=a_ds
-CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_NAME=Datenquellenanalyse
 CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_DESCRIPTION=Beschreibung der Datenquellenanalyse
-CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_KEY=a_xmla
-CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_NAME=xmla-aktiviert
 CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_DESCRIPTION=Analyse des XMLA-aktivierten Flag
-CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_KEY=m_id
-CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_NAME=Metadaten-Dom\u00e4nen-ID
 CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_DESCRIPTION=Metadaten-Dom\u00e4nen-ID
 
 

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_fr.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_fr.properties
@@ -207,80 +207,42 @@ CommandLineProcessor.ERROR_0005_INVALID_FILE_PATH=Chemin d'acc\u00e8s de fichier
 CommandLineProcessor.ERROR_0006_NON_ADMIN_CREDENTIALS=Les identifiants saisis ne sont pas ceux d'un administrateur
 CommandLineProcessor.ERROR_0007_FORBIDDEN=L'utilisateur n'est pas autoris\u00e9 \u00e0 effectuer cette op\u00e9ration\u0020: {0}
 
-CommandLineProcessor.INFO_OPTION_HELP_KEY=h
-CommandLineProcessor.INFO_OPTION_HELP_NAME=help
 CommandLineProcessor.INFO_OPTION_HELP_DESCRIPTION=imprimer ce message
 
-CommandLineProcessor.INFO_OPTION_IMPORT_KEY=i
-CommandLineProcessor.INFO_OPTION_IMPORT_NAME=importer
 CommandLineProcessor.INFO_OPTION_IMPORT_DESCRIPTION=importer
 
-CommandLineProcessor.INFO_OPTION_EXPORT_KEY=e
-CommandLineProcessor.INFO_OPTION_EXPORT_NAME=exporter
 CommandLineProcessor.INFO_OPTION_EXPORT_DESCRIPTION=exporter
 
-CommandLineProcessor.INFO_OPTION_BACKUP_KEY=sauvegarder
-CommandLineProcessor.INFO_OPTION_BACKUP_NAME=sauvegarder
 CommandLineProcessor.INFO_OPTION_BACKUP_DESCRIPTION=G\u00e9n\u00e8re un fichier de sauvegarde syst\u00e8me compl\u00e8te \u00e0 utiliser avec le service de restauration syst\u00e8me.
 
-CommandLineProcessor.INFO_OPTION_RESTORE_KEY=restaurer
-CommandLineProcessor.INFO_OPTION_RESTORE_NAME=restaurer
 CommandLineProcessor.INFO_OPTION_RESTORE_DESCRIPTION=Effectue une restauration syst\u00e8me \u00e0 partir d'un fichier de sauvegarde donn\u00e9.
 
-CommandLineProcessor.INFO_OPTION_USERNAME_KEY=u
-CommandLineProcessor.INFO_OPTION_USERNAME_NAME=username
 CommandLineProcessor.INFO_OPTION_USERNAME_DESCRIPTION=nom d'utilisateur du r\u00e9f\u00e9rentiel
 
-CommandLineProcessor.INFO_OPTION_PASSWORD_KEY=p
-CommandLineProcessor.INFO_OPTION_PASSWORD_NAME=password
 CommandLineProcessor.INFO_OPTION_PASSWORD_DESCRIPTION=mot de passe du r\u00e9f\u00e9rentiel
 
-CommandLineProcessor.INFO_OPTION_URL_KEY=a
-CommandLineProcessor.INFO_OPTION_URL_NAME=url
 CommandLineProcessor.INFO_OPTION_URL_DESCRIPTION=URL du r\u00e9f\u00e9rentiel (exemple\u0020: http://localhost:8080/pentaho)
 
-CommandLineProcessor.INFO_OPTION_FILEPATH_KEY=fp
-CommandLineProcessor.INFO_OPTION_FILEPATH_NAME=file-path
 CommandLineProcessor.INFO_OPTION_FILEPATH_DESCRIPTION=Chemin d'acc\u00e8s du r\u00e9pertoire de fichiers pour l'importation ou du fichier ZIP pour l'exportation
 
-CommandLineProcessor.INFO_OPTION_CHARSET_KEY=c
-CommandLineProcessor.INFO_OPTION_CHARSET_NAME=charset
 CommandLineProcessor.INFO_OPTION_CHARSET_DESCRIPTION=jeu de caract\u00e8res \u00e0 utiliser pour le r\u00e9f\u00e9rentiel (caract\u00e8res provenant de syst\u00e8mes externes convertis \u00e0 ce jeu)
 
-CommandLineProcessor.INFO_OPTION_LOGFILE_KEY=l
-CommandLineProcessor.INFO_OPTION_LOGFILE_NAME=logfile
 CommandLineProcessor.INFO_OPTION_LOGFILE_DESCRIPTION=chemin d'acc\u00e8s et nom de fichier complets des messages du fichier journal
 
-CommandLineProcessor.INFO_OPTION_PATH_KEY=f
-CommandLineProcessor.INFO_OPTION_PATH_NAME=path
 CommandLineProcessor.INFO_OPTION_PATH_DESCRIPTION=chemin d'acc\u00e8s du r\u00e9f\u00e9rentiel auquel ajouter des fichiers import\u00e9s ou vers lequel les exporter (ex.\u0020: /public)
 
-CommandLineProcessor.INFO_OPTION_OVERWRITE_KEY=o
-CommandLineProcessor.INFO_OPTION_OVERWRITE_NAME=overwrite
 CommandLineProcessor.INFO_OPTION_OVERWRITE_DESCRIPTION=\u00e9craser les fichiers (seulement \u00e0 l'importation)
 
-CommandLineProcessor.INFO_OPTION_PERMISSION_KEY=m
-CommandLineProcessor.INFO_OPTION_PERMISSION_NAME=permission
 CommandLineProcessor.INFO_OPTION_PERMISSION_DESCRIPTION=appliquer les autorisations ACL du Manifest aux fichiers et dossiers (seulement \u00e0 l'importation)
 
-CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_KEY=r
-CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_NAME=retainOwnership
 CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_DESCRIPTION=Conserver les informations propri\u00e9taires (seulement \u00e0 l'importation)
 
-CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_KEY=w
-CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_NAME=withManifest
 CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_DESCRIPTION=Exporter le fichier Manifest ACL inclus (seulement \u00e0 l'exportation)
 
-CommandLineProcessor.INFO_OPTION_REST_KEY=restant
-CommandLineProcessor.INFO_OPTION_REST_NAME=restant
 CommandLineProcessor.INFO_OPTION_REST_DESCRIPTION=Utiliser la version REST par d\u00e9faut (non locale pour serveur BI)
 
-CommandLineProcessor.INFO_OPTION_SERVICE_KEY=v
-CommandLineProcessor.INFO_OPTION_SERVICE_NAME=service
 CommandLineProcessor.INFO_OPTION_SERVICE_DESCRIPTION=c'est l'appel de service REST, ex.\u0020: ACL, enfants, propri\u00e9t\u00e9s
 
-CommandLineProcessor.INFO_OPTION_PARAMS_KEY=param\u00e8tres
-CommandLineProcessor.INFO_OPTION_PARAMS_NAME=param\u00e8tres
 CommandLineProcessor.INFO_OPTION_PARAMS_DESCRIPTION=param\u00e8tres \u00e0 passer \u00e0 l'appel de service REST
 
 CommandLineProcessor.INFO_REST_COMPLETED=REST termin\u00e9
@@ -296,23 +258,11 @@ CommandLineProcessor.INFO_PRINTHELP_CMDLINE=importexport
 CommandLineProcessor.INFO_PRINTHELP_HEADER=Outil unifi\u00e9 d'importation/exportation du r\u00e9f\u00e9rentiel en ligne de commande
 CommandLineProcessor.INFO_PRINTHELP_FOOTER=Options courantes d'importation/exportation utilisant les services REST. Arguments d'exemple pour l'importation\u0020:\n--import --url=http://localhost:8080/pentaho --username=admin\n--password=password --charset=UTF-8 --path=/public\n--file-path=c:/temp/steel-wheels\n--logfile=c:/temp/logfile.log\n--permission=true\n&quot; + &quot;--overwrite=true\n--retainOwnership=true\n\n\n\nArguments d'exemple pour l'exportation\u0020:\n--export --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --charset=UTF-8 --path=/public\n --withManifest=true--logfile=c:/temp/logfile.log\n\n\nArguments d'exemple pour la sauvegarde\u0020:\n--backup --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\n\nArguments d'exemple pour la restauration\u0020:\n--restore --url=http://localhost:8080/pentaho --username=admin --password=password \n--overwrite=true --file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\nArguments d'exemple pour l'ex\u00e9cution des services REST\u0020:\n--rest --url=http://localhost:8080/pentaho --username=admin --password=password \n-path=/public/pentaho-solutions/steel-wheels/reports\n--logfile=c:/temp/logfile.log --service=acl\n
 
-CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_KEY=res
-CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_NAME=resource-type
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=Type de source \u00e0 importer/exporter
-CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_KEY=ds
-CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_NAME=datasource-type
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=type de source de donn\u00e9es
-CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_KEY=cat
-CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_NAME=catalog
 CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_DESCRIPTION=description du catalogue
-CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_KEY=a_ds
-CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_NAME=analysis-datasource
 CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_DESCRIPTION=Description de la source de donn\u00e9es d'analyse
-CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_KEY=a_xmla
-CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_NAME=xmla-enabled
 CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_DESCRIPTION=Activation de l'analyse XMLA
-CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_KEY=m_id
-CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_NAME=metadata-domain-id
 CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_DESCRIPTION=ID de domaine de m\u00e9tadonn\u00e9es
 
 

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_ja.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_ja.properties
@@ -207,80 +207,42 @@ CommandLineProcessor.ERROR_0005_INVALID_FILE_PATH=Invalid file-path: {0}
 CommandLineProcessor.ERROR_0006_NON_ADMIN_CREDENTIALS=Non admin credentials entered
 CommandLineProcessor.ERROR_0007_FORBIDDEN=\u30e6\u30fc\u30b6\u30fc\u306f\u3053\u306e\u64cd\u4f5c\u306e\u5b9f\u884c\u3092\u8a31\u53ef\u3055\u308c\u3066\u3044\u307e\u305b\u3093: {0}
 
-CommandLineProcessor.INFO_OPTION_HELP_KEY=h
-CommandLineProcessor.INFO_OPTION_HELP_NAME=\u30d8\u30eb\u30d7
 CommandLineProcessor.INFO_OPTION_HELP_DESCRIPTION=\u3053\u306e\u30da\u30fc\u30b8\u3092\u30d7\u30ea\u30f3\u30c8
 
-CommandLineProcessor.INFO_OPTION_IMPORT_KEY=i
-CommandLineProcessor.INFO_OPTION_IMPORT_NAME=\u30a4\u30f3\u30dd\u30fc\u30c8
 CommandLineProcessor.INFO_OPTION_IMPORT_DESCRIPTION=\u30a4\u30f3\u30dd\u30fc\u30c8
 
-CommandLineProcessor.INFO_OPTION_EXPORT_KEY=e
-CommandLineProcessor.INFO_OPTION_EXPORT_NAME=\u30a8\u30af\u30b9\u30dd\u30fc\u30c8
 CommandLineProcessor.INFO_OPTION_EXPORT_DESCRIPTION=\u30a8\u30af\u30b9\u30dd\u30fc\u30c8
 
-CommandLineProcessor.INFO_OPTION_BACKUP_KEY=\u30d0\u30c3\u30af\u30a2\u30c3\u30d7
-CommandLineProcessor.INFO_OPTION_BACKUP_NAME=\u30d0\u30c3\u30af\u30a2\u30c3\u30d7
 CommandLineProcessor.INFO_OPTION_BACKUP_DESCRIPTION=\u30b7\u30b9\u30c6\u30e0\u30ea\u30b9\u30c8\u30a2\u30b5\u30fc\u30d3\u30b9\u3067\u4f7f\u7528\u3059\u308b\u5b8c\u5168\u306a\u30b7\u30b9\u30c6\u30e0\u30d0\u30c3\u30af\u30a2\u30c3\u30d7\u30d5\u30a1\u30a4\u30eb\u3092\u751f\u6210\u3057\u307e\u3059\u3002
 
-CommandLineProcessor.INFO_OPTION_RESTORE_KEY=\u30ea\u30b9\u30c8\u30a2
-CommandLineProcessor.INFO_OPTION_RESTORE_NAME=\u30ea\u30b9\u30c8\u30a2
 CommandLineProcessor.INFO_OPTION_RESTORE_DESCRIPTION=\u6307\u5b9a\u30d0\u30c3\u30af\u30a2\u30c3\u30d7\u30d5\u30a1\u30a4\u30eb\u304b\u3089\u30b7\u30b9\u30c6\u30e0\u30ea\u30b9\u30c8\u30a2\u3092\u5b9f\u884c\u3057\u307e\u3059\u3002
 
-CommandLineProcessor.INFO_OPTION_USERNAME_KEY=u
-CommandLineProcessor.INFO_OPTION_USERNAME_NAME=\u30e6\u30fc\u30b6\u30fc\u540d
 CommandLineProcessor.INFO_OPTION_USERNAME_DESCRIPTION=\u30ea\u30dd\u30b8\u30c8\u30ea\u30fc\u30e6\u30fc\u30b6\u30fc\u540d
 
-CommandLineProcessor.INFO_OPTION_PASSWORD_KEY=p
-CommandLineProcessor.INFO_OPTION_PASSWORD_NAME=\u30d1\u30b9\u30ef\u30fc\u30c9
 CommandLineProcessor.INFO_OPTION_PASSWORD_DESCRIPTION=\u30ea\u30dd\u30b8\u30c8\u30ea\u30fc\u30d1\u30b9\u30ef\u30fc\u30c9
 
-CommandLineProcessor.INFO_OPTION_URL_KEY=a
-CommandLineProcessor.INFO_OPTION_URL_NAME=url
 CommandLineProcessor.INFO_OPTION_URL_DESCRIPTION=\u30ea\u30dd\u30b8\u30c8\u30ea\u30fc\u306eurl (\u4f8b. http://localhost:8080/pentaho)
 
-CommandLineProcessor.INFO_OPTION_FILEPATH_KEY=fp
-CommandLineProcessor.INFO_OPTION_FILEPATH_NAME=\u30d5\u30a1\u30a4\u30eb\u30d1\u30b9
 CommandLineProcessor.INFO_OPTION_FILEPATH_DESCRIPTION=\u30d5\u30a1\u30a4\u30eb\u306e\u30d1\u30b9
 
-CommandLineProcessor.INFO_OPTION_CHARSET_KEY=c
-CommandLineProcessor.INFO_OPTION_CHARSET_NAME=\u30ad\u30e3\u30e9\u30af\u30bf\u30fc\u30bb\u30c3\u30c8
 CommandLineProcessor.INFO_OPTION_CHARSET_DESCRIPTION=\u30ea\u30dd\u30b8\u30c8\u30ea\u30fc\u3067\u4f7f\u7528\u3059\u308b\u30ad\u30e3\u30e9\u30af\u30bf\u30fc\u30bb\u30c3\u30c8 (\u5916\u90e8\u30b7\u30b9\u30c6\u30e0\u306e\u30ad\u30e3\u30e9\u30af\u30bf\u30fc\u30bb\u30c3\u30c8\u306f\u3053\u306e\u30ad\u30e3\u30e9\u30af\u30bf\u30fc\u30bb\u30c3\u30c8\u306b\u5909\u63db\u3055\u308c\u307e\u3059\u3002)
 
-CommandLineProcessor.INFO_OPTION_LOGFILE_KEY=l
-CommandLineProcessor.INFO_OPTION_LOGFILE_NAME=\u30ed\u30b0\u30d5\u30a1\u30a4\u30eb
 CommandLineProcessor.INFO_OPTION_LOGFILE_DESCRIPTION=\u30ed\u30b0\u30d5\u30a1\u30a4\u30eb\u306e\u30d5\u30eb\u30d1\u30b9\u3068\u30d5\u30a1\u30a4\u30eb\u540d
 
-CommandLineProcessor.INFO_OPTION_PATH_KEY=f
-CommandLineProcessor.INFO_OPTION_PATH_NAME=\u30d1\u30b9
 CommandLineProcessor.INFO_OPTION_PATH_DESCRIPTION=\u30a4\u30f3\u30dd\u30fc\u30c8\u3057\u305f\u30d5\u30a1\u30a4\u30eb\u3092\u8ffd\u52a0\u3059\u308b\u30ea\u30dd\u30b8\u30c8\u30ea\u30fc\u30d1\u30b9 (\u4f8b. /public) (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
 
-CommandLineProcessor.INFO_OPTION_OVERWRITE_KEY=o
-CommandLineProcessor.INFO_OPTION_OVERWRITE_NAME=\u4e0a\u66f8\u304d
 CommandLineProcessor.INFO_OPTION_OVERWRITE_DESCRIPTION=\u30d5\u30a1\u30a4\u30eb\u3092\u4e0a\u66f8\u304d (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
 
-CommandLineProcessor.INFO_OPTION_PERMISSION_KEY=m
-CommandLineProcessor.INFO_OPTION_PERMISSION_NAME=permission
 CommandLineProcessor.INFO_OPTION_PERMISSION_DESCRIPTION=\u30d5\u30a1\u30a4\u30eb\u3068\u30d5\u30a9\u30eb\u30c0\u306bACL\u3092\u9069\u7528  (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
 
-CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_KEY=r
-CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_NAME=\u6240\u6709\u6a29\u3092\u4fdd\u6301
 CommandLineProcessor.INFO_OPTION_RETAIN_OWNERSHIP_DESCRIPTION=\u6240\u6709\u6a29\u60c5\u5831\u3092\u4fdd\u6301 (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
 
-CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_KEY=w
-CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_NAME=\u30de\u30cb\u30d5\u30a7\u30b9\u30c8
 CommandLineProcessor.INFO_OPTION_WITH_MANIFEST_DESCRIPTION=\u30de\u30cb\u30d5\u30a7\u30b9\u30c8ACL\u30d5\u30a1\u30a4\u30eb\u3092\u30a8\u30af\u30b9\u30dd\u30fc\u30c8  (\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u306e\u307f)
 
-CommandLineProcessor.INFO_OPTION_REST_KEY=rest
-CommandLineProcessor.INFO_OPTION_REST_NAME=rest
 CommandLineProcessor.INFO_OPTION_REST_DESCRIPTION=REST (\u30c7\u30d5\u30a9\u30eb\u30c8)\u30d0\u30fc\u30b8\u30e7\u30f3\u3092\u4f7f\u7528 (local\u304b\u3089BI Server\u3067\u306f\u306a\u3044)
 
-CommandLineProcessor.INFO_OPTION_SERVICE_KEY=v
-CommandLineProcessor.INFO_OPTION_SERVICE_NAME=\u30b5\u30fc\u30d3\u30b9
 CommandLineProcessor.INFO_OPTION_SERVICE_DESCRIPTION=REST\u30b5\u30fc\u30d3\u30b9\u30b3\u30fc\u30eb\u3067\u3059\u3002\u4f8b. acl, children, properties
 
-CommandLineProcessor.INFO_OPTION_PARAMS_KEY=params
-CommandLineProcessor.INFO_OPTION_PARAMS_NAME=params
 CommandLineProcessor.INFO_OPTION_PARAMS_DESCRIPTION=REST\u30b5\u30fc\u30d3\u30b9\u30b3\u30fc\u30eb\u3078\u308f\u305f\u3059\u30d1\u30e9\u30e1\u30fc\u30bf\u30fc\u3067\u3059\u3002
 
 CommandLineProcessor.INFO_REST_COMPLETED=REST\u5b8c\u4e86
@@ -296,23 +258,11 @@ CommandLineProcessor.INFO_PRINTHELP_CMDLINE=\u30a4\u30f3\u30dd\u30fc\u30c8\u30a8
 CommandLineProcessor.INFO_PRINTHELP_HEADER=\u7d71\u5408\u30ea\u30dd\u30b8\u30c8\u30ea\u30fc\u30b3\u30de\u30f3\u30c9\u30e9\u30a4\u30f3\u30a4\u30f3\u30dd\u30fc\u30c8/\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u30c4\u30fc\u30eb
 CommandLineProcessor.INFO_PRINTHELP_FOOTER=\u30a4\u30f3\u30dd\u30fc\u30c8\u7528\u306eREST ServicesExample\u5f15\u6570\u3092\u4f7f\u7528\u3059\u308b\u3001\u30a4\u30f3\u30dd\u30fc\u30c8\u304a\u3088\u3073\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u306e\u5171\u901a\u30aa\u30d7\u30b7\u30e7\u30f3:\n--import --url=http://localhost:8080/pentaho --username=admin\n--password=password --charset=UTF-8 --path=/public\n--file-path=c:/temp/steel-wheels\n--logfile=c:/temp/logfile.log\n--permission=true\n&quot; + &quot;--overwrite=true\n--retainOwnership=true\n\n\n\n\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u7528\u306e\u5f15\u6570\u4f8b:\n--export --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --charset=UTF-8 --path=/public\n --withManifest=true--logfile=c:/temp/logfile.log\n\n\n\u30d0\u30c3\u30af\u30a2\u30c3\u30d7\u7528\u306e\u5f15\u6570\u4f8b:\n--backup --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\n\n\u30ea\u30b9\u30c8\u30a2\u7528\u306e\u5f15\u6570\u4f8b:\n--restore --url=http://localhost:8080/pentaho --username=admin --password=password \n--overwrite=true --file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\nREST\u30b5\u30fc\u30d3\u30b9\u5b9f\u884c\u7528\u306e\u5f15\u6570\u4f8b:\n--rest --url=http://localhost:8080/pentaho --username=admin --password=password \n-path=/public/pentaho-solutions/steel-wheels/reports\n--logfile=c:/temp/logfile.log --service=acl\n
 
-CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_KEY=res
-CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_NAME=resource-type
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=\u30a4\u30f3\u30dd\u30fc\u30c8/\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u306e\u30ea\u30bd\u30fc\u30b9\u30bf\u30a4\u30d7
-CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_KEY=ds
-CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_NAME=datasource-type
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=\u30c7\u30fc\u30bf\u30bd\u30fc\u30b9\u30bf\u30a4\u30d7
-CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_KEY=cat
-CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_NAME=catalog
 CommandLineProcessor.INFO_OPTION_ANALYSIS_CATALOG_DESCRIPTION=\u30ab\u30bf\u30ed\u30b0\u306e\u8a73\u7d30
-CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_KEY=a_ds
-CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_NAME=analysis-datasource
 CommandLineProcessor.INFO_OPTION_ANALYSIS_DATASOURCE_DESCRIPTION=\u5206\u6790\u30c7\u30fc\u30bf\u30bd\u30fc\u30b9\u8a73\u7d30
-CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_KEY=a_xmla
-CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_NAME=xmla-enabled
 CommandLineProcessor.INFO_OPTION_ANALYSIS_XMLA_ENABLED_DESCRIPTION=\u5206\u6790XMLA\u6709\u52b9\u5316\u30d5\u30e9\u30b0
-CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_KEY=m_id
-CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_NAME=metadata-domain-id
 CommandLineProcessor.INFO_OPTION_METADATA_DOMAIN_ID_DESCRIPTION=\u30e1\u30bf\u30c7\u30fc\u30bf\u30c9\u30e1\u30a4\u30f3ID
 
 

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorTest.java
@@ -116,25 +116,25 @@ public class CommandLineProcessorTest extends Assert {
     if ( key == null ) {
       return "";
     }
-    return prefix + Messages.getInstance().getString( "CommandLineProcessor." + key );
+    return prefix + key;
   }
 
   @Test
   public void get001ConstructorTest() throws ParseException {
     try {
-      testRequestType( "INFO_OPTION_HELP_KEY", null, RequestType.HELP );
-      testRequestType( "INFO_OPTION_REST_KEY", null, RequestType.REST );
-      testRequestType( "INFO_OPTION_BACKUP_KEY", null, RequestType.BACKUP );
-      testRequestType( "INFO_OPTION_RESTORE_KEY", null, RequestType.RESTORE );
-      testRequestType( "INFO_OPTION_IMPORT_KEY", null, RequestType.IMPORT );
-      testRequestType( "INFO_OPTION_EXPORT_KEY", null, RequestType.EXPORT );
+      testRequestType( "h", null, RequestType.HELP );
+      testRequestType( "rest", null, RequestType.REST );
+      testRequestType( "backup", null, RequestType.BACKUP );
+      testRequestType( "restore", null, RequestType.RESTORE );
+      testRequestType( "i", null, RequestType.IMPORT );
+      testRequestType( "e", null, RequestType.EXPORT );
 
-      testRequestType( null, "INFO_OPTION_HELP_NAME", RequestType.HELP );
-      testRequestType( null, "INFO_OPTION_REST_NAME", RequestType.REST );
-      testRequestType( null, "INFO_OPTION_BACKUP_NAME", RequestType.BACKUP );
-      testRequestType( null, "INFO_OPTION_RESTORE_NAME", RequestType.RESTORE );
-      testRequestType( null, "INFO_OPTION_IMPORT_NAME", RequestType.IMPORT );
-      testRequestType( null, "INFO_OPTION_EXPORT_NAME", RequestType.EXPORT );
+      testRequestType( null, "help", RequestType.HELP );
+      testRequestType( null, "rest", RequestType.REST );
+      testRequestType( null, "backup", RequestType.BACKUP );
+      testRequestType( null, "restore", RequestType.RESTORE );
+      testRequestType( null, "import", RequestType.IMPORT );
+      testRequestType( null, "export", RequestType.EXPORT );
 
       try {
         createCommandLineProcessor( null, null );
@@ -190,9 +190,9 @@ public class CommandLineProcessorTest extends Assert {
   public void get004GetOptionValueTest() throws ParseException {
     depensOnConstructor();
 
-    String requestType = getOption( "-", "INFO_OPTION_IMPORT_KEY" );
-    String shortOption = getOption( "INFO_OPTION_USERNAME_KEY" );
-    String longOption = getOption( "INFO_OPTION_USERNAME_NAME" );
+    String requestType = getOption( "-", "i" );
+    String shortOption = getOption( "u" );
+    String longOption = getOption( "username" );
 
     CommandLineProcessor clp = new CommandLineProcessor( new String[] { requestType, "-" + shortOption + "=value" } );
 


### PR DESCRIPTION
- parameters were pulled out of the message bundle;
- only English parameters are allowed now.