### PR TITLE
[COMP-6163] in relation to [BACKLOG-16372] Upgrading version of httpcore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <rome.version>1.0</rome.version>
     <javatar.version>2.5</javatar.version>
     <elasticsearch.version>0.16.3</elasticsearch.version>
-    <httpcore.version>4.4.3</httpcore.version>
+    <httpcore.version>4.4.4</httpcore.version>
     <jfreechart.version>1.0.13</jfreechart.version>
     <monetdb-jdbc.version>2.8</monetdb-jdbc.version>
     <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>


### PR DESCRIPTION
The currently used httpcore-4.4.3 was never officially officially approved but httpcore-4.4.4 is already approved and used in other parts of the product. The jar is pulled in as a run time dependency from exenstions project and assembled by pentaho-war.