### PR TITLE
[BACKLOG-16708] Changed behaviour of isPasswordValid in DefaultPasswordEncoder.java so that when a null password is valid the method returns false, rather than throwing an IllegalArgumentException.

### DIFF
--- a/repository/src/main/java/org/pentaho/platform/repository2/userroledao/jackrabbit/security/DefaultPentahoPasswordEncoder.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/userroledao/jackrabbit/security/DefaultPentahoPasswordEncoder.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.repository2.userroledao.jackrabbit.security;
@@ -29,21 +29,21 @@ import javax.jcr.SimpleCredentials;
 
 /**
  * Default password encoder for the BI Server.
- * 
+ *
  * <p>
  * This encoder Base64-encodes the raw password.
  * </p>
- * 
+ *
  * <p>
  * This class is instantiated by Pentaho Admin Console so there should not be a dependency on classes to which PAC
  * will not have access.
  * </p>
- * 
+ *
  * <p>
  * This implementation of password encoding is completely independent of any datasource connection password
  * encoding.
  * </p>
- * 
+ *
  * @author mlowery
  */
 public class DefaultPentahoPasswordEncoder implements PasswordEncoder {
@@ -66,10 +66,14 @@ public class DefaultPentahoPasswordEncoder implements PasswordEncoder {
 
   public boolean isPasswordValid( final String encPass, final String rawPass, final Object salt )
     throws DataAccessException {
-    Validate.notNull( encPass, Messages.getInstance().getString(
-        "DefaultPentahoPasswordEncoder.ERROR_0002_ENCPASS_CANNOT_BE_NULL" ) ); //$NON-NLS-1$
-    Validate.notNull( rawPass, Messages.getInstance().getString(
-        "DefaultPentahoPasswordEncoder.ERROR_0001_RAWPASS_CANNOT_BE_NULL" ) ); //$NON-NLS-1$
+    try {
+      Validate.notNull( encPass, Messages.getInstance().getString(
+          "DefaultPentahoPasswordEncoder.ERROR_0002_ENCPASS_CANNOT_BE_NULL" ) ); //$NON-NLS-1$
+      Validate.notNull( rawPass, Messages.getInstance().getString(
+          "DefaultPentahoPasswordEncoder.ERROR_0001_RAWPASS_CANNOT_BE_NULL" ) ); //$NON-NLS-1$
+    } catch ( IllegalArgumentException e ) {
+      return false;
+    }
     try {
       CryptedSimpleCredentials credentials = new CryptedSimpleCredentials( "dummyUser", encPass );
       return credentials.matches( new SimpleCredentials( "dummyUser", rawPass.toCharArray() ) );
@@ -77,5 +81,4 @@ public class DefaultPentahoPasswordEncoder implements PasswordEncoder {
       throw new RuntimeException( e );
     }
   }
-
 }

--- a/repository/src/test/java/org/pentaho/platform/security/userroledao/jackrabbit/DefaultPentahoPasswordEncoderTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/userroledao/jackrabbit/DefaultPentahoPasswordEncoderTest.java
@@ -1,0 +1,42 @@
+package org.pentaho.platform.security.userroledao.jackrabbit;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.pentaho.platform.repository2.userroledao.jackrabbit.security.DefaultPentahoPasswordEncoder;
+import org.pentaho.test.platform.security.userroledao.ws.UserRoleWebServiceBase;
+
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
+ */
+public class DefaultPentahoPasswordEncoderTest {
+
+  @Test
+  public void testValidCredentials( ) {
+    DefaultPentahoPasswordEncoder passwordEncoder = new DefaultPentahoPasswordEncoder();
+    String password = "helloworld";
+    String encryptedPassword =  new UserRoleWebServiceBase.PasswordEncoderMock().encodePassword( password, null );
+    Assert.assertTrue( passwordEncoder.isPasswordValid( encryptedPassword, password, null ) );
+  }
+
+  @Test
+  public void testInvalidCredentials( ) {
+    DefaultPentahoPasswordEncoder passwordEncoder = new DefaultPentahoPasswordEncoder( );
+    Assert.assertFalse( passwordEncoder.isPasswordValid( "password", null, null ) );
+    Assert.assertFalse( passwordEncoder.isPasswordValid( passwordEncoder.encodePassword( "", null ), "password", null ) );
+    Assert.assertFalse( passwordEncoder.isPasswordValid( null, null, null ) );
+  }
+}


### PR DESCRIPTION
PR related to the following JIRAS: 
http://jira.pentaho.com/browse/ESR-5827
http://jira.pentaho.com/browse/BACKLOG-16708

The fix allows for a multiple authentication provider setup to work correctly when using LDAP.   