### PR TITLE
Renaming IActionInvoker.runInBackgorund to invokeAction, as the original name was a misnomer and caused a lot of confusion

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/action/IActionInvoker.java
+++ b/api/src/main/java/org/pentaho/platform/api/action/IActionInvoker.java
@@ -27,7 +27,7 @@ import java.util.Map;
 public interface IActionInvoker {
 
   /**
-   * Invokes the {@link IAction} {@code action} in the background.
+   * Invokes the {@link IAction} {@code action}.
    *
    * @param action The {@link IAction} to be invoked
    * @param user   The user invoking the action
@@ -35,6 +35,6 @@ public interface IActionInvoker {
    * @return the {@link IActionInvokeStatus} object containing information about the action invocation
    * @throws Exception if the action cannot be run for some reason
    */
-  IActionInvokeStatus runInBackground( IAction action, final String user, final Map<String, Serializable> params )
+  IActionInvokeStatus invokeAction( IAction action, final String user, final Map<String, Serializable> params )
     throws Exception;
 }

--- a/extensions/src/main/java/org/pentaho/platform/plugin/action/DefaultActionInvoker.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/action/DefaultActionInvoker.java
@@ -103,13 +103,13 @@ public class DefaultActionInvoker implements IActionInvoker {
    * @throws Exception when the {@code IAction} cannot be invoked for some reason.
    */
   @Override
-  public IActionInvokeStatus runInBackground( final IAction actionBean, final String actionUser, final
+  public IActionInvokeStatus invokeAction( final IAction actionBean, final String actionUser, final
     Map<String, Serializable> params ) throws Exception {
     ActionUtil.prepareMap( params );
     // call getStreamProvider, in addition to creating the provider, this method also adds values to the map that
     // serialize the stream provider and make it possible to deserialize and recreate it for remote execution.
     getStreamProvider( params );
-    return runInBackgroundImpl( actionBean, actionUser, params );
+    return invokeActionImpl( actionBean, actionUser, params );
   }
 
   /**
@@ -121,7 +121,7 @@ public class DefaultActionInvoker implements IActionInvoker {
    * @return the {@link IActionInvokeStatus} object containing information about the action invocation
    * @throws Exception when the {@code IAction} cannot be invoked for some reason.
    */
-  protected IActionInvokeStatus runInBackgroundImpl( final IAction actionBean, final String actionUser, final
+  protected IActionInvokeStatus invokeActionImpl( final IAction actionBean, final String actionUser, final
     Map<String, Serializable> params ) throws Exception {
 
     if ( actionBean == null || params == null ) {

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/ActionResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/ActionResource.java
@@ -61,7 +61,7 @@ public class ActionResource {
    *
    * @param actionId     the action id, if applicable
    * @param actionClass  the action class name, if applicable
-   * @param user         the user invoking the action
+   * @param actionUser   the user invoking the action
    * @param actionParams the action parameters needed to instantiate and invoke the action
    * @return a {@link Response}
    */
@@ -77,10 +77,10 @@ public class ActionResource {
   public Response runInBackground(
     @QueryParam( ActionUtil.INVOKER_ACTIONID ) String actionId,
     @QueryParam( ActionUtil.INVOKER_ACTIONCLASS ) String actionClass,
-    @QueryParam( ActionUtil.INVOKER_ACTIONUSER ) String user,
+    @QueryParam( ActionUtil.INVOKER_ACTIONUSER ) String actionUser,
     final String actionParams ) {
 
-    executorService.submit( createRunnable( actionId, actionClass, user, actionParams ) );
+    executorService.submit( createRunnable( actionId, actionClass, actionUser, actionParams ) );
     return Response.status( HttpStatus.SC_ACCEPTED ).build();
   }
 
@@ -150,7 +150,7 @@ public class ActionResource {
         final IAction action = createActionBean( actionClass, actionId );
         final Map<String, Serializable> params = deserialize( action, actionParams );
 
-        final IActionInvokeStatus status = actionInvoker.runInBackground( action, user, params );
+        final IActionInvokeStatus status = actionInvoker.invokeAction( action, user, params );
         if ( status.getThrowable() == null ) {
           logger.info( Messages.getInstance().getRunningInBgLocallySuccess( action.getClass().getName(), params ),
             status.getThrowable() );

--- a/extensions/src/test/java/org/pentaho/platform/plugin/action/DefaultActionInvokerTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/action/DefaultActionInvokerTest.java
@@ -45,30 +45,30 @@ public class DefaultActionInvokerTest {
   }
 
   @Test
-  public void runInBackgroundLocallyTest() throws Exception {
+  public void invokeActionLocallyTest() throws Exception {
     Map<String, Serializable> testMap = new HashMap<>();
     testMap.put( ActionUtil.QUARTZ_ACTIONCLASS, "one" );
     testMap.put( ActionUtil.QUARTZ_ACTIONUSER, "two" );
     IAction iaction = ActionUtil.createActionBean( ActionSequenceAction.class.getName(), null );
     ActionInvokeStatus actionInvokeStatus =
-      (ActionInvokeStatus) defaultActionInvoker.runInBackground( iaction, "aUser", testMap );
+      (ActionInvokeStatus) defaultActionInvoker.invokeAction( iaction, "aUser", testMap );
     Assert.assertFalse( actionInvokeStatus.requiresUpdate() );
   }
 
   @Test
-  public void runInBackgroundTest() throws Exception {
+  public void invokeActionTest() throws Exception {
     Map<String, Serializable> testMap = new HashMap<>();
     testMap.put( ActionUtil.QUARTZ_ACTIONCLASS, "one" );
     testMap.put( ActionUtil.QUARTZ_ACTIONUSER, "two" );
     IAction iaction = ActionUtil.createActionBean( ActionSequenceAction.class.getName(), null );
     ActionInvokeStatus actionInvokeStatus =
-      (ActionInvokeStatus) defaultActionInvoker.runInBackground( iaction, "aUser", testMap );
+      (ActionInvokeStatus) defaultActionInvoker.invokeAction( iaction, "aUser", testMap );
     Assert.assertFalse( actionInvokeStatus.requiresUpdate() );
   }
 
   @Test( expected = ActionInvocationException.class )
-  public void runInBackgroundLocallyWithNullsThrowsExceptionTest() throws Exception {
-    defaultActionInvoker.runInBackground( null, "aUser", null );
+  public void invokeActionLocallyWithNullsThrowsExceptionTest() throws Exception {
+    defaultActionInvoker.invokeAction( null, "aUser", null );
   }
 
 

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/ActionResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/ActionResourceTest.java
@@ -99,7 +99,7 @@ public class ActionResourceTest {
 
   @Test
   public void testRunInBackgroundNegative() {
-    // verify that no matter what is passed to the runInBackground method, including nulls and other "bad" input, it
+    // verify that no matter what is passed to the invokeAction method, including nulls and other "bad" input, it
     // returns the expected status
     final String[] badStrInput = new String[] { null, "", " ", "foo" };
     for ( final String actionId : badStrInput ) {
@@ -116,7 +116,7 @@ public class ActionResourceTest {
   }
 
   /**
-   * Verifies that calling runInBackground has the desired effect, namely the executor submitting a RunnableAction
+   * Verifies that calling invokeAction has the desired effect, namely the executor submitting a RunnableAction
    * for execution.
    */
   @Test
@@ -197,22 +197,22 @@ public class ActionResourceTest {
     // verify that deserialize is called with the expected parameters
     Mockito.verify( runnableAction, Mockito.times( 1 ) ).deserialize( Mockito.any( actionClass ),
       Mockito.eq( actionParams ) );
-    // verify that runInBackgroundLocally is called with the expected parameters
-    Mockito.verify( defaultActionInvoker, Mockito.times( 1 ) ).runInBackground( Mockito.eq( action ), Mockito
+    // verify that invokeAction is called with the expected parameters
+    Mockito.verify( defaultActionInvoker, Mockito.times( 1 ) ).invokeAction( Mockito.eq( action ), Mockito
       .eq( actionUser ), Mockito.eq( params ) );
   }
 }
 
 /**
- * Test class, created so that we can override the runInBackgroundLocally to return null for testing puroses. When
- * mocking the action invoker and verifying a call to runInBackgroundLocally with Matchers, the actual values seen by
+ * Test class, created so that we can override the invokeAction to return null for testing puroses. When
+ * mocking the action invoker and verifying a call to invokeAction with Matchers, the actual values seen by
  * the method internally are null and that causes exceptions, which we want to avoid - we are only concerned with
  * ensuring that the call to the method is made with the correct parameter types.
  */
 class MyDefaultActionInvoker extends DefaultActionInvoker {
 
   @Override
-  public IActionInvokeStatus runInBackground( final IAction actionBean, final String actionUser, final
+  public IActionInvokeStatus invokeAction( final IAction actionBean, final String actionUser, final
   Map<String, Serializable> params ) throws Exception {
     return null;
   }

--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
@@ -134,7 +134,7 @@ public class ActionAdapterQuartzJob implements Job {
     }
 
     // Invoke the action and get the status of the invocation
-    final IActionInvokeStatus status = actionInvoker.runInBackground( actionBean, actionUser, params );
+    final IActionInvokeStatus status = actionInvoker.invokeAction( actionBean, actionUser, params );
 
     // Status may not be available for remote execution, which is expected
     if ( status == null ) {


### PR DESCRIPTION
In general, it is not ideal to change interface methods, however, due to the level of confusion, I think it is best to change it now, when it's still early on and we know that the interface is not being used by anyone other than those involved with worker node work, rather than live with this bad method name that only causes confusion.

@pentaho/rebelalliance 
@pentaho/rogueone 