### PR TITLE
[Cleanup] ActionParams auto serialization/deserialization.

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/action/ActionInvokerSystemListener.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/action/ActionInvokerSystemListener.java
@@ -145,9 +145,10 @@ public class ActionInvokerSystemListener implements IPentahoSystemListener {
       buildPayload( json, LocaleHelper.UTF_8 );
     }
 
-    public Response issueRequest( ) {
+    public Response issueRequest( ) throws IOException {
       ActionResource actionResource = new ActionResource();
-      return actionResource.invokeAction( ActionUtil.INVOKER_SYNC_VALUE, actionId, actionClass, actionUser, actionParams );
+      return actionResource.invokeAction( ActionUtil.INVOKER_SYNC_VALUE, actionId, actionClass, actionUser,
+        ActionParams.fromJson( actionParams ) );
     }
   }
 }

--- a/extensions/src/main/java/org/pentaho/platform/plugin/action/ActionParams.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/action/ActionParams.java
@@ -17,6 +17,7 @@
 
 package org.pentaho.platform.plugin.action;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -38,11 +39,12 @@ import java.util.Map;
 /**
  * This is a POJO representing the parameters coming in to the ActionResource.runInBackground()
  * endpoint. The incoming json fromatted params should be converted and used in the runInBackground method
- * singnature (TODO: investigate using the jax rs entity body reader customization for this).
+ * singnature.
  * <p>
  * This class provides logic to serialize and de-serialize the action parameters.
  * TODO: in the future investigate replacing this class with generic platform API if any.
  */
+@JsonRootName( "ActionParams" )
 public class ActionParams {
   private static final Log logger = LogFactory.getLog( ActionParams.class );
 
@@ -57,7 +59,7 @@ public class ActionParams {
    * For this the name of those are captured so that they could be recreated as needed
    * on the other side.
    */
-  private List<String> paramsToRecreate;
+  private List<String> paramsToRecreate = new ArrayList<>(  );
 
   public String getSerializedParams() {
     return serializedParams;

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/jaxrs/JacksonContextResolver.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/jaxrs/JacksonContextResolver.java
@@ -1,0 +1,35 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation.  All rights reserved.
+ */
+package org.pentaho.platform.web.servlet.jaxrs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Produces ( MediaType.APPLICATION_JSON )
+public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Override
+  public ObjectMapper getContext( final Class<?> type ) {
+    return mapper;
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/jaxrs/JacksonMessageBodyBase.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/jaxrs/JacksonMessageBodyBase.java
@@ -1,0 +1,53 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation.  All rights reserved.
+ */
+package org.pentaho.platform.web.servlet.jaxrs;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+public class JacksonMessageBodyBase {
+
+  @Context
+  private Providers contextProviders;
+
+  private ObjectMapper mapper;
+
+  protected boolean isSupported( Class<?> cls, Type type, Annotation[] annotations, MediaType mediaType ) {
+    return mediaType.equals( MediaType.APPLICATION_JSON_TYPE ) &&
+      cls.getAnnotation( JsonRootName.class ) != null ;
+  }
+
+  protected ObjectMapper getMapper( final Class<?> cls ) throws IllegalStateException {
+    if ( mapper == null ) {
+      final ContextResolver<ObjectMapper>
+        contextResolver = contextProviders.getContextResolver( ObjectMapper.class, MediaType.APPLICATION_JSON_TYPE );
+      if ( contextResolver == null ) {
+        throw new IllegalArgumentException();
+      }
+      mapper = contextResolver.getContext( cls );
+    }
+
+    return mapper;
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/jaxrs/JacksonMessageBodyReader.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/jaxrs/JacksonMessageBodyReader.java
@@ -1,0 +1,42 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation.  All rights reserved.
+ */
+package org.pentaho.platform.web.servlet.jaxrs;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+@Provider
+@Consumes( MediaType.APPLICATION_JSON )
+public class JacksonMessageBodyReader extends JacksonMessageBodyBase implements MessageBodyReader<Object> {
+  @Override public boolean isReadable( Class<?> cls, Type type, Annotation[] annotations, MediaType mediaType ) {
+    return isSupported( cls, type, annotations, mediaType );
+  }
+
+  @Override public Object readFrom( Class<Object> cls, Type type, Annotation[] annotations, MediaType mediaType,
+                                    MultivaluedMap<String, String> multivaluedMap, InputStream inputStream )
+    throws IOException, WebApplicationException {
+    return getMapper( cls ).readValue( inputStream, cls );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/jaxrs/JacksonMessageBodyWriter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/jaxrs/JacksonMessageBodyWriter.java
@@ -1,0 +1,52 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation.  All rights reserved.
+ */
+package org.pentaho.platform.web.servlet.jaxrs;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+@Provider
+@Produces( MediaType.APPLICATION_JSON )
+public class JacksonMessageBodyWriter extends JacksonMessageBodyBase implements MessageBodyWriter<Object> {
+
+  @Override
+  public boolean isWriteable( final Class<?> cls, Type type, Annotation[] annotations, MediaType mediaType ) {
+    return isSupported( cls, type, annotations, mediaType );
+  }
+
+  @Override
+  public void writeTo( Object obj, Class<?> cls, Type type, Annotation[] annotations, MediaType mediaType,
+                                 MultivaluedMap<String, Object> multivaluedMap, OutputStream outputStream )
+    throws IOException, WebApplicationException {
+    getMapper( cls ).writeValue( outputStream, obj );
+  }
+
+  @Override
+  public long getSize( Object o, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType ) {
+    // This method is deprecated an ignored by JAX-RS, return a dummy value
+    //
+    return 0;
+  }
+}


### PR DESCRIPTION
This PR should be reviewed and merged together with https://github.com/pentaho/pentaho-platform-ee/pull/1117.

The purpose of this PR is to add a JAXRS message-body provider  for jackson (faster xml) json serialization. This provider will handle POJOs decorated with the JsonRootName annotation (just like JAXB POJOs are decorated with XmlRootElement). The reason for this so the provider does not interfere with the "main path" of handling json, but only when asked explicitly (by the virtue of using this decoration). Note the use of this annotation in the ActionParams class. 

This change allows a proper signature for the REST resources (not only the ActionResource) moving foward instead of failing back to plain text and having the user code in the resource be responsible for writing it themselves.  It will also allows us to move to using jackson faster xml which has more to offer in terms of json serialization.  (cleaner, and easier to to maintain code).

 