### PR TITLE
[BACKLOG-17473] Fix unit test failures caused by new transitives from…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -558,6 +558,12 @@
       <artifactId>kettle-engine</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -1329,6 +1329,12 @@
       <artifactId>kettle-engine</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>


### PR DESCRIPTION
@pentaho/2-1b @smaring @pedrofvteixeira 

Fixes the unit test failures after kettle mavenization. This will also exclude a few jars from platform-ce assembly, as far as i could tell they are not needed. If you foresee any problem let me know, otherwise we shall monitor ir closely to see if the transitive exclusion breaks anything.

