### PR TITLE
BACKLOG-17562 : Upgrading jackrabbit version to 2.14.2

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -25,7 +25,7 @@
     <c3p0.version>0.9.1.2</c3p0.version>
     <xml-apis.version>2.0.2</xml-apis.version>
     <slf4j.version>1.7.7</slf4j.version>
-    <jackrabbit.version>2.10.0</jackrabbit.version>
+    <jackrabbit.version>2.14.2</jackrabbit.version>
     <jcommon-xml.version>1.0.12</jcommon-xml.version>
     <svgSalamander.version>1.0</svgSalamander.version>
     <package.resources.directory>${basedir}/src/main/webapp</package.resources.directory>

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <jackson.version>1.9.3</jackson.version>
     <barbecue.version>1.5-beta1</barbecue.version>
     <jaxws-spring.version>1.8</jaxws-spring.version>
-    <jackrabbit.version>2.10.0</jackrabbit.version>
+    <jackrabbit.version>2.14.2</jackrabbit.version>
     <snappy-java.version>1.1.0</snappy-java.version>
     <antlr-complete.version>3.5.2</antlr-complete.version>
     <hibernate-core.version>3.6.9.Final</hibernate-core.version>


### PR DESCRIPTION
Upgrading jackrabbit version to 2.14.2
Refer to BACKLOG-17562 and PPP-3714 for details. 
Related PRs being opened to upgrade other projects that depend on jackrabbit.
@pentaho/rogueone @pentaho/rebelalliance 

pentaho-kettle: pentaho/pentaho-kettle#4174
pdi-ee-plugin: pentaho/pdi-ee-plugin#340
data-access: https://github.com/pentaho/data-access/pull/917