### PR TITLE
[BACKLOG-17675] audit entry for remote execution

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/action/ActionInvokerSystemListener.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/action/ActionInvokerSystemListener.java
@@ -32,6 +32,7 @@ import org.pentaho.platform.api.engine.IPentahoSystemListener;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.util.ActionUtil;
 import org.pentaho.platform.util.messages.LocaleHelper;
+import org.pentaho.platform.web.http.api.resources.WorkerNodeActionInvokerAuditor;
 
 import java.io.Serializable;
 import java.io.File;
@@ -146,7 +147,7 @@ public class ActionInvokerSystemListener implements IPentahoSystemListener {
   }
 
   public IActionInvoker getActionInvoker( ) {
-    return PentahoSystem.get( IActionInvoker.class );
+    return new WorkerNodeActionInvokerAuditor( PentahoSystem.get( IActionInvoker.class ) );
   }
 
   class Payload {

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/ActionResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/ActionResource.java
@@ -176,7 +176,7 @@ public class ActionResource {
         Optional.ofNullable( mdcContextMap ).ifPresent( s -> MDC.setContextMap( mdcContextMap ) );
 
         // instantiate the DefaultActionInvoker directly to force local invocation of the action
-        final IActionInvoker actionInvoker = resource.getDefaultActionInvoker();
+        final IActionInvoker actionInvoker = new WorkerNodeActionInvokerAuditor ( resource.getDefaultActionInvoker() );
 
         IActionInvokeStatus status = actionInvoker.invokeAction( action, actionUser, params );
 

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/WorkerNodeActionInvokerAuditor.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/WorkerNodeActionInvokerAuditor.java
@@ -1,0 +1,75 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.platform.web.http.api.resources;
+
+
+import org.apache.commons.lang.time.StopWatch;
+import org.pentaho.platform.api.action.IAction;
+import org.pentaho.platform.api.action.IActionInvokeStatus;
+import org.pentaho.platform.api.action.IActionInvoker;
+import org.pentaho.platform.engine.core.audit.AuditHelper;
+import org.pentaho.platform.engine.core.audit.MessageTypes;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.util.ActionUtil;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WorkerNodeActionInvokerAuditor implements IActionInvoker {
+
+  private final IActionInvoker actionInvoker;
+  public static final String WORKER_NODE_SUFFIX = "%s.worker-node";
+
+
+  public WorkerNodeActionInvokerAuditor( IActionInvoker actionInvoker ) {
+    this.actionInvoker = actionInvoker;
+  }
+
+  @Override
+  public IActionInvokeStatus invokeAction( IAction action, String user, Map<String, Serializable> params ) throws Exception {
+    StopWatch stopWatch = new StopWatch();
+    stopWatch.start();
+    Map<String, Serializable> auditParams = new HashMap<>( params ); // the prams list key change after invokeAction. Need to preserve.
+    makeAuditRecord( 0, MessageTypes.INSTANCE_START, auditParams, action.getClass().getName() );
+    try {
+      return actionInvoker.invokeAction( action, user, params );
+    } finally {
+      makeAuditRecord( stopWatch.getTime() / 1000, MessageTypes.INSTANCE_END, auditParams, action.getClass().getName() );
+    }
+  }
+
+
+  protected void makeAuditRecord( final float time, final String messageType,
+                                 final Map<String, Serializable> actionParams, String className ) {
+
+    AuditHelper.audit( PentahoSessionHolder.getSession() != null ? PentahoSessionHolder.getSession().getId() : "",
+            getValue( actionParams, ActionUtil.INVOKER_ACTIONUSER ),
+            getValue( actionParams, ActionUtil.INVOKER_STREAMPROVIDER ),
+            className,
+            String.format( WORKER_NODE_SUFFIX, getValue( actionParams, ActionUtil.INVOKER_ACTIONID ) ),
+            messageType,
+            getValue( actionParams, ActionUtil.QUARTZ_LINEAGE_ID ),
+            null,
+            time,
+            null );
+  }
+
+  private String getValue( Map<String, Serializable> actionParams, String key ) {
+    return actionParams.get( key ) != null ? actionParams.get( key ).toString() : "";
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/ActionResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/ActionResourceTest.java
@@ -192,8 +192,30 @@ public class ActionResourceTest {
     // verify that invokeAction is called with the expected parameters
     Mockito.verify( defaultActionInvoker, Mockito.times( 1 ) ).invokeAction( Mockito.eq( actionMock ), Mockito
       .eq( actionUser ), Mockito.eq( actionMapMock ) );
+
   }
-}
+
+
+
+  @Test
+  public void testAuditInvoker() throws Exception {
+
+    // Mock the IPluginManager, so that when we call ActionHelper.createActionBean, IPluginManager is not null
+    IPluginManager pluginManager = Mockito.mock( IPluginManager.class );
+    PowerMockito.mockStatic( PentahoSystem.class );
+    BDDMockito.given( PentahoSystem.get( IPluginManager.class ) ).willReturn( pluginManager );
+    // mock the action invoker
+    final IActionInvoker actionInvoker = Mockito.spy( MyDefaultActionInvoker.class );
+
+    final WorkerNodeActionInvokerAuditor wnActionInvokerAuditer = new WorkerNodeActionInvokerAuditor( actionInvoker );
+    WorkerNodeActionInvokerAuditor wnaiu = Mockito.spy( wnActionInvokerAuditer );
+    wnaiu.invokeAction( actionMock, actionUser, actionMapMock );
+
+    Mockito.verify( actionInvoker, Mockito.times( 1 ) ).invokeAction(  Mockito.eq( actionMock ), Mockito.eq( actionUser ),  Mockito.eq( actionMapMock ) );
+
+    Mockito.verify( wnaiu, Mockito.times( 2 ) ).makeAuditRecord( Mockito.anyLong() ,Mockito.anyString(), Mockito.anyMap() ,  Mockito.anyString() );
+
+  }}
 
 /**
  * Test class, created so that we can override the invokeAction to return null for testing puroses. When

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/ActionResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/ActionResourceTest.java
@@ -113,7 +113,7 @@ public class ActionResourceTest {
    */
   @Test
   public void testRunInBackground() throws Exception {
-    final Map<String,Serializable> paramMap = ActionParams.deserialize( actionMock , actionParams );
+    final Map<String, Serializable> paramMap = ActionParams.deserialize( actionMock, actionParams );
     // mock the RunnableAction and how it's created by the resource
     final ActionResource.CallableAction callableAction = Mockito.spy( ActionResource.CallableAction.class );
     Mockito.doReturn( callableAction ).when( resourceMock ).createCallable( actionMock, actionUser, paramMap );
@@ -123,7 +123,7 @@ public class ActionResourceTest {
       .invokeAction( ActionUtil.INVOKER_DEFAULT_ASYNC_EXEC_VALUE, actionId, actionClassName, actionUser, actionParams );
 
     // verify that the createRunnable method was called with the expected parameters
-    Mockito.verify( resourceMock, Mockito.times( 1 ) ).createCallable( actionMock, actionUser, paramMap ) ;
+    Mockito.verify( resourceMock, Mockito.times( 1 ) ).createCallable( actionMock, actionUser, paramMap );
 
     // within invokeAction(), we expect the createActionBean to be called with the expected parameters
     Mockito.verify( resourceMock, Mockito.times( 1 ) ).createActionBean( actionClassName, actionId );
@@ -213,9 +213,10 @@ public class ActionResourceTest {
 
     Mockito.verify( actionInvoker, Mockito.times( 1 ) ).invokeAction(  Mockito.eq( actionMock ), Mockito.eq( actionUser ),  Mockito.eq( actionMapMock ) );
 
-    Mockito.verify( wnaiu, Mockito.times( 2 ) ).makeAuditRecord( Mockito.anyLong() ,Mockito.anyString(), Mockito.anyMap() ,  Mockito.anyString() );
+    Mockito.verify( wnaiu, Mockito.times( 2 ) ).makeAuditRecord( Mockito.anyLong(), Mockito.anyString(), Mockito.anyMap(),  Mockito.anyString() );
 
-  }}
+  }
+}
 
 /**
  * Test class, created so that we can override the invokeAction to return null for testing puroses. When
@@ -227,7 +228,7 @@ class MyDefaultActionInvoker extends DefaultActionInvoker {
 
   @Override
   public IActionInvokeStatus invokeAction( final IAction actionBean, final String actionUser, final
-  Map<String, Serializable> params ) throws Exception {
+    Map<String, Serializable> params ) throws Exception {
     return null;
   }
 }


### PR DESCRIPTION
@pentaho/rebelalliance @pentaho/rogueone 

Adds audit entry for start / finish. Since the same id is used for the complete audit trail the duration per item is cumulative -- which is the accurate duration. 