### PR TITLE
[BACKLOG-17323] worker nodes OSGi with all configurations/properties …

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/action/IActionInvoker.java
+++ b/api/src/main/java/org/pentaho/platform/api/action/IActionInvoker.java
@@ -37,4 +37,12 @@ public interface IActionInvoker {
    */
   IActionInvokeStatus invokeAction( IAction action, final String user, final Map<String, Serializable> params )
         throws Exception;
+
+  /**
+   * Predicate that tells whether an {@link IActionInvoker} can handle a given {@link IAction}
+   *
+   * @param action The {@link IAction} to be handled
+   * @return true if the {@link IActionInvoker} can handle a given {@link IAction}
+   */
+  boolean isSupportedAction( IAction action );
 }

--- a/api/src/main/java/org/pentaho/platform/api/action/IRemoteActionInvoker.java
+++ b/api/src/main/java/org/pentaho/platform/api/action/IRemoteActionInvoker.java
@@ -1,0 +1,44 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2017 Pentaho Corporation..  All rights reserved.
+ */
+package org.pentaho.platform.api.action;
+
+/**
+ * A remote action invocation
+ */
+public interface IRemoteActionInvoker extends IActionInvoker {
+
+  /**
+   * @return hostname
+   */
+  String getHostname();
+
+  /**
+   * @return port
+   */
+  Integer getPort();
+
+  /**
+   * @return endpoint
+   */
+  String getEndpoint();
+
+  /**
+   * @return true if connection is made via https
+   */
+  boolean isHttps();
+
+}

--- a/extensions/src/main/java/org/pentaho/platform/plugin/action/DefaultActionInvoker.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/action/DefaultActionInvoker.java
@@ -176,4 +176,9 @@ public class DefaultActionInvoker implements IActionInvoker {
 
     return status;
   }
+
+  @Override
+  public boolean isSupportedAction( IAction action ) {
+    return true; // supports all
+  }
 }

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/WorkerNodeActionInvokerAuditor.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/WorkerNodeActionInvokerAuditor.java
@@ -70,4 +70,9 @@ public class WorkerNodeActionInvokerAuditor implements IActionInvoker {
   private String getValue( Map<String, Serializable> actionParams, String key ) {
     return actionParams.get( key ) != null ? actionParams.get( key ).toString() : "";
   }
+
+  @Override
+  public boolean isSupportedAction( IAction action ) {
+    return false; // not needed
+  }
 }


### PR DESCRIPTION
…being read from pentaho.workernodes.cfg

From this point onward, all worker nodes properties exist in `pentaho.workernodes.cfg` making this feature fully configurable ( in a restartless fashion )

- promoted `isSupportedAction( IAction action )` to `IActionInvoker` interface
- The `interface IRemoteActionInvoker extends IActionInvoker` was moved from within worker nodes OSGi into pentaho-platform-api; this will allow for OSGi plugins to register themselves onto non-OSGi's ActionInvokerDelegator class without clashing with registered IActionInvoker ( non-OSGi's ActionInvokerDelegator now knows of IRemoteActionInvoker interface )
- Worker Nodes OSGi now holds a `class WorkerNodesDelegator implements IRemoteActionInvoker`, and is the only one that gets published into PentahoSystem
  - `WorkerNodesDelegator` is the one that delegates execution to `AdvancedActionInvoker / MesosChronosActionInvoker`, depending on what's the `orchestrator` value specified in `pentaho.workernodes.cfg`
- `pentaho.workernodes.cfg` now holds an `orchestrator` property


To be merged alongside https://github.com/pentaho/pentaho-platform-ee/pull/1158 and https://github.com/pentaho/pentaho-ee/pull/462


@pentaho/rogueone @pentaho/rebelalliance 
