### PR TITLE
[PDI-13572]-Now plugin classloader loads jars not only from /lib folder b…

### DIFF
--- a/assemblies/pentaho-solutions/pom.xml
+++ b/assemblies/pentaho-solutions/pom.xml
@@ -157,13 +157,6 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.pentaho.di.plugins</groupId>
-                  <artifactId>pdi-pur-plugin</artifactId>
-                  <version>${project.version}</version>
-                  <type>zip</type>
-                  <outputDirectory>${prepared.kettle.plugins.directory}</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.pentaho.di.plugins</groupId>
                   <artifactId>kettle-json-plugin</artifactId>
                   <version>${project.version}</version>
                   <type>zip</type>

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/pluginmgr/PluginClassLoader.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/pluginmgr/PluginClassLoader.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.services.pluginmgr;
@@ -110,6 +110,7 @@ public class PluginClassLoader extends URLClassLoader {
               .getAbsolutePath(), libDir.getAbsolutePath() ), e );
     }
     addJars( urls, libDir );
+    addJars( urls, pluginDir );
     return urls.toArray( new URL[urls.size()] );
   }
 


### PR DESCRIPTION
…ut also from root plugin directory. The reason is that some plugins have their assembly jars in plugin root dir.