### PR TITLE
[BISERVER-13603] IE - PDF pane remains active when glass pane was act…

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTab.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTab.java
@@ -331,8 +331,12 @@ public class MantleTab extends org.pentaho.gwt.widgets.client.tabs.PentahoTab {
     this.solutionBrowserShowing = solutionBrowserShowing;
   }
 
-  private native boolean isIEBrowser()
+  private boolean isIEBrowser() {
+    return getUserAgent().contains( "msie" );
+  }
+
+  private static native String getUserAgent()
   /*-{
-    return !!document.documentMode;
+    return navigator.userAgent.toLowerCase();
   }-*/;
 }


### PR DESCRIPTION
…ivated, which blocks user from accepting/declining action in appeared dialog box

 - having IE check this way breaks sheduler`s "Execute now" run
 - changed IE check to a most recommended one