### PR TITLE
[BACKLOG-18429] adding pdi-core-plugins to pentaho-solutions assembly

### DIFF
--- a/assemblies/pentaho-solutions/pom.xml
+++ b/assemblies/pentaho-solutions/pom.xml
@@ -121,6 +121,13 @@
                   <outputDirectory>${prepared.plugins.directory}</outputDirectory>
                 </artifactItem>
                 <artifactItem>
+                  <groupId>org.pentaho.di.plugins</groupId>
+                  <artifactId>pdi-core-plugins</artifactId>
+                  <version>${project.version}</version>
+                  <type>zip</type>
+                  <outputDirectory>${prepared.kettle.plugins.directory}</outputDirectory>
+                </artifactItem>
+                <artifactItem>
                   <groupId>pentaho</groupId>
                   <artifactId>pentaho-big-data-plugin</artifactId>
                   <version>${project.version}</version>


### PR DESCRIPTION
With the effort of decoupling the steps from kettle, we need to add back the new artifact to the platform assemblies.

https://github.com/pentaho/pentaho-kettle/pull/4311

@pentaho/2-1b @smaring pls review