### PR TITLE
[SP-3755]-Backport of BISERVER-13723 - XMI models loaded through default-content can be duplicated when re-importing or re-publishing back to the Server

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.services.importer;
@@ -87,6 +87,8 @@ public class SolutionImportHandler implements IPlatformImportHandler {
 
   public static final String RESERVEDMAPKEY_LINEAGE_ID = "lineage-id";
 
+  private static final String XMI_EXTENSION = ".xmi";
+
   private static final String sep = ";";
 
   private IUnifiedRepository repository; // TODO inject via Spring
@@ -138,6 +140,9 @@ public class SolutionImportHandler implements IPlatformImportHandler {
       for ( ExportManifestMetadata exportManifestMetadata : metadataList ) {
 
         String domainId = exportManifestMetadata.getDomainId();
+        if ( domainId != null && !domainId.endsWith( XMI_EXTENSION ) ) {
+          domainId = domainId + XMI_EXTENSION;
+        }
         boolean overWriteInRepository = isOverwriteFile();
         RepositoryFileImportBundle.Builder bundleBuilder =
             new RepositoryFileImportBundle.Builder().charSet( "UTF-8" )

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.services.metadata;
@@ -108,6 +108,8 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
 
   // The default mime-type for locale files
   private static final String LOCALE_MIME_TYPE = "text/plain";
+
+  private static final String XMI_EXTENSION = ".xmi";
 
   // caching immutable object
   private static final EnumSet<RepositoryFilePermission> READ = EnumSet.of( RepositoryFilePermission.READ );
@@ -299,7 +301,10 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     }
 
     // Check to see if the domain already exists
-    final RepositoryFile domainFile = getMetadataRepositoryFile( domainId );
+    RepositoryFile domainFile = getMetadataRepositoryFile( domainId );
+    if ( domainFile == null && domainId.endsWith( XMI_EXTENSION ) ) {
+      domainFile = getMetadataRepositoryFile( domainId.substring( 0, domainId.length() - XMI_EXTENSION.length() ) );
+    }
     if ( !overwrite && domainFile != null ) {
       final String errorString =
         messages.getErrorString( "PentahoMetadataDomainRepository.ERROR_0002_DOMAIN_ALREADY_EXISTS", domainId );

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.services.metadata;
@@ -261,6 +261,19 @@ public class PentahoMetadataDomainRepositoryTest extends TestCase {
     sample.addLogicalModel( "test" );
     domainRepositorySpy.storeDomain( sample, true );
     assertEquals( 1, domainRepositorySpy.getDomain( SAMPLE_DOMAIN_ID ).getLogicalModels().size() );
+
+    MockDomain xmiExtensionSample = new MockDomain( SAMPLE_DOMAIN_ID + ".xmi" );
+    try {
+      domainRepositorySpy.storeDomain( sample, false ); fail( "A duplicate domain with overwrite=false should fail" );
+    } catch ( DomainAlreadyExistsException success ) {
+    }
+
+    xmiExtensionSample.addLogicalModel( "test1" );
+    xmiExtensionSample.addLogicalModel( "test2" );
+
+    domainRepositorySpy.storeDomain( xmiExtensionSample, true );
+
+    assertEquals( 2, domainRepositorySpy.getDomain( SAMPLE_DOMAIN_ID ).getLogicalModels().size() );
 
     final RepositoryFile folder = domainRepositorySpy.getMetadataDir();
     assertNotNull( folder );


### PR DESCRIPTION
…ult-content can be duplicated when re-importing or re-publishing back to the Server