### PR TITLE
[BACKLOG-18791] Changed workitem invalid chars for chronos 2.4.0

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
+++ b/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
@@ -72,7 +72,7 @@ public class ActionUtil {
   /**
    * Regex representing characters that are allowed in the work item uid (in compliance with chronos job names).
    */
-  private static final String WORK_ITEM_UID_INVALID_CHARS = "[^\\w\\\\.-]+";
+  private static final String WORK_ITEM_UID_INVALID_CHARS = "[^\\w\\\\-]+";
 
   private static final int WORK_ITEM_UID_LENGTH_LIMIT = 1000;
 


### PR DESCRIPTION
@pentaho/rogueone @pentaho/rebelalliance 