### PR TITLE
[BACKLOG-18810] - Update selected and hover states to revised colors …

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
@@ -97,7 +97,7 @@
 .adminCatTreeItem .tree-item-custom-widget:hover,
 .adminCatTreeItem .tree-item-custom-widget.tree-item-custom-widget-selected,
 .adminCatTreeItem .tree-item-custom-widget.tree-item-custom-widget-selected:hover {
-  background-image: url(images/dropdown_right_arrow_white.png);
+  background-image: url(images/dropdown_right_arrow_blue.png);
   background-repeat: no-repeat;
   background-position: right 10px center;
 }
@@ -1002,7 +1002,7 @@ div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem {
   text-align: left;
 }
 
-div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem:hover {
+div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem:hover:not(.gwt-MenuItem-disabled) {
   background-color: #E0E0E0;
   color: #000;
 }


### PR DESCRIPTION
…for Ruby theme:
- Administration page left list: selected tab right arrow color should be dark gray
- "Opened" menu item when is disabled shouldn't have a hover state