### PR TITLE
[PDI-14357] Need to prohibit empty names when adding new users or roles via REST

### DIFF
--- a/repository/src/main/java/org/pentaho/platform/security/userroledao/jackrabbit/JcrUserRoleDao.java
+++ b/repository/src/main/java/org/pentaho/platform/security/userroledao/jackrabbit/JcrUserRoleDao.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2017 Pentaho Corporation.  All rights reserved.
  */
 
 package org.pentaho.platform.security.userroledao.jackrabbit;
@@ -120,7 +120,8 @@ public class JcrUserRoleDao extends AbstractJcrBackedUserRoleDao {
       } );
     } catch ( DataAccessException e ) {
       if ( ( e instanceof JcrSystemException ) && ( e.getCause() instanceof AuthorizableExistsException ) ) {
-        throw new AlreadyExistsException( "" );
+        throw new AlreadyExistsException( Messages.getInstance().getString(
+                "JcrUserRoleDao.Role.Already.Exists" ) );
       }
       throw new UncategorizedUserRoleDaoException( Messages.getInstance().getString(
           "JcrUserRoleDao.ERROR_0002_CREATING_ROLE", e.getLocalizedMessage() ), e );
@@ -141,7 +142,8 @@ public class JcrUserRoleDao extends AbstractJcrBackedUserRoleDao {
       } );
     } catch ( DataAccessException e ) {
       if ( ( e instanceof JcrSystemException ) && ( e.getCause() instanceof AuthorizableExistsException ) ) {
-        throw new AlreadyExistsException( "" );
+        throw new AlreadyExistsException( Messages.getInstance().getString(
+                "JcrUserRoleDao.User.Already.Exists" ) );
       }
       throw new UncategorizedUserRoleDaoException( Messages.getInstance().getString(
           "JcrUserRoleDao.ERROR_0003_CREATING_USER", e.getLocalizedMessage() ), e );

--- a/repository/src/main/java/org/pentaho/platform/security/userroledao/ws/UserRoleWebService.java
+++ b/repository/src/main/java/org/pentaho/platform/security/userroledao/ws/UserRoleWebService.java
@@ -12,13 +12,14 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.platform.security.userroledao.ws;
 
 import org.apache.commons.lang.StringUtils;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
 import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
@@ -90,8 +91,14 @@ public class UserRoleWebService implements IUserRoleWebService {
 
   @Override
   public boolean createUser( ProxyPentahoUser proxyUser ) throws UserRoleException {
-    getDao().createUser( proxyUser.getTenant(), proxyUser.getName(), proxyUser.getPassword(),
-        proxyUser.getDescription(), null );
+    try {
+      getDao().createUser( proxyUser.getTenant(), proxyUser.getName(), proxyUser.getPassword(),
+              proxyUser.getDescription(), null );
+    } catch ( AlreadyExistsException e ) {
+      // User doesn't want see a stack trace. We need to use this workaround. See details in PDI-14357.
+      e.setStackTrace( new StackTraceElement[0] );
+      throw e;
+    }
     return true;
   }
 
@@ -215,7 +222,13 @@ public class UserRoleWebService implements IUserRoleWebService {
 
   @Override
   public boolean createRole( ProxyPentahoRole proxyRole ) throws UserRoleException {
-    getDao().createRole( proxyRole.getTenant(), proxyRole.getName(), proxyRole.getDescription(), new String[0] );
+    try {
+      getDao().createRole( proxyRole.getTenant(), proxyRole.getName(), proxyRole.getDescription(), new String[0] );
+    } catch ( AlreadyExistsException e ) {
+      // User doesn't want see a stack trace. We need to use this workaround. See details in PDI-14357.
+      e.setStackTrace( new StackTraceElement[0] );
+      throw e;
+    }
     return false;
   }
 

--- a/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2006 Pentaho Corporation.  All rights reserved.
+# Copyright 2006-2017 Pentaho Corporation.  All rights reserved.
 #
 # Copyright 2006 Pentaho Corporation.  All rights reserved.
 # This program is free software; you can redistribute it and/or modify it under the 
@@ -67,5 +67,7 @@ JcrUserRoleDao.ERROR_0008_LISTING_ROLES=Error listing roles. cause: [ {0} ]
 JcrUserRoleDao.ERROR_0009_LISTING_USERS=Error listing users. cause: [ {0} ]
 JcrUserRoleDao.ERROR_0010_GETTING_ROLE=Error getting role. cause: [ {0} ]
 JcrUserRoleDao.ERROR_0011_LISTING_ROLE_MEMBERS=Error listing role members. cause: [ {0} ]
+JcrUserRoleDao.Role.Already.Exists=Sorry, we can't create the role. That role already exists.
+JcrUserRoleDao.User.Already.Exists=Sorry, we can't create the user. That user name already exists.
 
 AbstractJcrBackedUserRoleDao.usersFolderDisplayName=Home

--- a/repository/src/test/java/org/pentaho/test/platform/security/userroledao/ws/UserRoleWebServiceBase.java
+++ b/repository/src/test/java/org/pentaho/test/platform/security/userroledao/ws/UserRoleWebServiceBase.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
  */
 
 package org.pentaho.test.platform.security.userroledao.ws;
@@ -21,6 +21,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
@@ -817,4 +818,49 @@ public class UserRoleWebServiceBase {
   protected String getSolutionPath() {
     return SOLUTION_PATH;
   }
+
+  @Test
+  public void testCreateDuplicateRole() throws UserRoleException {
+    UserRoleDaoMock userRoleDao = Mockito.mock( UserRoleDaoMock.class );
+    Mockito.doThrow( new AlreadyExistsException( "That role already exists." ) ).when( userRoleDao ).
+            createRole( Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any() );
+
+    UserRoleWebService userRoleWebService = new UserRoleWebService() {
+      @Override
+      protected IUserRoleDao getDao() throws UserRoleException {
+        return userRoleDao;
+      }
+    };
+
+    ProxyPentahoRole proxyPentahoRole = new ProxyPentahoRole();
+    try {
+      userRoleWebService.createRole(proxyPentahoRole);
+      Assert.fail();
+    } catch ( AlreadyExistsException e ) {
+      Assert.assertEquals( 0, e.getStackTrace().length );
+    }
+  }
+
+  @Test
+  public void testCreateDuplicateUser() throws UserRoleException {
+    UserRoleDaoMock userRoleDao = Mockito.mock( UserRoleDaoMock.class );
+    Mockito.doThrow( new AlreadyExistsException( "That user name already exists." ) ).when( userRoleDao ).
+            createUser(  Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any() );
+
+    UserRoleWebService userRoleWebService = new UserRoleWebService() {
+      @Override
+      protected IUserRoleDao getDao() throws UserRoleException {
+        return userRoleDao;
+      }
+    };
+
+    ProxyPentahoUser proxyPentahoUser = new ProxyPentahoUser();
+    try {
+      userRoleWebService.createUser( proxyPentahoUser );
+      Assert.fail();
+    } catch ( AlreadyExistsException e ) {
+      Assert.assertEquals( 0, e.getStackTrace().length );
+    }
+  }
+
 }


### PR DESCRIPTION
[PDI-14357] Need to prohibit empty names when adding new users or roles via REST

- added  clearing stack trace for AlreadyExistsException for cases create an user and a role
- added a correct message