### PR TITLE
[ENGOPS-3548] Removing deprecated checkstyle report configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,9 +363,6 @@
                 <inherited>false</inherited>
               </reportSet>
             </reportSets>
-            <configuration>
-              <linkJavadoc>true</linkJavadoc>
-            </configuration>
           </plugin>
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
@@ -378,9 +375,6 @@
                 <inherited>false</inherited>
               </reportSet>
             </reportSets>
-            <configuration>
-              <failOnError>false</failOnError>
-            </configuration>
           </plugin>
           <plugin>
             <artifactId>maven-checkstyle-plugin</artifactId>
@@ -393,12 +387,6 @@
                 <inherited>false</inherited>
               </reportSet>
             </reportSets>
-            <configuration>
-              <configLocation>${checkstyle-config-url}</configLocation>
-              <propertiesLocation>${checkstyle-properties-url}</propertiesLocation>
-              <linkXRef>true</linkXRef>
-              <cacheFile />
-            </configuration>
           </plugin>
         </plugins>
       </reporting>


### PR DESCRIPTION
@pentaho/2-1b @smaring @pentaho-amessier 

Removes the broken checkstyle config on the project so that the correct one on the parent POMs is used.