### PR TITLE
Revert "[ENGOPS-3554] Update jaas group ID for Pentaho"

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -466,7 +466,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.pentaho.karaf.jaas</groupId>
+      <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.boot</artifactId>
       <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>
@@ -478,7 +478,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.pentaho.karaf.jaas</groupId>
+      <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.modules</artifactId>
       <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>
@@ -490,7 +490,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.pentaho.karaf.jaas</groupId>
+      <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.config</artifactId>
       <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2254,13 +2254,13 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.pentaho.karaf.jaas</groupId>
+      <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.boot</artifactId>
       <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.pentaho.karaf.jaas</groupId>
+      <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.modules</artifactId>
       <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>


### PR DESCRIPTION
Reverts pentaho/pentaho-platform#3830
Decision is to remove karaf.jaas.module from WEB-INF/lib, custom build of the artifact is not needed for now.