### PR TITLE
[BACKLOG-18473] Removing karaf.jaas.modules karaf bundle jar from WEB-INF/lib

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -103,6 +103,10 @@
           <artifactId>hsqldb</artifactId>
           <groupId>org.hsqldb</groupId>
         </exclusion>
+        <exclusion>
+          <artifactId>org.apache.karaf.jaas.modules</artifactId>
+          <groupId>org.apache.karaf.jaas</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -468,18 +472,6 @@
     <dependency>
       <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.boot</artifactId>
-      <version>${org.apache.karaf.jaas.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.karaf.jaas</groupId>
-      <artifactId>org.apache.karaf.jaas.modules</artifactId>
       <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>
       <exclusions>


### PR DESCRIPTION
@pentaho/rebelalliance @pentaho/rogueone 
This PR is to remove karaf.jaas.modules karaf bundle FAT jar from being packaged in WEB-INF/lib.
Please review and merge if it looks good to you.