### PR TITLE
[BACKLOG-18582] Multiple Authentication Provider mechanism not workin…

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/PentahoCachingUserDetailsService.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/PentahoCachingUserDetailsService.java
@@ -90,7 +90,7 @@ public class PentahoCachingUserDetailsService implements UserDetailsService {
       throw new UsernameNotFoundException( e.getMessage(), e );
     }
 
-    return new User( user.getUsername(), user.getPassword(), user.isEnabled(), user.isAccountNonExpired(),
+    return new User( user.getUsername(), ( user.getPassword() == null ? "ignored" : user.getPassword() ), user.isEnabled(), user.isAccountNonExpired(),
       user.isCredentialsNonExpired(), user.isAccountNonLocked(), user.getAuthorities() );
   }
 }


### PR DESCRIPTION
…g in 7.0+

- in spring-security's 4.1.3-RELEASE User.java's constructor: https://github.com/spring-projects/spring-security/blob/4.1.3.RELEASE/core/src/main/java/org/springframework/security/core/userdetails/User.java
`if (((username == null) || "".equals(username)) || (password == null)) {
	throw new IllegalArgumentException( "Cannot pass null or empty values to constructor");
 }`

- In a multiple provider setup ( using for example , jackrabbit and LDAP ), and as per the documentation @ https://help.pentaho.com/Documentation/7.1/0P0/Setting_Up_User_Security/Implement_Advanced_Security/080, we still use the default `PentahoCachingUserDetailsService`. In our caching class, a null password is not being checked prior to instantiating a spring-security's User class, so it fails on providers that happen to not return a password (such as LDAP).

- *Also*: see required changes to the existing documentation, outlined at http://jira.pentaho.com/browse/BACKLOG-18582?focusedCommentId=316066&#comment-316066

@mbatchelor @lucboudreau @pentaho/rogueone @pentaho/rebelalliance 


