### PR TITLE
[PDI-16368] Unable to start blueprint container for bundle pdi-dataservice-server-plugin due to unresolved dependencies

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/action/kettle/KettleSystemListener.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/action/kettle/KettleSystemListener.java
@@ -58,13 +58,6 @@ public class KettleSystemListener implements IPentahoSystemListener {
 
   public boolean startup( final IPentahoSession session ) {
 
-    if ( usePlatformLogFile ) {
-      KettleLogStore.init( false, false );
-      initLogging();
-    }
-
-    hookInDataSourceProvider();
-
     // Default DI_HOME System Property if not set
     if ( StringUtils.isEmpty( System.getProperty( "DI_HOME" ) ) ) {
       String defaultKettleHomePath = PentahoSystem.getApplicationContext().getSolutionPath( "system" + File.separator
@@ -73,6 +66,13 @@ public class KettleSystemListener implements IPentahoSystemListener {
           + " will be used." );
       System.setProperty( "DI_HOME", defaultKettleHomePath );
     }
+
+    if ( usePlatformLogFile ) {
+      KettleLogStore.init( false, false );
+      initLogging();
+    }
+
+    hookInDataSourceProvider();
 
     try {
       KettleSystemListener.environmentInit( session );


### PR DESCRIPTION
- the order was changed: the property sets first, then the property is used in the KettleLogStore.init