### PR TITLE
[BACKLOG-19316] Updated String util with functions to trim whitespace from lists, strings and maps. For use in workernodes

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/StringUtil.java
+++ b/core/src/main/java/org/pentaho/platform/util/StringUtil.java
@@ -18,6 +18,7 @@
 package org.pentaho.platform.util;
 
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class StringUtil {
 
@@ -115,5 +117,32 @@ public class StringUtil {
     final ByteArrayOutputStream writtenBytes = new ByteArrayOutputStream();
     MapUtils.debugPrint( new PrintStream( writtenBytes ), "Map", map );
     return writtenBytes.toString();
+  }
+
+  /**
+   * Returns a map of String key-value pairs, in which each key and corresponding value has been trimmed of whitespace.
+   * @param map the {@link Map} of String key-value pairs to be trimmed
+   * @return a trimmed String {@link Map}
+   */
+  public static Map<String, String> trimStringMap( Map<String, String> map ) {
+    return map == null ? map : map.entrySet().stream().collect( Collectors.toMap( e -> StringUtils.trimToEmpty( e.getKey() ), e -> StringUtils.trimToEmpty( e.getValue() ) ) );
+  }
+
+  /**
+   * Returns a List of Strings in which each String has been trimmed of whitespace.
+   * @param list the {@link List} of Strings to be trimmed
+   * @return a trimmed {@link List} of Strings
+   */
+  public static List<String> trimStringList( List<String> list ) {
+    return list == null ? list : list.stream().map( StringUtils::trimToEmpty ).collect( Collectors.toList() );
+  }
+
+  /**
+   * Wrapper method around StringUtils.trim
+   * @param string the {@link String} to be trimmed
+   * @return the trimmed {@link String}
+   */
+  public static String trimToEmpty( String string ) {
+    return StringUtils.trimToEmpty( string );
   }
 }

--- a/core/src/test/java/org/pentaho/platform/util/StringUtilTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/StringUtilTest.java
@@ -19,15 +19,69 @@ package org.pentaho.platform.util;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.TreeMap;
 
 /**
  * Unit tests for the {@link org.pentaho.platform.util.StringUtil} class.
  */
 public class StringUtilTest {
+
+  @Test
+  public void testTrim() {
+    Assert.assertEquals( StringUtil.trimToEmpty( " foo " ), "foo" );
+    Assert.assertEquals( StringUtil.trimToEmpty(  "\n foo \t" ), "foo" );
+    for ( int i = 0; i <= 32; i++ ) {
+      Assert.assertEquals( StringUtil.trimToEmpty( (char) i  + "foo" ), "foo" );
+    }
+    Assert.assertEquals( StringUtil.trimToEmpty( "" ), "" );
+    Assert.assertEquals( StringUtil.trimToEmpty( null ), "" );
+  }
+
+  @Test
+  public void testTrimStringMap() {
+
+    Map<String, String> nullMap = null;
+    Assert.assertNull( StringUtil.trimStringMap( nullMap ) );
+
+    Map<String, String> stringMap = new HashMap<>();
+    stringMap.put( " spaces ", " spacesval " );
+    stringMap.put( "\t tabs \t", "\t tabsval \t" );
+    stringMap.put( "\n newline \n", "\n newlineval \n" );
+    stringMap.put( "empty", "" );
+    stringMap.put( "null", null );
+    stringMap.put( null, null );
+    stringMap = StringUtil.trimStringMap( stringMap );
+
+    Assert.assertEquals( stringMap.get( "spaces" ), "spacesval" );
+    Assert.assertEquals( stringMap.get( "tabs" ), "tabsval" );
+    Assert.assertEquals( stringMap.get( "newline" ), "newlineval" );
+    Assert.assertEquals( stringMap.get( "empty" ), "" );
+    Assert.assertEquals( stringMap.get( "null" ), "" );
+    Assert.assertEquals( stringMap.get( "" ), "" );
+  }
+
+  @Test
+  public void testTrimStringList() {
+    List<String> stringList = new ArrayList<>();
+    for ( int i = 0; i <= 32; i++ ) {
+      stringList.add( (char) i  + "foo" );
+    }
+    stringList.add( "" );
+    stringList.add( null );
+    stringList = StringUtil.trimStringList( stringList );
+    for ( int i = 0; i <= 32; i++ ) {
+      Assert.assertEquals( stringList.get( i ), "foo" );
+    }
+    Assert.assertEquals( stringList.get( 33 ), "" );
+    Assert.assertEquals( stringList.get( 34 ), "" );
+    Assert.assertEquals( StringUtil.trimStringList( null ), null );
+    List<String> empty = new ArrayList();
+    Assert.assertEquals( StringUtil.trimStringList( empty ), empty );
+  }
 
   @Test
   public void testTokenStringToArray() {


### PR DESCRIPTION
@pentaho/rogueone @pentaho/rebelalliance 