### PR TITLE
[BACKLOG-19462][PPP-3735] Added jersey-apache-client4 to the Pentaho …

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -821,6 +821,20 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>com.sun.jersey.contribs</groupId>
+      <artifactId>jersey-apache-client4</artifactId>
+      <version>${jersey.version}</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>
       <artifactId>jersey-spring</artifactId>


### PR DESCRIPTION
…Server builds as well

PPP-3735 added `jersey-apache-client4` to Spoon, but not to Pentaho Server; see  https://github.com/pentaho/pentaho-kettle/pull/4479/files

Do note that Spoon still holds both `jersey-apache-client` and `jersey-apache-client4` , but because they hold a different package naming, they do not collide. The same will be applied to Pentaho Server

To be merged alongside https://github.com/pentaho/pentaho-platform-ee/pull/1213
 
@pentaho/rogueone, @pentaho/rebelalliance, @pamval, @mchen-len-son please review

