### PR TITLE
[BISREVER-13750]-Missing scroll bar on Manage Users Perspective when using Chrome

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
@@ -1435,7 +1435,8 @@ div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem:hover:not(.gwt-
 
 .users-roles-list {
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: scroll;
 }
 
 .pentaho-tab-panel, #userRolesAdminPanel .pentaho-tab-panel {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/sapphire/mantleSapphire.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/sapphire/mantleSapphire.css
@@ -1422,7 +1422,8 @@ div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem {
 
 .users-roles-list {
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: scroll;
 }
 
 .pentaho-tab-panel, #userRolesAdminPanel .pentaho-tab-panel {


### PR DESCRIPTION
 -added overflow-y: scroll for Ruby and Sapphire themes