### PR TITLE
[PPP-3949] Authenticated directory traversal allows retrieval of arbi…

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/pluginmgr/PluginResourceLoader.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/pluginmgr/PluginResourceLoader.java
@@ -309,8 +309,12 @@ public class PluginResourceLoader implements IPluginResourceLoader {
    * we consider the request as malicious.
    */
   private void checkPathTraversal( String resourcePath, File f ) throws IOException {
+    // we need to support double slashes in path, like most web browsers do.
+    // here we rely on resource paths to be relative (not containing leading double slashes).
+    String path = resourcePath.replaceAll( "//", "/" );
+
     // converting to URI as to be system-independent
-    if ( !f.getCanonicalFile().toURI().getPath().endsWith( resourcePath ) ) {
+    if ( !f.getCanonicalFile().toURI().getPath().endsWith( path ) ) {
       Logger.error( this, String.format( "Illegal resource path ( directory traversal attempt? ): %s", resourcePath ) );
       throw new IllegalArgumentException( "Illegal resource path" );
     }

--- a/extensions/src/test/java/org/pentaho/test/platform/plugin/pluginmgr/PluginResourceLoaderTest.java
+++ b/extensions/src/test/java/org/pentaho/test/platform/plugin/pluginmgr/PluginResourceLoaderTest.java
@@ -262,4 +262,23 @@ public class PluginResourceLoaderTest {
     assertNotNull( resLoader.getResourceAsBytes( pluginClass, "settings.xml" ) );
     assertNotNull( resLoader.getResourceAsString( pluginClass, "settings.xml" ) );
   }
+
+  /**
+   * <p>
+   *   Path Traversal Mitigation.
+   * </p>
+   * <p>
+   *   Path values are often got from concatenated strings, and might therefore contain double slashes.
+   *   That slashes should be considered as one, and we should not fall here.
+   * </p>
+   * Given path of an existing resource file, NOT containing upper directories references,
+   * but containing double slashes.
+   * When the file is being requested on this path, the requested resource should be returned.
+   */
+  @Test
+  public void shouldNotFailWhenExistingResourcePathIsContainingDoubleSlashes() throws UnsupportedEncodingException {
+    assertNotNull( resLoader.getResourceAsStream( pluginClass, "resources//pluginResourceTest-inresources.properties" ) );
+    assertNotNull( resLoader.getResourceAsBytes( pluginClass, "resources//pluginResourceTest-inresources.properties" ) );
+    assertNotNull( resLoader.getResourceAsString( pluginClass, "resources//pluginResourceTest-inresources.properties" ) );
+  }
 }


### PR DESCRIPTION
…trary files within Tomcat webapps/pentaho directory

- added support of double slashes in resource paths