### PR TITLE
[BISREVER-13750]-Missing scroll bar on Manage Users Perspective when using Chrome

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
@@ -1458,7 +1458,8 @@ div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem:hover:not(.gwt-
 }
 
 .users-roles-selection-list {
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: scroll;
   height: 317px;
 }
 

--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/sapphire/mantleSapphire.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/sapphire/mantleSapphire.css
@@ -1445,7 +1445,8 @@ div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem {
 }
 
 .users-roles-selection-list {
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: scroll;
   height: 317px;
 }
 


### PR DESCRIPTION
-added overflow-y: scroll for Ruby and Sapphire themes
 for avaliable and selected roles on Manage Users tab, avaliable and selected
 user on Manage Roles tab