### PR TITLE
[BACKLOG-17248] Fix images/CSS in single-page HTML reports generated in background

### DIFF
--- a/core/src/main/java/org/pentaho/platform/engine/core/system/BasePentahoRequestContext.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/BasePentahoRequestContext.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2006 - 2018 Hitachi Vantara.  All rights reserved.
  */
 
 package org.pentaho.platform.engine.core.system;
@@ -30,7 +30,7 @@ public class BasePentahoRequestContext implements IPentahoRequestContext {
     super();
     if ( contextPath != null ) {
       String draftPath = contextPath + ( contextPath.endsWith( SLASH ) ? EMPTY : SLASH );
-      this.contextPath = draftPath.replaceAll( "(/){2,}", SLASH );
+      this.contextPath = draftPath.replaceAll( "(?<!^http:)(/){2,}", SLASH );
     } else {
       String path = PentahoSystem.getApplicationContext().getFullyQualifiedServerURL();
       this.contextPath = path + ( path != null && path.endsWith( SLASH ) ? EMPTY : SLASH );


### PR DESCRIPTION
JIRA: http://jira.pentaho.com/browse/BACKLOG-17248

Paths are filtered to remove groups of multiple slashes (as per [this](http://jira.pentaho.com/browse/BISERVER-13463) ticket). The `http://` we need gets caught in this filter though, so it gets turned into `http:/`. 

The regex was adjusted to allow an `http://` at the beginning of the string.