### PR TITLE
[BACKLOG-20385] As a customer using Worker Nodes on Foundry, I would …

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/MantleStyle.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/MantleStyle.css
@@ -898,3 +898,10 @@ code {
   border-top: 1px solid #cccccc;
   height: 15px;
 }
+
+.section-divider-title {
+  font-weight: bold;
+  padding-left: 8px;
+  padding-bottom: 10px;
+  padding-top: 10px;
+}

--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
@@ -1497,3 +1497,16 @@ hr {
   border: 0 none;
   border-top: 1px solid #e0e0e0;
 }
+
+.section-divider-title {
+  display: block;
+  padding-top: 0;
+  padding-left: 0;
+  padding-bottom: 5px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid #ccc;
+  color: #999;
+  font-family: opensansregular, Helvetica, Arial, Sans serif;
+  font-weight: normal;
+  font-size: 14px;
+}

--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/sapphire/mantleSapphire.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/sapphire/mantleSapphire.css
@@ -1484,3 +1484,16 @@ hr {
   border: 0 none;
   border-top: 1px solid #e0e0e0;
 }
+
+.section-divider-title {
+  display: block;
+  padding-top: 0;
+  padding-left: 0;
+  padding-bottom: 5px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid #ccc;
+  color: #999;
+  font-family: opensansregular, Helvetica, Arial, Sans serif;
+  font-weight: normal;
+  font-size: 14px;
+}


### PR DESCRIPTION
…like to be able to run work items on the Pentaho Server, so that these Work Items run on the Pentaho Server even though we are in Worker Node mode

- Applying the _"Run Options"_ styling as per defined in the UX mockups at http://ux.pentaho.com/puc-run-worker-node/#g=1&p=mockup

@pentaho/rogueone please review

To be merged alongside https://github.com/pentaho/pentaho-commons-gwt-modules/pull/661