### PR TITLE
[BACKLOG-21349] Update Tomcat to 8.5.27

### DIFF
--- a/assemblies/pentaho-server/pom.xml
+++ b/assemblies/pentaho-server/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <tomcat.directory>${project.build.directory}/apache-tomcat-${tomcat.version}</tomcat.directory>
     <replacer.version>1.5.2</replacer.version>
-    <tomcat.version>8.0.47</tomcat.version>
+    <tomcat.version>8.5.27</tomcat.version>
     <wkhtmltox.version>0.10.0_rc2</wkhtmltox.version>
     <wkhtmltoimage.version>${wkhtmltox.version}-static</wkhtmltoimage.version>
     <resources.directory>${basedir}/src/main/resources</resources.directory>


### PR DESCRIPTION
Updated to the most recent release of Tomcat 8.5.X

JIRA: https://jira.pentaho.com/browse/BACKLOG-21349

The new artifact in nexus here: http://nexus.pentaho.org/content/groups/omni/org/apache/tomcat/tomcat-windows-x64/8.5.27/

Merge along with: https://jira.pentaho.com/browse/BACKLOG-21354