### PR TITLE
[BACKLOG-21237] Modified the two interface IAction and IActionInvokeS…

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/action/IAction.java
+++ b/api/src/main/java/org/pentaho/platform/api/action/IAction.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.api.action;
@@ -50,5 +50,15 @@ public interface IAction {
    *           if there was an error executing the Action
    */
   public void execute() throws Exception;
+
+  /**
+   * Provide the execution status of last Action. For backward compatibility, it is declared as default method
+   * which returns true
+   * @return boolean Indicate true for success and false for failure
+   */
+  default boolean isExecutionSuccessful() {
+    return true;
+  }
+
 
 }

--- a/api/src/main/java/org/pentaho/platform/api/action/IActionInvokeStatus.java
+++ b/api/src/main/java/org/pentaho/platform/api/action/IActionInvokeStatus.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.api.action;
@@ -51,4 +51,19 @@ public interface IActionInvokeStatus {
   Object getStreamProvider();
 
   void setStreamProvider( final Object streamProvider );
+
+  /**
+   * Return the success/failure of the execution. Added default method to maintain backward compatibility.
+   * @return boolean
+   */
+  default boolean isExecutionSuccessful() {
+    return true;
+  }
+
+  /**
+   * Set the execution status. Added default method to maintain backward compatibility.
+   * @param status boolean
+   */
+  default void setExecutionStatus( boolean status ) {
+  }
 }

--- a/core/src/main/java/org/pentaho/platform/action/ActionInvokeStatus.java
+++ b/core/src/main/java/org/pentaho/platform/action/ActionInvokeStatus.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.action;
@@ -23,6 +23,7 @@ public class ActionInvokeStatus implements IActionInvokeStatus {
   private boolean requiresUpdate;
   private Throwable throwable;
   private Object streamProvider;
+  private boolean executionStatus;
 
   public void setRequiresUpdate( final boolean requiresUpdate ) {
     this.requiresUpdate = requiresUpdate;
@@ -46,5 +47,13 @@ public class ActionInvokeStatus implements IActionInvokeStatus {
 
   public Object getStreamProvider() {
     return this.streamProvider;
+  }
+
+  public boolean isExecutionSuccessful() {
+    return executionStatus;
+  }
+
+  public void setExecutionStatus( boolean status ) {
+    executionStatus = status;
   }
 }

--- a/core/src/test/java/org/pentaho/platform/action/ActionInvokeStatusTest.java
+++ b/core/src/test/java/org/pentaho/platform/action/ActionInvokeStatusTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.action;
@@ -36,5 +36,14 @@ public class ActionInvokeStatusTest {
     ActionInvokeStatus actionInvokeStatus = new ActionInvokeStatus();
     actionInvokeStatus.setThrowable( new Throwable( "test_message" ) );
     Assert.assertEquals( actionInvokeStatus.getThrowable().getMessage(), "test_message" );
+  }
+
+  @Test
+  public void setAndGetExecutionStatusTest() throws Exception {
+    ActionInvokeStatus actionInvokeStatus = new ActionInvokeStatus();
+    actionInvokeStatus.setExecutionStatus( true );
+    Assert.assertTrue( actionInvokeStatus.isExecutionSuccessful() );
+    actionInvokeStatus.setExecutionStatus( false );
+    Assert.assertFalse( actionInvokeStatus.isExecutionSuccessful() );
   }
 }

--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.scheduler2.action;
@@ -72,9 +72,13 @@ public class ActionRunner implements Callable<Boolean> {
   public Boolean call() throws ActionInvocationException {
     final String workItemUid = ActionUtil.extractUid( params );
     try {
-      final boolean result = callImpl();
-      WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.SUCCEEDED );
-      return result;
+      final ExecutionResult result = callImpl();
+      if ( result.isSuccess() ) {
+        WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.SUCCEEDED );
+      } else {
+        WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.FAILED );
+      }
+      return result.updateRequired();
     } catch ( final Throwable t ) {
       // ensure that the main thread isn't blocked on lock
       synchronized ( lock ) {
@@ -88,7 +92,9 @@ public class ActionRunner implements Callable<Boolean> {
     }
   }
 
-  private Boolean callImpl() throws Exception {
+  private ExecutionResult callImpl() throws Exception {
+    boolean executionStatus = true;
+
     final Object locale = params.get( LocaleHelper.USER_LOCALE_PARAM );
     if ( locale instanceof Locale ) {
       LocaleHelper.setLocaleOverride( (Locale) locale );
@@ -152,7 +158,7 @@ public class ActionRunner implements Callable<Boolean> {
     }
 
     actionBean.execute();
-
+    executionStatus = actionBean.isExecutionSuccessful();
     if ( stream != null ) {
       IOUtils.closeQuietly( stream );
     }
@@ -170,7 +176,10 @@ public class ActionRunner implements Callable<Boolean> {
       closeContentOutputStreams( (IPostProcessingAction) actionBean );
       markContentAsGenerated( (IPostProcessingAction) actionBean );
     }
-    return updateJob;
+
+    // Create the ExecutionResult to return the status and whether the update is required or not
+    ExecutionResult executionResult = new ExecutionResult( updateJob, executionStatus );
+    return executionResult;
   }
 
   private void deleteEmptyFile() {
@@ -220,5 +229,26 @@ public class ActionRunner implements Callable<Boolean> {
       return ( (FileContentItem) contentItem ).getFile().getName();
     }
     return null;
+  }
+
+  /**
+   * Class to hold the result of the invoke Action
+   */
+  private class ExecutionResult {
+    private boolean updateRequired;
+    private boolean isSuccess;
+
+    public ExecutionResult( Boolean updateRequired, Boolean isSuccess ) {
+      this.updateRequired = updateRequired;
+      this.isSuccess = isSuccess;
+    }
+    public Boolean updateRequired() {
+      return updateRequired;
+    }
+
+    public Boolean isSuccess() {
+      return isSuccess;
+    }
+
   }
 }

--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/DefaultActionInvoker.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/DefaultActionInvoker.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.scheduler2.action;
@@ -167,7 +167,8 @@ public class DefaultActionInvoker implements IActionInvoker {
       status.setThrowable( t );
     }
     status.setRequiresUpdate( requiresUpdate );
-
+    // Set the execution Status
+    status.setExecutionStatus( actionBean.isExecutionSuccessful() );
     return status;
   }
 

--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.scheduler2.quartz;
@@ -118,11 +118,11 @@ public class ActionAdapterQuartzJob implements Job {
       final Map.Entry<String, Serializable> entry = iter.next();
       final String key = entry.getKey();
       final Serializable value = entry.getValue();
-      if (value instanceof MapParamValue ) {
+      if ( value instanceof MapParamValue ) {
         serializableMap.put( key, new HashMap<String, Serializable>( (MapParamValue) value ) );
-      } else if (value instanceof ListParamValue ) {
+      } else if ( value instanceof ListParamValue ) {
         serializableMap.put( key, new ArrayList<Serializable>( (ListParamValue) value ) );
-      } else if (value instanceof StringParamValue ) {
+      } else if ( value instanceof StringParamValue ) {
         serializableMap.put( key, ( (StringParamValue) value ).getStringValue() );
       } else {
         serializableMap.put( key, value );
@@ -182,6 +182,15 @@ public class ActionAdapterQuartzJob implements Job {
           getActionIdentifier( actionBean, actionClassName, actionId ), StringUtil.getMapAsPrettyString( params ) ) );
       }
       return;
+    }
+
+    // Some of the ktr/kjb execution failures are not thrown as exception as scheduler might try them again.
+    // To resolve this, the errors are flagged. If the execution status returns false, then it throws the
+    // exception
+    if ( !status.isExecutionSuccessful() ) {
+      // throw job exception
+      throw new JobExecutionException( Messages.getInstance().getActionFailedToExecute( actionBean //$NON-NLS-1$
+        .getClass().getName() ) );
     }
 
     final boolean requiresUpdate = status.requiresUpdate();

--- a/scheduler/src/test/java/org/pentaho/platform/scheduler2/action/ActionRunnerTest.java
+++ b/scheduler/src/test/java/org/pentaho/platform/scheduler2/action/ActionRunnerTest.java
@@ -13,12 +13,13 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2018 Hitachi Vantara.  All rights reserved.
  */
 package org.pentaho.platform.scheduler2.action;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Assert;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -62,6 +63,9 @@ public class ActionRunnerTest {
     ActionRunner actionRunner = new ActionRunner( actionBeanSpy, "actionUser", paramsMap, null );
     actionRunner.call();
     Mockito.verify( actionBeanSpy ).execute();
+
+    // Verify that, by default the isExecutionSuccessful returns true
+    Assert.assertTrue( actionBeanSpy.isExecutionSuccessful() );
   }
 
 


### PR DESCRIPTION
…tatus

to get the execution status of ktr/kjb. These method have the default
keyward to maintain backward compatibility.
ActionRunner logs the correct WorkItemLifecyclePhase success or failure
depending of the IAction. ActionAdaptorQuartzJob now looks at the
IActionInvokeStatus.isExecutionSuccessful() in addition to  getThrowable()
to know whether the execution was successful.