### PR TITLE
[PPP-3892] - Use of vulnerable component org.codehaus.jackson : jacks…

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -1052,6 +1052,10 @@
           <groupId>com.sun.xml.bind</groupId>
           <artifactId>jaxb-impl</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
…on-mapper-asl : 1.5.2, org.codehaus.jackson : jackson-mapper-asl : 1.9.12, org.codehaus.jackson : jackson-mapper-asl 1.9.13,org.codehaus.jackson:jackson-mapper-asl-1.8.8.jar CVE-2017-7525

 - remove jackson-mapper-asl from assemblies

@pamval, @mbatchelor, could you please take a look?  