### PR TITLE
[BACKLOG-22550] Exception thrown java.lang.ClassCastException when op…

### DIFF
--- a/repository/src/main/java/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfs.java
+++ b/repository/src/main/java/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfs.java
@@ -25,11 +25,11 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.commons.vfs2.provider.AbstractFileProvider;
 
 import java.util.Collection;
 
-public class SolutionRepositoryVfs implements FileProvider {
+public class SolutionRepositoryVfs extends AbstractFileProvider {
 
   public SolutionRepositoryVfs() {
     super();


### PR DESCRIPTION
…ening kettle.cda sample

- commons-vfs2-2.2's `DefaultFileSystemManager` does a hardcoded cast of the FileProvider impl to `AbstractFileProvider`, in order to call for the new method `freeUnusedResources()` 
- `freeUnusedResources()` already has a default method impl in the abstract, so we needn't implement it ourselves
- `AbstractFileProvider implements FileProvider`

So making `SolutionRepositoryVfs extends AbstractFileProvider` instead on `SolutionRepositoryVfs implements FileProvider`  

@pentaho/rogueone please review
Tested & validated on an end-to-end build ( thanks to @mdamour1976 's build tool )

CC'ing @pamval 
