### PR TITLE
[BACKLOG-22228] write to log a UUID, if one was passed along

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
+++ b/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
@@ -64,6 +64,7 @@ public class ActionUtil {
   public static final String INVOKER_ACTIONCLASS = "actionClass"; //$NON-NLS-1$
   public static final String INVOKER_ACTIONUSER = "actionUser"; //$NON-NLS-1$
   public static final String INVOKER_ACTIONID = "actionId"; //$NON-NLS-1$
+  public static final String INVOKER_UUID = "UUID"; //$NON-NLS-1$
   public static final String INVOKER_STREAMPROVIDER = "streamProvider"; //$NON-NLS-1$
   public static final String INVOKER_STREAMPROVIDER_INPUT_FILE = "inputFile"; //$NON-NLS-
   public static final String INVOKER_STREAMPROVIDER_OUTPUT_FILE_PATTERN = "outputFilePattern"; //$

--- a/core/src/main/java/org/pentaho/platform/workitem/WorkItemLifecycleEventUtil.java
+++ b/core/src/main/java/org/pentaho/platform/workitem/WorkItemLifecycleEventUtil.java
@@ -126,6 +126,10 @@ public class WorkItemLifecycleEventUtil {
       }
     }
 
+    if ( detailsMap.containsKey( ActionUtil.INVOKER_UUID ) ) {
+      sb.append( ActionUtil.INVOKER_UUID ).append( " " ).append( detailsMap.get( ActionUtil.INVOKER_UUID ).toString() );
+    }
+
     return sb.toString();
   }
 }


### PR DESCRIPTION
@pentaho/rogueone please review

The request of execution returns the newly generated UUID back in the Response; PS can merely log it, as it logs nowadays lines pertaining the `SUBMITTED` and `DISPATCHED` actions

To be merged on `master` alone ( i.e. 9.0 work ), and to be merged alongside https://github.com/pentaho/pentaho-ee/pull/1197