### PR TITLE
[BACKLOG-23124] The current method of generating workItem Name is not…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
+++ b/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
@@ -77,13 +77,14 @@ public class ActionUtil {
   public static final String INVOKER_SYNC_VALUE = "false";
 
   public static final String WORK_ITEM_UID = "workItemUid"; //$NON-NLS-1$
+  public static final String WORK_ITEM_NAME = "workItemName"; //$NON-NLS-1$
 
   /**
    * Regex representing characters that are allowed in the work item uid (in compliance with chronos job names).
    */
   private static final String WORK_ITEM_UID_INVALID_CHARS = "[^\\w\\\\-]+";
 
-  private static final int WORK_ITEM_UID_LENGTH_LIMIT = 1000;
+  private static final int WORK_ITEM_LENGTH_LIMIT = 1000;
 
   private static final Map<String, String> KEY_MAP;
 
@@ -168,18 +169,16 @@ public class ActionUtil {
   }
 
   /**
-   * Looks up the {@code ActionUtil.WORK_ITEM_UID} within the {@link Map}. If available, the value is returned,
-   * otherwise a new uid is generated and placed within the {@link Map}. This is done ONLY if the
-   * {@link IWorkItemLifecycleEventPublisher} bean is defined, if the bean is not defined, {@code null} is returned.
-   * It is the caller's responsibility to handle this case gracefully.
+   * Looks up the work item name within the {@link Map}. If available, the value is returned,
+   * otherwise a new name is generated and returned.
    *
-   * @param params a {@link Map} that may contain the {@code ActionUtil.WORK_ITEM_UID}
-   * @return {@code ActionUtil.WORK_ITEM_UID} from the {@link Map} or a new uid, or {@code null} in the absence of
+   * @param params a {@link Map} that may contain the name
+   * @return work item name from the {@link Map} or a new one, or {@code null} in the absence of
    * the {@link IWorkItemLifecycleEventPublisher} bean
    */
-  public static String extractUid( final Map<String, Serializable> params ) {
+  public static String extractName( final Map<String, Serializable> params ) {
     final IWorkItemLifecycleEventPublisher publisher = PentahoSystem.get( IWorkItemLifecycleEventPublisher.class );
-    // if the published bean is null, we do not want to generate the work item UID, as this is a worker nodes
+    // if the published bean is null, we do not want to generate the work item name, as this is a worker nodes
     // concept, and we do not want any worker nodes related information in the logs. Given that
     // IWorkItemLifecycleEventPublisher only exists when worker nodes are enabled, we can use the existence of this
     // bean to determine whether to generate the work item UID or not
@@ -187,27 +186,27 @@ public class ActionUtil {
       return null;
     }
     if ( params == null ) {
-      return generateWorkItemUid( params );
+      return generateWorkItemName( params );
     }
 
-    String uid = (String) params.get( WORK_ITEM_UID );
-    if ( uid == null ) {
-      uid = generateWorkItemUid( params );
-      params.put( WORK_ITEM_UID, uid );
+    String name = (String) params.get( WORK_ITEM_NAME );
+    if ( name == null ) {
+      name = generateWorkItemName( params );
+      params.put( WORK_ITEM_NAME, name );
     }
 
-    return uid;
+    return name;
   }
 
   /**
    * @param params a {@link Map} containing action/work item related attributes, in particular {@code inputFile} and
    *               {@code actionUser}, which are both used for the purpose of generating the uid.
-   * @return a unique id for the work item
-   * @see {@link #generateWorkItemUid(String, String)}
+   * @return a name for the work item
+   * @see {@link #generateWorkItemName(String, String)}
    */
-  public static String generateWorkItemUid( final Map<String, Serializable> params ) {
+  public static String generateWorkItemName( final Map<String, Serializable> params ) {
     if ( params == null ) {
-      return generateWorkItemUid( null, null );
+      return generateWorkItemName( null, null );
     }
     // at the time this method is called, the quartz specific map keys may not have been mapped to their
     // corresponding action keys (see KEY_MAP), fall back on the quartz key, if the action key cannot be found
@@ -222,7 +221,7 @@ public class ActionUtil {
       inputFilePath = getInlineInputFileOnStreamProvider( params );
     }
 
-    return generateWorkItemUid( inputFilePath, userName );
+    return generateWorkItemName( inputFilePath, userName );
   }
 
   public static boolean isInlinePassingOfInputOnStreamProvider( final Map<String, Serializable> params ) {
@@ -256,40 +255,35 @@ public class ActionUtil {
   }
 
   /**
-   * Returns a unique id for a work item which includes the input file name (derived from {@code inputFilePath}),
-   * {@code user} and {@code date}, in the following format: WI-%input file name%-%user%-%date%, stripping any
+   * Returns a name for a work item which includes the input file name (derived from {@code inputFilePath}) and
+   * {@code user} that executed it, in the following format: %input file name%-%user%, stripping any
    * invalid characters.
+   *
+   * This workItemName will be used for logging only
    *
    * @param inputFilePath the path of the input file of the action being invoked - optional
    * @param userName      the user executing the action
-   * @return a unique id for the work item
+   * @return a name for the work item
    */
-  public static String generateWorkItemUid( final String inputFilePath,
+  public static String generateWorkItemName( final String inputFilePath,
                                             final String userName ) {
 
     if ( StringUtil.isEmpty( inputFilePath ) ) {
-      logger.info( "Input file path is not provided and will not be part of the work item uid." );
+      logger.info( "Input file path is not provided." );
     }
     if ( StringUtil.isEmpty( userName ) ) {
-      logger.info( "User name is not provided and will not be part of the work item uid." );
+      logger.info( "User name is not provided." );
     }
-    // we only care about the file name, not the full path, which may be long and not very helpful
-    String inputFileName =  ( new File(  inputFilePath == null ? "" : inputFilePath ) ).getName();
 
-    // sanitize inputFileName and user name by removing invalid characters
-    final String sanitizedInputFileName = inputFileName.replaceAll( WORK_ITEM_UID_INVALID_CHARS, "_" );
-    final String sanitizedUserName = ( userName == null ? "" : userName ).replaceAll( WORK_ITEM_UID_INVALID_CHARS, "_" );
+    String workItemName = String.format( "%s[%s]",
+            Optional.ofNullable( inputFilePath ).orElse( StringUtils.EMPTY ),
+            Optional.ofNullable( userName ).orElse( StringUtils.EMPTY ) );
 
-    String workItemUid = String.format( "WI-%s-%s-%s", sanitizedInputFileName, sanitizedUserName,
-      System.currentTimeMillis() );
-    // remove any double dash, in case user name or inputFileName is missing
-    workItemUid = workItemUid.replaceAll( "[-]+", "-" );
-
-    if ( workItemUid.length() > WORK_ITEM_UID_LENGTH_LIMIT ) {
-      logger.info( String.format( "Work item uid exceeds max character limit of %d: %d", WORK_ITEM_UID_LENGTH_LIMIT,
-        workItemUid.length() ) );
+    if ( workItemName.length() > WORK_ITEM_LENGTH_LIMIT ) {
+      logger.info( String.format( "Work item name exceeds max character limit of %d: %d", WORK_ITEM_LENGTH_LIMIT,
+              workItemName.length() ) );
     }
-    return workItemUid;
+    return workItemName;
   }
 
   private static final long RETRY_COUNT = 6;

--- a/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
+++ b/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
@@ -35,7 +35,6 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.util.messages.Messages;
 import org.pentaho.platform.util.web.MimeHelper;
 
-import java.io.File;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java
@@ -153,27 +153,27 @@ public class ActionUtilTest {
   }
 
   @Test
-  public void testExtractUid() {
-    // fake the publisher, so that a call to extractUid returns a value and puts it in the params map
+  public void testExtractName() {
+    // fake the publisher, so that a call to extractName returns a value and puts it in the params map
     PowerMockito.mockStatic( PentahoSystem.class );
     when( PentahoSystem.get( isA( IWorkItemLifecycleEventPublisher.class.getClass() ) ) ).thenReturn( new DummyPublisher() );
 
     final Map<String, Serializable> params = new HashMap<>();
 
-    assertNotNull( ActionUtil.extractUid( params ) );
+    assertNotNull( ActionUtil.extractName( params ) );
     // the map should now contain a uid
-    assertTrue( params.containsKey( ActionUtil.WORK_ITEM_UID ) );
-    final String uid = (String) params.get( ActionUtil.WORK_ITEM_UID );
-    assertEquals( uid, ActionUtil.extractUid( params ) );
+    assertTrue( params.containsKey( ActionUtil.WORK_ITEM_NAME ) );
+    final String uid = (String) params.get( ActionUtil.WORK_ITEM_NAME );
+    assertEquals( uid, ActionUtil.extractName( params ) );
     assertEquals( 1, params.size() );
   }
 
   @Test
-  public void testExtractUidWithoutPublisher() {
-    // by default, there is no IWorkItemLifecycleEventPublisher bean, call to extractUid should return null
+  public void testExtractNameWithoutPublisher() {
+    // by default, there is no IWorkItemLifecycleEventPublisher bean, call to extractName should return null
     final Map<String, Serializable> params = new HashMap<>();
 
-    assertNull( ActionUtil.extractUid( params ) );
+    assertNull( ActionUtil.extractName( params ) );
     assertFalse( params.containsKey( ActionUtil.WORK_ITEM_UID ) );
   }
 
@@ -191,58 +191,58 @@ public class ActionUtilTest {
   }
 
   @Test
-  public void testGenerateWorkItemUidWithMap() throws NoSuchFieldException, IllegalAccessException {
+  public void testGenerateWorkItemNameWithMap() throws NoSuchFieldException, IllegalAccessException {
 
     final long currentTime = freezeTime();
     Map map = null;
     String result;
 
     // null map
-    result = ActionUtil.generateWorkItemUid( map );
-    assertEquals( "WI-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( map );
+    assertEquals( "[]", result );
 
     // empty map
     map = new HashMap();
-    result = ActionUtil.generateWorkItemUid( map );
-    assertEquals( "WI-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( map );
+    assertEquals( "[]", result );
 
     // quartz username only
     map = new HashMap();
     map.put( ActionUtil.QUARTZ_ACTIONUSER, "quartzAdmin" );
-    result = ActionUtil.generateWorkItemUid( map );
-    assertEquals( "WI-quartzAdmin-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( map );
+    assertEquals( "[quartzAdmin]", result );
 
     // action username only
     map = new HashMap();
     map.put( ActionUtil.INVOKER_ACTIONUSER, "actionAdmin" );
-    result = ActionUtil.generateWorkItemUid( map );
-    assertEquals( "WI-actionAdmin-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( map );
+    assertEquals( "[actionAdmin]", result );
 
     // quartz and action username
     map = new HashMap();
     map.put( ActionUtil.QUARTZ_ACTIONUSER, "quartzAdmin" );
     map.put( ActionUtil.INVOKER_ACTIONUSER, "actionAdmin" );
-    result = ActionUtil.generateWorkItemUid( map );
-    assertEquals( "WI-actionAdmin-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( map );
+    assertEquals( "[actionAdmin]", result );
 
     // quartz username only
     map = new HashMap();
     map.put( ActionUtil.QUARTZ_STREAMPROVIDER_INPUT_FILE, "quartzInputFile" );
-    result = ActionUtil.generateWorkItemUid( map );
-    assertEquals( "WI-quartzInputFile-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( map );
+    assertEquals( "quartzInputFile[]", result );
 
     // action username only
     map = new HashMap();
     map.put( ActionUtil.INVOKER_STREAMPROVIDER_INPUT_FILE, "adminInputFile" );
-    result = ActionUtil.generateWorkItemUid( map );
-    assertEquals( "WI-adminInputFile-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( map );
+    assertEquals( "adminInputFile[]", result );
 
     // quartz and action username
     map = new HashMap();
     map.put( ActionUtil.QUARTZ_STREAMPROVIDER_INPUT_FILE, "quartzInputFile" );
     map.put( ActionUtil.INVOKER_STREAMPROVIDER_INPUT_FILE, "adminInputFile" );
-    result = ActionUtil.generateWorkItemUid( map );
-    assertEquals( "WI-adminInputFile-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( map );
+    assertEquals( "adminInputFile[]", result );
 
     // all values present
     map = new HashMap();
@@ -250,38 +250,38 @@ public class ActionUtilTest {
     map.put( ActionUtil.INVOKER_STREAMPROVIDER_INPUT_FILE, "adminInputFile" );
     map.put( ActionUtil.QUARTZ_ACTIONUSER, "quartzAdmin" );
     map.put( ActionUtil.INVOKER_ACTIONUSER, "actionAdmin" );
-    result = ActionUtil.generateWorkItemUid( map );
-    assertEquals( "WI-adminInputFile-actionAdmin-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( map );
+    assertEquals( "adminInputFile[actionAdmin]", result );
 
   }
 
   @Test
-  public void testGenerateWorkItemUid() throws NoSuchFieldException, IllegalAccessException {
+  public void testGenerateWorkItemName() throws NoSuchFieldException, IllegalAccessException {
 
     final long currentTime = freezeTime();
     String result;
 
     // simple case
-    result = ActionUtil.generateWorkItemUid( "Test.prpt", "admin" );
-    assertEquals( "WI-Test_prpt-admin-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( "Test.prpt", "admin" );
+    assertEquals( "Test.prpt[admin]", result );
 
     // bad characters
-    result = ActionUtil.generateWorkItemUid( "!@#$%^&*.prpt", "adm&*&in" );
-    assertEquals( "WI-_prpt-adm_in-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( "!@#$%^&*.prpt", "adm&*&in" );
+    assertEquals( "!@#$%^&*.prpt[adm&*&in]", result );
 
     // all bad characters
-    result = ActionUtil.generateWorkItemUid( "!@#$%^&*.prpt", "&*&(*&" );
-    assertEquals( "WI-_prpt-_-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( "!@#$%^&*.prpt", "&*&(*&" );
+    assertEquals( "!@#$%^&*.prpt[&*&(*&]", result );
 
     // file path and spaces
-    result = ActionUtil.generateWorkItemUid( "folder/Test File.prpt", "adm&*&in" );
-    assertEquals( "WI-Test_File_prpt-adm_in-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( "folder/Test File.prpt", "adm&*&in" );
+    assertEquals( "folder/Test File.prpt[adm&*&in]", result );
 
     // missing user and file
-    result = ActionUtil.generateWorkItemUid( "", "" );
-    assertEquals( "WI-" + currentTime, result );
-    result = ActionUtil.generateWorkItemUid( null, null );
-    assertEquals( "WI-" + currentTime, result );
+    result = ActionUtil.generateWorkItemName( "", "" );
+    assertEquals( "[]", result );
+    result = ActionUtil.generateWorkItemName( null, null );
+    assertEquals( "[]", result );
   }
 
   @Test

--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
@@ -73,13 +73,13 @@ public class ActionRunner implements Callable<Boolean> {
   }
 
   public Boolean call() throws ActionInvocationException {
-    final String workItemUid = ActionUtil.extractUid( params );
+    final String workItemName = ActionUtil.extractName( params );
     try {
       final ExecutionResult result = callImpl();
       if ( result.isSuccess() ) {
-        WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.SUCCEEDED );
+        WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.SUCCEEDED );
       } else {
-        WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.FAILED );
+        WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED );
       }
       return result.updateRequired();
     } catch ( final Throwable t ) {
@@ -87,7 +87,7 @@ public class ActionRunner implements Callable<Boolean> {
       synchronized ( lock ) {
         lock.notifyAll();
       }
-      WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.FAILED, t.toString() );
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED, t.toString() );
       // We should not distinguish between checked and unchecked exceptions here. All job execution failures
       // should result in a rethrow of the exception
       throw new ActionInvocationException( Messages.getInstance().getActionFailedToExecute( actionBean //$NON-NLS-1$

--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/DefaultActionInvoker.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/DefaultActionInvoker.java
@@ -78,17 +78,17 @@ public class DefaultActionInvoker implements IActionInvoker {
   public void validate( final IAction actionBean, final String actionUser,
                         final Map<String, Serializable> params ) throws ActionInvocationException {
 
-    final String workItemUid = ActionUtil.extractUid( params );
+    final String workItemName = ActionUtil.extractName( params );
 
     if ( actionBean == null || params == null ) {
       final String failureMessage = Messages.getInstance().getCantInvokeNullAction();
-      WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.FAILED,  failureMessage );
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED,  failureMessage );
       throw new ActionInvocationException( failureMessage );
     }
 
     if ( !isSupportedAction( actionBean ) ) {
       final String failureMessage = Messages.getInstance().getUnsupportedAction( actionBean.getClass().getName() );
-      WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.FAILED, failureMessage );
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED, failureMessage );
       throw new ActionInvocationException( failureMessage );
     }
   }
@@ -123,15 +123,15 @@ public class DefaultActionInvoker implements IActionInvoker {
                                            final String actionUser,
                                            final Map<String, Serializable> params ) throws Exception {
 
-    final String workItemUid = ActionUtil.extractUid( params );
+    final String workItemName = ActionUtil.extractName( params );
 
     if ( actionBean == null || params == null ) {
       final String failureMessage = Messages.getInstance().getCantInvokeNullAction();
-      WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.FAILED, failureMessage );
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED, failureMessage );
       throw new ActionInvocationException( failureMessage );
     }
 
-    WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.IN_PROGRESS );
+    WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.IN_PROGRESS );
 
     if ( logger.isDebugEnabled() ) {
       logger.debug( Messages.getInstance().getRunningInBackgroundLocally( actionBean.getClass().getName(), params ) );
@@ -166,7 +166,7 @@ public class DefaultActionInvoker implements IActionInvoker {
         requiresUpdate = SecurityHelper.getInstance().runAsUser( actionUser, actionBeanRunner );
       }
     } catch ( final Throwable t ) {
-      WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.FAILED, t.toString() );
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED, t.toString() );
       status.setThrowable( t );
     }
     status.setRequiresUpdate( requiresUpdate );

--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
@@ -151,9 +151,9 @@ public class ActionAdapterQuartzJob implements Job {
   protected void invokeAction( final String actionClassName, final String actionId, final String actionUser, final
     JobExecutionContext context, final Map<String, Serializable> params ) throws Exception {
 
-    final String workItemUid = ActionUtil.extractUid( params );
+    final String workItemName = ActionUtil.extractName( params );
 
-    WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.SUBMITTED );
+    WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.SUBMITTED );
 
     // creates an instance of IActionInvoker, which knows how to invoke this IAction - if the IActionInvoker bean is
     // not defined through spring, fall back on the default action invoker
@@ -166,7 +166,7 @@ public class ActionAdapterQuartzJob implements Job {
       final String failureMessage = Messages.getInstance().getErrorString(
         "ActionAdapterQuartzJob.ERROR_0002_FAILED_TO_CREATE_ACTION", //$NON-NLS-1$
         getActionIdentifier( null, actionClassName, actionId ), StringUtil.getMapAsPrettyString( params ) );
-      WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.FAILED, failureMessage );
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED, failureMessage );
       throw new LoggingJobExecutionException( failureMessage );
     }
 
@@ -224,7 +224,7 @@ public class ActionAdapterQuartzJob implements Job {
             QuartzJobKey jobKey = QuartzJobKey.parse( context.getJobDetail().getName() );
             String jobName = jobKey.getJobName();
             jobParams.put( QuartzScheduler.RESERVEDMAPKEY_RESTART_FLAG, Boolean.TRUE );
-            WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.RESTARTED );
+            WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.RESTARTED );
             scheduler.createJob( jobName, iaction, jobParams, trigger, streamProvider );
             log.warn( "New RunOnce job created for " + jobName + " -> possible startup synchronization error" );
             return null;
@@ -254,7 +254,7 @@ public class ActionAdapterQuartzJob implements Job {
             streamProvider.setStreamingAction( null ); // remove generated content
             QuartzJobKey jobKey = QuartzJobKey.parse( context.getJobDetail().getName() );
             String jobName = jobKey.getJobName();
-            WorkItemLifecycleEventUtil.publish( workItemUid, params, WorkItemLifecyclePhase.RESTARTED );
+            WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.RESTARTED );
             org.pentaho.platform.api.scheduler2.Job j =
               scheduler.createJob( jobName, iaction, jobParams, trigger, streamProvider );
             log.warn( "New Job: " + j.getJobId() + " created" );


### PR DESCRIPTION
… generating unique name, causing the workItems to fail

- to remove duplicate logic, pentaho-platform no longer has `workItemUuid` generation; only content-execution-broker will have it from this point onward
  - pentaho-platform's `workItemUuid` logic was re-purposed to become a simple `workItemName` generator
  - to align with this, pentaho-platform's `ActionUtil.extractUid()` was renamed to `ActionUtil.extractName()`
  - unit tests updated in accordance
- content-execution-broker returns the generated `workItemUuid` as part of the response
- content-execution-broker `workItemUuid` composition:
  - was `WI-<sanitized_name>-<sanitized_user>-<timestamp>`
  - now is `<sanitized_name>-<sanitized_user>-<UUID.randomUUID()>`


@pentaho/rogueone please review
CC'ing @pdesai16 
To be merged alongside https://github.com/pentaho/pentaho-ee/pull/1239


Example of the logs now displayed at the Pentaho Server side:

```
09:16:34,763 INFO  [WorkItemLifecycleEventFileWriter] /public/print_received_params.ktr[admin]|SUBMITTED  |19 May 2018 09:16:34,762|192.168.1.104|192.168.1.104
09:16:34,812 INFO  [WorkItemLifecycleEventFileWriter] /public/print_received_params.ktr[admin]|DISPATCHED |19 May 2018 09:16:34,812|192.168.1.104|192.168.1.104|/public/print_received_params.ktr[admin]
09:16:35,714 INFO  [WorkItemLifecycleEventFileWriter] /public/print_received_params.ktr[admin]|RECEIVED   |19 May 2018 09:16:35,714|192.168.1.104|192.168.1.104|UUID print_received_params_ktr_admin-b6f4d423-d76b-4fa3-ae3a-7e2ad9e403c5
```


Example of the extra logs now displayed at the CEB side:

```
09:16:35,508 INFO  [FoundryJobExecutor] -------------------------- JOB EXECUTION REQUEST --------------------------
09:16:35,508 INFO  [FoundryJobExecutor] Username:admin
09:16:35,508 INFO  [FoundryJobExecutor] InputFilePath:/public/print_received_params.ktr
09:16:35,508 INFO  [FoundryJobExecutor] WorkItem UUID:print_received_params_ktr_admin-b6f4d423-d76b-4fa3-ae3a-7e2ad9e403c5
09:16:35,508 INFO  [FoundryJobExecutor] (internal) Job UUID:994ae63e-e0d1-4ef0-8217-7c228bfe8a6f
09:16:35,508 INFO  [FoundryJobExecutor] Run job status:200
09:16:35,508 INFO  [FoundryJobExecutor] ---------------------------------------------------------------------------

```
