### PR TITLE
[SP-4312] - Backport of BISERVER-13916 - Mondrian roles displaying er…

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/memory/UserRoleListEnhancedUserMap.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/memory/UserRoleListEnhancedUserMap.java
@@ -1,4 +1,5 @@
 /*!
+ *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -12,7 +13,9 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
  */
 
 package org.pentaho.platform.plugin.services.security.userrole.memory;
@@ -71,7 +74,7 @@ public class UserRoleListEnhancedUserMap {
     for ( GrantedAuthority role : authoritiesSet ) {
       roles.add( role.getAuthority() );
     }
-    return (String[]) roles.toArray();
+    return roles.toArray( new String[0] );
   }
 
   public String[] getAllUsers() {

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource.java
@@ -1,4 +1,5 @@
 /*!
+ *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -12,7 +13,9 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
  */
 
 package org.pentaho.platform.web.http.api.resources;
@@ -900,13 +903,10 @@ public class UserRoleDaoResource extends AbstractJaxRSResource {
 
   protected void updateRolesForCurrentSession() {
     List<String> userRoles = userRoleDaoService.getRolesForUser( getSession().getName() ).getRoles();
-    GrantedAuthority[] authoritys = new GrantedAuthority[ userRoles.size() ];
+    List<GrantedAuthority> authorities = new ArrayList<>();
+    userRoles.forEach( role -> authorities.add( new SimpleGrantedAuthority( role ) ) );
 
-    for ( int i = 0; i < authoritys.length; i++ ) {
-      authoritys[ i ] = new SimpleGrantedAuthority( userRoles.get( i ) );
-    }
-
-    getSession().setAttribute( IPentahoSession.SESSION_ROLES, authoritys );
+    getSession().setAttribute( IPentahoSession.SESSION_ROLES, authorities );
   }
 
   protected IPentahoSession getSession() {

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/UserRoleDaoResource_RolesUpdatedTest.java
@@ -1,4 +1,5 @@
 /*!
+ *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -12,7 +13,9 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
  */
 
 package org.pentaho.platform.web.http.api.resources;
@@ -34,11 +37,19 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static junit.framework.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 
 public class UserRoleDaoResource_RolesUpdatedTest {
   private UserRoleDaoResource resource;
@@ -78,13 +89,11 @@ public class UserRoleDaoResource_RolesUpdatedTest {
   public void sessionAttributeIsSetCorrectly_WhenRolesAreUpdated() {
     resource.updateRolesForCurrentSession();
 
-    GrantedAuthority[] authoritys = new GrantedAuthority[ allRoles.size() ];
-    for ( int i = 0; i < allRoles.size(); i++ ) {
-      authoritys[ i ] = new SimpleGrantedAuthority( allRoles.get( i ) );
-    }
+    List<GrantedAuthority> authorities = new ArrayList<>();
+    allRoles.forEach( role -> authorities.add( new SimpleGrantedAuthority( role ) ) );
 
-    GrantedAuthority[] seessionAuthoritys = (GrantedAuthority[]) session.getAttribute( IPentahoSession.SESSION_ROLES );
-    assertTrue( Arrays.equals( authoritys, seessionAuthoritys ) );
+    Collection<? extends GrantedAuthority> seessionAuthoritys = (Collection) session.getAttribute( IPentahoSession.SESSION_ROLES );
+    assertEquals( authorities, seessionAuthoritys );
   }
 
   @Test

--- a/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/ldap/RolePreprocessingMapperTests.java
+++ b/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/ldap/RolePreprocessingMapperTests.java
@@ -1,4 +1,5 @@
 /*!
+ *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -12,7 +13,9 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
  */
 
 package org.pentaho.test.platform.plugin.services.security.userrole.ldap;
@@ -25,12 +28,12 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.ldap.SpringSecurityLdapTemplate;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for <code>RolePreprocessingMapper</code>. Essentially mimics the steps taken by
@@ -57,8 +60,7 @@ public class RolePreprocessingMapperTests extends AbstractPentahoLdapIntegration
         new SpringSecurityLdapTemplate( getContextSource() ).searchForSingleAttributeValues(
             "ou=roles", "roleoccupant={0}", new String[] { "uid=suzy,ou=users,dc=pentaho,dc=org", "suzy" }, "cn" ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
-    List<GrantedAuthority> authorities = Arrays.asList( new GrantedAuthority[extraRoles.size()] );
-    int i = 0;
+    List<GrantedAuthority> authorities = new ArrayList<>();
     for ( String extraRole : extraRoles ) {
       authorities.add( new SimpleGrantedAuthority( extraRole ) );
     }
@@ -68,12 +70,14 @@ public class RolePreprocessingMapperTests extends AbstractPentahoLdapIntegration
     System.out.println( userDetails );
 
     // this asserts the ordering too; not strictly necessary
-    Collection<? extends GrantedAuthority> expectedAuthorities = Arrays.asList( new GrantedAuthority[] { new SimpleGrantedAuthority( "A" ),
-      new SimpleGrantedAuthority( "cto" ), new SimpleGrantedAuthority( "is" ), new SimpleGrantedAuthority( "Authenticated" ) } );
+    Collection<? extends GrantedAuthority> expectedAuthorities = new ArrayList<GrantedAuthority>() {{
+        add( new SimpleGrantedAuthority( "A" ) );
+        add( new SimpleGrantedAuthority( "Authenticated" ) );
+        add( new SimpleGrantedAuthority( "is" ) );
+        add( new SimpleGrantedAuthority( "cto" ) ); }};
 
     Collection<? extends GrantedAuthority> unexpectedAuthorities = userDetails.getAuthorities();
-    unexpectedAuthorities.removeAll( expectedAuthorities );
 
-    assertTrue( unexpectedAuthorities.isEmpty() );
+    assertEquals( expectedAuthorities, unexpectedAuthorities );
   }
 }

--- a/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/ldap/UnionizingLdapAuthoritiesPopulatorTests.java
+++ b/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/ldap/UnionizingLdapAuthoritiesPopulatorTests.java
@@ -1,4 +1,5 @@
 /*!
+ *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -12,7 +13,9 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
  */
 
 package org.pentaho.test.platform.plugin.services.security.userrole.ldap;
@@ -25,10 +28,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.ldap.SpringSecurityLdapTemplate;
 import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertTrue;
@@ -68,11 +69,10 @@ public class UnionizingLdapAuthoritiesPopulatorTests extends AbstractPentahoLdap
 
     assertTrue( null != auths && auths.size() > 0 );
 
-    List authsList = Arrays.asList( auths );
-    assertTrue( authsList.contains( new SimpleGrantedAuthority( "ROLE_POWER_USER" ) ) ); //$NON-NLS-1$
-    assertTrue( authsList.contains( new SimpleGrantedAuthority( "ROLE_MARKETING" ) ) ); //$NON-NLS-1$
-
-    System.out.println( authsList );
+    assertTrue( auths.contains( new SimpleGrantedAuthority( "ROLE_CTO" ) ) ); //$NON-NLS-1$
+    assertTrue( auths.contains( new SimpleGrantedAuthority( "ROLE_AUTHENTICATED" ) ) ); //$NON-NLS-1$
+    assertTrue( auths.contains( new SimpleGrantedAuthority( "ROLE_MARKETING" ) ) ); //$NON-NLS-1$
+    assertTrue( auths.contains( new SimpleGrantedAuthority( "ROLE_IS" ) ) ); //$NON-NLS-1$
   }
 
 }

--- a/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/memory/UserRoleListEnhancedUserMapFactoryBeanTests.java
+++ b/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/memory/UserRoleListEnhancedUserMapFactoryBeanTests.java
@@ -1,4 +1,5 @@
 /*!
+ *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -12,7 +13,9 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
  */
 
 package org.pentaho.test.platform.plugin.services.security.userrole.memory;
@@ -26,7 +29,6 @@ import org.springframework.util.Assert;
 import java.io.ByteArrayInputStream;
 import java.util.Properties;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class UserRoleListEnhancedUserMapFactoryBeanTests extends AbstractUserMapFactoryBeanTestBase {
@@ -47,10 +49,22 @@ public class UserRoleListEnhancedUserMapFactoryBeanTests extends AbstractUserMap
     /* assertNotNull( map.getUser( "admin" ) ); //$NON-NLS-1$ TODO */
     // Next assert is unnecessary by interface contract
     // assertTrue(map.getUser("admin") instanceof UserDetails); //$NON-NLS-1$
-    assertTrue( isRolePresent( map.getAllAuthorities(), "ROLE_CEO" ) ); //$NON-NLS-1$
-    assertTrue( isUserPresent( map.getUserNamesInRole( "ROLE_CEO" ), "admin" ) ); //$NON-NLS-1$//$NON-NLS-2$
+    assertTrue( isRolePresent( map.getAllAuthorities(), "ROLE_REPORT_AUTHOR" ) ); //$NON-NLS-1$
+    assertTrue( isRolePresent( map.getAllAuthorities(), "ROLE_AUTHENTICATED" ) ); //$NON-NLS-1$
+    assertTrue( isRolePresent( map.getAllAuthorities(), "ROLE_ADMINISTRATOR" ) ); //$NON-NLS-1$
+    assertTrue( isRolePresent( map.getAllAuthorities(), "ROLE_BUSINESS_ANALYST" ) ); //$NON-NLS-1$
+    assertTrue( isUserPresent( map.getUserNamesInRole( "ROLE_REPORT_AUTHOR" ), "tiffany" ) ); //$NON-NLS-1$//$NON-NLS-2$
+    assertTrue( isUserPresent( map.getUserNamesInRole( "ROLE_AUTHENTICATED" ), "admin" ) ); //$NON-NLS-1$//$NON-NLS-2$
+    assertTrue( isUserPresent( map.getUserNamesInRole( "ROLE_AUTHENTICATED" ), "pat" ) ); //$NON-NLS-1$//$NON-NLS-2$
+    assertTrue( isUserPresent( map.getUserNamesInRole( "ROLE_AUTHENTICATED" ), "suzy" ) ); //$NON-NLS-1$//$NON-NLS-2$
+    assertTrue( isUserPresent( map.getUserNamesInRole( "ROLE_AUTHENTICATED" ), "tiffany" ) ); //$NON-NLS-1$//$NON-NLS-2$
+    assertTrue( isUserPresent( map.getUserNamesInRole( "ROLE_ADMINISTRATOR" ), "admin" ) ); //$NON-NLS-1$//$NON-NLS-2$
+    assertTrue( isUserPresent( map.getUserNamesInRole( "ROLE_BUSINESS_ANALYST" ), "pat" ) ); //$NON-NLS-1$//$NON-NLS-2$
     // System.out.println(StringUtils.arrayToCommaDelimitedString(map.getAllUsers()));
+    assertTrue( isUserPresent( map.getAllUsers(), "pat" ) ); //$NON-NLS-1$
     assertTrue( isUserPresent( map.getAllUsers(), "suzy" ) ); //$NON-NLS-1$
+    assertTrue( isUserPresent( map.getAllUsers(), "admin" ) ); //$NON-NLS-1$
+    assertTrue( isUserPresent( map.getAllUsers(), "tiffany" ) ); //$NON-NLS-1$
     // System.out.println(map.getUser("admin"));
   }
 


### PR DESCRIPTION
…rors with: Lorg.springframework.security.core.GrantedAuthority; cannot be cast to java.util.Collection (7.1 Suite)

* Backport of BISERVER-13916 - Mondrian roles displaying errors with: Lorg.springframework.security.core.GrantedAuthority; cannot be cast to java.util.Collection (7.1 Suite)