### PR TITLE
[BACKLOG-23247] javadoc version override for build-utils

### DIFF
--- a/build-utils/pom.xml
+++ b/build-utils/pom.xml
@@ -10,6 +10,7 @@
   <artifactId>pentaho-platform-build-utils</artifactId>
   <version>9.0.0.0-SNAPSHOT</version>
   <properties>
+    <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
     <mockito-all.version>1.9.5</mockito-all.version>
     <license.header.definition.file>${basedir}/../license/styles/javadoc_style_license_header.xml</license.header.definition.file>
     <license.header.file>${basedir}/../license/templates/LGPL-2.1.txt</license.header.file>


### PR DESCRIPTION
@pentaho/x-wing 
