### PR TITLE
[BISERVER-13832] Server is no longer displaying the appropriate error…

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
+++ b/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
@@ -172,4 +172,5 @@
    </file-upload-defaults>
   <default-theme>ruby</default-theme>
   <session-expired-dialog>true</session-expired-dialog>
+  <set-empty-entity-rest-services>false</set-empty-entity-rest-services>
 </pentaho-system>


### PR DESCRIPTION
… page for URLs starting with /pentaho/api

@pamval 