### PR TITLE
[BISERVER-13898] Created an new folder in root at same level of Home …

### DIFF
--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/DirectoryResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/DirectoryResourceTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.pentaho.platform.web.http.api.resources.services.FileService;
 
 public class DirectoryResourceTest {
-  private static final String PATH = "/parentDir/dirName";
+  private static final String PATH = "/home/dirName";
   private static final String ROOTLEVEL_PATH = "/dirName";
 
   private DirectoryResource directoryResource;


### PR DESCRIPTION
…and Public folders

The fix for BISERVER-13898 doesn't allow the creation of root level folders with the name "parentDir".
This PR fixes the test case that didn't conform to this rule.

@pedrofvteixeira 