### PR TITLE
[BACKLOG-22942] Use randomUUID to generate quartzJobKey, added misfire instruction and logs

### DIFF
--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzJobKey.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzJobKey.java
@@ -36,7 +36,8 @@ import org.pentaho.platform.scheduler2.messsages.Messages;
 public class QuartzJobKey {
   private String userName;
   private String jobName;
-  private long timeInMillis;
+  // BACKLOG-22942, changing timInMillis from long to randomUUID
+  private String randomUuid;
 
   /**
    * Use this constructor when you wish to create a new unique job key.
@@ -56,7 +57,7 @@ public class QuartzJobKey {
     }
     userName = username;
     this.jobName = jobName;
-    timeInMillis = System.currentTimeMillis();
+    randomUuid = java.util.UUID.randomUUID().toString();
   }
 
   private QuartzJobKey() {
@@ -80,12 +81,8 @@ public class QuartzJobKey {
     QuartzJobKey key = new QuartzJobKey();
     key.userName = elements[0];
     key.jobName = elements[1];
-    try {
-      key.timeInMillis = Long.parseLong( elements[2] );
-    } catch ( NumberFormatException ex ) {
-      throw new SchedulerException( MessageFormat.format( Messages.getInstance().getErrorString(
-          "QuartzJobKey.ERROR_0002" ), jobId ) ); //$NON-NLS-1$
-    }
+    key.randomUuid = elements[2];
+
     return key;
   }
 
@@ -99,6 +96,6 @@ public class QuartzJobKey {
 
   @Override
   public String toString() {
-    return userName + "\t" + jobName + "\t" + timeInMillis; //$NON-NLS-1$ //$NON-NLS-2$
+    return userName + "\t" + jobName + "\t" + randomUuid; //$NON-NLS-1$ //$NON-NLS-2$
   }
 }

--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -240,10 +240,11 @@ public class QuartzScheduler implements IScheduler {
     } else {
       throw new SchedulerException( Messages.getInstance().getString( "QuartzScheduler.ERROR_0002_TRIGGER_WRONG_TYPE" ) ); //$NON-NLS-1$
     }
+    quartzTrigger.setMisfireInstruction( SimpleTrigger.MISFIRE_INSTRUCTION_FIRE_NOW );
     if ( quartzTrigger instanceof SimpleTrigger ) {
-      quartzTrigger.setMisfireInstruction( SimpleTrigger.MISFIRE_INSTRUCTION_RESCHEDULE_NEXT_WITH_REMAINING_COUNT );
-    } else {
-      quartzTrigger.setMisfireInstruction( SimpleTrigger.MISFIRE_INSTRUCTION_FIRE_NOW );
+      if ( ( (SimpleTrigger) quartzTrigger ).getRepeatCount() != 0 ) {
+        quartzTrigger.setMisfireInstruction( SimpleTrigger.MISFIRE_INSTRUCTION_RESCHEDULE_NEXT_WITH_REMAINING_COUNT );
+      }
     }
     return quartzTrigger;
   }
@@ -278,6 +279,7 @@ public class QuartzScheduler implements IScheduler {
     }
 
     QuartzJobKey jobId = new QuartzJobKey( jobName, curUser );
+    logger.debug( " QuartzScheduler has received a request to createJob with jobId " + jobId  );
 
     Trigger quartzTrigger = createQuartzTrigger( trigger, jobId );
 
@@ -314,6 +316,8 @@ public class QuartzScheduler implements IScheduler {
               .format(
                   "Scheduling job {0} with trigger {1} and job parameters [ {2} ]", jobId.toString(), trigger, prettyPrintMap( jobParams ) ) ); //$NON-NLS-1$
       scheduler.scheduleJob( jobDetail, quartzTrigger );
+
+      logger.debug( MessageFormat.format("Scheduled job {0} successfully", jobId.toString() ) ); //$NON-NLS-1$
     } catch ( org.quartz.SchedulerException e ) {
       throw new SchedulerException( Messages.getInstance().getString(
           "QuartzScheduler.ERROR_0001_FAILED_TO_SCHEDULE_JOB", jobName ), e ); //$NON-NLS-1$


### PR DESCRIPTION
1. Changed `QuartzJobKey` to use `randomUUID `instead of `currentTimeInMillis `to create unique QuartzJobKeys
2. Changed `QuartzScheduler` to add `MISFIRE_INSTRUCTION_FIRE_NOW` for `SimpleTrigger `with `repeatCount = 0`
3. Added more logs on `QuartzScheduler`

@pentaho/rogueone 