### PR TITLE
[BISERVER-13648] Double login after logout when viewing a report

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
@@ -23,7 +23,7 @@
     <constructor-arg>
       <util:list>
         <sec:filter-chain pattern="/webservices/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS" />
-        <sec:filter-chain pattern="/api/repos/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS,preFlightFilter" />
+        <sec:filter-chain pattern="/api/repos/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilter,filterInvocationInterceptorForWS,preFlightFilter" />
         <sec:filter-chain pattern="/api/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS" />
         <sec:filter-chain pattern="/plugin/reporting/api/jobs/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS,preFlightFilter" />
         <sec:filter-chain pattern="/plugin/**" filters="securityContextHolderAwareRequestFilterForWS,httpSessionPentahoSessionContextIntegrationFilter,httpSessionContextIntegrationFilter,basicProcessingFilter,requestParameterProcessingFilter,anonymousProcessingFilter,sessionMgmtFilter,exceptionTranslationFilterForWS,filterInvocationInterceptorForWS" />
@@ -60,7 +60,7 @@
 
 
   <bean id="basicProcessingFilterEntryPoint"
-        class="org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint">
+        class="org.pentaho.platform.web.http.security.PentahoBasicAuthenticationEntryPoint">
     <property name="realmName" value="Pentaho Realm" />
   </bean>
 

--- a/extensions/src/main/java/org/pentaho/platform/web/http/security/PentahoBasicAuthenticationEntryPoint.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/security/PentahoBasicAuthenticationEntryPoint.java
@@ -1,0 +1,60 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.web.http.security;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class PentahoBasicAuthenticationEntryPoint extends BasicAuthenticationEntryPoint implements
+  AuthenticationEntryPoint, InitializingBean {
+
+  public PentahoBasicAuthenticationEntryPoint() {
+  }
+
+  @Override
+  public void commence( HttpServletRequest request, HttpServletResponse response, AuthenticationException authException ) throws
+    IOException, ServletException {
+
+    // The BasicAuthenticationEntryPoint will send a WWW-Authenticate header and a 401 status code back to the browser,
+    // forcing the user to autenticate. If there is a session end cookie present, this will trigger a second authentication.
+    // In order to prevent a second authentication, we must clear the session end cookie before sending the 401 status code.
+    Cookie[] cookies = request.getCookies();
+
+    if ( cookies != null ) {
+      for ( Cookie c : cookies ) {
+        if ( c.getName().endsWith( "session-flushed" ) ) {
+          c.setMaxAge( 0 );
+          c.setPath( request.getContextPath() != null ? request.getContextPath() : "/" );
+          response.addCookie( c );
+        }
+      }
+    }
+    super.commence( request, response, authException );
+  }
+}


### PR DESCRIPTION
This PR fixes the double auth issue. For this we need the new `PentahoBasicAuthenticationEntryPoint` and we need to point the bean _basicProcessingFilterEntryPoint_ to this new class.

The change in line 26 changes the default behavior to redirect to the configured login page when an unauthenticated user tries to access a report, instead of using the browser's popup dialog. After a successful authentication, the user will e redirected back to the report.

@pmalves @pamval @mbatchelor @pedrofvteixeira 