### PR TITLE
[BACKLOG-22942] Changing java.util.UUID with Pentaho's UUIDUtil

### DIFF
--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzJobKey.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzJobKey.java
@@ -25,6 +25,7 @@ import java.text.MessageFormat;
 import org.apache.commons.lang.StringUtils;
 import org.pentaho.platform.api.scheduler2.SchedulerException;
 import org.pentaho.platform.scheduler2.messsages.Messages;
+import org.pentaho.platform.util.UUIDUtil;
 
 /**
  * This class is the key by which we identify a quartz job. It provides the means to create a new key or derive a key
@@ -57,7 +58,7 @@ public class QuartzJobKey {
     }
     userName = username;
     this.jobName = jobName;
-    randomUuid = java.util.UUID.randomUUID().toString();
+    randomUuid = UUIDUtil.getUUIDAsString();
   }
 
   private QuartzJobKey() {


### PR DESCRIPTION
Changed `QuartzJobKey` to use Pentaho platform's `UUIDUtil.getUUIDAsString()` instead of `java.util.UUID.randomUUID().toString()` to generate random uuids which is much faster and Pentaho platform has been using `UUIDUtil` ( which internally uses LGPL library - Jug ) for years now.


@pentaho/rogueone @mbatchelor 