### PR TITLE
[BISERVER-13893] In Firefox Quantum, with a new installation, when we…

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserSettingsResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserSettingsResource.java
@@ -93,10 +93,17 @@ public class UserSettingsResource extends AbstractJaxRSResource {
   @GET
   @Path( "{setting : .+}" )
   @Facet ( name = "Unsupported" )
+  @Produces( { APPLICATION_JSON, APPLICATION_XML } )
   public Response getUserSetting( @PathParam( "setting" ) String setting ) {
     IUserSettingService settingsService = getUserSettingService();
     IUserSetting userSetting = settingsService.getUserSetting( setting, null );
-    return Response.ok( userSetting != null ? userSetting.getSettingValue() : null ).build();
+
+    if ( userSetting != null && userSetting.getSettingValue() != null ) {
+      return Response.ok( userSetting.getSettingValue() ).build();
+    } else {
+      // this returns a 204 http status which will not trigger the jQuery JSON parser while still returning a success status
+      return Response.noContent().build();
+    }
   }
 
   /**
@@ -110,6 +117,7 @@ public class UserSettingsResource extends AbstractJaxRSResource {
   @POST
   @Path( "{setting : .+}" )
   @Facet ( name = "Unsupported" )
+  @Produces( { APPLICATION_JSON, APPLICATION_XML } )
   public Response setUserSetting( @PathParam( "setting" ) String setting, String settingValue ) {
     IUserSettingService settingsService = getUserSettingService();
 

--- a/user-console/src/main/resources/org/pentaho/mantle/public/home/js/favorites.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/home/js/favorites.js
@@ -131,8 +131,8 @@ define(["common-ui/util/PentahoSpinner", "common-ui/util/spin"], function (spinn
       $.ajax({
         url: that.getUrlBase() + that.serviceUrl + "?ts=" + now.getTime(),
 
-        success: function (result) {
-          callback(result)
+        success: function (result, status) {
+          callback(status == "nocontent" ? [] : result);
           if (that._contentRefreshed) {
             that._contentRefreshed();
           }


### PR DESCRIPTION
… open PUC or open a sample it gives the Console error 'XML Parsing Error: no root element found Location: http://localhost:8080/pentaho/api/user-settings/favorites'

- Updates `UserSettingsResource` to always set the content type header instead of leaving the browser to guess the type of the content in the payload. This is even more important when there is no content.
- Sets the correct HTTP status code when there is no content: **204** instead of **200**. Both represent success but the former will not trigger the JSON parser in jQuery and will trigger the success handler instead of the error one.

@kurtwalker @ricardosilva88 @cravobranco @pedrofvteixeira 