### PR TITLE
[BACKLOG-22672] Added utility method and new work item constants

### DIFF
--- a/core/src/main/java/org/pentaho/platform/workitem/WorkItemLifecycleEventUtil.java
+++ b/core/src/main/java/org/pentaho/platform/workitem/WorkItemLifecycleEventUtil.java
@@ -86,6 +86,25 @@ public class WorkItemLifecycleEventUtil {
     publish( workItemLifecycleEvent );
   }
 
+  /**
+   * A convenience method for publishing changes to the work item's lifecycles that creates an instance of {@link
+   * WorkItemLifecycleEvent} and calls the {@link #publish(IWorkItemLifecycleEvent)} method
+   *
+   * @param workItemUid            a {@link String} containing unique identifier for the {@link
+   *                               IWorkItemLifecycleEvent}
+   * @param details                a {@link String} containing details of the {@link IWorkItemLifecycleEvent}
+   * @param workItemLifecyclePhase a {@link WorkItemLifecyclePhase} representing the lifecycle event
+   * @param lifecycleDetails       a {@link String} containing lifecycle of the {@link IWorkItemLifecycleEvent}
+   */
+  public static void publish( final String workItemUid,
+                              final String details,
+                              final WorkItemLifecyclePhase workItemLifecyclePhase,
+                              final String lifecycleDetails ) {
+    final IWorkItemLifecycleEvent workItemLifecycleEvent = createEvent( workItemUid, details,
+      workItemLifecyclePhase, lifecycleDetails, null );
+    publish( workItemLifecycleEvent );
+  }
+
   protected static IWorkItemLifecycleEvent createEvent( final String workItemUid,
                                                         final String workItemDetails,
                                                         final WorkItemLifecyclePhase workItemLifecyclePhase,

--- a/core/src/main/java/org/pentaho/platform/workitem/WorkItemLifecyclePhase.java
+++ b/core/src/main/java/org/pentaho/platform/workitem/WorkItemLifecyclePhase.java
@@ -47,6 +47,14 @@ public enum WorkItemLifecyclePhase implements IWorkItemLifecyclePhase {
    */
   IN_PROGRESS,
   /**
+   * The work item execution is in progress
+   */
+  COMPLETED,
+  /**
+   * The work item execution is in progress
+   */
+  COMPLETED_WITH_ERRORS,
+  /**
    * The work item execution has succeeded
    */
   SUCCEEDED,


### PR DESCRIPTION
Added utility method on `WorkItemLifecycleEventUtil ` and new constants on `WorkItemLifecyclePhase` to support events posting from etl-execution plugin.

To be merged alongside https://github.com/pentaho/pentaho-ee/pull/1384

@pentaho/rogueone