### PR TITLE
[BISERVER-13893] In Firefox Quantum, with a new installation, when we…

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/UserRolesAdminPanelController.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/UserRolesAdminPanelController.java
@@ -236,7 +236,7 @@ public class UserRolesAdminPanelController extends UserRolesAdminPanel implement
         }
 
         public void onResponseReceived( Request request, Response response ) {
-          if ( response.getStatusCode() != Response.SC_OK ) {
+          if ( response.getStatusCode() != Response.SC_NO_CONTENT ) {
             showXulErrorMessage( Messages.getString( "changePasswordErrorTitle" ), Messages.getString( "changePasswordErrorMessage" ) );
             callback.serviceResult( false );
           } else {

--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/filepicklist/AbstractFilePickList.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/filepicklist/AbstractFilePickList.java
@@ -214,6 +214,7 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
 
     RequestBuilder builder = new RequestBuilder( RequestBuilder.POST, url );
     try {
+      builder.setHeader( "accept", "application/json" );
       builder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
       builder.sendRequest( toJson().toString(), new RequestCallback() {
 
@@ -246,7 +247,10 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
         }
 
         public void onResponseReceived( Request request, Response response ) {
-          if ( response.getStatusCode() == Response.SC_OK ) {
+          if( response.getStatusCode() == Response.SC_NO_CONTENT && FILE_PICK_ADD.equals( command ) ) {
+            filePickList = new ArrayList<T>();
+            add( filePickList.size(), pickListItem );
+          } else if ( response.getStatusCode() == Response.SC_OK ) {
             try {
               JSONArray jsonArr = ( JSONArray ) JSONParser.parse( response.getText() );
               filePickList = new ArrayList<T>();

--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/filepicklist/AbstractFilePickList.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/filepicklist/AbstractFilePickList.java
@@ -112,8 +112,7 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
   public void remove( T pickListItem ) {
     if ( pickListItem instanceof FavoritePickItem ) {
       reloadFavorites( pickListItem, FILE_PICK_REMOVE );
-    }
-    else if ( pickListItem instanceof RecentPickItem ) {
+    } else if ( pickListItem instanceof RecentPickItem ) {
       reloadRecents( pickListItem, FILE_PICK_REMOVE );
     }
   }
@@ -247,12 +246,12 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
         }
 
         public void onResponseReceived( Request request, Response response ) {
-          if( response.getStatusCode() == Response.SC_NO_CONTENT && FILE_PICK_ADD.equals( command ) ) {
+          if ( response.getStatusCode() == Response.SC_NO_CONTENT && FILE_PICK_ADD.equals( command ) ) {
             filePickList = new ArrayList<T>();
             add( filePickList.size(), pickListItem );
           } else if ( response.getStatusCode() == Response.SC_OK ) {
             try {
-              JSONArray jsonArr = ( JSONArray ) JSONParser.parse( response.getText() );
+              JSONArray jsonArr = (JSONArray) JSONParser.parse( response.getText() );
               filePickList = new ArrayList<T>();
               T filePickItem;
               for ( int i = 0; i < jsonArr.size(); i++ ) {
@@ -261,17 +260,14 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
               }
               if ( FILE_PICK_ADD.equals( command ) ) {
                 add( filePickList.size(), pickListItem );
-              }
-              else if ( FILE_PICK_REMOVE.equals( command ) ) {
+              } else if ( FILE_PICK_REMOVE.equals( command ) ) {
                 filePickList.remove( pickListItem );
                 fireItemsChangedEvent();
               }
-            }
-            catch( Exception e ) {
+            } catch ( Exception e ) {
               if ( FILE_PICK_ADD.equals( command ) ) {
                 add( filePickList.size(), pickListItem );
-              }
-              else if ( FILE_PICK_REMOVE.equals( command ) ) {
+              } else if ( FILE_PICK_REMOVE.equals( command ) ) {
                 filePickList.remove( pickListItem );
                 fireItemsChangedEvent();
               }
@@ -299,7 +295,7 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
         public void onResponseReceived( Request request, Response response ) {
           if ( response.getStatusCode() == Response.SC_OK ) {
             try {
-              JSONArray jsonArr = ( JSONArray ) JSONParser.parse( response.getText() );
+              JSONArray jsonArr = (JSONArray) JSONParser.parse( response.getText() );
               filePickList = new ArrayList<T>();
               T filePickItem;
               for ( int i = 0; i < jsonArr.size(); i++ ) {
@@ -310,8 +306,7 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
                 filePickList.remove( pickListItem );
                 fireItemsChangedEvent();
               }
-            }
-            catch( Exception e ) {
+            } catch ( Exception e ) {
               if ( FILE_PICK_REMOVE.equals( command ) ) {
                 filePickList.remove( pickListItem );
                 fireItemsChangedEvent();

--- a/user-console/src/main/resources/org/pentaho/mantle/public/home/js/favorites.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/home/js/favorites.js
@@ -196,7 +196,7 @@ define(["common-ui/util/PentahoSpinner", "common-ui/util/spin"], function (spinn
       var template = Handlebars.compile(this.template.html);
       if (items.length > 0) {
         try {
-          context[this.name] = JSON.parse(items);
+          context[this.name] = items;
           context.isEmpty = context[this.name].length == 0;
           this.currentItems = context[this.name];
           if (context.isEmpty) {


### PR DESCRIPTION
… open PUC or open a sample it gives the Console error 'XML Parsing Error: no root element found Location: http://localhost:8080/pentaho/api/user-settings/favorites'

Fixes regressions introduced with #4185 and #4186:
- Changing a user password in Administration perspective would present an error to the user even when the password was changed successfully because the return code is now 204 instead of 200
- Favorites and Recents widgets would never display any data
- Users could not add a file to favorites

@kurtwalker @cravobranco @ricardosilva88 @pedrofvteixeira 