### PR TITLE
[SP-4471] - Backport of BISERVER-13970 - CC and BCC fields on schedul…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/Emailer.java
+++ b/core/src/main/java/org/pentaho/platform/util/Emailer.java
@@ -66,22 +66,22 @@ public class Emailer {
   }
 
   public void setTo( String to ) {
-    to = to.replaceAll( ";", "," );
     if ( to != null && !"".equals( to ) ) {
+      to = to.replaceAll( ";", "," );
       props.put( "to", to );
     }
   }
 
   public void setCc( String cc ) {
-    cc = cc.replaceAll( ";", "," );
     if ( cc != null && !"".equals( cc ) ) {
+      cc = cc.replaceAll( ";", "," );
       props.put( "cc", cc );
     }
   }
 
   public void setBcc( String bcc ) {
-    bcc = bcc.replaceAll( ";", "," );
     if ( bcc != null && !"".equals( bcc ) ) {
+      bcc = bcc.replaceAll( ";", "," );
       props.put( "bcc", bcc );
     }
   }
@@ -160,6 +160,10 @@ public class Emailer {
 
   public String getEmailFromName() {
     return Messages.getInstance().getString( "emailFromName" ); //$NON-NLS-1$
+  }
+
+  public Properties getProperties() {
+    return props;
   }
 
   public boolean setup() {

--- a/core/src/test/java/org/pentaho/platform/util/EmailerTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/EmailerTest.java
@@ -1,0 +1,85 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class EmailerTest {
+
+  private Emailer emailer = new Emailer();
+
+  @Test
+  public void setTo_NullTest() {
+    emailer.setTo( null );
+    assertNull( emailer.getProperties().getProperty( "to" ) );
+  }
+
+  @Test
+  public void setTo_ValidTest() {
+    emailer.setTo( "to@domain.com" );
+    assertEquals( "to@domain.com", emailer.getProperties().getProperty( "to" ) );
+  }
+
+  @Test
+  public void setTo_ReplaceToCommaTest() {
+    emailer.setTo( "to@domain.com; another_to@domain.com" );
+    assertEquals( "to@domain.com, another_to@domain.com", emailer.getProperties().getProperty( "to" ) );
+  }
+
+  @Test
+  public void setCc_NullTest() {
+    emailer.setCc( null );
+    assertNull( emailer.getProperties().getProperty( "cc" ) );
+  }
+
+  @Test
+  public void setCc_Test() {
+    emailer.setCc( "cc@domain.com" );
+    assertEquals( "cc@domain.com", emailer.getProperties().getProperty( "cc" ) );
+  }
+
+  @Test
+  public void setCc_ReplaceToCommaTest() {
+    emailer.setCc( "cc@domain.com; another_cc@domain.com" );
+    assertEquals( "cc@domain.com, another_cc@domain.com", emailer.getProperties().getProperty( "cc" ) );
+  }
+
+  @Test
+  public void setBcc_NullTest() {
+    emailer.setBcc( null );
+    assertNull( emailer.getProperties().getProperty( "bcc" ) );
+  }
+
+  @Test
+  public void setBcc_ValidTest() {
+    emailer.setBcc( "bcc@domain.com" );
+    assertEquals( "bcc@domain.com", emailer.getProperties().getProperty( "bcc" ) );
+  }
+
+  @Test
+  public void setBcc_ReplaceToCommaTest() {
+    emailer.setBcc( "bcc@domain.com; another_bcc@domain.com" );
+    assertEquals( "bcc@domain.com, another_bcc@domain.com", emailer.getProperties().getProperty( "bcc" ) );
+  }
+}


### PR DESCRIPTION
…es are throwing NullPointerExceptions for imported schedules (8.1 Suite)

* Fixed NPE when Cc and Bcc fields don't exist during a schedule execution.

(cherry picked from commit 0e280bc9394fa80f68e1d79cf06c9cebde2a7ee0)
@pentaho-lmartins , @ricardosilva88 