### PR TITLE
[SP-4470] - Backport of BISERVER-13970 - CC and BCC fields on schedul…

### DIFF
--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/email/Emailer.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/email/Emailer.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.scheduler2.email;
@@ -64,22 +64,22 @@ public class Emailer {
   }
 
   public void setTo( String to ) {
-    to = to.replaceAll( ";", "," );
     if ( to != null && !"".equals( to ) ) {
+      to = to.replaceAll( ";", "," );
       props.put( "to", to );
     }
   }
 
   public void setCc( String cc ) {
-    cc = cc.replaceAll( ";", "," );
     if ( cc != null && !"".equals( cc ) ) {
+      cc = cc.replaceAll( ";", "," );
       props.put( "cc", cc );
     }
   }
 
   public void setBcc( String bcc ) {
-    bcc = bcc.replaceAll( ";", "," );
     if ( bcc != null && !"".equals( bcc ) ) {
+      bcc = bcc.replaceAll( ";", "," );
       props.put( "bcc", bcc );
     }
   }
@@ -154,6 +154,10 @@ public class Emailer {
 
   public void setBody( String body ) {
     props.put( "body", body );
+  }
+
+  public Properties getProperties() {
+    return props;
   }
 
   public boolean setup() {

--- a/scheduler/src/test/java/org/pentaho/platform/scheduler2/email/EmailerTest.java
+++ b/scheduler/src/test/java/org/pentaho/platform/scheduler2/email/EmailerTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.platform.scheduler2.email;
@@ -119,6 +119,60 @@ public class EmailerTest {
     final String bodyPartContent = (String) bodyPart.getContent();
     assertTrue( bodyPartContent.contains( "Shiny test string" ) );
     assertTrue( bodyPartContent.contains( body ) );
+  }
+
+  @Test
+  public void setTo_NullTest() {
+    emailer.setTo( null );
+    assertNull( emailer.getProperties().getProperty( "to" ) );
+  }
+
+  @Test
+  public void setTo_ValidTest() {
+    emailer.setTo( "to@domain.com" );
+    assertEquals( "to@domain.com", emailer.getProperties().getProperty( "to" ) );
+  }
+
+  @Test
+  public void setTo_ReplaceToCommaTest() {
+    emailer.setTo( "to@domain.com; another_to@domain.com" );
+    assertEquals( "to@domain.com, another_to@domain.com", emailer.getProperties().getProperty( "to" ) );
+  }
+
+  @Test
+  public void setCc_NullTest() {
+    emailer.setCc( null );
+    assertNull( emailer.getProperties().getProperty( "cc" ) );
+  }
+
+  @Test
+  public void setCc_Test() {
+    emailer.setCc( "cc@domain.com" );
+    assertEquals( "cc@domain.com", emailer.getProperties().getProperty( "cc" ) );
+  }
+
+  @Test
+  public void setCc_ReplaceToCommaTest() {
+    emailer.setCc( "cc@domain.com; another_cc@domain.com" );
+    assertEquals( "cc@domain.com, another_cc@domain.com", emailer.getProperties().getProperty( "cc" ) );
+  }
+
+  @Test
+  public void setBcc_NullTest() {
+    emailer.setBcc( null );
+    assertNull( emailer.getProperties().getProperty( "bcc" ) );
+  }
+
+  @Test
+  public void setBcc_ValidTest() {
+    emailer.setBcc( "bcc@domain.com" );
+    assertEquals( "bcc@domain.com", emailer.getProperties().getProperty( "bcc" ) );
+  }
+
+  @Test
+  public void setBcc_ReplaceToCommaTest() {
+    emailer.setBcc( "bcc@domain.com; another_bcc@domain.com" );
+    assertEquals( "bcc@domain.com, another_bcc@domain.com", emailer.getProperties().getProperty( "bcc" ) );
   }
 
 }


### PR DESCRIPTION
…es are throwing NullPointerExceptions for imported schedules (7.1 Suite)

* Backport of BISERVER-13970 - CC and BCC fields on schedules are throwing NullPointerExceptions for imported schedules (7.1 Suite)

@pentaho-lmartins , @ricardosilva88 
Note: There is a slight difference on EmailerTest class, it's ok because at this time it was only available in one package. (From 8.1 onwards a second package was created).