### PR TITLE
[BACKLOG-23730] As an admin I would like to have a user that could upload/download files using PUC outside of its home folder

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
+++ b/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
@@ -23,6 +23,13 @@
       If true, show hint about sample users. Ultimately, should replace login-show-users-list.
     -->
     <login-show-sample-users-hint>true</login-show-sample-users-hint>
+
+	  <!--
+	  The download-roles defines user/roles that have download action permissions. It accepts a comma-separated list of roles.
+	  System admins must change what are the users/roles that have permissions for download action. If not defined here,
+	  the default value is set to 'Administrator'.
+	  -->
+	  <download-roles>Administrator</download-roles>
         
     <!--
 	This is the URL to the user guide

--- a/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
+++ b/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
@@ -24,12 +24,12 @@
     -->
     <login-show-sample-users-hint>true</login-show-sample-users-hint>
 
-	  <!--
-	  The download-roles defines user/roles that have download action permissions. It accepts a comma-separated list of roles.
-	  System admins must change what are the users/roles that have permissions for download action. If not defined here,
-	  the default value is set to 'Administrator'.
-	  -->
-	  <download-roles>Administrator</download-roles>
+	<!--
+	The download-roles defines user/roles that have download action permissions. It accepts a comma-separated list of roles.
+	System admins must change what are the users/roles that have permissions for download action. If not defined here,
+	the default value is set to 'Administrator'.
+	-->
+	<download-roles>Administrator</download-roles>
         
     <!--
 	This is the URL to the user guide

--- a/core/src/main/java/org/pentaho/platform/engine/core/system/PentahoSystem.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/PentahoSystem.java
@@ -190,6 +190,11 @@ public class PentahoSystem {
   private static final List UnmodifiableACLFileExtensionList = UnmodifiableList
       .decorate( PentahoSystem.ACLFileExtensionList );
 
+  private static final List DownloadRolesList = new ArrayList();
+
+  private static final List UnmodifiableDownloadRolesList = UnmodifiableList
+    .decorate( PentahoSystem.DownloadRolesList );
+
   private static final List logoutListeners = Collections.synchronizedList( new ArrayList() );
 
   private static final IServerStatusProvider serverStatusProvider = IServerStatusProvider.LOCATOR.getProvider();
@@ -291,6 +296,19 @@ public class PentahoSystem {
           extn = "." + extn; //$NON-NLS-1$
         }
         PentahoSystem.ACLFileExtensionList.add( extn );
+      }
+
+      if ( debug ) {
+        Logger.debug( PentahoSystem.class, "Reading Download Roles from pentaho.xml" ); //$NON-NLS-1$
+      }
+      // Set up Download Roles by reading pentaho.xml for download-roles
+      //
+      // Read the roles that are permitted to download content from repository
+      //
+      String downloadRoles = PentahoSystem.getSystemSetting( "download-roles", "Administrator" ); //$NON-NLS-1$ //$NON-NLS-2$
+      st = new StringTokenizer( downloadRoles, "," ); //$NON-NLS-1$
+      while ( st.hasMoreElements() ) {
+        PentahoSystem.DownloadRolesList.add( st.nextToken() );
       }
     }
 
@@ -1275,6 +1293,10 @@ public class PentahoSystem {
 
   public static List getACLFileExtensionList() {
     return PentahoSystem.UnmodifiableACLFileExtensionList;
+  }
+
+  public static List getDownloadRolesList() {
+    return PentahoSystem.UnmodifiableDownloadRolesList;
   }
 
   // Stuff for the logout listener subsystem

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -67,6 +67,7 @@ import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.util.xml.XMLParserFactoryProducer;
 import org.pentaho.platform.web.http.api.resources.services.FileService;
 import org.pentaho.platform.web.http.api.resources.utils.FileUtils;
+import org.pentaho.platform.web.http.api.resources.utils.SystemUtils;
 import org.pentaho.platform.web.http.messages.Messages;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
@@ -2091,6 +2092,58 @@ public class FileResource extends AbstractJaxRSResource {
     return new FileVersioningConfiguration(
       repositoryVersionManager.isVersioningEnabled( path ),
       repositoryVersionManager.isVersionCommentEnabled( path ) );
+  }
+
+  /**
+   * Validates if a current user is authorized to download content from the given dir.
+   *
+   * <p><b>Example Request:</b><br />
+   *    GET pentaho/api/repo/files/canDownload
+   * </p>
+   *
+   * @param dirPath  to be validated for download action for the current user.
+   *
+   * @return A boolean response based on the current user being authorized to download within the system.
+   *
+   * <p><b>Example Response:</b></p>
+   * <pre function="syntax.xml">
+   *     false
+   * </pre>
+   */
+  @GET
+  @Path ( "/canDownload" )
+  @Produces ( { MediaType.TEXT_PLAIN } )
+  @StatusCodes ( {
+    @ResponseCode ( code = 200, condition = "Returns a boolean response." )
+  } )
+  public Response canDownload( @QueryParam ( "dirPath" ) @DefaultValue( "" ) String dirPath ) {
+    return Response.ok( ( String.valueOf( SystemUtils.canDownload( dirPath ) ) ) ).build();
+  }
+
+  /**
+   * Validates if a current user is authorized to upload content to the given dir
+   *
+   * <p><b>Example Request:</b><br />
+   *    GET pentaho/api/repo/files/canUpload
+   * </p>
+   *
+   * @param dirPath  to be validated for upload action for the current user.
+   *
+   * @return A boolean response based on the current user being authorized to upload to given dir
+   *
+   * <p><b>Example Response:</b></p>
+   * <pre function="syntax.xml">
+   *     false
+   * </pre>
+   */
+  @GET
+  @Path ( "/canUpload" )
+  @Produces ( { MediaType.TEXT_PLAIN } )
+  @StatusCodes ( {
+    @ResponseCode ( code = 200, condition = "Returns a boolean response." )
+  } )
+  public Response canUpload( @QueryParam ( "dirPath" ) @DefaultValue( "" ) String dirPath ) {
+    return Response.ok( ( String.valueOf( SystemUtils.canUpload( dirPath ) ) ) ).build();
   }
 
   protected boolean isPathValid( String path ) {

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryImportResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryImportResource.java
@@ -35,7 +35,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.codehaus.enunciate.Facet;
-import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.api.mimetype.IPlatformMimeResolver;
 import org.pentaho.platform.api.repository2.unified.IPlatformImportBundle;
@@ -46,16 +45,11 @@ import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
 import org.pentaho.platform.plugin.services.importer.RepositoryFileImportBundle;
 import org.pentaho.platform.plugin.services.importexport.IRepositoryImportLogger;
 import org.pentaho.platform.plugin.services.importexport.ImportSession;
-import org.pentaho.platform.repository2.unified.ServerRepositoryPaths;
-import org.pentaho.platform.repository2.unified.jcr.JcrTenantUtils;
-import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
-import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
-import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
-import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
 import org.pentaho.platform.web.http.api.resources.services.FileService;
 
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataParam;
+import org.pentaho.platform.web.http.api.resources.utils.SystemUtils;
 
 @Path ( "/repo/files/import" )
 public class RepositoryImportResource {
@@ -185,7 +179,7 @@ public class RepositoryImportResource {
     }
 
     try {
-      validateAccess( importDir );
+      validateImportAccess( importDir );
 
       boolean overwriteFileFlag = ( "false".equals( overwriteFile ) ? false : true );
       boolean overwriteAclSettingsFlag = ( "true".equals( overwriteAclPermissions ) ? true : false );
@@ -267,28 +261,9 @@ public class RepositoryImportResource {
     return Response.ok( responseBody, MediaType.TEXT_HTML ).build();
   }
 
-  protected void validateAccess( String importDir ) throws PentahoAccessControlException {
-    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
-    //check if we are admin or have publish permisson
-    boolean isAdmin = policy.isAllowed( RepositoryReadAction.NAME ) && policy.isAllowed( RepositoryCreateAction.NAME )
-                    && ( policy.isAllowed( AdministerSecurityAction.NAME ) || policy.isAllowed( PublishAction.NAME ) );
-    if ( !isAdmin ) {
-      //the user does not have admin or publish permisson, so we will check if the user imports to their home folder
-      boolean importingToHomeFolder = false;
-      String tenatedUserName = PentahoSessionHolder.getSession().getName();
-      //get user home home folder path
-      String userHomeFolderPath = ServerRepositoryPaths.getUserHomeFolderPath(
-          JcrTenantUtils.getUserNameUtils().getTenant( tenatedUserName ),
-            JcrTenantUtils.getUserNameUtils().getPrincipleName( tenatedUserName ) );
-      if ( userHomeFolderPath != null && userHomeFolderPath.length() > 0 ) {
-        //we pass the relative path so add serverside root folder for every home folder
-        importingToHomeFolder = ( ServerRepositoryPaths.getTenantRootFolderPath() + importDir )
-            .contains( userHomeFolderPath );
-      }
-      if ( !( importingToHomeFolder && policy.isAllowed( RepositoryCreateAction.NAME )
-          && policy.isAllowed( RepositoryReadAction.NAME ) ) ) {
-        throw new PentahoAccessControlException( "User is not authorized to perform this operation" );
-      }
+  protected void validateImportAccess( String importDir ) throws PentahoAccessControlException {
+    boolean canUpload = SystemUtils.canUpload( importDir );
+    if ( !canUpload ) {
+      throw new PentahoAccessControlException( "User is not authorized to perform this operation" );
     }
-  }
-}
+  } }

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/SystemUtils.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/SystemUtils.java
@@ -21,16 +21,89 @@
 package org.pentaho.platform.web.http.api.resources.utils;
 
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.engine.IUserRoleListService;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.repository2.unified.ServerRepositoryPaths;
+import org.pentaho.platform.repository2.unified.jcr.JcrTenantUtils;
 import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
+import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
 
+import java.util.Collections;
+import java.util.List;
+
 public class SystemUtils {
+
+  private static final Log logger = LogFactory.getLog( SystemUtils.class );
+
   public static boolean canAdminister() {
     IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
     return policy.isAllowed( RepositoryReadAction.NAME ) && policy.isAllowed( RepositoryCreateAction.NAME )
         && ( policy.isAllowed( AdministerSecurityAction.NAME ) );
   }
+
+  public static boolean canUpload( String uploadDir ) {
+    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
+
+    //check if we are admin or have publish permission
+    boolean isAdmin = policy.isAllowed( RepositoryReadAction.NAME ) && policy.isAllowed( RepositoryCreateAction.NAME )
+      && ( policy.isAllowed( AdministerSecurityAction.NAME ) || policy.isAllowed( PublishAction.NAME ) );
+
+    //the user does not have admin or publish permission, so we will check if the user imports to their home folder
+    if ( !isAdmin && !StringUtils.isEmpty( uploadDir ) ) {
+      return validateAccessToHomeFolder( uploadDir );
+    }
+
+    return isAdmin;
+  }
+
+  public static boolean canDownload( String downloadDir ) {
+    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
+
+    IUserRoleListService userRoleListService = PentahoSystem.get( IUserRoleListService.class );
+    String tenantedUserName = PentahoSessionHolder.getSession().getName();
+    List<String> tenantedUserRoles = userRoleListService.getRolesForUser( JcrTenantUtils.getUserNameUtils().getTenant( tenantedUserName ), tenantedUserName );
+
+    //check if we are admin or have download-roles
+    boolean isAdminOrHaveDownloadActionRole = policy.isAllowed( RepositoryReadAction.NAME )
+      && policy.isAllowed( RepositoryCreateAction.NAME )
+      && ( policy.isAllowed( AdministerSecurityAction.NAME )
+      || !Collections.disjoint( tenantedUserRoles, PentahoSystem.getDownloadRolesList() ) );
+
+    //the user does not have admin or download-roles assigned, so we will check if the user downloads from their home folder
+    if ( !isAdminOrHaveDownloadActionRole && !StringUtils.isEmpty( downloadDir ) ) {
+      return validateAccessToHomeFolder( downloadDir );
+    }
+
+    return isAdminOrHaveDownloadActionRole;
+  }
+
+  public static boolean validateAccessToHomeFolder( String dir ) {
+    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
+
+    boolean usingHomeFolder = false;
+    String tenantedUserName = PentahoSessionHolder.getSession().getName();
+    //get user home folder path
+    String userHomeFolderPath = ServerRepositoryPaths
+      .getUserHomeFolderPath( JcrTenantUtils.getUserNameUtils().getTenant( tenantedUserName ),
+        JcrTenantUtils.getUserNameUtils().getPrincipleName( tenantedUserName ) );
+    if ( userHomeFolderPath != null && userHomeFolderPath.length() > 0 ) {
+      //we pass the relative path so add serverside root folder for every home folder
+      usingHomeFolder = ( ServerRepositoryPaths.getTenantRootFolderPath() + dir )
+        .contains( userHomeFolderPath );
+    }
+    if ( !( usingHomeFolder && policy.isAllowed( RepositoryCreateAction.NAME )
+      && policy.isAllowed( RepositoryReadAction.NAME ) ) ) {
+      return false;
+    }
+
+    return true;
+  }
+
 }

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
@@ -79,6 +79,7 @@ import org.mockito.stubbing.Answer;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IPentahoObjectFactory;
 import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.IUserRoleListService;
 import org.pentaho.platform.api.engine.ObjectFactoryException;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
 import org.pentaho.platform.api.mt.ITenant;
@@ -179,6 +180,10 @@ public class FileServiceTest {
             return null;
         } } );
     PentahoSystem.registerObjectFactory( pentahoObjectFactory );
+
+    IUserRoleListService userRoleListService = mock( IUserRoleListService.class );
+    PentahoSystem.registerObject( userRoleListService );
+
     IPentahoSession session = mock( IPentahoSession.class );
     doReturn( "sampleSession" ).when( session ).getName();
     PentahoSessionHolder.setSession( session );
@@ -1099,6 +1104,9 @@ public class FileServiceTest {
 
     IAuthorizationPolicy mockAuthPolicy = mock( IAuthorizationPolicy.class );
 
+    /* register  mockAuthPolicy with PentahoSystem so SystemUtils can use it */
+    PentahoSystem.registerObject( mockAuthPolicy );
+
     when( mockAuthPolicy.isAllowed( anyString() ) ).thenReturn( true );
 
     BaseExportProcessor mockExportProcessor = mock( BaseExportProcessor.class );
@@ -1142,6 +1150,9 @@ public class FileServiceTest {
     doReturn( false ).when( mockAuthPolicy ).isAllowed( AdministerSecurityAction.NAME );
 
     doReturn( mockAuthPolicy ).when( fileService ).getPolicy();
+
+    /* register  mockAuthPolicy with PentahoSystem so SystemUtils can use it */
+    PentahoSystem.registerObject( mockAuthPolicy );
 
     // Test 1: in the home-folder
     try {
@@ -1196,6 +1207,9 @@ public class FileServiceTest {
     IAuthorizationPolicy mockAuthPolicy = mock( IAuthorizationPolicy.class );
     doReturn( false ).when( mockAuthPolicy ).isAllowed( anyString() );
     doReturn( mockAuthPolicy ).when( fileService ).getPolicy();
+
+    /* register  mockAuthPolicy with PentahoSystem so SystemUtils can use it */
+    PentahoSystem.registerObject( mockAuthPolicy );
 
     try {
       fileService.doGetFileOrDirAsDownload( "", "mock:path:fileName", "true" );

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/utils/SystemUtilsTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/utils/SystemUtilsTest.java
@@ -1,0 +1,185 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.web.http.api.resources.utils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.engine.IPentahoObjectFactory;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.IUserRoleListService;
+import org.pentaho.platform.api.engine.ObjectFactoryException;
+import org.pentaho.platform.api.mt.ITenant;
+import org.pentaho.platform.api.mt.ITenantedPrincipleNameResolver;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
+import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
+import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
+import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( FileUtils.class )
+public class SystemUtilsTest {
+
+
+  private static final String REAL_USER = "testUser";
+
+  private static final String IMPORT_DIR = "/home/" + REAL_USER;
+
+  private IPentahoObjectFactory pentahoObjectFactory;
+
+  private ITenantedPrincipleNameResolver resolver;
+
+  @Before
+  public void setUp() throws ObjectFactoryException {
+
+    PentahoSystem.init();
+    ITenant tenant = mock( ITenant.class );
+
+    resolver = mock( ITenantedPrincipleNameResolver.class );
+    doReturn( tenant ).when( resolver ).getTenant( anyString() );
+    doReturn( REAL_USER ).when( resolver ).getPrincipleName( anyString() );
+    pentahoObjectFactory = mock( IPentahoObjectFactory.class );
+    when( pentahoObjectFactory.objectDefined( anyString() ) ).thenReturn( true );
+    when( pentahoObjectFactory.get( this.anyClass(), anyString(), any( IPentahoSession.class ) ) ).thenAnswer(
+      new Answer<Object>() {
+        @Override
+        public Object answer( InvocationOnMock invocation ) throws Throwable {
+          if ( invocation.getArguments()[0].equals( ITenantedPrincipleNameResolver.class ) ) {
+            return resolver;
+          }
+          return null;
+        } } );
+
+    PentahoSystem.registerObjectFactory( pentahoObjectFactory );
+
+    IUserRoleListService userRoleListService = mock( IUserRoleListService.class );
+    PentahoSystem.registerObject( userRoleListService );
+
+    IPentahoSession session = mock( IPentahoSession.class );
+    doReturn( "sampleSession" ).when( session ).getName();
+    PentahoSessionHolder.setSession( session );
+  }
+
+  @After
+  public void tearDown() {
+    PentahoSystem.deregisterObjectFactory( pentahoObjectFactory );
+    PentahoSystem.shutdown();
+  }
+
+  @Test
+  public void testCanDownload() {
+    IAuthorizationPolicy mockAuthPolicy = mock( IAuthorizationPolicy.class );
+
+    /* register  mockAuthPolicy with PentahoSystem so SystemUtils can use it */
+    PentahoSystem.registerObject( mockAuthPolicy );
+
+    doReturn( true ).when( mockAuthPolicy ).isAllowed( RepositoryReadAction.NAME ); /* user has 'Read Content' */
+    doReturn( true ).when( mockAuthPolicy ).isAllowed( RepositoryCreateAction.NAME ); /* user has 'Create Content' */
+    /* non-admin user */
+    doReturn( false ).when( mockAuthPolicy ).isAllowed( AdministerSecurityAction.NAME );
+
+    // Test 1: empty folder specified, should not grant access
+    assertFalse( SystemUtils.canDownload( "" ) );
+
+    // Test 2: user gains administer security, should grant access
+    doReturn( true ).when( mockAuthPolicy ).isAllowed( AdministerSecurityAction.NAME );
+    assertTrue( SystemUtils.canDownload( "/mock/path" ) );
+
+    // Test 3: user loses administer security, neither does it have download roles nor it's on home folder shouldn't grant access
+    doReturn( false ).when( mockAuthPolicy ).isAllowed( AdministerSecurityAction.NAME );
+    assertFalse( SystemUtils.canDownload( "/mock/path" ) );
+
+    // Test 4: user loses administer security, neither does it have download roles but it's on home folder, so it should grant access
+    assertTrue( SystemUtils.canDownload( IMPORT_DIR ) );
+
+    // Test 5: user is on home folder but loses read content, should not grant access
+    doReturn( false ).when( mockAuthPolicy ).isAllowed( RepositoryReadAction.NAME );
+    assertFalse( SystemUtils.canDownload( IMPORT_DIR ) );
+
+  }
+
+  @Test
+  public void testCanUpload() {
+    IAuthorizationPolicy mockAuthPolicy = mock( IAuthorizationPolicy.class );
+
+    /* register  mockAuthPolicy with PentahoSystem so SystemUtils can use it */
+    PentahoSystem.registerObject( mockAuthPolicy );
+
+    doReturn( true ).when( mockAuthPolicy ).isAllowed( RepositoryReadAction.NAME ); /* user has 'Read Content' */
+    doReturn( true ).when( mockAuthPolicy ).isAllowed( RepositoryCreateAction.NAME ); /* user has 'Create Content' */
+    /* non-admin user */
+    doReturn( false ).when( mockAuthPolicy ).isAllowed( AdministerSecurityAction.NAME );
+    doReturn( false ).when( mockAuthPolicy ).isAllowed( PublishAction.NAME );
+
+    // Test 1: empty folder specified, should not grant access
+    assertFalse( SystemUtils.canUpload( "" ) );
+
+    // Test 2: user gains administer security, should grant access
+    doReturn( true ).when( mockAuthPolicy ).isAllowed( AdministerSecurityAction.NAME );
+    assertTrue( SystemUtils.canUpload( "/mock/path" ) );
+
+    // Test 3: user loses administer security, but has publish action, should grant access
+    doReturn( false ).when( mockAuthPolicy ).isAllowed( AdministerSecurityAction.NAME );
+    doReturn( true ).when( mockAuthPolicy ).isAllowed( PublishAction.NAME );
+    assertFalse( SystemUtils.canDownload( "/mock/path" ) );
+
+    // Test 4: user loses administer security, neither does it have publish content, but on ome folder, should grant access
+    assertTrue( SystemUtils.canDownload( IMPORT_DIR ) );
+
+    // Test 5: user is on home folder but loses read content, should not grant access
+    doReturn( false ).when( mockAuthPolicy ).isAllowed( RepositoryReadAction.NAME );
+    assertFalse( SystemUtils.canDownload( IMPORT_DIR ) );
+
+    // Test 5: user is on home folder but loses create content, should not grant access
+    doReturn( true ).when( mockAuthPolicy ).isAllowed( RepositoryReadAction.NAME );
+    doReturn( false ).when( mockAuthPolicy ).isAllowed( RepositoryCreateAction.NAME );
+    assertFalse( SystemUtils.canDownload( IMPORT_DIR ) );
+  }
+
+  private Class<?> anyClass() {
+    return argThat( new AnyClassMatcher() );
+  }
+
+  private class AnyClassMatcher extends ArgumentMatcher<Class<?>> {
+    @Override
+    public boolean matches( final Object arg ) {
+      return true;
+    }
+  }
+}

--- a/extensions/src/test/resources/SystemConfig/system/pentaho.xml
+++ b/extensions/src/test/resources/SystemConfig/system/pentaho.xml
@@ -19,6 +19,13 @@
   -->
   <login-show-sample-users-hint>true</login-show-sample-users-hint>
 
+	<!--
+	The download-roles defines user/roles that have download action permissions. It accepts a comma-separated list of roles.
+	System admins must change what are the users/roles that have permissions for download action. If not defined here,
+	the default value is set to 'Administrator'.
+	-->
+	<download-roles>Administrator</download-roles>
+
     <!--
 	This is the URL to the user guide
     -->

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/index.jsp
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/index.jsp
@@ -286,9 +286,11 @@
     }
   }
 
+  // With the fix BACKLOG-23730, server-side and client-side code uses centralized logic to check if user
+  // can download/upload content
   function checkDownload() {
     $.ajax({
-      url: CONTEXT_PATH + "api/authorization/action/isauthorized?authAction=org.pentaho.security.administerSecurity",
+      url: CONTEXT_PATH + "api/repo/files/canDownload?dirPath=",
       type: "GET",
       async: true,
       success: function (response) {
@@ -328,9 +330,11 @@
     });
   }
 
+  // With the fix BACKLOG-23730, server-side and client-side code uses centralized logic to check if user
+  // can download/upload content
   function checkPublish(canDownload, showHiddenFiles, showDescriptions) {
     $.ajax({
-      url: CONTEXT_PATH + "api/authorization/action/isauthorized?authAction=org.pentaho.security.administerSecurity",
+      url: CONTEXT_PATH + "api/repo/files/canDownload?dirPath=",
       type: "GET",
       async: true,
       success: function (response) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/index.jsp
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/index.jsp
@@ -290,7 +290,7 @@
   // can download/upload content
   function checkDownload() {
     $.ajax({
-      url: CONTEXT_PATH + "api/repo/files/canDownload?dirPath=",
+      url: CONTEXT_PATH + "api/repo/files/canDownload",
       type: "GET",
       async: true,
       success: function (response) {
@@ -334,7 +334,7 @@
   // can download/upload content
   function checkPublish(canDownload, showHiddenFiles, showDescriptions) {
     $.ajax({
-      url: CONTEXT_PATH + "api/repo/files/canDownload?dirPath=",
+      url: CONTEXT_PATH + "api/repo/files/canDownload",
       type: "GET",
       async: true,
       success: function (response) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -328,29 +328,22 @@ define([
 		var model = FileBrowser.fileBrowserModel; // trap model
 		var folderPath = Encoder.encodeRepositoryPath( _folderPath);
 
-		folderButtons.canDownload(this.get("canDownload"));
-        folderButtons.canPublish(this.get("canPublish"));
-        //Leaving this here...if UX decides they want the hiddenFileLabel style preserved when switching folders
-        //model.get('browserUtils').applyCutItemsStyle();
-
-        /*
-         * BACKLOG-7846: a non-admin user will be granted upload/download permissions when:
-         * 1) is located in his home folder
-         * 2) has 'Read Content' permission
-         * 3) has 'Create Content' permission
-         */
-        var inHomeFolder = ( folderPath == userHomePath ) || folderPath.indexOf( userHomePath ) > -1;
-        var canUploadAndDownload = this.get("canDownload") && this.get("canPublish");
-
-        if( !canUploadAndDownload && inHomeFolder ) {
-          var hasReadPermission = this.get("canRead");
-          var hasCreatePermission = this.get("canCreate")
-
-          if( hasReadPermission && hasCreatePermission ) {
-            folderButtons.canPublish(true); // enable upload button
-            folderButtons.canDownload(true); // enable download button
-          }
-        }
+    // With the fix BACKLOG-23730, server-side and client-side code uses centralized logic to check if user
+    // can download/upload content
+    // Ajax request to check if user can download/upload(publish)
+    $.ajax({
+      url: CONTEXT_PATH + "api/repo/files/canDownload?dirPath=" + _folderPath,
+      type: "GET",
+      async: true,
+      success: function (response) {
+        folderButtons.canDownload(response == "true");
+        folderButtons.canPublish(response == "true");
+      },
+      error: function (response) {
+        folderButtons.canDownload(false);
+        folderButtons.canPublish(false);
+      }
+    });
 
         //Ajax request to check write permissions for folder
       $.ajax({

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -328,7 +328,7 @@ define([
 		var model = FileBrowser.fileBrowserModel; // trap model
 		var folderPath = Encoder.encodeRepositoryPath( _folderPath);
 
-    // With the fix BACKLOG-23730, server-side and client-side code uses centralized logic to check if user
+    // With the fix for BACKLOG-23730, server-side and client-side code uses centralized logic to check if user
     // can download/upload content
     // Ajax request to check if user can download/upload(publish)
     $.ajax({
@@ -377,25 +377,6 @@ define([
       //TODO handle file button press
       var filePath = clickedFile.obj.attr("path");
       filePath = Encoder.encodeRepositoryPath(filePath);
-
-      /*
-       * BACKLOG-7846: a non-admin user will be granted upload/download permissions when:
-       * 1) is located in his home folder
-       * 2) has 'Read Content' permission
-       * 3) has 'Create Content' permission
-       */
-      var userHomePath = Encoder.encodeRepositoryPath( window.parent.HOME_FOLDER );
-      var inHomeFolder = filePath.indexOf( userHomePath ) > -1;
-      var canDownload = this.get("canDownload");
-
-      if( !canDownload && inHomeFolder ) {
-        var hasReadPermission = this.get("canRead");
-        var hasCreatePermission = this.get("canCreate")
-
-        if( hasReadPermission && hasCreatePermission ) {
-          fileButtons.canDownload(true); // enable download button
-        }
-      }
 
       //Ajax request to check write permissions for file
       $.ajax({


### PR DESCRIPTION
1. Created a new config property `download-roles` on `pentaho.xml`. This property holds a comma-separated list of roles that can download ( outside of their home folder ) content from repository
2. Added two end endpoints on `FileResource `- `/canUpload` and `/canDownload`
3. These endpoints now calls `SystemUtils` utility methods `canUpload` and `canDownload` and defer the decision of uploading/downloading content

Per this new logic, rules for

1. Downloading content:
If a user has permissions to "Read content" and "Create content", plus one of 2: "Administrator" OR "has a role listed on `<download-roles>`

2. Uploading content: ( no changes here )
If a user has permissions to "Read content" and "Create content", plus one of 2: "Administrator" OR "Publish Content"

@pentaho/rogueone