### PR TITLE
[BACKLOG-23730] As an admin I would like to have a user that could upload/download files using PUC outside of its home folder

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
@@ -102,35 +102,23 @@ define([
     canPublish: function (canPublish) {
       if (canPublish) {
         $('#uploadButton').show();
+        $('#optional-separator').show();
       }
       else {
         $('#uploadButton').hide();
+        $('#optional-separator').hide();
       }
-      if ((  $('#uploadButton').css('display') == "none" ) &&
-          (  $('#downloadButton').css('display') == "none" )) {
-        $('#optional-separator').hide()
-      }
-      else {
-        $('#optional-separator').show()
-      }
-
     },
 
     canDownload: function (canDownload) {
       if (canDownload) {
         $('#downloadButton').show();
+        $('#optional-separator').show();
       }
       else {
         $('#downloadButton').hide();
+        $('#optional-separator').hide();
       }
-      if ((  $('#uploadButton').css('display') == "none" ) &&
-          (  $('#downloadButton').css('display') == "none" )) {
-        $('#optional-separator').hide()
-      }
-      else {
-        $('#optional-separator').show()
-      }
-
     },
 
     updateFolderPermissionButtons: function (permissions, multiSelectItems, renameAllowed) {


### PR DESCRIPTION
JavaScript changes to properly display/hide file action separator on PUC when navigating the folder structure ( as upload/download permissions get changed ).

The script that is getting removed in this PR is related to displaying upload/download action separator that was used in conjunction with the logic to display/hide upload/download links. Since this logic is now getting done on server side, this additional logic to display/hide separator is not required on the client side.

@pentaho/rogueone 