### PR TITLE
[ANALYZER-3545] Unable to Define a Hyperlink to an Analyzer report sa…

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/GeneratorStreamingOutput.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/GeneratorStreamingOutput.java
@@ -280,7 +280,11 @@ public class GeneratorStreamingOutput {
     pathParams.setParameter( "httprequest", httpServletRequest ); //$NON-NLS-1$
     pathParams.setParameter( "remoteaddr", httpServletRequest.getRemoteAddr() ); //$NON-NLS-1$
     if ( file != null ) {
-      pathParams.setParameter( "path", URLEncoder.encode( file.getPath(), "UTF-8" ) ); //$NON-NLS-1$
+      if ( this.httpServletRequest.getParameter(  "filePath" )  != null ) {
+        pathParams.setParameter( "path", this.httpServletRequest.getParameter(  "filePath" ) );
+      } else {
+        pathParams.setParameter( "path", URLEncoder.encode( file.getPath(), "UTF-8" ) );
+      }
       pathParams.setParameter( "file", file ); //$NON-NLS-1$
     }
     if ( command != null ) {

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
@@ -189,6 +189,10 @@ public class RepositoryResource extends AbstractJaxRSResource {
       }
     }
 
+    if ( this.httpServletRequest.getParameter(  "filePath" )  != null ) {
+      contextId = this.httpServletRequest.getParameter(  "filePath" );
+    }
+
     return doService( contextId, resourceId );
   }
 
@@ -647,12 +651,18 @@ public class RepositoryResource extends AbstractJaxRSResource {
       PluginBeanException, IOException, URISyntaxException {
 
     ctxt( "Is [{0}] a repository file id?", contextId ); //$NON-NLS-1$
-    if ( contextId.startsWith( ":" ) || contextId.matches( "^[A-z]\t:.*" ) ) { //$NON-NLS-1$
+    if ( contextId.startsWith( ":" ) || contextId.matches( "^[A-z]\t:.*" ) || contextId.startsWith( "/" ) ) { //$NON-NLS-1$
       //
       // The context is a repository file (A)
       //
 
-      final RepositoryFile file = repository.getFile( FileResource.idToPath( contextId ) );
+      RepositoryFile file = null;
+      if ( contextId.startsWith( "/" ) ) {
+        file = repository.getFile( contextId );
+      } else {
+        file = repository.getFile( FileResource.idToPath( contextId ) );
+      }
+
       if ( file == null ) {
         logger.error( MessageFormat.format( "Repository file [{0}] not found", contextId ) );
         return Response.serverError().build();


### PR DESCRIPTION
…ved in a folder having a colon (:)

Previously, the link to ask for analysis report's parameters was something like:
http://localhost:8080/pentaho/api/repos/:public:Steel%20Wheels:Widget%20Library:Analysis%20Views:Country%20Orders:test.xanalyzer/parameter
In other words, the '/' characters of the file path were substituted by ':' characters. Thus, if the filename had a ':', it would represent an issue. To handle this, the correct file path was introduced in the request body.

Nevertheless, it would be a good idea to use a numerical file identifier instead of the file path in these cases.

More code: https://github.com/pentaho/pentaho-analyzer/pull/1841

@pamval @duarteteixeira
@pentaho-lmartins @ricardosilva88