### PR TITLE
[BACKLOG-25016] PUC File Action separators duplicated

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
@@ -102,22 +102,32 @@ define([
     canPublish: function (canPublish) {
       if (canPublish) {
         $('#uploadButton').show();
-        $('#optional-separator').show();
       }
       else {
         $('#uploadButton').hide();
-        $('#optional-separator').hide();
+      }
+      if ( ( $('#downloadButton').css('display') == "inline-block" ) ||
+          ( $('#uploadButton').css('display') == "inline-block" ) ) {
+        $('#optional-separator').show()
+      }
+      else {
+        $('#optional-separator').hide()
       }
     },
 
     canDownload: function (canDownload) {
       if (canDownload) {
         $('#downloadButton').show();
-        $('#optional-separator').show();
       }
       else {
         $('#downloadButton').hide();
-        $('#optional-separator').hide();
+      }
+      if ( ( $('#downloadButton').css('display') == "inline-block" ) ||
+          ( $('#uploadButton').css('display') == "inline-block" ) ) {
+        $('#optional-separator').show()
+      }
+      else {
+        $('#optional-separator').hide()
       }
     },
 


### PR DESCRIPTION
JavaScript changes to display/hide file action separator. 

Essentially this is a revert of PR https://github.com/pentaho/pentaho-platform/pull/4206 - here we're  explicitly checking for a condition whether upload/download buttons are being displayed rather than not being displayed, as sometimes these buttons ( and the css for them ) are `undefined` 

@pentaho/rogueone 