### PR TITLE
[BISERVER-13896] Issues with RepositoryResource endpoints in Pentaho …

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
@@ -126,6 +126,11 @@ public class RepositoryResource extends AbstractJaxRSResource {
     StringBuffer buffer = null;
     String url = null;
     String path = FileResource.idToPath( pathId );
+
+    if ( FileResource.getRepository().getFile( path ) == null ) {
+      return Response.status( Status.NOT_FOUND ).build();
+    }
+
     String extension = path.substring( path.lastIndexOf( '.' ) + 1 );
     IPluginManager pluginManager = PentahoSystem.get( IPluginManager.class, PentahoSessionHolder.getSession() );
     IContentInfo info = pluginManager.getContentTypeInfo( extension );

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/RepositoryResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/RepositoryResourceTest.java
@@ -1,0 +1,59 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( FileResource.class )
+public class RepositoryResourceTest {
+
+  private IUnifiedRepository repository = mock( IUnifiedRepository.class );
+
+  @Before
+  public void setup() {
+    mockStatic( FileResource.class );
+    when( FileResource.idToPath( anyString() ) ).thenCallRealMethod();
+    when( FileResource.getRepository() ).thenReturn( repository );
+  }
+
+  @Test
+  public void doExecuteDefaultNotFound() throws Exception {
+    doReturn( null ).when( repository ).getFile( "/home/admin/comments.wcdf" );
+    Response response = new RepositoryResource().doExecuteDefault( ":home:admin:comments.wcdf" );
+
+    assertEquals( Response.Status.NOT_FOUND.getStatusCode(), response.getStatus() );
+  }
+}


### PR DESCRIPTION
…REST API

Updates the method `doExecuteDefault` to return 404 when the requested file doesn't exist or is inaccessible to the logged on user. Because this method only cares about the file extension to know which plugin to call, it would never validate if the file actually existed.

The API documentation already specified this behavior so there is no need to update the documentation with this.

@pedrofvteixeira @pamval @mbatchelor 