### PR TITLE
[BACKLOG-22526] Use of vulnerable component spring-security 4.1.3 CVE…

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/SecuritySystemListener.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/SecuritySystemListener.java
@@ -20,24 +20,70 @@
 
 package org.pentaho.platform.plugin.services.security.userrole;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.IPentahoSystemListener;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
 
 /**
  * This listener ensures that the Authentication system has been loaded. Security must be started before the repository.
  */
 public class SecuritySystemListener implements IPentahoSystemListener {
 
+  private static final Log logger = LogFactory.getLog( SecuritySystemListener.class );
+
   @Override
   public boolean startup( IPentahoSession session ) {
     PentahoSystem.get( ProviderManager.class, "authenticationManager", session  );
+
+    changeFilterChainProxyHttpFirewall(); // BACKLOG-22526
+
     return true;
   }
 
   @Override
   public void shutdown() {
     // do nothing
+  }
+
+  /**
+   * https://jira.pentaho.com/browse/BACKLOG-22526
+   *
+   * StrictHttpFirewall was added and made the default HTTPFirewall for FilterChainProxy. As per its javadoc, it is meant
+   * to block requests that contains one of the following characters in the URL: period, forward slash, backslash, semicolon, percentage
+   *
+   * StrictHttpFirewall was added to address 3 different CVEs: CVE-2016-5007, CVE-2016-9879, CVE-2018-1199
+   *
+   * However, Pentaho's file/folder endpoint resources are passed as path params. And we do support file/folder names with the
+   * aforementioned characters. In light of this, we are setting a more lenient HttpFirewall for FilterChainProxy
+   *
+   * @link https://github.com/spring-projects/spring-security/blob/4.1.5.RELEASE/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
+   */
+  private void changeFilterChainProxyHttpFirewall() {
+
+    StrictHttpFirewall notSoStrictHttpFirewall = new StrictHttpFirewall();
+
+    notSoStrictHttpFirewall.setAllowSemicolon( true );
+    notSoStrictHttpFirewall.setAllowUrlEncodedPercent( true );
+    notSoStrictHttpFirewall.setAllowUrlEncodedPeriod( true );
+
+    try {
+
+      FilterChainProxy filterChainProxy = PentahoSystem.get( FilterChainProxy.class, "filterChainProxy", null );
+
+      if ( filterChainProxy != null ) {
+        logger.debug( "Changing FilterChainProxy's HttpFirewall to a more lenient one that allows for the passing "
+            + "of semicolons, periods, and percentages signs in the URL path" ); //$NON-NLS-1$
+
+        filterChainProxy.setFirewall( notSoStrictHttpFirewall );
+      }
+
+    } catch ( Throwable t ) {
+      logger.error( t );
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <edtftpj.version>2.1.0</edtftpj.version>
     <jzlib.version>1.0.7</jzlib.version>
     <org.apache.karaf.management.boot.version>3.0.3</org.apache.karaf.management.boot.version>
-    <spring.security.version>4.1.3.RELEASE</spring.security.version>
+    <spring.security.version>4.1.5.RELEASE</spring.security.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <junit.version>4.12</junit.version>
     <mockrunner.version>0.3.1</mockrunner.version>


### PR DESCRIPTION
…-2018-1199

**Minor patch upgrade**: from `4.1.3 RELEASE` to `4.1.5 RELEASE`
- In addition, `SecuritySystemListener` on bootup fetches the registered `FilterChainProxy` bean, and updates its declared `HTTPFirewall` class, making it more lenient when it comes to blocking semicolon, period and percentage signs.

@pentaho/rogueone
CC'ing @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅ 

List of PRs:
- https://github.com/pentaho/pentaho-platform/pull/4229
- https://github.com/pentaho/pentaho-osgi-bundles/pull/288
- https://github.com/pentaho/pentaho-platform-ee/pull/1276
- https://github.com/pentaho/pentaho-kettle/pull/5750
- https://github.com/pentaho/pentaho-reporting/pull/1179
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/115
- https://github.com/pentaho/pdi-ee-plugin/pull/361
- https://github.com/pentaho/pentaho-karaf-assembly/pull/478
- https://github.com/pentaho/pentaho-metadata-editor/pull/128
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/38
- https://github.com/pentaho/marketplace/pull/152