### PR TITLE
[BACKLOG-22526][CLEANUP] Promoting current spring-security.version to…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -300,7 +300,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-acl</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -324,7 +324,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-ldap</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -445,7 +445,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version> <!-- see maven-parent-pom -->
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -457,7 +457,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -469,12 +469,12 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-ldap</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,6 @@
     <edtftpj.version>2.1.0</edtftpj.version>
     <jzlib.version>1.0.7</jzlib.version>
     <org.apache.karaf.management.boot.version>3.0.3</org.apache.karaf.management.boot.version>
-    <spring.security.version>4.1.5.RELEASE</spring.security.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <junit.version>4.12</junit.version>
     <mockrunner.version>0.3.1</mockrunner.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -610,7 +610,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -621,7 +621,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>  <!-- see maven-parent-pom -->
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>


### PR DESCRIPTION
… maven-parent-pom

**Notes**
- This is not changing the current version
  - we are merely promoting it to maven-parent-pom as a cleanup + centralization effort
- Wingman **will** fail on these
  - the referenced dependency property version `spring-security.version` is not yet in play 
  - see related PR adding it to maven-parent-pom: https://github.com/pentaho/maven-parent-poms/pull/71

@pentaho/rogueone @pentaho-lmartins

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅

**List of PRs:**
- https://github.com/pentaho/maven-parent-poms/pull/71
- https://github.com/pentaho/marketplace/pull/153
- https://github.com/pentaho/pentaho-platform/pull/4231
- https://github.com/pentaho/pentaho-platform-ee/pull/1278
- https://github.com/pentaho/pentaho-kettle/pull/5752
- https://github.com/pentaho/pentaho-reporting/pull/1181
- https://github.com/pentaho/pdi-ee-plugin/pull/362
- https://github.com/pentaho/pentaho-osgi-bundles/pull/289
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/116
- https://github.com/pentaho/pentaho-metadata-editor/pull/130
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/40
