### PR TITLE
[SP-4653] Backport of PPP-4160 - Import-Export tool requires plain-te…

### DIFF
--- a/assemblies/pentaho-server/src/main/resources/biserver/import-export.bat
+++ b/assemblies/pentaho-server/src/main/resources/biserver/import-export.bat
@@ -1,6 +1,27 @@
 @echo off
+
+REM *******************************************************************************************
+REM This program is free software; you can redistribute it and/or modify it under the
+REM terms of the GNU General Public License, version 2 as published by the Free Software
+REM Foundation.
+REM
+REM You should have received a copy of the GNU General Public License along with this
+REM program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+REM or from the Free Software Foundation, Inc.,
+REM 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+REM
+REM This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+REM without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+REM See the GNU General Public License for more details.
+REM
+REM
+REM Copyright 2011 - 2018 Hitachi Vantara.  All rights reserved.
+REM *******************************************************************************************
+
 setlocal
 cd /D %~dp0
 call "%~dp0set-pentaho-env.bat"
 
-"%_PENTAHO_JAVA%" -Xmx2048m -XX:MaxPermSize=256m -Dfile.encoding=utf8 -classpath "%~dp0tomcat\webapps\pentaho\WEB-INF\lib\*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor %*
+SET DI_HOME="%~dp0pentaho-solutions\system\kettle"
+
+"%_PENTAHO_JAVA%" -Xmx2048m -XX:MaxPermSize=256m -Dfile.encoding=utf8 -DDI_HOME="%DI_HOME%" -classpath "%~dp0tomcat\webapps\pentaho\WEB-INF\lib\*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor %*

--- a/assemblies/pentaho-server/src/main/resources/biserver/import-export.sh
+++ b/assemblies/pentaho-server/src/main/resources/biserver/import-export.sh
@@ -1,4 +1,23 @@
 #!/bin/sh
+
+# *******************************************************************************************
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License, version 2 as published by the Free Software
+# Foundation.
+#
+# You should have received a copy of the GNU General Public License along with this
+# program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+# or from the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+#
+# Copyright 2011 - 2018 Hitachi Vantara.  All rights reserved.
+# ******************************************************************************************* 
+
 DIR_REL=`dirname $0`
 cd $DIR_REL
 DIR=`pwd`
@@ -7,6 +26,13 @@ DIR=`pwd`
 . "$DIR/set-pentaho-env.sh"
 setPentahoEnv
 
+### =========================================================== ###
+## Set a variable for DI_HOME (to be used as a system property)  ##
+## The plugin loading system for kettle needs this set to know   ##
+## where to load the plugins from                                ##
+### =========================================================== ###
+DI_HOME="$DIR"/pentaho-solutions/system/kettle
+
 # uses Java 6 classpath wildcards
 # quotes required around classpath to prevent shell expansion
-"$_PENTAHO_JAVA" -Xmx2048m -XX:MaxPermSize=256m -Dfile.encoding=utf8 -classpath "$DIR/tomcat/webapps/pentaho/WEB-INF/lib/*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor ${1+"$@"}
+"$_PENTAHO_JAVA" -Xmx2048m -XX:MaxPermSize=256m -Dfile.encoding=utf8 -DDI_HOME="$DI_HOME" -classpath "$DIR/tomcat/webapps/pentaho/WEB-INF/lib/*" org.pentaho.platform.plugin.services.importexport.CommandLineProcessor ${1+"$@"}

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessor.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessor.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2018 Pentaho Corporation.  All rights reserved.
+ * Copyright 2006 - 2018 Hitachi Vantara.  All rights reserved.
  */
 
 package org.pentaho.platform.plugin.services.importexport;
@@ -36,6 +36,7 @@ import javax.xml.ws.BindingProvider;
 import javax.xml.ws.Service;
 import javax.xml.ws.soap.SOAPBinding;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
@@ -45,7 +46,9 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.pentaho.di.core.encryption.KettleTwoWayPasswordEncoder;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.encryption.Encr;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.plugin.services.messages.Messages;
 import org.pentaho.platform.repository.RepositoryFilenameUtils;
@@ -307,7 +310,7 @@ public class CommandLineProcessor {
    * 
    * @throws ParseException
    */
-  private void performREST() throws ParseException, InitializationException {
+  private void performREST() throws ParseException, InitializationException, KettleException {
 
     String contextURL = getOptionValue( INFO_OPTION_URL_NAME, true, false );
     String path = getOptionValue( INFO_OPTION_PATH_NAME, true, false );
@@ -347,21 +350,30 @@ public class CommandLineProcessor {
     }
   }
 
+  @VisibleForTesting
+  String getUsername() throws ParseException {
+    return getOptionValue( INFO_OPTION_USERNAME_NAME, true, false );
+  }
+
+  @VisibleForTesting
+  String getPassword() throws ParseException, KettleException {
+    if ( !KettleClientEnvironment.isInitialized() ) {
+      KettleClientEnvironment.init();
+    }
+
+    return Encr.decryptPasswordOptionallyEncrypted( getOptionValue( INFO_OPTION_PASSWORD_NAME, true, false ) );
+  }
+
   /**
    * Used only for REST Jersey calls
    * 
    * @throws ParseException
    */
-  private void initRestService() throws ParseException, InitializationException {
-    // get information about the remote connection
-    String username = getOptionValue( INFO_OPTION_USERNAME_NAME, true, false );
-    String password = getOptionValue( INFO_OPTION_PASSWORD_NAME, true, false );
-    password = KettleTwoWayPasswordEncoder.decryptPasswordOptionallyEncrypted( password );
+  private void initRestService() throws ParseException, InitializationException, KettleException {
     ClientConfig clientConfig = new DefaultClientConfig();
     clientConfig.getFeatures().put( JSONConfiguration.FEATURE_POJO_MAPPING, Boolean.TRUE );
     client = Client.create( clientConfig );
-    client.addFilter( new HTTPBasicAuthFilter( username, password ) );
-
+    client.addFilter( new HTTPBasicAuthFilter( getUsername(), getPassword() ) );
   }
 
   /**
@@ -694,7 +706,7 @@ public class CommandLineProcessor {
    *           --logfile=c:/temp/steel-wheels.log --file-path=c:/temp/backup.zip
    * @throws java.io.IOException
    */
-  private void performBackup() throws ParseException, InitializationException, IOException {
+  private void performBackup() throws ParseException, InitializationException, IOException, KettleException {
     String contextURL = getOptionValue( INFO_OPTION_URL_NAME, true, false );
     String logFile = getOptionValue( INFO_OPTION_LOGFILE_NAME, false, true );
     String backupURL = contextURL + "/api/repo/files/backup";
@@ -802,7 +814,7 @@ public class CommandLineProcessor {
    *           --logfile=c:/temp/steel-wheels.log --withManifest=true
    * @throws java.io.IOException
    */
-  private void performExport() throws ParseException, IOException, InitializationException {
+  private void performExport() throws ParseException, IOException, InitializationException, KettleException {
     String contextURL = getOptionValue( INFO_OPTION_URL_NAME, true, false );
     String path = getOptionValue( INFO_OPTION_PATH_NAME, true, false );
     String withManifest = getOptionValue( INFO_OPTION_WITH_MANIFEST_NAME, false, true );
@@ -934,7 +946,7 @@ public class CommandLineProcessor {
    * <li>User must specify path to Jackrabbit files (i.e. system/jackrabbit).</li>
    * </ul>
    */
-  protected synchronized IUnifiedRepository getRepository() throws ParseException {
+  protected synchronized IUnifiedRepository getRepository() throws ParseException, KettleException {
     if ( repository != null ) {
       return repository;
     }
@@ -958,10 +970,8 @@ public class CommandLineProcessor {
     Service service = Service.create( url, new QName( NAMESPACE_URI, SERVICE_NAME ) );
     IUnifiedRepositoryJaxwsWebService port = service.getPort( IUnifiedRepositoryJaxwsWebService.class );
     // http basic authentication
-    ( (BindingProvider) port ).getRequestContext().put( BindingProvider.USERNAME_PROPERTY,
-        getOptionValue( INFO_OPTION_USERNAME_NAME, true, false ) );
-    ( (BindingProvider) port ).getRequestContext().put( BindingProvider.PASSWORD_PROPERTY,
-        getOptionValue( INFO_OPTION_PASSWORD_NAME, true, true ) );
+    ( (BindingProvider) port ).getRequestContext().put( BindingProvider.USERNAME_PROPERTY, getUsername() );
+    ( (BindingProvider) port ).getRequestContext().put( BindingProvider.PASSWORD_PROPERTY, getPassword() );
     // accept cookies to maintain session on server
     ( (BindingProvider) port ).getRequestContext().put( BindingProvider.SESSION_MAINTAIN_PROPERTY, true );
     // support streaming binary data

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorAESPasswordTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorAESPasswordTest.java
@@ -1,0 +1,74 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2018 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.importexport;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.encryption.Encr;
+import org.pentaho.di.core.encryption.KettleTwoWayPasswordEncoder;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.util.EnvUtil;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.reflect.Whitebox.getInternalState;
+
+/**
+ * @author Luis Martins
+ */
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( EnvUtil.class )
+public class CommandLineProcessorAESPasswordTest {
+
+  private static final String INFO_OPTION_USERNAME_NAME = "username";
+  private static final String INFO_OPTION_PASSWORD_NAME = "password";
+
+  @Before
+  public void setup() {
+    spy( EnvUtil.class );
+  }
+
+  @Test( expected = KettleException.class )
+  public void testInitRestServiceWithAESPassword() throws Exception {
+    when( EnvUtil.getSystemProperty( Const.KETTLE_PASSWORD_ENCODER_PLUGIN ) ).thenReturn( "AES" );
+
+    CommandLineProcessor cmd = mock( CommandLineProcessor.class );
+    doCallRealMethod().when( cmd ).getPassword();
+    doReturn( "AES PtdCGOdq6NMSvvjs5CCKIg==" ).when( cmd ).getOptionValue( INFO_OPTION_PASSWORD_NAME, true, false );
+
+    try {
+      cmd.getPassword();
+    } catch ( KettleException e ) {
+      assertEquals( "\nUnable to find plugin with ID 'AES'\n", e.getMessage() );
+      throw e;
+    }
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorPasswordTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorPasswordTest.java
@@ -1,0 +1,82 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2018 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.importexport;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.encryption.Encr;
+import org.pentaho.di.core.encryption.KettleTwoWayPasswordEncoder;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.util.EnvUtil;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.reflect.Whitebox.getInternalState;
+
+/**
+ * @author Luis Martins
+ */
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( EnvUtil.class )
+public class CommandLineProcessorPasswordTest {
+
+  private static final String INFO_OPTION_USERNAME_NAME = "username";
+  private static final String INFO_OPTION_PASSWORD_NAME = "password";
+
+  @Before
+  public void setup() {
+    spy( EnvUtil.class );
+  }
+
+  @Test
+  public void testGetUsername() throws Exception {
+    CommandLineProcessor cmd = mock( CommandLineProcessor.class );
+    doCallRealMethod().when( cmd ).getUsername();
+    doReturn( "admin" ).when( cmd ).getOptionValue( INFO_OPTION_USERNAME_NAME, true, false );
+
+    assertEquals( "admin", cmd.getUsername() );
+  }
+
+  /**
+   * {@link org.pentaho.di.core.encryption.Encr} will use {@link org.pentaho.di.core.encryption.KettleTwoWayPasswordEncoder} as default.
+   */
+  @Test
+  public void testInitRestServiceWithKettlePassword() throws Exception {
+    when( EnvUtil.getSystemProperty( Const.KETTLE_PASSWORD_ENCODER_PLUGIN ) ).thenReturn( null );
+
+    CommandLineProcessor cmd = mock( CommandLineProcessor.class );
+    doCallRealMethod().when( cmd ).getPassword();
+    doReturn( "Encrypted 2be98afc86aa7f2e4bb18bd63c99dbdde" ).when( cmd ).getOptionValue( INFO_OPTION_PASSWORD_NAME, true, false );
+
+    assertEquals( "password", cmd.getPassword() );
+    assertTrue( getInternalState( Encr.class, "encoder" ) instanceof KettleTwoWayPasswordEncoder );
+  }
+}


### PR DESCRIPTION
…xt password (7.1 Suite)

Cherry pick of #4237 to 7.1 branch.

Because `KettleClientEnvironment.reset()` doesn't exist in 7.1 and backporting it would require adding much more code just for the tests to run properly, a different approach was taken.

The tests for the different encryption types were split into different test suites so it isn't required to reset the Ketlle environment between each test.

@ssamora @bantonio82