### PR TITLE
[BACKLOG-26250] Not able to download a file with special characters

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -332,7 +332,7 @@ define([
     //
     // Ajax request to check if user can download
     $.ajax({
-      url: CONTEXT_PATH + "api/repo/files/canDownload?dirPath=" + _folderPath,
+      url: CONTEXT_PATH + "api/repo/files/canDownload?dirPath=" + encodeURIComponent( _folderPath ),
       type: "GET",
       async: true,
       success: function (response) {
@@ -345,7 +345,7 @@ define([
 
     // Ajax request to check if user can upload (a.k.a. publish)
     $.ajax({
-      url: CONTEXT_PATH + "api/repo/files/canUpload?dirPath=" + _folderPath,
+      url: CONTEXT_PATH + "api/repo/files/canUpload?dirPath=" + encodeURIComponent( _folderPath ),
       type: "GET",
       async: true,
       success: function (response) {


### PR DESCRIPTION
- `canUpload` / `canDownload` are GET methods and the path to file is sent as a request parameter
  - reserved chars such as `&` in the `dirPath` param were creating an incomplete/inconsistent value

@pentaho/rogueone please review