### PR TITLE
[SP-4728] - Backport of PDI-17664 - Inconsistent Time zone when alter…

### DIFF
--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -378,6 +378,14 @@ public class QuartzScheduler implements IScheduler {
         scheduler.addCalendar( jobId.toString(), triggerCalendar, true, true );
         quartzTrigger.setCalendarName( jobId.toString() );
       }
+
+      if ( quartzTrigger instanceof CronTrigger ) {
+        Serializable timezone = jobParams.get( "timezone" );
+        if ( timezone != null ) {
+          setTimezone( (CronTrigger) quartzTrigger, timezone.toString() );
+        }
+      }
+
       scheduler.rescheduleJob( jobId, jobKey.getUserName(), quartzTrigger );
       // if (triggerState != Trigger.STATE_PAUSED) {
       // scheduler.resumeTrigger(jobId, jobKey.getUserName());


### PR DESCRIPTION
…ing the scheduling of a job/transformation when server and client are in different time zones (7.1 Suite)

* Backport of PDI-17664 - Inconsistent Time zone when altering the scheduling of a job/transformation when server and client are in different time zones (7.1 Suite)

@smmribeiro , @LeonardoCoelho71950 