### PR TITLE
[BACKLOG-26593] - CLONE: Ability to Disable user folder creation under Home directory in PUC

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
@@ -11,3 +11,6 @@ enable-async-default-content-loading=true
 
 # Set to false to disable caching of domain information
 # enableDomainIdCache = false
+
+# Whether or not to hide the user home folder on user creation
+hideUserHomeFolderOnCreate=false

--- a/core/src/main/java/org/pentaho/platform/engine/core/system/PentahoSystem.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/PentahoSystem.java
@@ -199,6 +199,9 @@ public class PentahoSystem {
 
   private static final IServerStatusProvider serverStatusProvider = IServerStatusProvider.LOCATOR.getProvider();
 
+  public static final String HIDE_USER_HOME_FOLDER_ON_CREATION_PROPERTY =
+    "system.hideUserHomeFolderOnCreate";
+
   // TODO even if logging is not configured messages need to make it out to
   // the console
 

--- a/repository/src/main/java/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDao.java
+++ b/repository/src/main/java/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDao.java
@@ -34,6 +34,7 @@ import org.apache.jackrabbit.core.security.user.PentahoUserManagerImpl;
 import org.apache.jackrabbit.spi.Name;
 import org.apache.jackrabbit.spi.NameFactory;
 import org.apache.jackrabbit.spi.commons.name.NameFactoryImpl;
+import org.pentaho.platform.api.engine.ISystemConfig;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
 import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
@@ -841,9 +842,14 @@ public abstract class AbstractJcrBackedUserRoleDao implements IUserRoleDao {
           JcrRepositoryFileUtils.getFileByAbsolutePath( session, ServerRepositoryPaths.getUserHomeFolderPath(
               theTenant, username ), pathConversionHelper, lockHelper, false, null );
       if ( userHomeFolder == null ) {
+        RepositoryFile.Builder newFolder = new RepositoryFile.Builder( username ).folder( true );
+        String hidePropertyValue = PentahoSystem.get( ISystemConfig.class )
+          .getProperty( PentahoSystem.HIDE_USER_HOME_FOLDER_ON_CREATION_PROPERTY );
+        Boolean hideUserHomeFolder = hidePropertyValue != null && "true".equals( hidePropertyValue.toLowerCase() );
+        newFolder = newFolder.hidden( hideUserHomeFolder );
         userHomeFolder =
-            internalCreateFolder( session, tenantHomeFolder.getId(), new RepositoryFile.Builder( username ).folder(
-                true ).build(), aclsForUserHomeFolder.build(), "user home folder" ); //$NON-NLS-1$
+            internalCreateFolder( session, tenantHomeFolder.getId(), newFolder.build(),
+              aclsForUserHomeFolder.build(), "user home folder" ); //$NON-NLS-1$
       }
 
     }


### PR DESCRIPTION
It has been creaed a new property in the file system.properties, named "hideUserHomeFolderOnCreate", which by default it is set to "false". To activate the feature in this story, it is necessary to change it to "true" and restart the server.
When a new user is added/created (both through PUC interface or through Spoon interface), depending on the value of the above mentioned property, the user home folder is automatically hidden or not (hidden if the property's value is set to true, not if the property's value is set to false or any other value).