### PR TITLE
[PPP-4266] Use of Vulnerable Component commons-fileupload CVE-2016-1000031

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -108,7 +108,6 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>${commons-fileupload.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <urlrewrite.version>3.2.0</urlrewrite.version>
-    <commons-fileupload.version>1.3.2</commons-fileupload.version>
     <jsr305.version>1.3.9</jsr305.version>
     <aopalliance.version>1.0</aopalliance.version>
     <spring-binding.version>2.4.4.RELEASE</spring-binding.version>


### PR DESCRIPTION
* [PPP-4266] Removing version from main pom.xml file. Removing version reference from extensions\pom.xml. This will force the project to rely on the version/dependency from the maven-parent-poms project.

This is a series of PRs, please see pentaho/maven-parent-poms#83