### PR TITLE
[SP-4827] - Backport of PPP-4266 - Use of Vulnerable Component: commons-fileupload-1.3.2.jar (CVE-2016-1000031 | sonatype-2014-01730) (7.1 Suite)

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -115,7 +115,6 @@
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
-			<version>${commons-fileupload.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
   <commons-codec.version>1.9</commons-codec.version>
   <commons-collections.version>3.2.2</commons-collections.version>
   <commons-dbcp.version>1.4</commons-dbcp.version>
-  <commons-fileupload.version>1.3.2</commons-fileupload.version>
   <commons-httpclient.version>3.1</commons-httpclient.version>
   <commons-io.version>2.1</commons-io.version>
   <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
This is a series of PRs, please see: https://github.com/pentaho/maven-parent-poms/pull/86