### PR TITLE
Revert "[BISERVER-14087] Localized file/folder names are not shown in the Save As window"

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -934,44 +934,13 @@ public class FileResource extends AbstractJaxRSResource {
   @Path ( "{pathId : .+}/localeProperties" )
   @Produces ( { MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON } )
   @StatusCodes ( {
-      @ResponseCode ( code = 200, condition = "Updated locale properties, unable to rename File/Folder" ),
-      @ResponseCode ( code = 204, condition = "Successfully updated locale properties." ),
+      @ResponseCode ( code = 200, condition = "Successfully updated locale properties." ),
       @ResponseCode ( code = 500, condition = "Unable to update locale properties due to some other error." ) } )
   public Response doSetLocaleProperties( @PathParam ( "pathId" ) String pathId, @QueryParam ( "locale" ) String locale,
                                          List<StringKeyStringValueDto> properties ) {
-    boolean success = true;
-    String responseMsg = "";
     try {
-      /*
-       [BISERVER-14087] If one of the properties is to change the file/folder name, it is also necessary to run this command to
-       get the file's path to update as well. We need to remove it from the properties, because it can affect future
-       renames. We need to keep it consistent.
-      */
-      String[] pathSplit = pathId.split( ":" );
-      String originalFilename = pathSplit[ pathSplit.length - 1 ];
-      StringKeyStringValueDto fileTitle = null;
-      for ( StringKeyStringValueDto property : properties ) {
-        // Check to see if the file.title is listed here, it may be used to rename the file/folder
-        if ( property.getKey().equals( "file.title" ) ) {
-          // Check to see if the file title is different than the current file/folder, if it is, we need to move it.
-          // Setting up the response message now
-          responseMsg = Messages.getInstance().getString( "FileResource.FILE_RENAME_FAILED", originalFilename );
-          fileTitle = property;
-          // we need to remove this property, so that the filename and the path remain consistent.
-          properties.remove( fileTitle );
-          break;
-        }
-      }
       fileService.doSetLocaleProperties( pathId, locale, properties );
-      if ( fileTitle != null && !originalFilename.equals( fileTitle.getValue() ) ) {
-        success = fileService.doRename( pathId, fileTitle.getValue() );
-      }
-      // We use a similar response to doRename, the default here before was to just send an OK Response regardless.
-      if ( success ) {
-        return buildOkNoContentResponse();
-      } else {
-        return buildOkResponse( responseMsg );
-      }
+      return Response.ok().build();
     } catch ( Throwable t ) {
       return Response.serverError().entity( t.getMessage() ).build();
     }
@@ -2158,10 +2127,6 @@ public class FileResource extends AbstractJaxRSResource {
 
   protected Response buildOkResponse( String msg ) {
     return Response.ok( msg ).build();
-  }
-
-  protected Response buildOkNoContentResponse() {
-    return Response.noContent().build();
   }
 
   protected Response buildPlainTextOkResponse( String msg ) {

--- a/extensions/src/main/resources/org/pentaho/platform/web/http/messages/messages.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/web/http/messages/messages.properties
@@ -119,7 +119,6 @@ FileResource.EXPORT_FAILED=Export failed: {0}
 FileResource.DESTINATION_PATH_UNKNOWN=Destination path not found: {0}
 FileResource.FILE_NOT_FOUND=File not found: {0}
 FileResource.FILE_MOVE_FAILED=Move failed for path: {0}
-FileResource.FILE_RENAME_FAILED=Unable to rename File/Folder: {0}
 FileResource.FILE_MOVE_ACCESS_DENIED=Access denied while moving files: {0}
 FileResource.FILE_COPY_ACCESS_DENIED=Access denied while copying files: {0}
 FileResource.FILE_RESTORE_FAILED=Restore failed for path: {0}

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -76,13 +76,11 @@ import static org.mockito.Mockito.*;
 public class FileResourceTest {
   private static final String XML_EXTENSION = "xml";
   private static final String PATH_ID = "pathId.xml";
-  private static final String PATH_ID_WITHOUT_EXTENSION = "pathId";
+  private static final String PATH_ID_WITHOUTH_EXTENSION = "pathId";
   private static final String PATH_ID_INCORRECT_EXTENSION = "pathId.wrong";
   private static final String NAME_NEW_FILE = "nameNewFile.xml";
-  private static final String NAME_NEW_FILE_WITHOUT_EXTENSION = "nameNewFile";
+  private static final String NAME_NEW_FILE_WITHOUTH_EXTENSION = "nameNewFile";
   private static final String NAME_NEW_FILE_WRONG_EXTENSION = "nameNewFile.wrong";
-  private static final int HTTP_OK_CONTENT_STATUS = 200;
-  private static final int HTTP_OK_NO_CONTENT_STATUS = 204;
 
   private static final String FILE_ID = "444324fd54ghad";
   private FileResource fileResource;
@@ -281,7 +279,7 @@ public class FileResourceTest {
   @Test
   public void testCreateFileWithoutExtension() throws Exception {
     InputStream mockInputStream = mock( InputStream.class );
-    Response testResponse = fileResource.createFile( PATH_ID_WITHOUT_EXTENSION, mockInputStream );
+    Response testResponse = fileResource.createFile( PATH_ID_WITHOUTH_EXTENSION, mockInputStream );
     assertEquals( Status.INTERNAL_SERVER_ERROR.getStatusCode(), testResponse.getStatus() );
 
     verify( fileResource, times( 1 ) ).buildServerErrorResponse( anyString() );
@@ -1380,69 +1378,25 @@ public class FileResourceTest {
     doReturn( mockOkMsgResponse ).when( fileResource ).buildOkResponse( errMsg );
 
     // Test 1
-    doReturn( true ).when( fileResource.fileService ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUT_EXTENSION );
+    doReturn( true ).when( fileResource.fileService ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
 
-    Response testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WITHOUT_EXTENSION );
+    Response testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
     assertEquals( mockOkResponse, testResponse );
 
     // Test 2
-    doReturn( false ).when( fileResource.fileService ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUT_EXTENSION );
+    doReturn( false ).when( fileResource.fileService ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
 
-    testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WITHOUT_EXTENSION );
+    testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
     assertEquals( mockOkMsgResponse, testResponse );
 
-    verify( fileResource.fileService, times( 2 ) ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUT_EXTENSION );
+    verify( fileResource.fileService, times( 2 ) ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
     verify( fileResource, times( 1 ) ).buildOkResponse();
     verify( fileResource, times( 1 ) ).buildOkResponse( errMsg );
   }
 
   @Test
-  public void testDoSetLocaleProperties() throws Exception {
-    String locale = "locale";
-    String newName = "TestA.xml";
-    List<StringKeyStringValueDto> properties = new ArrayList<>();
-    properties.add( new StringKeyStringValueDto( "file.title", newName ) );
-    properties.add( new StringKeyStringValueDto( "file.description", "test description" ) );
-
-    doNothing().when( fileResource.fileService ).doSetLocaleProperties( PATH_ID, locale, properties );
-
-//    Response mockOkResponse = mock( Response.class );
-//    doReturn( mockOkResponse ).when( fileResource ).buildOkResponse();
-
-    String errMsg = "Unable to rename File/Folder: " + PATH_ID;
-
-    // Test 1 - File title exists and rename works
-    doReturn( true ).when( fileResource.fileService ).doRename( PATH_ID, newName );
-
-    Response testResponse = fileResource.doSetLocaleProperties( PATH_ID, locale, properties );
-    assertEquals( testResponse.getStatus(), HTTP_OK_NO_CONTENT_STATUS );
-
-    // Test 2 - no file title in the properties
-    properties = new ArrayList<>();
-    properties.add( new StringKeyStringValueDto( "file.description", "test description" ) );
-
-    testResponse = fileResource.doSetLocaleProperties( PATH_ID, locale, properties );
-    assertEquals( testResponse.getStatus(), HTTP_OK_NO_CONTENT_STATUS );
-
-    // Test 3 - File title exists, but rename fails.
-    properties = new ArrayList<>();
-    properties.add( new StringKeyStringValueDto( "file.title", newName ) );
-    properties.add( new StringKeyStringValueDto( "file.description", "test description" ) );
-    doReturn( false ).when( fileResource.fileService ).doRename( PATH_ID, newName );
-
-    testResponse = fileResource.doSetLocaleProperties( PATH_ID, locale, properties );
-    assertEquals( testResponse.getStatus(), HTTP_OK_CONTENT_STATUS );
-    assertEquals( testResponse.getEntity(), errMsg );
-
-    verify( fileResource.fileService, times( 3 ) ).doSetLocaleProperties( PATH_ID, locale, properties );
-    verify( fileResource.fileService, times( 2 ) ).doRename( PATH_ID, newName );
-    verify( fileResource, times( 2 ) ).buildOkNoContentResponse();
-    verify( fileResource, times( 1 ) ).buildOkResponse( errMsg );
-  }
-
-  @Test
   public void testDoRenameCorrectExtension() throws Exception {
-    Response testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WITHOUT_EXTENSION );
+    Response testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
     assertEquals( Status.OK.getStatusCode(), testResponse.getStatus() );
 
     verify( fileResource, times( 1 ) ).buildOkResponse( anyString() );
@@ -1451,7 +1405,7 @@ public class FileResourceTest {
   @Test
   public void testDoRenameError() throws Exception {
     Throwable mockThrowable = mock( RuntimeException.class );
-    doThrow( mockThrowable ).when( fileResource.fileService ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUT_EXTENSION );
+    doThrow( mockThrowable ).when( fileResource.fileService ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
 
     String msg = "msg";
     doReturn( msg ).when( mockThrowable ).getMessage();
@@ -1459,10 +1413,10 @@ public class FileResourceTest {
     Response mockResponse = mock( Response.class );
     doReturn( mockResponse ).when( fileResource ).buildServerErrorResponse( msg );
 
-    Response testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WITHOUT_EXTENSION );
+    Response testResponse = fileResource.doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
     assertEquals( mockResponse, testResponse );
 
-    verify( fileResource.fileService, times( 1 ) ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUT_EXTENSION );
+    verify( fileResource.fileService, times( 1 ) ).doRename( PATH_ID, NAME_NEW_FILE_WITHOUTH_EXTENSION );
     verify( mockThrowable, times( 1 ) ).getMessage();
     verify( fileResource, times( 1 ) ).buildServerErrorResponse( msg );
   }


### PR DESCRIPTION
Reverts pentaho/pentaho-platform#4329

A better solution to BISERVER-14087 is in PR https://github.com/pentaho/pentaho-commons-gwt-modules/pull/712