### PR TITLE
[PPP-4323] Use of Vulnerable Component: svgSalamander-1.0.jar (CVE-20…

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -29,7 +29,6 @@
     <slf4j.version>1.7.7</slf4j.version>
     <jackrabbit.version>2.14.2</jackrabbit.version>
     <jcommon-xml.version>1.0.12</jcommon-xml.version>
-    <svgSalamander.version>1.0</svgSalamander.version>
     <package.resources.directory>${basedir}/src/main/webapp</package.resources.directory>
     <replacer.version>1.5.2</replacer.version>
     <kafka-clients.version>0.10.2.1</kafka-clients.version>
@@ -988,11 +987,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>svgSalamander</groupId>
-      <artifactId>svgSalamander</artifactId>
-      <version>${svgSalamander.version}</version>
     </dependency>
     <dependency>
       <groupId>jcommon</groupId>


### PR DESCRIPTION
…17-5617)

I can't find any evidence that this artifact is still used. There are no references to it in our code and doesn't seem to be a transitive of a third party dependency. Removing and hoping for the best.

@graimundo @wseyler @ricardosilva88 @pentaho/tatooine 