### PR TITLE
[BACKLOG-27567] Fixes missing org.osgi.compendium-4.3.1.jar in the webapp assembly

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -585,6 +585,7 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>


### PR DESCRIPTION
@graimundo please review.