### PR TITLE
[BACKLOG-27567] - Added missing dependency to OSGi core. This is need…

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -505,6 +505,17 @@
       <version>${felix.http.version}</version>
       <scope>compile</scope>
     </dependency>
+    <!-- OSGi Dependencies -->
+    <!-- Because of: -->
+    <!-- pentaho-platform-core (PentahoSystem) and pdi-osgi-bridge-core (KarafLifecycleListener and OSGIPluginRegistryExtension) -->
+    <!-- Also, we are explicitly overriding OSGi core to 5.0.0 because of the org.osgi.framework.wiring.BundleWire.getProvider() method, -->
+    <!-- as Felix Framework 4.2.1 is partially OSGi 5.0 complaint. -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <version>5.0.0</version>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>


### PR DESCRIPTION
…ed as there are parts on the non OSGi part of the platform that are still coupled to OSGi.