### PR TITLE
[BACKLOG-27567] Remove org.osgi.core version override

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -508,12 +508,9 @@
     <!-- OSGi Dependencies -->
     <!-- Because of: -->
     <!-- pentaho-platform-core (PentahoSystem) and pdi-osgi-bridge-core (KarafLifecycleListener and OSGIPluginRegistryExtension) -->
-    <!-- Also, we are explicitly overriding OSGi core to 5.0.0 because of the org.osgi.framework.wiring.BundleWire.getProvider() method, -->
-    <!-- as Felix Framework 4.2.1 is partially OSGi 5.0 complaint. -->
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
-      <version>5.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Merge after https://github.com/pentaho/maven-parent-poms/pull/105.
@graimundo please review.