### PR TITLE
[BACKLOG-27577] Centralize karaf dependencies management

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -442,7 +442,6 @@
     <dependency>
       <groupId>org.apache.karaf</groupId>
       <artifactId>org.apache.karaf.main</artifactId>
-      <version>${org.apache.karaf.main.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -454,7 +453,6 @@
     <dependency>
       <groupId>org.apache.karaf.management</groupId>
       <artifactId>org.apache.karaf.management.boot</artifactId>
-      <version>${org.apache.karaf.management.boot.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -466,7 +464,6 @@
     <dependency>
       <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.boot</artifactId>
-      <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -478,7 +475,6 @@
     <dependency>
       <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.config</artifactId>
-      <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -490,7 +486,6 @@
     <dependency>
       <groupId>org.apache.karaf</groupId>
       <artifactId>org.apache.karaf.util</artifactId>
-      <version>${org.apache.karaf.main.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2209,19 +2209,16 @@
     <dependency>
       <groupId>org.apache.karaf</groupId>
       <artifactId>org.apache.karaf.main</artifactId>
-      <version>${org.apache.karaf.main.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.boot</artifactId>
-      <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.modules</artifactId>
-      <version>${org.apache.karaf.jaas.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
     <js.version>1.7R3</js.version>
     <wstx-asl.version>3.2.4</wstx-asl.version>
     <icu4j.version>54.1.1</icu4j.version>
-    <org.apache.karaf.main.version>3.0.3</org.apache.karaf.main.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <gdata-analytics-meta.version>2.1</gdata-analytics-meta.version>
     <syslog4j.version>0.9.46</syslog4j.version>
@@ -162,7 +161,6 @@
     <quartz-oracle.version>1.7.2</quartz-oracle.version>
     <edtftpj.version>2.1.0</edtftpj.version>
     <jzlib.version>1.0.7</jzlib.version>
-    <org.apache.karaf.management.boot.version>3.0.3</org.apache.karaf.management.boot.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <junit.version>4.12</junit.version>
     <mockrunner.version>0.3.1</mockrunner.version>
@@ -188,7 +186,6 @@
     <itext.version>2.1.7</itext.version>
     <mondrian.version>8.3.0.0-SNAPSHOT</mondrian.version>
     <mockito-all.version>1.10.19</mockito-all.version>
-    <org.apache.karaf.jaas.version>3.0.3</org.apache.karaf.jaas.version>
     <log4j.version>1.2.17</log4j.version>
     <wsdl4j-qname.version>1.6.1</wsdl4j-qname.version>
     <rome.version>1.0</rome.version>


### PR DESCRIPTION
@graimundo and @Pancho7 please review.

Note that this targets pentaho:karaf_update, so wingman will not run. Our build pipeline will, when all related PRs are merged.

Needs [pentaho/maven-parent-poms#107](https://github.com/pentaho/maven-parent-poms/pull/107).