### PR TITLE
[BISERVER-14120] Component tika-core 1.19.0 or earlier is vulnerable …

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -22,7 +22,7 @@
     <hibernate-ehcache.version>3.6.9.Final</hibernate-ehcache.version>
     <commons-io.version>2.2</commons-io.version>
     <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
-    <tika-core.version>1.15</tika-core.version>
+    <tika-core.version>1.19.1</tika-core.version>
     <xmlgraphics-commons.version>2.2</xmlgraphics-commons.version>
     <c3p0.version>0.9.1.2</c3p0.version>
     <xml-apis.version>2.0.2</xml-apis.version>


### PR DESCRIPTION
…to a number of CVEs

@pentaho/tatooine @pentaho-lmartins 