### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -25,7 +25,7 @@
     <tika-core.version>1.19.1</tika-core.version>
     <xmlgraphics-commons.version>2.2</xmlgraphics-commons.version>
     <c3p0.version>0.9.1.2</c3p0.version>
-    <xml-apis.version>2.0.2</xml-apis.version>
+    <slf4j.version>1.7.7</slf4j.version>
     <jackrabbit.version>2.14.2</jackrabbit.version>
     <jcommon-xml.version>1.0.12</jcommon-xml.version>
     <package.resources.directory>${basedir}/src/main/webapp</package.resources.directory>
@@ -910,7 +910,6 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>${xml-apis.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>

--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -25,7 +25,6 @@
     <tika-core.version>1.19.1</tika-core.version>
     <xmlgraphics-commons.version>2.2</xmlgraphics-commons.version>
     <c3p0.version>0.9.1.2</c3p0.version>
-    <slf4j.version>1.7.7</slf4j.version>
     <jackrabbit.version>2.14.2</jackrabbit.version>
     <jcommon-xml.version>1.0.12</jcommon-xml.version>
     <package.resources.directory>${basedir}/src/main/webapp</package.resources.directory>

--- a/build-utils/pom.xml
+++ b/build-utils/pom.xml
@@ -19,7 +19,6 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>${xercesImpl.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -134,7 +133,7 @@
                 <docletArtifact>
                   <groupId>xerces</groupId>
                   <artifactId>xercesImpl</artifactId>
-                  <version>${xercesImpl.version}</version>
+                  <version>${xercesImpl.version}</version><!-- Needed by the Javadoc plugin: maven-javadoc-plugin:2.10.4:javadoc failed: For artifact {xerces:xercesImpl:null:pom}: The version cannot be empty. -->
                 </docletArtifact>
               </docletArtifacts>
               <additionalparam>-output ${project.build.outputDirectory}/resourcedoc.xml</additionalparam>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
     <license.current.year>2018</license.current.year>
     <jboss-modules.version>1.4.3.Final</jboss-modules.version>
-    <xercesImpl.version>2.9.1</xercesImpl.version>
     <jsp-api.version>2.1</jsp-api.version>
     <castor.version>1.4.1</castor.version>
     <kfs.version>0.3</kfs.version>
@@ -112,7 +111,6 @@
     <jmock-junit4.version>2.5.1</jmock-junit4.version>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <xml-apis.version>1.3.04</xml-apis.version>
     <jetty-webapp.version>8.1.15.v20140411</jetty-webapp.version>
     <jmi.version>200507110943</jmi.version>
     <pentaho-concurrent.version>1.0.0</pentaho-concurrent.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -684,7 +684,6 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>${xml-apis.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 