### PR TITLE
[PDI-17667] Use of vulnerable component jetty 8.1.15, CVE-2017-9735, …

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2302,14 +2302,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util-ajax</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
-      <version>${jetty-webapp.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.mockrunner</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
     <jmock-junit4.version>2.5.1</jmock-junit4.version>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <jetty-webapp.version>8.1.15.v20140411</jetty-webapp.version>
     <jmi.version>200507110943</jmi.version>
     <pentaho-concurrent.version>1.0.0</pentaho-concurrent.version>
     <xmlunit.version>1.6</xmlunit.version>


### PR DESCRIPTION
…CVE-2017-7657 CVE-2015-2080

[PPP-4183] Use of Vulnerable Component: Multiple Jetty Components [Listed in Description] (CVE-2017-7656 | CVE-2017-7657 | CVE-2017-7658 | CVE-2015-2080 | CVE-2017-9735 )



Centralized Jetty components: use dependency management.
Added a new dependency.


Depends on pentaho/maven-parent-poms#121

@pentaho-lmartins @pentaho/tatooine
@graimundo @nantunes 