### PR TITLE
[BACKLOG-28357] Updates Apache Derby version to 10.15.1.3 (now in mav…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,6 @@
     <owasp.encoder.version>1.2</owasp.encoder.version>
     <powermock.version>1.6.3</powermock.version>
     <httpclient.version>4.5.3</httpclient.version>
-    <derby.version>10.5.3.0_1</derby.version>
     <ehcache-core.version>2.5.1</ehcache-core.version>
     <mockito-core.version>1.10.19</mockito-core.version>
     <apacheds.version>1.5.5</apacheds.version>


### PR DESCRIPTION
…en-parent-poms)

Removal of the Apache Derby version in favor of retrieving a unified version from the Maven parent POM. At the time of this PR, the latest version of Apache Derby is 10.15.1.3. Other PRs related to this one are listed below:
https://github.com/pentaho/maven-parent-poms/pull/122
https://github.com/pentaho/pentaho-platform/pull/4399
https://github.com/pentaho/pentaho-kettle/pull/6402
https://github.com/pentaho/pentaho-reporting/pull/1256
https://github.com/pentaho/data-access/pull/1053
