### PR TITLE
Revert "[BACKLOG-28357] Updates Apache Derby version to 10.15.1.3 (no…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
     <owasp.encoder.version>1.2</owasp.encoder.version>
     <powermock.version>1.6.3</powermock.version>
     <httpclient.version>4.5.3</httpclient.version>
+    <derby.version>10.5.3.0_1</derby.version>
     <ehcache-core.version>2.5.1</ehcache-core.version>
     <mockito-core.version>1.10.19</mockito-core.version>
     <apacheds.version>1.5.5</apacheds.version>


### PR DESCRIPTION
…w in maven-parent-poms) (#4399)"

This reverts commit 47ac6cd3ccec35a527e52f94b4244facb2b7eb5a.