### PR TITLE
[PDI-16770] Use of vulnerable component Apache xmlrpc 1.3.1 CVE-2016-…

### DIFF
--- a/assemblies/pentaho-solutions/pom.xml
+++ b/assemblies/pentaho-solutions/pom.xml
@@ -242,13 +242,6 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.pentaho.di.plugins</groupId>
-                  <artifactId>kettle-openerp-plugin</artifactId>
-                  <version>${project.version}</version>
-                  <type>zip</type>
-                  <outputDirectory>${prepared.kettle.plugins.directory}</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.pentaho.di.plugins</groupId>
                   <artifactId>kettle-palo-plugin</artifactId>
                   <version>${project.version}</version>
                   <type>zip</type>


### PR DESCRIPTION
…5002 CVE-2016-5003 CVE-2016-5004

Openerp Plugin removed from Kettle core plugins (1/3 PRs):
Also check:
https://github.com/pentaho/pentaho-kettle/pull/6425
https://github.com/pentaho/marketplace-metadata/pull/701

@pamval @pentaho-lmartins 
