### PR TITLE
[PRD-6031] Exporting a report in Excel via IE gives the filename as "content" instead of giving the prpt's name as filename

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/web/MimeHelper.java
+++ b/core/src/main/java/org/pentaho/platform/util/web/MimeHelper.java
@@ -25,67 +25,67 @@ import java.util.Map;
 
 public class MimeHelper {
 
-  public static final String MIMETYPE_RTF = "application/rtf"; //$NON-NLS-1$
-  public static final String RTF_EXTENSION = ".rtf"; //$NON-NLS-1$
-  public static final String MIMETYPE_MS_WORD = "application/msword"; //$NON-NLS-1$
-  public static final String MS_WORD_EXTENSION = ".doc"; //$NON-NLS-1$
-  public static final String MIMETYPE_PDF = "application/pdf"; //$NON-NLS-1$
-  public static final String PDF_EXTENSION = ".pdf"; //$NON-NLS-1$
-  public static final String MIMETYPE_MS_EXCEL = "application/vnd.ms-excel"; //$NON-NLS-1$
-  public static final String MS_EXCEL_EXTENSION = ".xls"; //$NON-NLS-1$
-  public static final String MIMETYPE_MS_PPT = "application/vnd.ms-powerpoint"; //$NON-NLS-1$
-  public static final String MS_PPT_EXTENSION = ".ppt"; //$NON-NLS-1$
-  public static final String MIMETYPE_MS_PROJECT = "application/vnd.ms-project"; //$NON-NLS-1$
-  public static final String MS_PROJECT_EXTENSION = ".mpp"; //$NON-NLS-1$
-  public static final String MIMETYPE_ZIP = "application/zip"; //$NON-NLS-1$
-  public static final String ZIP_EXTENSION = ".zip"; //$NON-NLS-1$
-  public static final String MIMETYPE_MP3 = "audio/mpeg"; //$NON-NLS-1$
-  public static final String MP3_EXTENSION = ".mp3"; //$NON-NLS-1$
-  public static final String MIMETYPE_WAV = "audio/x-wav"; //$NON-NLS-1$
-  public static final String WAV_EXTENSION = ".wav"; //$NON-NLS-1$
-  public static final String MIMETYPE_BMP = "image/bmp"; //$NON-NLS-1$
-  public static final String BMP_EXTENSION = ".bmp"; //$NON-NLS-1$
-  public static final String MIMETYPE_GIF = "image/gif"; //$NON-NLS-1$
-  public static final String GIF_EXTENSION = ".gif"; //$NON-NLS-1$
-  public static final String MIMETYPE_JPEG = "image/jpeg"; //$NON-NLS-1$
-  public static final String JPEG_EXTENSION_1 = ".jpg"; //$NON-NLS-1$
-  public static final String JPEG_EXTENSION_2 = ".jpe"; //$NON-NLS-1$
-  public static final String JPEG_EXTENSION_3 = ".jpeg"; //$NON-NLS-1$
-  public static final String MIMETYPE_PNG = "image/png"; //$NON-NLS-1$
-  public static final String PNG_EXTENSION = ".png"; //$NON-NLS-1$
-  public static final String MIMETYPE_SVG = "image/svg+xml"; //$NON-NLS-1$
-  public static final String SVG_EXTENSION = ".svg"; //$NON-NLS-1$
-  public static final String MIMETYPE_TIFF = "image/tiff"; //$NON-NLS-1$
-  public static final String TIFF_EXTENSION_1 = ".tif"; //$NON-NLS-1$
-  public static final String TIFF_EXTENSION_2 = ".tiff"; //$NON-NLS-1$
-  public static final String MIMETYPE_CSV = "text/csv"; //$NON-NLS-1$
-  public static final String CSV_EXTENSION = ".csv"; //$NON-NLS-1$
-  public static final String MIMETYPE_HTML = "text/html"; //$NON-NLS-1$
-  public static final String HTML_EXTENSION_1 = ".html"; //$NON-NLS-1$
-  public static final String HTML_EXTENSION_2 = ".htm"; //$NON-NLS-1$
-  public static final String MIMETYPE_TEXT = "text/plain"; //$NON-NLS-1$
-  public static final String TEXT_EXTENSION = ".txt"; //$NON-NLS-1$
-  public static final String PROPERTIES_EXTENSION = ".properties"; //$NON-NLS-1$
-  public static final String MIMETYPE_MPG = "video/mpeg"; //$NON-NLS-1$
-  public static final String MPG_EXTENSION_1 = ".mpg"; //$NON-NLS-1$
-  public static final String MPG_EXTENSION_2 = ".mpe"; //$NON-NLS-1$
-  public static final String MPG_EXTENSION_3 = ".mpeg"; //$NON-NLS-1$
-  public static final String MIMETYPE_AVI = "video/x-msvideo"; //$NON-NLS-1$
-  public static final String AVI_EXTENSION = ".avi"; //$NON-NLS-1$
-  public static final String MIMETYPE_XACTION = "text/xaction+xml"; //$NON-NLS-1$
-  public static final String XACTION_EXTENSION = ".xaction"; //$NON-NLS-1$
-  public static final String MIMETYPE_CSS = "text/css"; //$NON-NLS-1$
-  public static final String CSS_EXTENSION = ".css"; //$NON-NLS-1$
-  public static final String MIMETYPE_JS = "text/javascript"; //$NON-NLS-1$
-  public static final String JS_EXTENSION = ".js"; //$NON-NLS-1$
-  public static final String MIMETYPE_XML = "text/xml"; //$NON-NLS-1$
-  public static final String XML_EXTENSION = ".xml"; //$NON-NLS-1$
-  public static final String MIMETYPE_FLASH = "application/x-shockwave-flash"; //$NON-NLS-1$
-  public static final String FLASH_EXTENSION = ".swf"; //$NON-NLS-1$
-  public static final String MIMETYPE_MS_EXCEL_2007 = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"; //$NON-NLS-1$
-  public static final String MS_EXCEL_2007_EXTENSION = ".xlsx"; //$NON-NLS-1$
-  public static final String MIMETYPE_EMAIL_MSG = "mime-message/text/html"; //$NON-NLS-1$
-  public static final String EMAIL_MSG_EXTENSION = ".eml"; //$NON-NLS-1$
+  public static final String MIMETYPE_RTF = "application/rtf";
+  public static final String RTF_EXTENSION = ".rtf";
+  public static final String MIMETYPE_MS_WORD = "application/msword";
+  public static final String MS_WORD_EXTENSION = ".doc";
+  public static final String MIMETYPE_PDF = "application/pdf";
+  public static final String PDF_EXTENSION = ".pdf";
+  public static final String MIMETYPE_MS_EXCEL = "application/vnd.ms-excel";
+  public static final String MS_EXCEL_EXTENSION = ".xls";
+  public static final String MIMETYPE_MS_PPT = "application/vnd.ms-powerpoint";
+  public static final String MS_PPT_EXTENSION = ".ppt";
+  public static final String MIMETYPE_MS_PROJECT = "application/vnd.ms-project";
+  public static final String MS_PROJECT_EXTENSION = ".mpp";
+  public static final String MIMETYPE_ZIP = "application/zip";
+  public static final String ZIP_EXTENSION = ".zip";
+  public static final String MIMETYPE_MP3 = "audio/mpeg";
+  public static final String MP3_EXTENSION = ".mp3";
+  public static final String MIMETYPE_WAV = "audio/x-wav";
+  public static final String WAV_EXTENSION = ".wav";
+  public static final String MIMETYPE_BMP = "image/bmp";
+  public static final String BMP_EXTENSION = ".bmp";
+  public static final String MIMETYPE_GIF = "image/gif";
+  public static final String GIF_EXTENSION = ".gif";
+  public static final String MIMETYPE_JPEG = "image/jpeg";
+  public static final String JPEG_EXTENSION_1 = ".jpg";
+  public static final String JPEG_EXTENSION_2 = ".jpe";
+  public static final String JPEG_EXTENSION_3 = ".jpeg";
+  public static final String MIMETYPE_PNG = "image/png";
+  public static final String PNG_EXTENSION = ".png";
+  public static final String MIMETYPE_SVG = "image/svg+xml";
+  public static final String SVG_EXTENSION = ".svg";
+  public static final String MIMETYPE_TIFF = "image/tiff";
+  public static final String TIFF_EXTENSION_1 = ".tif";
+  public static final String TIFF_EXTENSION_2 = ".tiff";
+  public static final String MIMETYPE_CSV = "text/csv";
+  public static final String CSV_EXTENSION = ".csv";
+  public static final String MIMETYPE_HTML = "text/html";
+  public static final String HTML_EXTENSION_1 = ".html";
+  public static final String HTML_EXTENSION_2 = ".htm";
+  public static final String MIMETYPE_TEXT = "text/plain";
+  public static final String TEXT_EXTENSION = ".txt";
+  public static final String PROPERTIES_EXTENSION = ".properties";
+  public static final String MIMETYPE_MPG = "video/mpeg";
+  public static final String MPG_EXTENSION_1 = ".mpg";
+  public static final String MPG_EXTENSION_2 = ".mpe";
+  public static final String MPG_EXTENSION_3 = ".mpeg";
+  public static final String MIMETYPE_AVI = "video/x-msvideo";
+  public static final String AVI_EXTENSION = ".avi";
+  public static final String MIMETYPE_XACTION = "text/xaction+xml";
+  public static final String XACTION_EXTENSION = ".xaction";
+  public static final String MIMETYPE_CSS = "text/css";
+  public static final String CSS_EXTENSION = ".css";
+  public static final String MIMETYPE_JS = "text/javascript";
+  public static final String JS_EXTENSION = ".js";
+  public static final String MIMETYPE_XML = "text/xml";
+  public static final String XML_EXTENSION = ".xml";
+  public static final String MIMETYPE_FLASH = "application/x-shockwave-flash";
+  public static final String FLASH_EXTENSION = ".swf";
+  public static final String MIMETYPE_MS_EXCEL_2007 = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+  public static final String MS_EXCEL_2007_EXTENSION = ".xlsx";
+  public static final String MIMETYPE_EMAIL_MSG = "mime-message/text/html";
+  public static final String EMAIL_MSG_EXTENSION = ".eml";
 
   private static final String UTF_CHARACTER_ENCODING = "UTF-8";
   private static final Map<String, String> mimes = new HashMap<String, String>();
@@ -93,7 +93,6 @@ public class MimeHelper {
   private static final Map<String, String> defaultCharset = new HashMap<String, String>();
 
   static {
-
     MimeHelper.mimes.put( MIMETYPE_RTF, RTF_EXTENSION );
     MimeHelper.mimes.put( MIMETYPE_MS_WORD, MS_WORD_EXTENSION );
     MimeHelper.mimes.put( MIMETYPE_PDF, PDF_EXTENSION );
@@ -159,7 +158,6 @@ public class MimeHelper {
 
     MimeHelper.defaultCharset.put( MIMETYPE_HTML, UTF_CHARACTER_ENCODING );
     MimeHelper.defaultCharset.put( MIMETYPE_TEXT, UTF_CHARACTER_ENCODING );
-
   }
 
   public static String getExtension( final String mimeType ) {
@@ -181,5 +179,4 @@ public class MimeHelper {
   public static String getDefaultCharset( final String mimeType ) {
     return MimeHelper.defaultCharset.get( mimeType );
   }
-
 }

--- a/core/src/main/java/org/pentaho/platform/util/web/MimeHelper.java
+++ b/core/src/main/java/org/pentaho/platform/util/web/MimeHelper.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -25,81 +25,140 @@ import java.util.Map;
 
 public class MimeHelper {
 
-  public static String MIMETYPE_XACTION = "text/xaction+xml"; //$NON-NLS-1$
+  public static final String MIMETYPE_RTF = "application/rtf"; //$NON-NLS-1$
+  public static final String RTF_EXTENSION = ".rtf"; //$NON-NLS-1$
+  public static final String MIMETYPE_MS_WORD = "application/msword"; //$NON-NLS-1$
+  public static final String MS_WORD_EXTENSION = ".doc"; //$NON-NLS-1$
+  public static final String MIMETYPE_PDF = "application/pdf"; //$NON-NLS-1$
+  public static final String PDF_EXTENSION = ".pdf"; //$NON-NLS-1$
+  public static final String MIMETYPE_MS_EXCEL = "application/vnd.ms-excel"; //$NON-NLS-1$
+  public static final String MS_EXCEL_EXTENSION = ".xls"; //$NON-NLS-1$
+  public static final String MIMETYPE_MS_PPT = "application/vnd.ms-powerpoint"; //$NON-NLS-1$
+  public static final String MS_PPT_EXTENSION = ".ppt"; //$NON-NLS-1$
+  public static final String MIMETYPE_MS_PROJECT = "application/vnd.ms-project"; //$NON-NLS-1$
+  public static final String MS_PROJECT_EXTENSION = ".mpp"; //$NON-NLS-1$
+  public static final String MIMETYPE_ZIP = "application/zip"; //$NON-NLS-1$
+  public static final String ZIP_EXTENSION = ".zip"; //$NON-NLS-1$
+  public static final String MIMETYPE_MP3 = "audio/mpeg"; //$NON-NLS-1$
+  public static final String MP3_EXTENSION = ".mp3"; //$NON-NLS-1$
+  public static final String MIMETYPE_WAV = "audio/x-wav"; //$NON-NLS-1$
+  public static final String WAV_EXTENSION = ".wav"; //$NON-NLS-1$
+  public static final String MIMETYPE_BMP = "image/bmp"; //$NON-NLS-1$
+  public static final String BMP_EXTENSION = ".bmp"; //$NON-NLS-1$
+  public static final String MIMETYPE_GIF = "image/gif"; //$NON-NLS-1$
+  public static final String GIF_EXTENSION = ".gif"; //$NON-NLS-1$
+  public static final String MIMETYPE_JPEG = "image/jpeg"; //$NON-NLS-1$
+  public static final String JPEG_EXTENSION_1 = ".jpg"; //$NON-NLS-1$
+  public static final String JPEG_EXTENSION_2 = ".jpe"; //$NON-NLS-1$
+  public static final String JPEG_EXTENSION_3 = ".jpeg"; //$NON-NLS-1$
+  public static final String MIMETYPE_PNG = "image/png"; //$NON-NLS-1$
+  public static final String PNG_EXTENSION = ".png"; //$NON-NLS-1$
+  public static final String MIMETYPE_SVG = "image/svg+xml"; //$NON-NLS-1$
+  public static final String SVG_EXTENSION = ".svg"; //$NON-NLS-1$
+  public static final String MIMETYPE_TIFF = "image/tiff"; //$NON-NLS-1$
+  public static final String TIFF_EXTENSION_1 = ".tif"; //$NON-NLS-1$
+  public static final String TIFF_EXTENSION_2 = ".tiff"; //$NON-NLS-1$
+  public static final String MIMETYPE_CSV = "text/csv"; //$NON-NLS-1$
+  public static final String CSV_EXTENSION = ".csv"; //$NON-NLS-1$
+  public static final String MIMETYPE_HTML = "text/html"; //$NON-NLS-1$
+  public static final String HTML_EXTENSION_1 = ".html"; //$NON-NLS-1$
+  public static final String HTML_EXTENSION_2 = ".htm"; //$NON-NLS-1$
+  public static final String MIMETYPE_TEXT = "text/plain"; //$NON-NLS-1$
+  public static final String TEXT_EXTENSION = ".txt"; //$NON-NLS-1$
+  public static final String PROPERTIES_EXTENSION = ".properties"; //$NON-NLS-1$
+  public static final String MIMETYPE_MPG = "video/mpeg"; //$NON-NLS-1$
+  public static final String MPG_EXTENSION_1 = ".mpg"; //$NON-NLS-1$
+  public static final String MPG_EXTENSION_2 = ".mpe"; //$NON-NLS-1$
+  public static final String MPG_EXTENSION_3 = ".mpeg"; //$NON-NLS-1$
+  public static final String MIMETYPE_AVI = "video/x-msvideo"; //$NON-NLS-1$
+  public static final String AVI_EXTENSION = ".avi"; //$NON-NLS-1$
+  public static final String MIMETYPE_XACTION = "text/xaction+xml"; //$NON-NLS-1$
+  public static final String XACTION_EXTENSION = ".xaction"; //$NON-NLS-1$
+  public static final String MIMETYPE_CSS = "text/css"; //$NON-NLS-1$
+  public static final String CSS_EXTENSION = ".css"; //$NON-NLS-1$
+  public static final String MIMETYPE_JS = "text/javascript"; //$NON-NLS-1$
+  public static final String JS_EXTENSION = ".js"; //$NON-NLS-1$
+  public static final String MIMETYPE_XML = "text/xml"; //$NON-NLS-1$
+  public static final String XML_EXTENSION = ".xml"; //$NON-NLS-1$
+  public static final String MIMETYPE_FLASH = "application/x-shockwave-flash"; //$NON-NLS-1$
+  public static final String FLASH_EXTENSION = ".swf"; //$NON-NLS-1$
+  public static final String MIMETYPE_MS_EXCEL_2007 = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"; //$NON-NLS-1$
+  public static final String MS_EXCEL_2007_EXTENSION = ".xlsx"; //$NON-NLS-1$
+  public static final String MIMETYPE_EMAIL_MSG = "mime-message/text/html"; //$NON-NLS-1$
+  public static final String EMAIL_MSG_EXTENSION = ".eml"; //$NON-NLS-1$
 
+  private static final String UTF_CHARACTER_ENCODING = "UTF-8";
   private static final Map<String, String> mimes = new HashMap<String, String>();
-
   private static final Map<String, String> extensions = new HashMap<String, String>();
-
   private static final Map<String, String> defaultCharset = new HashMap<String, String>();
 
   static {
 
-    MimeHelper.mimes.put( "application/rtf", ".rtf" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "application/msword", ".doc" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "application/pdf", ".pdf" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "application/vnd.ms-excel", ".xls" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "application/vnd.ms-powerpoint", ".ppt" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "application/vnd.ms-project", ".mpp" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "application/zip", ".zip" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "audio/mpeg", ".mp3" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "audio/x-wav", ".wav" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "image/bmp", ".bmp" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "image/gif", ".gif" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "image/jpeg", ".jpg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "image/png", ".png" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "image/svg+xml", ".svg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "image/tiff", ".tif" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "text/csv", ".csv" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "text/html", ".html" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "text/plain", ".txt" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "video/mpeg", ".mpg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "video/x-msvideo", ".avi" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "text/xaction+xml", ".xaction" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "text/css", ".css" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "text/javascript", ".js" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "text/xml", ".xml" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "application/x-shockwave-flash", ".swf" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.mimes.put( "mime-message/text/html", ".eml" );
+    MimeHelper.mimes.put( MIMETYPE_RTF, RTF_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_MS_WORD, MS_WORD_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_PDF, PDF_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_MS_EXCEL, MS_EXCEL_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_MS_PPT, MS_PPT_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_MS_PROJECT, MS_PROJECT_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_ZIP, ZIP_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_MP3, MP3_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_WAV, WAV_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_BMP, BMP_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_GIF, GIF_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_JPEG, JPEG_EXTENSION_1 );
+    MimeHelper.mimes.put( MIMETYPE_PNG, PNG_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_SVG, SVG_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_TIFF, TIFF_EXTENSION_1 );
+    MimeHelper.mimes.put( MIMETYPE_CSV, CSV_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_HTML, HTML_EXTENSION_1 );
+    MimeHelper.mimes.put( MIMETYPE_TEXT, TEXT_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_MPG, MPG_EXTENSION_1 );
+    MimeHelper.mimes.put( MIMETYPE_AVI, AVI_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_XACTION, XACTION_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_CSS, CSS_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_JS, JS_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_XML, XML_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_FLASH, FLASH_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_MS_EXCEL_2007, MS_EXCEL_2007_EXTENSION );
+    MimeHelper.mimes.put( MIMETYPE_EMAIL_MSG, EMAIL_MSG_EXTENSION );
 
-    MimeHelper.extensions.put( ".rtf", "application/rtf" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".doc", "application/msword" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".pdf", "application/pdf" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".xls", "application/vnd.ms-excel" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".ppt", "application/vnd.ms-powerpoint" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".mpp", "application/vnd.ms-project" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".zip", "application/zip" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".mp3", "audio/mpeg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".wav", "audio/x-wav" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".bmp", "image/bmp" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".gif", "image/gif" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".jpe", "image/jpeg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".jpeg", "image/jpeg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".jpg", "image/jpeg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".png", "image/png" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".svg", "image/svg+xml" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".tif", "image/tiff" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".tiff", "image/tiff" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".csv", "text/csv" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".htm", "text/html" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".html", "text/html" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".txt", "text/plain" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".mpe", "video/mpeg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".mpeg", "video/mpeg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".mpg", "video/mpeg" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".avi", "video/x-msvideo" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".xaction", "text/xaction+xml" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".css", "text/css" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".js", "text/javascript" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".xml", "text/xml" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".swf", "application/x-shockwave-flash" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".properties", "text/plain" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.extensions.put( ".eml", "mime-message/text/html" );
+    MimeHelper.extensions.put( RTF_EXTENSION, MIMETYPE_RTF );
+    MimeHelper.extensions.put( MS_WORD_EXTENSION, MIMETYPE_MS_WORD );
+    MimeHelper.extensions.put( PDF_EXTENSION, MIMETYPE_PDF );
+    MimeHelper.extensions.put( MS_EXCEL_EXTENSION, MIMETYPE_MS_EXCEL );
+    MimeHelper.extensions.put( MS_PPT_EXTENSION, MIMETYPE_MS_PPT );
+    MimeHelper.extensions.put( MS_PROJECT_EXTENSION, MIMETYPE_MS_PROJECT );
+    MimeHelper.extensions.put( ZIP_EXTENSION, MIMETYPE_ZIP );
+    MimeHelper.extensions.put( MP3_EXTENSION, MIMETYPE_MP3 );
+    MimeHelper.extensions.put( WAV_EXTENSION, MIMETYPE_WAV );
+    MimeHelper.extensions.put( BMP_EXTENSION, MIMETYPE_BMP );
+    MimeHelper.extensions.put( GIF_EXTENSION, MIMETYPE_GIF );
+    MimeHelper.extensions.put( JPEG_EXTENSION_1, MIMETYPE_JPEG );
+    MimeHelper.extensions.put( JPEG_EXTENSION_2, MIMETYPE_JPEG );
+    MimeHelper.extensions.put( JPEG_EXTENSION_3, MIMETYPE_JPEG );
+    MimeHelper.extensions.put( PNG_EXTENSION, MIMETYPE_PNG );
+    MimeHelper.extensions.put( SVG_EXTENSION, MIMETYPE_SVG );
+    MimeHelper.extensions.put( TIFF_EXTENSION_1, MIMETYPE_TIFF );
+    MimeHelper.extensions.put( TIFF_EXTENSION_2, MIMETYPE_TIFF );
+    MimeHelper.extensions.put( CSV_EXTENSION, MIMETYPE_CSV );
+    MimeHelper.extensions.put( HTML_EXTENSION_1, MIMETYPE_HTML );
+    MimeHelper.extensions.put( HTML_EXTENSION_2, MIMETYPE_HTML );
+    MimeHelper.extensions.put( TEXT_EXTENSION, MIMETYPE_TEXT );
+    MimeHelper.extensions.put( MPG_EXTENSION_1, MIMETYPE_MPG );
+    MimeHelper.extensions.put( MPG_EXTENSION_2, MIMETYPE_MPG );
+    MimeHelper.extensions.put( MPG_EXTENSION_3, MIMETYPE_MPG );
+    MimeHelper.extensions.put( AVI_EXTENSION, MIMETYPE_AVI );
+    MimeHelper.extensions.put( XACTION_EXTENSION, MIMETYPE_XACTION );
+    MimeHelper.extensions.put( CSS_EXTENSION, MIMETYPE_CSS );
+    MimeHelper.extensions.put( JS_EXTENSION, MIMETYPE_JS );
+    MimeHelper.extensions.put( XML_EXTENSION, MIMETYPE_XML );
+    MimeHelper.extensions.put( FLASH_EXTENSION, MIMETYPE_FLASH );
+    MimeHelper.extensions.put( MS_EXCEL_2007_EXTENSION, MIMETYPE_MS_EXCEL_2007 );
+    MimeHelper.extensions.put( PROPERTIES_EXTENSION, MIMETYPE_TEXT );
+    MimeHelper.extensions.put( EMAIL_MSG_EXTENSION, MIMETYPE_EMAIL_MSG );
 
-    MimeHelper.defaultCharset.put( "text/html", "UTF-8" ); //$NON-NLS-1$ //$NON-NLS-2$
-    MimeHelper.defaultCharset.put( "text/plain", "UTF-8" ); //$NON-NLS-1$ //$NON-NLS-2$
+    MimeHelper.defaultCharset.put( MIMETYPE_HTML, UTF_CHARACTER_ENCODING );
+    MimeHelper.defaultCharset.put( MIMETYPE_TEXT, UTF_CHARACTER_ENCODING );
 
   }
 

--- a/core/src/test/java/org/pentaho/platform/util/web/MimeHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/web/MimeHelperTest.java
@@ -1,0 +1,156 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright (c) 2019 Hitachi Vantara. All rights reserved.
+ *
+ */
+package org.pentaho.platform.util.web;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.pentaho.di.core.util.Assert.assertNull;
+
+public class MimeHelperTest {
+  private static final String UTF_ENCODING = "UTF-8";
+
+  @Test
+  public void getExtensionTest() {
+    assertEquals( MimeHelper.RTF_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_RTF ) );
+    assertEquals( MimeHelper.MS_WORD_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_MS_WORD ) );
+    assertEquals( MimeHelper.PDF_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_PDF ) );
+    assertEquals( MimeHelper.MS_EXCEL_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_MS_EXCEL ) );
+    assertEquals( MimeHelper.MS_PPT_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_MS_PPT ) );
+    assertEquals( MimeHelper.MS_PROJECT_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_MS_PROJECT ) );
+    assertEquals( MimeHelper.ZIP_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_ZIP ) );
+    assertEquals( MimeHelper.MP3_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_MP3 ) );
+    assertEquals( MimeHelper.WAV_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_WAV ) );
+    assertEquals( MimeHelper.BMP_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_BMP ) );
+    assertEquals( MimeHelper.GIF_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_GIF ) );
+    assertEquals( MimeHelper.JPEG_EXTENSION_1, MimeHelper.getExtension( MimeHelper.MIMETYPE_JPEG ) );
+    assertEquals( MimeHelper.PNG_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_PNG ) );
+    assertEquals( MimeHelper.SVG_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_SVG ) );
+    assertEquals( MimeHelper.TIFF_EXTENSION_1, MimeHelper.getExtension( MimeHelper.MIMETYPE_TIFF ) );
+    assertEquals( MimeHelper.CSV_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_CSV ) );
+    assertEquals( MimeHelper.HTML_EXTENSION_1, MimeHelper.getExtension( MimeHelper.MIMETYPE_HTML ) );
+    assertEquals( MimeHelper.TEXT_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_TEXT ) );
+    assertEquals( MimeHelper.MPG_EXTENSION_1, MimeHelper.getExtension( MimeHelper.MIMETYPE_MPG ) );
+    assertEquals( MimeHelper.AVI_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_AVI ) );
+    assertEquals( MimeHelper.XACTION_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_XACTION ) );
+    assertEquals( MimeHelper.CSS_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_CSS ) );
+    assertEquals( MimeHelper.JS_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_JS ) );
+    assertEquals( MimeHelper.XML_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_XML ) );
+    assertEquals( MimeHelper.FLASH_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_FLASH ) );
+    assertEquals( MimeHelper.MS_EXCEL_2007_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_MS_EXCEL_2007 ) );
+    assertEquals( MimeHelper.EMAIL_MSG_EXTENSION, MimeHelper.getExtension( MimeHelper.MIMETYPE_EMAIL_MSG ) );
+  }
+
+  @Test
+  public void getMimeTypeFromExtensionTest() {
+    assertEquals( MimeHelper.MIMETYPE_RTF, MimeHelper.getMimeTypeFromExtension( MimeHelper.RTF_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_WORD, MimeHelper.getMimeTypeFromExtension( MimeHelper.MS_WORD_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_PDF, MimeHelper.getMimeTypeFromExtension( MimeHelper.PDF_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_EXCEL, MimeHelper.getMimeTypeFromExtension( MimeHelper.MS_EXCEL_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_PPT, MimeHelper.getMimeTypeFromExtension( MimeHelper.MS_PPT_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_PROJECT, MimeHelper.getMimeTypeFromExtension( MimeHelper.MS_PROJECT_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_ZIP, MimeHelper.getMimeTypeFromExtension( MimeHelper.ZIP_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MP3, MimeHelper.getMimeTypeFromExtension( MimeHelper.MP3_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_WAV, MimeHelper.getMimeTypeFromExtension( MimeHelper.WAV_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_BMP, MimeHelper.getMimeTypeFromExtension( MimeHelper.BMP_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_GIF, MimeHelper.getMimeTypeFromExtension( MimeHelper.GIF_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_JPEG, MimeHelper.getMimeTypeFromExtension( MimeHelper.JPEG_EXTENSION_1 ) );
+    assertEquals( MimeHelper.MIMETYPE_JPEG, MimeHelper.getMimeTypeFromExtension( MimeHelper.JPEG_EXTENSION_2 ) );
+    assertEquals( MimeHelper.MIMETYPE_JPEG, MimeHelper.getMimeTypeFromExtension( MimeHelper.JPEG_EXTENSION_3 ) );
+    assertEquals( MimeHelper.MIMETYPE_PNG, MimeHelper.getMimeTypeFromExtension( MimeHelper.PNG_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_SVG, MimeHelper.getMimeTypeFromExtension( MimeHelper.SVG_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_TIFF, MimeHelper.getMimeTypeFromExtension( MimeHelper.TIFF_EXTENSION_1 ) );
+    assertEquals( MimeHelper.MIMETYPE_TIFF, MimeHelper.getMimeTypeFromExtension( MimeHelper.TIFF_EXTENSION_2 ) );
+    assertEquals( MimeHelper.MIMETYPE_CSV, MimeHelper.getMimeTypeFromExtension( MimeHelper.CSV_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_HTML, MimeHelper.getMimeTypeFromExtension( MimeHelper.HTML_EXTENSION_1 ) );
+    assertEquals( MimeHelper.MIMETYPE_HTML, MimeHelper.getMimeTypeFromExtension( MimeHelper.HTML_EXTENSION_2 ) );
+    assertEquals( MimeHelper.MIMETYPE_TEXT, MimeHelper.getMimeTypeFromExtension( MimeHelper.TEXT_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_TEXT, MimeHelper.getMimeTypeFromExtension( MimeHelper.PROPERTIES_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MPG, MimeHelper.getMimeTypeFromExtension( MimeHelper.MPG_EXTENSION_1 ) );
+    assertEquals( MimeHelper.MIMETYPE_MPG, MimeHelper.getMimeTypeFromExtension( MimeHelper.MPG_EXTENSION_2 ) );
+    assertEquals( MimeHelper.MIMETYPE_MPG, MimeHelper.getMimeTypeFromExtension( MimeHelper.MPG_EXTENSION_3 ) );
+    assertEquals( MimeHelper.MIMETYPE_AVI, MimeHelper.getMimeTypeFromExtension( MimeHelper.AVI_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_XACTION, MimeHelper.getMimeTypeFromExtension( MimeHelper.XACTION_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_CSS, MimeHelper.getMimeTypeFromExtension( MimeHelper.CSS_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_JS, MimeHelper.getMimeTypeFromExtension( MimeHelper.JS_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_XML, MimeHelper.getMimeTypeFromExtension( MimeHelper.XML_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_FLASH, MimeHelper.getMimeTypeFromExtension( MimeHelper.FLASH_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_EXCEL_2007, MimeHelper.getMimeTypeFromExtension( MimeHelper.MS_EXCEL_2007_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_EMAIL_MSG, MimeHelper.getMimeTypeFromExtension( MimeHelper.EMAIL_MSG_EXTENSION ) );
+  }
+
+  @Test
+  public void getMimeTypeFromFileNameTest() {
+    String filename = "test";
+    assertEquals( MimeHelper.MIMETYPE_RTF, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.RTF_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_WORD, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.MS_WORD_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_PDF, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.PDF_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_EXCEL, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.MS_EXCEL_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_PPT, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.MS_PPT_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_PROJECT, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.MS_PROJECT_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_ZIP, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.ZIP_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MP3, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.MP3_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_WAV, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.WAV_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_BMP, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.BMP_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_GIF, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.GIF_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_JPEG, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.JPEG_EXTENSION_1 ) );
+    assertEquals( MimeHelper.MIMETYPE_JPEG, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.JPEG_EXTENSION_2 ) );
+    assertEquals( MimeHelper.MIMETYPE_JPEG, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.JPEG_EXTENSION_3 ) );
+    assertEquals( MimeHelper.MIMETYPE_PNG, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.PNG_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_SVG, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.SVG_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_TIFF, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.TIFF_EXTENSION_1 ) );
+    assertEquals( MimeHelper.MIMETYPE_TIFF, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.TIFF_EXTENSION_2 ) );
+    assertEquals( MimeHelper.MIMETYPE_CSV, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.CSV_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_HTML, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.HTML_EXTENSION_1 ) );
+    assertEquals( MimeHelper.MIMETYPE_HTML, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.HTML_EXTENSION_2 ) );
+    assertEquals( MimeHelper.MIMETYPE_TEXT, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.TEXT_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_TEXT, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.PROPERTIES_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MPG, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.MPG_EXTENSION_1 ) );
+    assertEquals( MimeHelper.MIMETYPE_MPG, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.MPG_EXTENSION_2 ) );
+    assertEquals( MimeHelper.MIMETYPE_MPG, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.MPG_EXTENSION_3 ) );
+    assertEquals( MimeHelper.MIMETYPE_AVI, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.AVI_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_XACTION, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.XACTION_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_CSS, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.CSS_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_JS, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.JS_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_XML, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.XML_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_FLASH, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.FLASH_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_MS_EXCEL_2007, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.MS_EXCEL_2007_EXTENSION ) );
+    assertEquals( MimeHelper.MIMETYPE_EMAIL_MSG, MimeHelper.getMimeTypeFromFileName( filename + MimeHelper.EMAIL_MSG_EXTENSION ) );
+  }
+
+  @Test
+  public void getDefaultCharsetTest() {
+    assertEquals( UTF_ENCODING, MimeHelper.getDefaultCharset( MimeHelper.MIMETYPE_HTML ) );
+    assertEquals( UTF_ENCODING, MimeHelper.getDefaultCharset( MimeHelper.MIMETYPE_TEXT ) );
+  }
+
+  @Test
+  public void verifyNullForBadMimeTypesTest() {
+    String falseMimeType = "false/mimeType";
+    String falseExtension = ".badExt";
+    String badFilename = "test.badExt";
+    String noExtension = "test";
+    assertNull( MimeHelper.getExtension( falseMimeType ) );
+    assertNull( MimeHelper.getMimeTypeFromExtension( falseExtension ) );
+    assertNull( MimeHelper.getMimeTypeFromFileName( badFilename ) );
+    assertNull( MimeHelper.getMimeTypeFromFileName( noExtension ) );
+    assertNull( MimeHelper.getDefaultCharset( "false/mimeType" ) );
+  }
+}


### PR DESCRIPTION
@pentaho/tatooine @wseyler @pentaho-lmartins 

* [PRD-6031] Modifying MimeHelper to create public references so that we can use those references in other projects (pentaho-platform-plugin-reporting, where we decide to use attachment or inline for Content-Disposition depending on what mime-type is used).
* [PRD-6031] Create test to validate the references and verify the static methods behave appropriately.

This Pull Request is depended on by the following PR:
https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/714