### PR TITLE
[BISERVER-14235] - Output files getting generated twice in User Home …

### DIFF
--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
@@ -106,7 +106,6 @@ public class ActionRunner implements Callable<Boolean> {
     }
     // sync job params to the action bean
     ActionHarness actionHarness = new ActionHarness( actionBean );
-    boolean updateJob = false;
 
     final Map<String, Object> actionParams = new HashMap<String, Object>();
     actionParams.putAll( params );
@@ -144,7 +143,8 @@ public class ActionRunner implements Callable<Boolean> {
 
       if ( !outputPath.equals( streamProvider.getOutputPath() ) ) {
         streamProvider.setOutputFilePath( outputPath ); // set fallback path
-        updateJob = true; // job needs to be deleted and recreated with the new output path
+        // Job output path requires update. The update triggers a new job that will fulfill the execution.
+        return new ExecutionResult( true, true );
       }
 
       stream = streamProvider.getOutputStream();
@@ -184,7 +184,7 @@ public class ActionRunner implements Callable<Boolean> {
     }
 
     // Create the ExecutionResult to return the status and whether the update is required or not
-    ExecutionResult executionResult = new ExecutionResult( updateJob, executionStatus );
+    ExecutionResult executionResult = new ExecutionResult( false, executionStatus );
     return executionResult;
   }
 


### PR DESCRIPTION
…directory when trying to write the Generated Output content to a Read Only Folder.

When the output folder differs from the one defined in the scheduler, the scheduler is updated, which consists in creating a new job with the updated output folder.
What was happening was that when the job execution detected that the output folder differed, it updated the variable locally, marked the job for update and continued the execution. Then, returned an execution status marked has update and finished. This caused the creation of a new job that was executed producing a duplicate report. This fix prevents the first job from executing when it detects that the output folder differs, being only executed the updated job.