### PR TITLE
[CDE-994] Localization of CDE dashboard does not work for Non-Admin u…

### DIFF
--- a/repository/src/main/java/org/pentaho/platform/repository/RepositoryDownloadWhitelist.java
+++ b/repository/src/main/java/org/pentaho/platform/repository/RepositoryDownloadWhitelist.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -24,7 +24,7 @@ import java.util.StringTokenizer;
 
 public class RepositoryDownloadWhitelist {
 
-  private String extensions = "gif,jpg,jpeg,png,bmp,tiff,csv,xls,xlsx,pdf,txt,css,html,js,xml,doc,ppt,eml";
+  private String extensions = "gif,jpg,jpeg,png,bmp,tiff,csv,xls,xlsx,pdf,txt,css,html,js,xml,doc,ppt,eml,properties";
 
   public RepositoryDownloadWhitelist() {
   }


### PR DESCRIPTION
…sers without Publish permission.

@pentaho/tatooine @pentaho-lmartins 

Properties file extension wasn't in our download whitelist, therefore we couldn't perform the desired translation.
Even if it wasn't in the whitelist, if a user had Publish permission it would allow downloading anyway. That's why Admin or anyone with Publish permission had access to properties files.
