### PR TITLE
[BACKLOG-29432] DSW model export fails

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
@@ -20,7 +20,6 @@
 
 package org.pentaho.platform.plugin.services.metadata;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
@@ -423,10 +422,9 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
             toMap( entry -> "messages_" + entry.getKey() + ".properties",
               item -> getRepositoryFileInputStream( item.getValue() ) ) );
       //    ^ keys of map are locale file names, e.g. "messages_fr_FR.properties"
-      return ImmutableMap.<String, InputStream>builder()
-        .putAll( localeFiles )
-        .put( getXmiFilename( domainId ), getRepositoryFileInputStream( metadataMapping.getDomainFile( domainId ) ) )
-        .build();
+      Map<String, InputStream> map = new HashMap<>( localeFiles );
+      map.put( getXmiFilename( domainId ), getRepositoryFileInputStream( metadataMapping.getDomainFile( domainId ) ) );
+      return map;
     } finally {
       lock.readLock().unlock();
     }


### PR DESCRIPTION
Broken with the fix for BISERVER-14265, with this change:
https://github.com/pentaho/pentaho-platform/pull/4454/files#diff-032e7ddd40c89218e2561a2f06684ed0R426

That made the domain map immutable, but downstream logic expects to be able to add to the same map.

Making the map mutable again.

https://jira.pentaho.com/browse/BACKLOG-29432