### PR TITLE
[PPP-4372] Not possible to use '[' and ']' on requests when trying to…

### DIFF
--- a/assemblies/pentaho-server/pom.xml
+++ b/assemblies/pentaho-server/pom.xml
@@ -186,7 +186,7 @@
             <configuration>
               <file>${tomcat.directory}/conf/server.xml</file>
               <token>&lt;Connector</token>
-              <value>&lt;Connector URIEncoding="UTF-8"</value>
+              <value>&lt;Connector URIEncoding="UTF-8" relaxedPathChars="[]|" relaxedQueryChars="^{}[]|&amp;"</value>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
… filter a report through parameters

Twin of https://github.com/pentaho/pentaho-platform-ee/pull/1305 for **CE**. Different approach in **CE** where replacements are made to the default `server.xml` file instead of replacing the entire file.

Please review and merge: @ssamora @LeonardoCoelho71950 @pentaho/tatooine 