### PR TITLE
[PPP-4372] Not possible to use '[' and ']' on requests when trying to…

### DIFF
--- a/assemblies/pentaho-server/pom.xml
+++ b/assemblies/pentaho-server/pom.xml
@@ -186,7 +186,7 @@
             <configuration>
               <file>${tomcat.directory}/conf/server.xml</file>
               <token>&lt;Connector</token>
-              <value>&lt;Connector URIEncoding="UTF-8" relaxedPathChars="[]|" relaxedQueryChars="^{}[]|&amp;"</value>
+              <value>&lt;Connector URIEncoding="UTF-8" relaxedPathChars="[]|" relaxedQueryChars="^{}[]|<![CDATA[&amp;]]>"</value>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
… filter a report through parameters

Had to escape &amp; for the CE version

@pentaho/tatooine 
@pentaho-lmartins @bantonio82 