### PR TITLE
[SP-5179] Backport of PPP-4372 - Not possible to use '[' and ']' on r…

### DIFF
--- a/assemblies/pentaho-server/pom.xml
+++ b/assemblies/pentaho-server/pom.xml
@@ -186,7 +186,7 @@
             <configuration>
               <file>${tomcat.directory}/conf/server.xml</file>
               <token>&lt;Connector</token>
-              <value>&lt;Connector URIEncoding="UTF-8"</value>
+              <value>&lt;Connector URIEncoding="UTF-8" relaxedPathChars="[]|" relaxedQueryChars="^{}[]|<![CDATA[&amp;]]>"</value>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
…equests when trying to filter a report through parameters (8.3 Suite)

@pentaho-lmartins @ssamora 