### PR TITLE
[SP-5178] Backport of PPP-4372 - Not possible to use '[' and ']' on r…

### DIFF
--- a/assemblies/pentaho-server/pom.xml
+++ b/assemblies/pentaho-server/pom.xml
@@ -197,7 +197,7 @@
             <configuration>
               <file>${tomcat.directory}/conf/server.xml</file>
               <token>&lt;Connector</token>
-              <value>&lt;Connector URIEncoding=&quot;UTF-8&quot;</value>
+              <value>&lt;Connector URIEncoding="UTF-8" relaxedPathChars="[]|" relaxedQueryChars="^{}[]|<![CDATA[&amp;]]>"</value>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
…equests when trying to filter a report through parameters (7.1 Suite)

@pentaho-lmartins @ssamora 