### PR TITLE
[BACKLOG-29696] CSRF Marketo Use Case

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/WebUtil.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/WebUtil.java
@@ -36,23 +36,38 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 public class WebUtil {
 
   // region CORS
-  static String ORIGIN_HEADER = "origin";
-  static String CORS_ALLOW_ORIGIN_HEADER = "Access-Control-Allow-Origin";
-  static String CORS_ALLOW_CREDENTIALS_HEADER = "Access-Control-Allow-Credentials";
+  static final String ORIGIN_HEADER = "origin";
+  static final String CORS_ALLOW_ORIGIN_HEADER = "Access-Control-Allow-Origin";
+  static final String CORS_ALLOW_CREDENTIALS_HEADER = "Access-Control-Allow-Credentials";
+  public static final String CORS_EXPOSE_HEADERS_HEADER = "Access-Control-Expose-Headers";
 
   public static void setCorsResponseHeaders( HttpServletRequest request, HttpServletResponse response ) {
+    setCorsResponseHeaders( request, response, null );
+  }
+
+  public static void setCorsResponseHeaders( HttpServletRequest request, HttpServletResponse response,
+                                             Map<String, List<String>> corsHeadersConfiguration ) {
     if ( !WebUtil.isCorsRequestsAllowed() ) {
       return;
     }
 
-    String origin = request.getHeader( ORIGIN_HEADER );
+    final String origin = request.getHeader( ORIGIN_HEADER );
     if ( WebUtil.isCorsRequestOriginAllowed( origin ) ) {
       response.setHeader( CORS_ALLOW_ORIGIN_HEADER, origin );
       response.setHeader( CORS_ALLOW_CREDENTIALS_HEADER, "true" );
+
+      if ( corsHeadersConfiguration != null ) {
+        corsHeadersConfiguration.forEach( ( header, parameters ) -> {
+          final String value = String.join( ",", parameters );
+
+          response.setHeader( header, value );
+        } );
+      }
     }
   }
 

--- a/extensions/src/main/java/org/pentaho/platform/web/http/security/CsrfTokenResponseHeaderFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/security/CsrfTokenResponseHeaderFilter.java
@@ -71,7 +71,7 @@ public class CsrfTokenResponseHeaderFilter extends OncePerRequestFilter {
     response.setHeader( RESPONSE_PARAM_NAME, tokenParameterName );
 
     final String tokenValue = token.getToken();
-    response.setHeader( RESPONSE_TOKEN_NAME , tokenValue );
+    response.setHeader( RESPONSE_TOKEN_NAME, tokenValue );
 
     // Add CORS headers, if CORS is enabled.
     WebUtil.setCorsResponseHeaders( request, response, getCorsHeadersConfiguration() );
@@ -83,7 +83,7 @@ public class CsrfTokenResponseHeaderFilter extends OncePerRequestFilter {
   Map<String, List<String>> getCorsHeadersConfiguration() {
     Map<String, List<String>> corsConfiguration = new HashMap<>( 1 );
 
-    List<String> exposedHeaders = Arrays.asList( RESPONSE_HEADER_NAME, RESPONSE_PARAM_NAME , RESPONSE_TOKEN_NAME );
+    List<String> exposedHeaders = Arrays.asList( RESPONSE_HEADER_NAME, RESPONSE_PARAM_NAME, RESPONSE_TOKEN_NAME );
     corsConfiguration.put( CORS_EXPOSE_HEADERS_HEADER, exposedHeaders );
 
     return corsConfiguration;

--- a/extensions/src/main/java/org/pentaho/platform/web/http/security/CsrfTokenResponseHeaderFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/security/CsrfTokenResponseHeaderFilter.java
@@ -19,6 +19,7 @@
  */
 package org.pentaho.platform.web.http.security;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.http.HttpStatus;
 import org.pentaho.platform.web.WebUtil;
 import org.springframework.security.web.csrf.CsrfToken;
@@ -28,6 +29,12 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.FilterChain;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.pentaho.platform.web.WebUtil.CORS_EXPOSE_HEADERS_HEADER;
 
 /**
  * Binds a {@link org.springframework.security.web.csrf.CsrfToken} to the {@link HttpServletResponse} headers if the
@@ -54,7 +61,7 @@ public class CsrfTokenResponseHeaderFilter extends OncePerRequestFilter {
 
     final CsrfToken token = (CsrfToken) request.getAttribute( REQUEST_ATTRIBUTE_NAME );
     if ( token == null ) {
-      throw new ServletException("Invalid filter usage.");
+      throw new ServletException( "Invalid filter usage." );
     }
 
     final String tokenHeaderName = token.getHeaderName();
@@ -67,8 +74,18 @@ public class CsrfTokenResponseHeaderFilter extends OncePerRequestFilter {
     response.setHeader( RESPONSE_TOKEN_NAME , tokenValue );
 
     // Add CORS headers, if CORS is enabled.
-    WebUtil.setCorsResponseHeaders( request, response );
+    WebUtil.setCorsResponseHeaders( request, response, getCorsHeadersConfiguration() );
 
     response.setStatus( HttpStatus.SC_NO_CONTENT );
+  }
+
+  @VisibleForTesting
+  Map<String, List<String>> getCorsHeadersConfiguration() {
+    Map<String, List<String>> corsConfiguration = new HashMap<>( 1 );
+
+    List<String> exposedHeaders = Arrays.asList( RESPONSE_HEADER_NAME, RESPONSE_PARAM_NAME , RESPONSE_TOKEN_NAME );
+    corsConfiguration.put( CORS_EXPOSE_HEADERS_HEADER, exposedHeaders );
+
+    return corsConfiguration;
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/web/http/security/CsrfTokenResponseHeaderFilterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/security/CsrfTokenResponseHeaderFilterTest.java
@@ -40,6 +40,17 @@ import javax.servlet.http.HttpServletResponse;
 import org.mockito.Mockito;
 import org.springframework.security.web.csrf.CsrfToken;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( WebUtil.class )
 public class CsrfTokenResponseHeaderFilterTest {
@@ -56,19 +67,20 @@ public class CsrfTokenResponseHeaderFilterTest {
   @Before
   public void setUp() throws Exception {
 
-    this.mockRequest = Mockito.mock( HttpServletRequest.class );
-    this.mockResponse = Mockito.mock( HttpServletResponse.class );
-    this.filter = new CsrfTokenResponseHeaderFilter();
+    this.mockRequest = mock( HttpServletRequest.class );
+    this.mockResponse = mock( HttpServletResponse.class );
+
+    this.filter = spy( new CsrfTokenResponseHeaderFilter() );
     this.filterChain = new MockFilterChain();
   }
 
   private static CsrfToken createToken() {
 
-    CsrfToken token = Mockito.mock( CsrfToken.class );
+    CsrfToken token = mock( CsrfToken.class );
 
-    Mockito.when( token.getHeaderName() ).thenReturn( RESPONSE_HEADER_VALUE );
-    Mockito.when( token.getParameterName() ).thenReturn( RESPONSE_PARAM_VALUE );
-    Mockito.when( token.getToken() ).thenReturn( RESPONSE_TOKEN_VALUE );
+    when( token.getHeaderName() ).thenReturn( RESPONSE_HEADER_VALUE );
+    when( token.getParameterName() ).thenReturn( RESPONSE_PARAM_VALUE );
+    when( token.getToken() ).thenReturn( RESPONSE_TOKEN_VALUE );
 
     return token;
   }
@@ -82,7 +94,7 @@ public class CsrfTokenResponseHeaderFilterTest {
 
     filter.doFilter( this.mockRequest, this.mockResponse, this.filterChain );
 
-    Mockito.verify( mockResponse, Mockito.never() ).setHeader( Mockito.anyString(), Mockito.anyString() );
+    verify( mockResponse, Mockito.never() ).setHeader( anyString(), anyString() );
   }
 
   @Test
@@ -94,39 +106,39 @@ public class CsrfTokenResponseHeaderFilterTest {
 
     CsrfToken token = createToken();
 
-    Mockito.when( this.mockRequest.getAttribute( CsrfTokenResponseHeaderFilter.REQUEST_ATTRIBUTE_NAME ) )
-        .thenReturn( token );
+    when( this.mockRequest.getAttribute( CsrfTokenResponseHeaderFilter.REQUEST_ATTRIBUTE_NAME ) ).thenReturn( token );
 
     filter.doFilter( this.mockRequest, this.mockResponse, this.filterChain );
 
-    Mockito.verify( mockResponse, Mockito.times( 1 ))
+    verify( mockResponse, times( 1 ) )
             .setHeader( CsrfTokenResponseHeaderFilter.RESPONSE_HEADER_NAME, RESPONSE_HEADER_VALUE );
 
-    Mockito.verify( mockResponse, Mockito.times( 1 ))
+    verify( mockResponse, times( 1 ) )
             .setHeader( CsrfTokenResponseHeaderFilter.RESPONSE_PARAM_NAME, RESPONSE_PARAM_VALUE );
 
-    Mockito.verify( mockResponse, Mockito.times( 1 ))
+    verify( mockResponse, times( 1 ) )
             .setHeader( CsrfTokenResponseHeaderFilter.RESPONSE_TOKEN_NAME, RESPONSE_TOKEN_VALUE );
   }
 
   @Test
   public void TestWhenCsrfTokenThenCorsResponseHeaders() throws Exception {
-
     MockFilterConfig cfg = new MockFilterConfig();
 
     filter.init( cfg );
 
     CsrfToken token = createToken();
 
-    Mockito.when( this.mockRequest.getAttribute( CsrfTokenResponseHeaderFilter.REQUEST_ATTRIBUTE_NAME ) )
-        .thenReturn( token );
+    when( this.mockRequest.getAttribute( CsrfTokenResponseHeaderFilter.REQUEST_ATTRIBUTE_NAME ) ).thenReturn( token );
+
+    Map<String, List<String>> configuration = Collections.emptyMap();
+    when( this.filter.getCorsHeadersConfiguration() ).thenReturn( configuration );
 
     PowerMockito.mockStatic( WebUtil.class );
 
     filter.doFilter( this.mockRequest, this.mockResponse, this.filterChain );
 
-    PowerMockito.verifyStatic( Mockito.times( 1 ) );
-    WebUtil.setCorsResponseHeaders( this.mockRequest, this.mockResponse );
+    PowerMockito.verifyStatic( times( 1 ) );
+    WebUtil.setCorsResponseHeaders( this.mockRequest, this.mockResponse, configuration );
   }
 
   @Test
@@ -138,12 +150,10 @@ public class CsrfTokenResponseHeaderFilterTest {
 
     CsrfToken token = createToken();
 
-    Mockito.when( this.mockRequest.getAttribute( CsrfTokenResponseHeaderFilter.REQUEST_ATTRIBUTE_NAME ) )
-        .thenReturn( token );
+    when( this.mockRequest.getAttribute( CsrfTokenResponseHeaderFilter.REQUEST_ATTRIBUTE_NAME ) ).thenReturn( token );
 
     filter.doFilter( this.mockRequest, this.mockResponse, this.filterChain );
 
-    Mockito.verify( mockResponse, Mockito.times( 1 ))
-        .setStatus( HttpStatus.SC_NO_CONTENT );
+    verify( mockResponse, times( 1 ) ).setStatus( HttpStatus.SC_NO_CONTENT );
   }
 }


### PR DESCRIPTION
 - Added extra CORS headers configurations (**Access-Control-Expose-Headers**), to make Csrf's service independent of users own CORS configuration.

@pentaho/millenniumfalcon please review