### PR TITLE
[ANALYZER-3802] Error pressing Cancel in Select Data Source window when creating a new PAZ

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -273,8 +273,18 @@ public class MantleTabPanel extends org.pentaho.gwt.widgets.client.tabs.PentahoT
           if (a) {
               for (i = a.length - 1; i >= 0; i -= 1) {
                   n = a[i].name;
-                  d[n] = null;
-                  $wnd.removedAttributes++;
+
+                  if ( n === "src" ) {
+                    if ( d.tagName === "IFRAME" ) {
+                      d[n] = "about:blank";
+                      $wnd.removedAttributes++;
+                    }
+                    // else "IMG", "SCRIPT", others...
+                    // Do nothing, as some browser's like IE, Safari and Firefox will request the "./null" resource.
+                  } else {
+                    d[n] = null;
+                    $wnd.removedAttributes++;
+                  }
               }
           }
           a = d.childNodes;


### PR DESCRIPTION
@pentaho/tatooine @dcleao @pentaho-lmartins 
* [ANALYZER-3802] Issue lived in the Mantle Tab Panel, fix was to ensure that when purging a tab, we make sure that under certain circumstances, we shouldn't send null resource. This allows a fix for the ticket by giving an about:blank, rather than a null resource (which was what was being triggered when cancel was clicked). So with the null not being sent, the service doesn't try and run and run into an error.