### PR TITLE
[BISERVER-14294] "Browse File" crashes when changing the owner of a folder/file with "<script>alert(999)</script>"

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -38,6 +38,7 @@ import org.pentaho.platform.api.engine.IParameterProvider;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.IPluginManager;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
+import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
 import org.pentaho.platform.api.mimetype.IPlatformMimeResolver;
 import org.pentaho.platform.api.repository2.unified.Converter;
 import org.pentaho.platform.api.repository2.unified.IRepositoryContentConverterHandler;
@@ -66,6 +67,7 @@ import org.pentaho.platform.api.repository2.unified.webservices.StringKeyStringV
 import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.util.xml.XMLParserFactoryProducer;
 import org.pentaho.platform.web.http.api.resources.services.FileService;
+import org.pentaho.platform.web.http.api.resources.services.UserRoleListService;
 import org.pentaho.platform.web.http.api.resources.utils.FileUtils;
 import org.pentaho.platform.web.http.api.resources.utils.SystemUtils;
 import org.pentaho.platform.web.http.messages.Messages;
@@ -128,6 +130,8 @@ public class FileResource extends AbstractJaxRSResource {
   protected static DefaultUnifiedRepositoryWebService repoWs;
 
   protected static IAuthorizationPolicy policy;
+
+  protected static UserRoleListService userRoleListService;
 
   IRepositoryContentConverterHandler converterHandler;
   Map<String, Converter> converters;
@@ -733,19 +737,19 @@ public class FileResource extends AbstractJaxRSResource {
   public Response setFileAcls( @PathParam ( "pathId" ) String pathId, RepositoryFileAclDto acl ) {
     /*
      * [BISERVER-14294] Ensuring the owner is set to a non-null, non-empty string value to prevent any issues
-     * that might cause problems with the repository.
+     * that might cause problems with the repository. Then following it up with a user existence check
      */
-    if ( isNotBlank( acl.getOwner() ) ) {
-      try {
+    try {
+      if ( isNotBlank( acl.getOwner() ) && getAllUsers().contains( acl.getOwner() ) ) {
         fileService.setFileAcls( pathId, acl );
         return buildOkResponse();
-      } catch ( Exception exception ) {
-        logger.error( getMessagesInstance().getString( "SystemResource.GENERAL_ERROR" ), exception );
-        return buildStatusResponse( Response.Status.INTERNAL_SERVER_ERROR );
+      } else {
+        logger.error( getMessagesInstance().getString( "SystemResource.GENERAL_ERROR" ) );
+        return buildStatusResponse( Response.Status.FORBIDDEN );
       }
-    } else {
-      logger.error( getMessagesInstance().getString( "SystemResource.GENERAL_ERROR" ) );
-      return buildStatusResponse( Response.Status.FORBIDDEN );
+    } catch ( Exception exception ) {
+      logger.error( getMessagesInstance().getString( "SystemResource.GENERAL_ERROR" ), exception );
+      return buildStatusResponse( Response.Status.INTERNAL_SERVER_ERROR );
     }
   }
 
@@ -2256,6 +2260,8 @@ public class FileResource extends AbstractJaxRSResource {
   protected String getUserHomeFolder() {
     return ClientRepositoryPaths.getUserHomeFolderPath( PentahoSessionHolder.getSession().getName() );
   }
+
+  protected List<String> getAllUsers() {
+    return new UserListWrapper( PentahoSystem.get( IUserRoleDao.class ).getUsers() ).getUsers();
+  }
 }
-
-

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
@@ -30,10 +30,13 @@ import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IContentGenerator;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
+import org.pentaho.platform.api.engine.security.userroledao.IPentahoUser;
+import org.pentaho.platform.api.engine.security.userroledao.IUserRoleDao;
 import org.pentaho.platform.api.repository2.unified.IRepositoryContentConverterHandler;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.UnifiedRepositoryAccessDeniedException;
+import org.pentaho.platform.core.mt.Tenant;
 import org.pentaho.platform.engine.core.output.SimpleOutputHandler;
 import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
@@ -49,6 +52,7 @@ import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.web.http.api.resources.services.FileService;
 import org.pentaho.platform.web.http.api.resources.utils.FileUtils;
 import org.pentaho.platform.web.http.messages.Messages;
+import org.pentaho.test.mock.MockPentahoUser;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -68,6 +72,7 @@ import java.nio.channels.IllegalSelectorException;
 import java.security.GeneralSecurityException;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -105,7 +110,12 @@ public class FileResourceTest {
   public static void initTest() {
     IRepositoryContentConverterHandler handler = mock( IRepositoryContentConverterHandler.class );
     when( handler.getConverter( XML_EXTENSION ) ).thenReturn( new StreamConverter() );
+    IUserRoleDao userRoleDao = mock( IUserRoleDao.class );
+    List<IPentahoUser> users = new ArrayList<>();
+    users.add( new MockPentahoUser( new Tenant(), ACL_OWNER, null, null, false ) );
+    when( userRoleDao.getUsers() ).thenReturn( users );
     PentahoSystem.registerObject( handler );
+    PentahoSystem.registerObject( userRoleDao );
   }
 
   @Test
@@ -868,6 +878,28 @@ public class FileResourceTest {
   public void testSetFileAclsErrorNoOwner() throws Exception {
     RepositoryFileAclDto mockRepositoryFileAclDto = mock( RepositoryFileAclDto.class );
     doReturn( "" ).when( mockRepositoryFileAclDto ).getOwner();
+
+    Messages mockMessages = mock( Messages.class );
+    doReturn( mockMessages ).when( fileResource ).getMessagesInstance();
+
+    Response mockForbiddenErrorResponse = mock( Response.class );
+    doReturn( mockForbiddenErrorResponse ).when( fileResource ).buildStatusResponse( Response.Status.FORBIDDEN );
+
+    Response testResponse = fileResource.setFileAcls( PATH_ID, mockRepositoryFileAclDto );
+    assertEquals( mockForbiddenErrorResponse, testResponse );
+
+    verify( fileResource, times( 1 ) ).getMessagesInstance();
+    verify( fileResource, times( 1 ) ).buildStatusResponse( Response.Status.FORBIDDEN );
+    verify( fileResource.fileService, times( 0 ) ).setFileAcls( PATH_ID, mockRepositoryFileAclDto );
+  }
+
+  /*
+   * [BISERVER-14294] Validating the ACL unknown owner is tested against.
+   */
+  @Test
+  public void testSetFileAclsWrongOwnerError() throws Exception {
+    RepositoryFileAclDto mockRepositoryFileAclDto = mock( RepositoryFileAclDto.class );
+    doReturn( "Wrong Owner" ).when( mockRepositoryFileAclDto ).getOwner();
 
     Messages mockMessages = mock( Messages.class );
     doReturn( mockMessages ).when( fileResource ).getMessagesInstance();


### PR DESCRIPTION
@pentaho/tatooine @RPAraujo @ssamora 

* [BISERVER-14294] Updated code to check for available users and to make sure the acl owner has to exist, otherwise throw a bad response back.