### PR TITLE
[PDI-17667] Use of vulnerable component jetty 8.1.15, CVE-2017-9735, …

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2295,7 +2295,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
-      <version>${jetty-webapp.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@
     <jmock-junit4.version>2.5.1</jmock-junit4.version>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <jetty-webapp.version>8.1.15.v20140411</jetty-webapp.version>
     <jmi.version>200507110943</jmi.version>
     <pentaho-concurrent.version>1.0.0</pentaho-concurrent.version>
     <xmlunit.version>1.6</xmlunit.version>


### PR DESCRIPTION
…CVE-2017-7657 CVE-2015-2080

[PPP-4183] Use of Vulnerable Component: Multiple Jetty Components [Listed in Description] (CVE-2017-7656 | CVE-2017-7657 | CVE-2017-7658 | CVE-2015-2080 | CVE-2017-9735 )
[PDI-11851] Improve the jetty server version of Carte Server
[PPP-4402] Use of Vulnerable Component: jetty-server & jetty-util (CVE-2019-10246 | CVE-2019-10247)


To better cope with the synchronization with the Karaf upgrade, it was decided that the Jetty upgrade was to be split into two phases: the first would basically consist on centralizing the Jetty version on the parent POM (leaving the version as it is); the second phase (to be integrated into the Karaf upgrade development) would include the upgrade itself and any other changes required.

This PR belongs to phase 1 (check [maven-parent-poms#161](https://github.com/pentaho/maven-parent-poms/pull/161) for the complete list of PRs for phase 1).

**For this specific PR:**
Centralized Jetty components: use dependency management.


