### PR TITLE
[MONDRIAN-1713] cellBatchSize should be included in mondrian.properties

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/mondrian/mondrian.properties
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/mondrian/mondrian.properties
@@ -139,3 +139,39 @@ mondrian.spi.dataSourceResolverClass=org.pentaho.platform.web.servlet.PentahoDat
 # Maximum number of MDX query threads per Mondrian server instance.
 # Defaults to 20.
 mondrian.rolap.maxQueryThreads=20
+
+###############################################################################
+# Integer property which controls the number of cells that Mondrian will try to load
+# in a single batch (typically one or two Segment.load SQL statements per batch).
+# A single cell consists of the intersection of all dimensions members in a query 
+# including the measure member.
+# For example, if a query contains 5 measures, 1000 customers, 100 products 
+# and a filter on 10 dates with no calculated members,
+# then the cell count is 5*1000*100*10=5M.
+# In more general terms, cell count is equal to the multiplication of the 
+# number of tuples on each of the query axis.  
+# So, in the above example, suppose:
+# Row Axis = Customers * Products = 1000 * 100 = 100,000
+# Column Axis = Measures = 5
+# Slicer Axis = Dates = 10
+# Total Cell Count = 100,000 * 5 * 10 = 5M
+# If using a NonEmptyCrossJoin on the Row Axis, typically far fewer tuples will
+# be returned since not every Customer buys every Product.
+#
+# In the above example, if the batch size was set to 1M, then at most 
+# 5M Cells / 1M Cells/Batch = 5 batches of Segment.load SQL statements would be
+# needed to execute the query on cold cache.
+# Within a single batch, based on the cardinality of a dimension and the number of
+# dimension members requested, Mondrian may drop predicates on a dimension to
+# pre-cache cells when mondrian.rolap.aggregates.optimizePredicates is set to true.
+# Mondrian may also drop predicates when the mondrian.rolap.maxConstraints is exceeded
+# in a single batch.  
+#
+# The default value for mondrian.rolap.cellBatchSize is 100,000 if not set.  
+# If a query generates excessive Segment.load SQL statements, try increasing
+# cell batch size so that more cells can be processed in a single batch.
+# Alternatively, looks for ways to simplify the query to reduce the total cell count
+# by only having NonEmpty tuples on each axis, reducing the number of dimensions
+# on each axis or reducing the number of axis used.
+mondrian.rolap.cellBatchSize=1000000
+


### PR DESCRIPTION
@mkambol @kurtwalker @lucboudreau  Hi Guys, I did my best to try to document this existing property from an admin point of view trying to tune their Mondrian query performance.  Please let me know if you have any suggestions or if anything is inaccurate.  Thanks