### PR TITLE
[PPP-4448] Use of Vulnerable Component - XStream 1.4.10

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -861,11 +861,6 @@
       <version>${jackcess.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>${xstream.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>javax.mail</artifactId>
       <version>${mail.version}</version>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -339,12 +339,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>${xstream.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.xmlbeans</groupId>
       <artifactId>xmlbeans</artifactId>
       <version>${xmlbeans.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,6 @@
     <avalon.version>4.1.5</avalon.version>
     <jta.version>1.1</jta.version>
     <jdom.version>1.0</jdom.version>
-    <xstream.version>1.4.10</xstream.version>
     <jxl.version>2.6.12</jxl.version>
     <soap.version>2.3</soap.version>
     <jakarta-regexp.version>1.2</jakarta-regexp.version>


### PR DESCRIPTION
This is part of a series of PRs. See https://github.com/pentaho/maven-parent-poms/pull/170 for details.

**Don't merge before the PR above.**

With the exclusions in `pentaho-metadata` we no longer need to explicitly declare dependencies for `xstream`, it will be included as a transitive and the `pentaho-war` assemply will include it.