### PR TITLE
[BISERVER-14356] Browse Files Perspective | Check 'Inherits folder pe…

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/repository2/unified/RepositoryFileSid.java
+++ b/api/src/main/java/org/pentaho/platform/api/repository2/unified/RepositoryFileSid.java
@@ -80,7 +80,18 @@ public class RepositoryFileSid implements Serializable {
   }
 
   public static enum Type {
-    USER, ROLE;
+    USER ( 0 ),
+    ROLE ( 1 );
+
+    private final int value;
+
+    Type( int value ) {
+      this.value = value;
+    }
+
+    public int getValue() {
+      return value;
+    }
   }
 
   @Override


### PR DESCRIPTION
…rmissions' - Error 'Sorry. You can do that right now'

There were two issues with the previous fix:
1. The code would not account for the special case when the repository admin is logged in
2. The code would only check the ACL owner (the user setting the permissions) not the ACL recipients (the users who are being given permissions)

I think I'm done with this case. I want reviews from all three.

@ssamora @gryphendowre @RPAraujo 
