### PR TITLE
[PPP-4447] Use of vulnerable component - Tika Core 1.1x

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -22,10 +22,8 @@
     <hibernate-ehcache.version>3.6.9.Final</hibernate-ehcache.version>
     <commons-io.version>2.2</commons-io.version>
     <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
-    <tika-core.version>1.19.1</tika-core.version>
     <xmlgraphics-commons.version>2.2</xmlgraphics-commons.version>
     <c3p0.version>0.9.1.2</c3p0.version>
-    <jackrabbit.version>2.14.2</jackrabbit.version>
     <jcommon-xml.version>1.0.12</jcommon-xml.version>
     <package.resources.directory>${basedir}/src/main/webapp</package.resources.directory>
     <replacer.version>1.5.2</replacer.version>
@@ -895,26 +893,6 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-jcr-commons</artifactId>
-      <version>${jackrabbit.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-spi</artifactId>
-      <version>${jackrabbit.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-spi-commons</artifactId>
-      <version>${jackrabbit.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
-      <version>${tika-core.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -20,7 +20,6 @@
     <jstl.version>1.0.5</jstl.version>
     <license.header.definition.file>${basedir}/../license/styles/javadoc_style_license_header.xml</license.header.definition.file>
     <hamcrest-library.version>1.3</hamcrest-library.version>
-    <tika-parser.version>1.12</tika-parser.version>
     <commons-xul.version>9.0.0.0-SNAPSHOT</commons-xul.version>
     <pdi.version>9.0.0.0-SNAPSHOT</pdi.version>
     <pentaho-reporting.version>9.0.0.0-SNAPSHOT</pentaho-reporting.version>
@@ -2750,7 +2749,6 @@
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-api</artifactId>
-      <version>${jackrabbit.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -2758,36 +2756,6 @@
           <groupId>*</groupId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-core</artifactId>
-      <version>${jackrabbit.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-spi</artifactId>
-      <version>${jackrabbit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-spi-commons</artifactId>
-      <version>${jackrabbit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-data</artifactId>
-      <version>${jackrabbit.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
@@ -2812,12 +2780,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
-      <version>${tika-parser.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.websocket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,6 @@
     <bcmail.version>138</bcmail.version>
     <barbecue.version>1.5-beta1</barbecue.version>
     <jaxws-spring.version>1.8</jaxws-spring.version>
-    <jackrabbit.version>2.14.2</jackrabbit.version>
     <snappy-java.version>1.1.0</snappy-java.version>
     <antlr-complete.version>3.5.2</antlr-complete.version>
     <hibernate-core.version>3.6.9.Final</hibernate-core.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -477,7 +477,6 @@
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-core</artifactId>
-      <version>${jackrabbit.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>concurrent</artifactId>
@@ -486,10 +485,6 @@
         <exclusion>
           <artifactId>derby</artifactId>
           <groupId>org.apache.derby</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jackrabbit-data</artifactId>
-          <groupId>org.apache.jackrabbit</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -500,14 +495,19 @@
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-data</artifactId>
-      <version>${jackrabbit.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
+      <artifactId>jackrabbit-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-spi-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-jcr-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
Replaces #4569. Changes to `pentaho-war` will produce a war file with all artifacts.

**Do not merge before https://github.com/pentaho/maven-parent-poms/pull/178!**

@ssamora @RPAraujo