### PR TITLE
[PDI-17775] Process Files step no longer supports HTTP scheme

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -139,7 +139,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <version>${commons-vfs2.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
     <sassyreader.version>0.5</sassyreader.version>
     <activation.version>1.1</activation.version>
     <enunciate-jersey-rt.version>1.27</enunciate-jersey-rt.version>
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <pentaho-json.version>9.0.0.0-SNAPSHOT</pentaho-json.version>
     <poi.version>3.17</poi.version>
     <bsh.version>1.3.0</bsh.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -108,7 +108,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <version>${commons-vfs2.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/repository/src/main/java/org/pentaho/platform/repository/solution/filebased/MondrianVfs.java
+++ b/repository/src/main/java/org/pentaho/platform/repository/solution/filebased/MondrianVfs.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 

--- a/repository/src/main/java/org/pentaho/platform/repository/solution/filebased/MondrianVfs.java
+++ b/repository/src/main/java/org/pentaho/platform/repository/solution/filebased/MondrianVfs.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -25,7 +25,7 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.commons.vfs2.provider.AbstractFileProvider;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.MondrianSchemaAnnotator;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
@@ -36,12 +36,13 @@ import java.util.Collection;
 /**
  * @author Ezequiel Cuellar
  */
-public class MondrianVfs implements FileProvider {
+public class MondrianVfs extends AbstractFileProvider {
 
   public static final String SCHEMA_XML = "schema.xml";
   public static final String ANNOTATIONS_XML = "annotations.xml";
   public static final String ANNOTATOR_KEY = "inlineModeling";
 
+  @Override
   public FileObject createFileSystem( String arg0, FileObject arg1,
                                       FileSystemOptions arg2 ) throws FileSystemException {
     // TODO Auto-generated method stub
@@ -69,14 +70,17 @@ public class MondrianVfs implements FileProvider {
       + "mondrian" + catalog + RepositoryFile.SEPARATOR + fileName );
   }
 
+  @Override
   public Collection getCapabilities() {
     return null;
   }
 
+  @Override
   public FileSystemConfigBuilder getConfigBuilder() {
     return null;
   }
 
+  @Override
   public FileName parseUri( FileName arg0, String arg1 ) throws FileSystemException {
     return null;
   }


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @ssamora 

* [PDI-17775] Removing version reference, maven parent pom will control version.

This PR is a part of a series of PR to upgrade commons-vfs2 and fix VFS issues with HTTP:
- https://github.com/pentaho/apache-vfs-browser/pull/60
- https://github.com/pentaho/big-data-plugin/pull/1929
- https://github.com/webdetails/cpk/pull/85
- https://github.com/pentaho/data-access/pull/1083
- https://github.com/pentaho/maven-parent-poms/pull/185
- https://github.com/pentaho/mondrian/pull/1177
- https://github.com/pentaho/pdi-jms-plugin/pull/73
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/102
- https://github.com/pentaho/pdi-plugins-ee/pull/139
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/82
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/51
- https://github.com/pentaho/pentaho-big-data-ee/pull/426
- https://github.com/pentaho/pentaho-commons-database/pull/177
- https://github.com/pentaho/pentaho-data-mining/pull/24
- https://github.com/pentaho/pentaho-det-ee/pull/608
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/21
- https://github.com/pentaho/pentaho-karaf-assembly/pull/615
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/277
- https://github.com/pentaho/pentaho-kettle/pull/7130
- https://github.com/pentaho/pentaho-metaverse/pull/614
- https://github.com/pentaho/pentaho-osgi-bundles/pull/347
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1493
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/328
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/765
- https://github.com/pentaho/pentaho-platform/pull/4598
- https://github.com/pentaho/pentaho-reporting/pull/1305
- https://github.com/pentaho/pentaho-s3-vfs/pull/87
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/14