### PR TITLE
[PPP-4283] Use of Vulnerable Components: commons-httpclient-3.0.1.jar…

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/ProxyServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/ProxyServlet.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -143,7 +144,7 @@ public class ProxyServlet extends ServletBase {
       String trustUserParam = "_TRUST_USER_"; //$NON-NLS-1$
       try {
         uriBuilder = new URIBuilder( theUrl );
-        List<NameValuePair> queryParams = uriBuilder.getQueryParams();
+        List<NameValuePair> queryParams = uriBuilder.isQueryEmpty() ? new ArrayList<>() : uriBuilder.getQueryParams();
         for ( NameValuePair nameValuePair : queryParams ) {
           // Just in case someone is trying to spoof the proxy
           if ( nameValuePair.getName().equals( trustUserParam ) ) {


### PR DESCRIPTION
… and httpclient-4.0.1.jar (sonatype-2007-0004 | CVE-2011-1498 | CVE-2012-6153 | CVE-2012-5783)

URIBuilder class has changed from 4.5.3 to 4.5.9, so we have to change our code accordingly:

httpclient-4.5.9.jar
\org\apache\http\client\utils\URIBuilder.class
    public List getQueryParams()
    {
        return ((List) (queryParams == null ? Collections.emptyList() : new ArrayList(queryParams)));
    }

@smmribeiro 