### PR TITLE
[SP-5361] Backport of BISERVER-14364 - Email Attachments with long non-ascii filenames are garbled when report is scheduled (8.3 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/Emailer.java
+++ b/core/src/main/java/org/pentaho/platform/util/Emailer.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -307,7 +307,7 @@ public class Emailer {
         // attach the file to the message
         MimeBodyPart attachmentBodyPart = new MimeBodyPart();
         attachmentBodyPart.setDataHandler( new DataHandler( dataSource ) );
-        attachmentBodyPart.setFileName( MimeUtility.encodeText( attachmentName, "UTF-8", null ) );
+        attachmentBodyPart.setFileName( attachmentName );
         multipart.addBodyPart( attachmentBodyPart );
 
         // add the Multipart to the message

--- a/core/src/main/java/org/pentaho/platform/util/Emailer.java
+++ b/core/src/main/java/org/pentaho/platform/util/Emailer.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 


### PR DESCRIPTION
**Attention: This is the outcome of an automated process!**
Merge Masters: @ppatricio and @bcostahitachivantara
Cherry-picks:
* https://github.com/Pentaho/pentaho-platform/commit/a0162bc0d36b96ec26fb45aa2fd0e03ac7b14c92
