### PR TITLE
[PPP-4392] Use of Vulnerable Component: Tomcat Components (CVE-2019-0…

### DIFF
--- a/assemblies/pentaho-server/pom.xml
+++ b/assemblies/pentaho-server/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <tomcat.directory>${project.build.directory}/apache-tomcat-${tomcat.version}</tomcat.directory>
     <replacer.version>1.5.2</replacer.version>
-    <tomcat.version>8.5.50</tomcat.version>
     <wkhtmltox.version>0.10.0_rc2</wkhtmltox.version>
     <wkhtmltoimage.version>${wkhtmltox.version}-static</wkhtmltoimage.version>
     <resources.directory>${basedir}/src/main/resources</resources.directory>


### PR DESCRIPTION
…199)

Moving tomcat version to parent POM. See: https://github.com/pentaho/maven-parent-poms/pull/206.