### PR TITLE
[PPP-4486] Use of Vulnerable Component: commons-codec [Multiple Versi…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -89,14 +89,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -34,14 +34,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
     <lucene-core.version>3.6.0</lucene-core.version>
     <georss-rome.version>0.9.8</georss-rome.version>
     <jmock-junit4.version>2.5.1</jmock-junit4.version>
-    <commons-codec.version>1.9</commons-codec.version>
     <commons-lang.version>2.6</commons-lang.version>
     <jmi.version>200507110943</jmi.version>
     <pentaho-concurrent.version>1.0.0</pentaho-concurrent.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -36,17 +36,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <version>${commons-collections.version}</version>


### PR DESCRIPTION
…ons] (sonatype-2012-0050)

Bumping `commons-codec` to version 1.14 to address multiple CVEs.
Moving dependency management to the parent POMs.
Removing unnecessary dependencies.

Please see https://github.com/pentaho/maven-parent-poms/pull/214 for details.