### PR TITLE
[PPP-4496] Use of Vulnerable Component: Components/kafka

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -27,7 +27,6 @@
     <jcommon-xml.version>1.0.12</jcommon-xml.version>
     <package.resources.directory>${basedir}/src/main/webapp</package.resources.directory>
     <replacer.version>1.5.2</replacer.version>
-    <kafka-clients.version>0.10.2.1</kafka-clients.version>
     <rxjava.version>2.2.3</rxjava.version>
     <snowflake-jdbc.version>3.6.28</snowflake-jdbc.version>
   </properties>
@@ -892,7 +891,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>${kafka-clients.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
* [PPP-4496] Upgrading to version 0.10.2.2
* [PPP-4496] Removing version reference, maven-parent-pom will control version info.

This is from a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/218
- https://github.com/pentaho/big-data-plugin/pull/2032
- https://github.com/pentaho/pdi-plugins-ee/pull/168
- https://github.com/pentaho/pentaho-platform/pull/4649
- https://github.com/pentaho/pentaho-reporting/pull/1327
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/152
- https://github.com/pentaho/pentaho-metadata-editor/pull/190
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/85
- https://github.com/pentaho/pentaho-kettle/pull/7309
- https://github.com/pentaho/pentaho-big-data-ee/pull/441