### PR TITLE
[PPP-4497] Use of vulnerable component jstl version 1.0.5 (CVE-2015-0…

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -16,7 +16,6 @@
     <maven-failsafe-plugin.reuseForks>false</maven-failsafe-plugin.reuseForks>
     <nekohtml.version>1.9.15</nekohtml.version>
     <maven-surefire-plugin.reuseForks>false</maven-surefire-plugin.reuseForks>
-    <jstl.version>1.0.5</jstl.version>
     <license.header.definition.file>${basedir}/../license/styles/javadoc_style_license_header.xml</license.header.definition.file>
     <hamcrest-library.version>1.3</hamcrest-library.version>
     <commons-xul.version>9.1.0.0-SNAPSHOT</commons-xul.version>
@@ -949,12 +948,6 @@
           <groupId>*</groupId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jstl</artifactId>
-      <version>${jstl.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>javatar</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,6 @@
     <dumbster.version>1.6.0</dumbster.version>
     <bcprov-jdk14.version>138</bcprov-jdk14.version>
     <commons-pool.version>1.5.7</commons-pool.version>
-    <jstl.version>1.2</jstl.version>
     <jsch.version>0.1.54</jsch.version>
     <jcommon-logging-log4jlog.version>1.0.2</jcommon-logging-log4jlog.version>
     <h2.version>1.2.131</h2.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -830,11 +830,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jstl</artifactId>
-      <version>${jstl.version}</version>
-    </dependency>
-    <dependency>
       <groupId>simple-jndi</groupId>
       <artifactId>simple-jndi</artifactId>
       <version>${simple-jndi.version}</version>


### PR DESCRIPTION
…254)

Removing `jstl` to address [CVE-2015-0254](https://nvd.nist.gov/vuln/detail/CVE-2015-0254).

After some research, the only place where `jstl` is used is in [pentaho-platform-plugin-jpivot](https://github.com/pentaho/pentaho-platform-plugin-jpivot) which doesn't ship with `pentaho-server`.

`jstl` will be replaced with `org.apache.taglibs` version **1.2.5** which is not vulnerable to the CVE above and placed in the plugin lib.

Related PRs:
- https://github.com/pentaho/pentaho-platform/pull/4671 (this)
- https://github.com/pentaho/pentaho-platform-plugin-jpivot/pull/77
- https://github.com/pentaho/pentaho-karaf-assembly/pull/636
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/291