### PR TITLE
[SP-5447] Backport of BISERVER-14353 - Database Connection's Password is exposed in clear text in exportManifest.xml (9.0 Suite)

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporter.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -22,7 +22,6 @@ package org.pentaho.platform.plugin.services.exporter;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
@@ -45,6 +44,7 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.TenantUtils;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
+import org.pentaho.platform.plugin.services.importexport.DatabaseConnectionConverter;
 import org.pentaho.platform.plugin.services.importexport.DefaultExportHandler;
 import org.pentaho.platform.plugin.services.importexport.ExportException;
 import org.pentaho.platform.plugin.services.importexport.ExportFileNameEncoder;
@@ -170,10 +170,9 @@ public class PentahoPlatformExporter extends ZipExportProcessor {
     log.debug( "export datasources" );
     // get all connection to export
     try {
-      List<IDatabaseConnection> datasources = getDatasourceMgmtService().getDatasources();
-      for ( IDatabaseConnection datasource : datasources ) {
-        if ( datasource instanceof DatabaseConnection ) {
-          getExportManifest().addDatasource( (DatabaseConnection) datasource );
+      for ( IDatabaseConnection datasource : getDatasourceMgmtService().getDatasources() ) {
+        if ( datasource instanceof org.pentaho.database.model.DatabaseConnection ) {
+          getExportManifest().addDatasource( DatabaseConnectionConverter.model2export( datasource ) );
         }
       }
     } catch ( DatasourceMgmtServiceException e ) {

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -63,6 +63,7 @@ import org.pentaho.platform.api.usersettings.pojo.IUserSetting;
 import org.pentaho.platform.core.mt.Tenant;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.TenantUtils;
+import org.pentaho.platform.plugin.services.importexport.DatabaseConnectionConverter;
 import org.pentaho.platform.plugin.services.importexport.ExportFileNameEncoder;
 import org.pentaho.platform.plugin.services.importexport.ExportManifestUserSetting;
 import org.pentaho.platform.plugin.services.importexport.ImportSession;
@@ -304,10 +305,10 @@ public class SolutionImportHandler implements IPlatformImportHandler {
       importSchedules( manifest.getScheduleList() );
 
       // Add Hitachi Vantara Connections
-      List<org.pentaho.database.model.DatabaseConnection> datasourceList = manifest.getDatasourceList();
+      List<org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseConnection> datasourceList = manifest.getDatasourceList();
       if ( datasourceList != null ) {
         IDatasourceMgmtService datasourceMgmtSvc = PentahoSystem.get( IDatasourceMgmtService.class );
-        for ( org.pentaho.database.model.DatabaseConnection databaseConnection : datasourceList ) {
+        for ( org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseConnection databaseConnection : datasourceList ) {
           if ( databaseConnection.getDatabaseType() == null ) {
             // don't try to import the connection if there is no type it will cause an error
             // However, if this is the DI Server, and the connection is defined in a ktr, it will import automatically
@@ -321,10 +322,11 @@ public class SolutionImportHandler implements IPlatformImportHandler {
             if ( existingDBConnection != null && existingDBConnection.getName() != null ) {
               if ( isOverwriteFile() ) {
                 databaseConnection.setId( existingDBConnection.getId() );
-                datasourceMgmtSvc.updateDatasourceByName( databaseConnection.getName(), databaseConnection );
+                datasourceMgmtSvc.updateDatasourceByName( databaseConnection.getName(),
+                  DatabaseConnectionConverter.export2model( databaseConnection ) );
               }
             } else {
-              datasourceMgmtSvc.createDatasource( databaseConnection );
+              datasourceMgmtSvc.createDatasource( DatabaseConnectionConverter.export2model( databaseConnection ) );
             }
           } catch ( Exception e ) {
             e.printStackTrace();

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/DatabaseConnectionConverter.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/DatabaseConnectionConverter.java
@@ -1,0 +1,275 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2019-2020 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.importexport;
+
+
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseAccessType;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseConnection;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseType;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.MapExport;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.PartitionDatabaseMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DatabaseConnectionConverter {
+
+  private DatabaseConnectionConverter() {
+    // Private constructor to be compliant with squid:S1118
+  }
+
+  public static DatabaseConnection model2export( org.pentaho.database.model.IDatabaseConnection databaseConnection ) {
+    DatabaseConnection databaseConnectionExport = null;
+
+    if ( null != databaseConnection ) {
+      databaseConnectionExport = new DatabaseConnection();
+
+      databaseConnectionExport.setAccessType( model2export( databaseConnection.getAccessType() ) );
+
+      DatabaseConnection.Attributes attributes = new DatabaseConnection.Attributes();
+      attributes.getEntry().addAll( mapModel2export( databaseConnection.getAttributes() ) );
+      databaseConnectionExport.setAttributes( attributes );
+
+      databaseConnectionExport.setChanged( databaseConnection.getChanged() );
+
+      DatabaseConnection.ConnectionPoolingProperties connectionPoolingProperties =
+        new DatabaseConnection.ConnectionPoolingProperties();
+      connectionPoolingProperties.getEntry()
+        .addAll( mapModel2export( databaseConnection.getConnectionPoolingProperties() ) );
+      databaseConnectionExport.setConnectionPoolingProperties( connectionPoolingProperties );
+
+      databaseConnectionExport.setConnectSql( databaseConnection.getConnectSql() );
+      databaseConnectionExport.setDatabaseName( databaseConnection.getDatabaseName() );
+      databaseConnectionExport.setDatabasePort( databaseConnection.getDatabasePort() );
+      databaseConnectionExport.setDatabaseType( model2export( databaseConnection.getDatabaseType() ) );
+      databaseConnectionExport.setDataTablespace( databaseConnection.getDataTablespace() );
+
+      DatabaseConnection.ExtraOptions extraOptions = new DatabaseConnection.ExtraOptions();
+      extraOptions.getEntry().addAll( mapModel2export( databaseConnection.getExtraOptions() ) );
+      databaseConnectionExport.setExtraOptions( extraOptions );
+
+      DatabaseConnection.ExtraOptionsOrder extraOptionsOrder = new DatabaseConnection.ExtraOptionsOrder();
+      extraOptionsOrder.getEntry().addAll( mapModel2export( databaseConnection.getExtraOptionsOrder() ) );
+      databaseConnectionExport.setExtraOptionsOrder( extraOptionsOrder );
+
+      databaseConnectionExport.setForcingIdentifiersToLowerCase( databaseConnection.isForcingIdentifiersToLowerCase() );
+      databaseConnectionExport.setForcingIdentifiersToUpperCase( databaseConnection.isForcingIdentifiersToUpperCase() );
+      databaseConnectionExport.setHostname( databaseConnection.getHostname() );
+      databaseConnectionExport.setId( databaseConnection.getId() );
+      databaseConnectionExport.setIndexTablespace( databaseConnection.getIndexTablespace() );
+      databaseConnectionExport.setInformixServername( databaseConnection.getInformixServername() );
+      databaseConnectionExport.setInitialPoolSize( databaseConnection.getInitialPoolSize() );
+      databaseConnectionExport.setMaximumPoolSize( databaseConnection.getMaximumPoolSize() );
+      databaseConnectionExport.setName( databaseConnection.getName() );
+      databaseConnectionExport.setPartitioned( databaseConnection.isPartitioned() );
+      partitioningInformationModel2export( databaseConnection, databaseConnectionExport );
+      databaseConnectionExport.setPassword( databaseConnection.getPassword() );
+      databaseConnectionExport.setQuoteAllFields( databaseConnection.isQuoteAllFields() );
+      databaseConnectionExport.setSQLServerInstance( databaseConnection.getSQLServerInstance() );
+      databaseConnectionExport.setStreamingResults( databaseConnection.isStreamingResults() );
+      databaseConnectionExport.setUsername( databaseConnection.getUsername() );
+      databaseConnectionExport.setUsingConnectionPool( databaseConnection.isUsingConnectionPool() );
+      databaseConnectionExport
+        .setUsingDoubleDecimalAsSchemaTableSeparator( databaseConnection.isUsingDoubleDecimalAsSchemaTableSeparator() );
+    }
+
+    return databaseConnectionExport;
+  }
+
+  public static org.pentaho.database.model.IDatabaseConnection export2model(
+    DatabaseConnection databaseConnectionExport ) {
+    org.pentaho.database.model.DatabaseConnection databaseConnection = null;
+
+    if ( null != databaseConnectionExport ) {
+      databaseConnection = new org.pentaho.database.model.DatabaseConnection();
+
+      databaseConnection.setAccessType( export2model( databaseConnectionExport.getAccessType() ) );
+      databaseConnection.setAttributes( mapExport2model( databaseConnectionExport.getAttributes() ) );
+      databaseConnection.setChanged( databaseConnectionExport.isChanged() );
+      databaseConnection
+        .setConnectionPoolingProperties( mapExport2model( databaseConnectionExport.getConnectionPoolingProperties() ) );
+      databaseConnection.setConnectSql( databaseConnectionExport.getConnectSql() );
+      databaseConnection.setDatabaseName( databaseConnectionExport.getDatabaseName() );
+      databaseConnection.setDatabasePort( databaseConnectionExport.getDatabasePort() );
+      databaseConnection.setDatabaseType( export2model( databaseConnectionExport.getDatabaseType() ) );
+      databaseConnection.setDataTablespace( databaseConnectionExport.getDataTablespace() );
+      databaseConnection.setExtraOptions( mapExport2model( databaseConnectionExport.getExtraOptions() ) );
+      databaseConnection.setExtraOptionsOrder( mapExport2model( databaseConnectionExport.getExtraOptionsOrder() ) );
+      databaseConnection.setForcingIdentifiersToLowerCase( databaseConnectionExport.isForcingIdentifiersToLowerCase() );
+      databaseConnection.setForcingIdentifiersToUpperCase( databaseConnectionExport.isForcingIdentifiersToUpperCase() );
+      databaseConnection.setHostname( databaseConnectionExport.getHostname() );
+      databaseConnection.setId( databaseConnectionExport.getId() );
+      databaseConnection.setIndexTablespace( databaseConnectionExport.getIndexTablespace() );
+      databaseConnection.setInformixServername( databaseConnectionExport.getInformixServername() );
+      databaseConnection.setInitialPoolSize( databaseConnectionExport.getInitialPoolSize() );
+      databaseConnection.setMaximumPoolSize( databaseConnectionExport.getMaximumPoolSize() );
+      databaseConnection.setName( databaseConnectionExport.getName() );
+      databaseConnection.setPartitioned( databaseConnectionExport.isPartitioned() );
+      partitioningInformationExport2model( databaseConnectionExport, databaseConnection );
+      databaseConnection.setPassword( databaseConnectionExport.getPassword() );
+      databaseConnection.setQuoteAllFields( databaseConnectionExport.isQuoteAllFields() );
+      databaseConnection.setSQLServerInstance( databaseConnectionExport.getSQLServerInstance() );
+      databaseConnection.setStreamingResults( databaseConnectionExport.isStreamingResults() );
+      databaseConnection.setUsername( databaseConnectionExport.getUsername() );
+      databaseConnection.setUsingConnectionPool( databaseConnectionExport.isUsingConnectionPool() );
+      databaseConnection.setUsingDoubleDecimalAsSchemaTableSeparator(
+        databaseConnectionExport.isUsingDoubleDecimalAsSchemaTableSeparator() );
+    }
+
+    return databaseConnection;
+  }
+
+  public static DatabaseAccessType model2export( org.pentaho.database.model.DatabaseAccessType databaseAccessType ) {
+    DatabaseAccessType databaseAccessTypeExport = null;
+
+    if ( null != databaseAccessType ) {
+      databaseAccessTypeExport = DatabaseAccessType.fromValue( databaseAccessType.getValue() );
+    }
+
+    return databaseAccessTypeExport;
+  }
+
+  public static org.pentaho.database.model.DatabaseAccessType export2model(
+    DatabaseAccessType databaseAccessTypeExport ) {
+    org.pentaho.database.model.DatabaseAccessType databaseAccessType = null;
+
+    if ( null != databaseAccessTypeExport ) {
+      databaseAccessType =
+        org.pentaho.database.model.DatabaseAccessType.valueOf( databaseAccessTypeExport.value() );
+    }
+
+    return databaseAccessType;
+  }
+
+  public static DatabaseType model2export( org.pentaho.database.model.IDatabaseType databaseType ) {
+    DatabaseType databaseTypeExport = new DatabaseType();
+
+    if ( null != databaseType ) {
+      databaseTypeExport.setDefaultDatabaseName( databaseType.getDefaultDatabaseName() );
+      databaseTypeExport.setDefaultDatabasePort( databaseType.getDefaultDatabasePort() );
+      DatabaseType.DefaultOptions defaultOptions = new DatabaseType.DefaultOptions();
+      defaultOptions.getEntry().addAll( mapModel2export( databaseType.getDefaultOptions() ) );
+      databaseTypeExport.setDefaultOptions( defaultOptions );
+      databaseTypeExport.setExtraOptionsHelpUrl( databaseType.getExtraOptionsHelpUrl() );
+      databaseTypeExport.setName( databaseType.getName() );
+      databaseTypeExport.setShortName( databaseType.getShortName() );
+      for ( org.pentaho.database.model.DatabaseAccessType supportedAccessType : databaseType
+        .getSupportedAccessTypes() ) {
+        databaseTypeExport.getSupportedAccessTypes().add( model2export( supportedAccessType ) );
+      }
+    }
+
+    return databaseTypeExport;
+  }
+
+  public static org.pentaho.database.model.DatabaseType export2model( DatabaseType databaseTypeExport ) {
+    org.pentaho.database.model.DatabaseType databaseType = new org.pentaho.database.model.DatabaseType();
+
+    if ( null != databaseTypeExport ) {
+      databaseType.setDefaultDatabaseName( databaseTypeExport.getDefaultDatabaseName() );
+      databaseType.setDefaultDatabasePort( databaseTypeExport.getDefaultDatabasePort() );
+      databaseType.setDefaultOptions( mapExport2model( databaseTypeExport.getDefaultOptions() ) );
+      databaseType.setExtraOptionsHelpUrl( databaseTypeExport.getExtraOptionsHelpUrl() );
+      databaseType.setName( databaseTypeExport.getName() );
+      databaseType.setShortName( databaseTypeExport.getShortName() );
+      List<org.pentaho.database.model.DatabaseAccessType> supportedAccessTypes = new ArrayList<>();
+      for ( DatabaseAccessType supportedAccessType : databaseTypeExport.getSupportedAccessTypes() ) {
+        supportedAccessTypes.add( export2model( supportedAccessType ) );
+      }
+      databaseType.setSupportedAccessTypes( supportedAccessTypes );
+    }
+
+    return databaseType;
+  }
+
+  public static List<MapExport.Entry> mapModel2export( Map<String, String> mapModel ) {
+    List<MapExport.Entry> exportList = new ArrayList<>();
+
+    if ( null != mapModel ) {
+      for ( Map.Entry<String, String> modelEntry : mapModel.entrySet() ) {
+        MapExport.Entry exportEntry = new MapExport.Entry();
+        exportEntry.setKey( modelEntry.getKey() );
+        exportEntry.setValue( modelEntry.getValue() );
+        exportList.add( exportEntry );
+      }
+    }
+
+    return exportList;
+  }
+
+  public static Map<String, String> mapExport2model( MapExport mapExport ) {
+    Map<String, String> mapModel = new HashMap<>();
+
+    if ( null != mapExport ) {
+      for ( MapExport.Entry exportEntry : mapExport.getEntry() ) {
+        mapModel.put( exportEntry.getKey(), exportEntry.getValue() );
+      }
+    }
+
+    return mapModel;
+  }
+
+  public static void partitioningInformationModel2export(
+    org.pentaho.database.model.IDatabaseConnection databaseConnection, DatabaseConnection databaseConnectionExport ) {
+    List<org.pentaho.database.model.PartitionDatabaseMeta> partitioningInformationList =
+      databaseConnection.getPartitioningInformation();
+    List<PartitionDatabaseMeta> partitioningInformationExportList =
+      databaseConnectionExport.getPartitioningInformation();
+
+    if ( null != partitioningInformationList ) {
+      for ( org.pentaho.database.model.PartitionDatabaseMeta partitioningInformation : partitioningInformationList ) {
+        PartitionDatabaseMeta partitionDatabaseMetaExport = new PartitionDatabaseMeta();
+        partitionDatabaseMetaExport.setDatabaseName( partitioningInformation.getDatabaseName() );
+        partitionDatabaseMetaExport.setHostname( partitioningInformation.getHostname() );
+        partitionDatabaseMetaExport.setPartitionId( partitioningInformation.getPartitionId() );
+        partitionDatabaseMetaExport.setPassword( partitioningInformation.getPassword() );
+        partitionDatabaseMetaExport.setPort( partitioningInformation.getPort() );
+        partitionDatabaseMetaExport.setUsername( partitioningInformation.getUsername() );
+        partitioningInformationExportList.add( partitionDatabaseMetaExport );
+      }
+    }
+  }
+
+  public static void partitioningInformationExport2model( DatabaseConnection databaseConnectionExport,
+                                                          org.pentaho.database.model.IDatabaseConnection databaseConnection ) {
+    List<org.pentaho.database.model.PartitionDatabaseMeta> partitioningInformationList = new ArrayList<>();
+    List<PartitionDatabaseMeta> partitioningInformationExportList =
+      databaseConnectionExport.getPartitioningInformation();
+
+    if ( null != partitioningInformationExportList ) {
+      for ( PartitionDatabaseMeta partitioningInformationExport : partitioningInformationExportList ) {
+        org.pentaho.database.model.PartitionDatabaseMeta partitionDatabaseMeta =
+          new org.pentaho.database.model.PartitionDatabaseMeta();
+        partitionDatabaseMeta.setDatabaseName( partitioningInformationExport.getDatabaseName() );
+        partitionDatabaseMeta.setHostname( partitioningInformationExport.getHostname() );
+        partitionDatabaseMeta.setPartitionId( partitioningInformationExport.getPartitionId() );
+        partitionDatabaseMeta.setPassword( partitioningInformationExport.getPassword() );
+        partitionDatabaseMeta.setPort( partitioningInformationExport.getPort() );
+        partitionDatabaseMeta.setUsername( partitioningInformationExport.getUsername() );
+        partitioningInformationList.add( partitionDatabaseMeta );
+      }
+    }
+
+    databaseConnection.setPartitioningInformation( partitioningInformationList );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifest.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifest.java
@@ -14,23 +14,24 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.plugin.services.importexport.exportManifest;
 
-import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.plugin.services.importexport.ExportManifestUserSetting;
 import org.pentaho.platform.plugin.services.importexport.RoleExport;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseConnection;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestDto;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestEntityDto;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetaStore;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetadata;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMondrian;
+import org.pentaho.platform.util.StringUtil;
 import org.pentaho.platform.util.xml.XMLParserFactoryProducer;
 import org.pentaho.platform.web.http.api.resources.JobScheduleRequest;
 import org.xml.sax.InputSource;
@@ -68,17 +69,17 @@ public class ExportManifest {
   private HashMap<String, ExportManifestEntity> exportManifestEntities;
 
   private ExportManifestDto.ExportManifestInformation manifestInformation;
-  private List<ExportManifestMetadata> metadataList = new ArrayList<ExportManifestMetadata>();
-  private List<ExportManifestMondrian> mondrianList = new ArrayList<ExportManifestMondrian>();
-  private List<JobScheduleRequest> scheduleList = new ArrayList<JobScheduleRequest>();
-  private List<DatabaseConnection> datasourceList = new ArrayList<DatabaseConnection>();
-  private List<UserExport> userExports = new ArrayList<UserExport>();
-  private List<RoleExport> roleExports = new ArrayList<RoleExport>();
+  private List<ExportManifestMetadata> metadataList = new ArrayList<>();
+  private List<ExportManifestMondrian> mondrianList = new ArrayList<>();
+  private List<JobScheduleRequest> scheduleList = new ArrayList<>();
+  private List<DatabaseConnection> datasourceList = new ArrayList<>();
+  private List<UserExport> userExports = new ArrayList<>();
+  private List<RoleExport> roleExports = new ArrayList<>();
   private List<ExportManifestUserSetting> globalUserSettings = new ArrayList<>();
   private ExportManifestMetaStore metaStore;
 
   public ExportManifest() {
-    this.exportManifestEntities = new HashMap<String, ExportManifestEntity>();
+    this.exportManifestEntities = new HashMap<>();
     this.manifestInformation = new ExportManifestDto.ExportManifestInformation();
   }
 
@@ -151,16 +152,13 @@ public class ExportManifest {
     if ( !isValid() ) {
       throw new ExportManifestFormatException( "Invalid root Folder for manifest" );
     }
-    final JAXBContext jaxbContext = JAXBContext.newInstance( ExportManifestDto.class );
-    Marshaller marshaller = getMarshaller();
-    marshaller.marshal( new JAXBElement<ExportManifestDto>( new QName( "http://www.pentaho.com/schema/",
+    getMarshaller().marshal( new JAXBElement<ExportManifestDto>( new QName( "http://www.pentaho.com/schema/",
       "ExportManifest" ), ExportManifestDto.class, getExportManifestDto() ), outputStream );
   }
 
   public String toXmlString() throws JAXBException {
     StringWriter sw = new StringWriter();
     Marshaller marshaller = getMarshaller();
-    marshaller.setProperty( Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE );
     marshaller.marshal( new JAXBElement<ExportManifestDto>( new QName( "http://www.pentaho.com/schema/",
         "ExportManifest" ), ExportManifestDto.class, getExportManifestDto() ), sw );
     return sw.toString();
@@ -208,7 +206,7 @@ public class ExportManifest {
     ExportManifestDto rawExportManifest = new ExportManifestDto();
     List<ExportManifestEntityDto> rawEntityList = rawExportManifest.getExportManifestEntity();
     rawExportManifest.setExportManifestInformation( manifestInformation );
-    TreeSet<String> ts = new TreeSet<String>( exportManifestEntities.keySet() );
+    TreeSet<String> ts = new TreeSet<>( exportManifestEntities.keySet() );
     for ( String path : ts ) {
       rawEntityList.add( exportManifestEntities.get( path ).getExportManifestEntityDto() );
     }
@@ -236,13 +234,13 @@ public class ExportManifest {
   }
 
   public boolean isValid() {
-    if ( this.exportManifestEntities.size() > 0 ) {
+    if ( !this.exportManifestEntities.isEmpty() ) {
       for ( ExportManifestEntity manEntity : exportManifestEntities.values() ) {
         if ( !manEntity.isValid() ) {
           return false;
         }
       }
-      if ( manifestInformation.getRootFolder() == null || manifestInformation.getRootFolder().length() == 0 ) {
+      if ( StringUtil.isEmpty( manifestInformation.getRootFolder() ) ) {
         return false;
       }
     }
@@ -326,6 +324,7 @@ public class ExportManifest {
   public List<ExportManifestUserSetting> getGlobalUserSettings() {
     return globalUserSettings;
   }
+
   public void addGlobalUserSetting( ExportManifestUserSetting globalSetting ) {
     globalUserSettings.add( globalSetting );
   }

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseConnection.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseConnection.java
@@ -761,12 +761,12 @@ public class DatabaseConnection {
   public static class PasswordEncryptionAdapter extends XmlAdapter<String, String> {
     @Override
     public String marshal( final String plainText ) throws Exception {
-      return Encr.encryptPassword( plainText );
+      return Encr.encryptPasswordIfNotUsingVariables( plainText );
     }
 
     @Override
     public String unmarshal( final String encodedText ) throws Exception {
-      return Encr.decryptPassword( encodedText );
+      return Encr.decryptPasswordOptionallyEncrypted( encodedText );
     }
   }
 }

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseConnection.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseConnection.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -27,10 +27,14 @@
 
 package org.pentaho.platform.plugin.services.importexport.exportManifest.bindings;
 
+import org.pentaho.di.core.encryption.Encr;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -138,38 +142,61 @@ import java.util.List;
  *         &lt;element name="streamingResults" type="{http://www.w3.org/2001/XMLSchema}boolean"/>
  *         &lt;element name="username" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
  *         &lt;element name="usingConnectionPool" type="{http://www.w3.org/2001/XMLSchema}boolean"/>
- *         &lt;element name="usingDoubleDecimalAsSchemaTableSeparator" type="{http://www.w3
- *         .org/2001/XMLSchema}boolean"/>
+ *         &lt;element name="usingDoubleDecimalAsSchemaTableSeparator" type="{http://www.w3.org/2001/XMLSchema}boolean"/>
+ *         &lt;element name="extraOptionsOrder">
+ *           &lt;complexType>
+ *             &lt;complexContent>
+ *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 &lt;sequence>
+ *                   &lt;element name="entry" maxOccurs="unbounded" minOccurs="0">
+ *                     &lt;complexType>
+ *                       &lt;complexContent>
+ *                         &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                           &lt;sequence>
+ *                             &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *                             &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *                           &lt;/sequence>
+ *                         &lt;/restriction>
+ *                       &lt;/complexContent>
+ *                     &lt;/complexType>
+ *                   &lt;/element>
+ *                 &lt;/sequence>
+ *               &lt;/restriction>
+ *             &lt;/complexContent>
+ *           &lt;/complexType>
+ *         &lt;/element>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
  */
-@XmlAccessorType ( XmlAccessType.FIELD )
-@XmlType ( name = "databaseConnection", propOrder = { "accessType", "accessTypeValue", "attributes", "changed",
-    "connectSql", "connectionPoolingProperties", "dataTablespace", "databaseName", "databasePort", "databaseType",
-    "extraOptions", "forcingIdentifiersToLowerCase", "forcingIdentifiersToUpperCase", "hostname", "id",
-    "indexTablespace", "informixServername", "initialPoolSize", "maximumPoolSize", "name", "partitioned",
-    "partitioningInformation", "password", "quoteAllFields", "sqlServerInstance", "streamingResults", "username",
-    "usingConnectionPool", "usingDoubleDecimalAsSchemaTableSeparator" } )
+@XmlAccessorType( XmlAccessType.FIELD )
+@XmlType( name = "databaseConnection", propOrder = { "accessType", "accessTypeValue", "attributes", "changed",
+  "connectSql", "connectionPoolingProperties", "dataTablespace", "databaseName", "databasePort", "databaseType",
+  "extraOptions", "forcingIdentifiersToLowerCase", "forcingIdentifiersToUpperCase", "hostname", "id",
+  "indexTablespace", "informixServername", "initialPoolSize", "maximumPoolSize", "name", "partitioned",
+  "partitioningInformation", "password", "quoteAllFields", "sqlServerInstance", "streamingResults", "username",
+  "usingConnectionPool", "usingDoubleDecimalAsSchemaTableSeparator", "extraOptionsOrder" } )
 public class DatabaseConnection {
 
   protected DatabaseAccessType accessType;
   protected String accessTypeValue;
-  @XmlElement ( required = true )
+  @XmlElement( required = true )
   protected DatabaseConnection.Attributes attributes;
   protected boolean changed;
   protected String connectSql;
-  @XmlElement ( required = true )
+  @XmlElement( required = true )
   protected DatabaseConnection.ConnectionPoolingProperties connectionPoolingProperties;
   protected String dataTablespace;
   protected String databaseName;
   protected String databasePort;
-  @XmlElement ( namespace = "http://www.pentaho.com/schema/" )
+  @XmlElement( namespace = "http://www.pentaho.com/schema/" )
   protected DatabaseType databaseType;
-  @XmlElement ( required = true )
+  @XmlElement( required = true )
   protected DatabaseConnection.ExtraOptions extraOptions;
+  @XmlElement( required = true )
+  protected DatabaseConnection.ExtraOptionsOrder extraOptionsOrder;
   protected boolean forcingIdentifiersToLowerCase;
   protected boolean forcingIdentifiersToUpperCase;
   protected String hostname;
@@ -180,11 +207,12 @@ public class DatabaseConnection {
   protected int maximumPoolSize;
   protected String name;
   protected boolean partitioned;
-  @XmlElement ( nillable = true )
+  @XmlElement( nillable = true )
   protected List<PartitionDatabaseMeta> partitioningInformation;
+  @XmlJavaTypeAdapter( PasswordEncryptionAdapter.class )
   protected String password;
   protected boolean quoteAllFields;
-  @XmlElement ( name = "SQLServerInstance" )
+  @XmlElement( name = "SQLServerInstance" )
   protected String sqlServerInstance;
   protected boolean streamingResults;
   protected String username;
@@ -386,6 +414,24 @@ public class DatabaseConnection {
   }
 
   /**
+   * Gets the value of the extraOptionsOrder property.
+   *
+   * @return possible object is {@link DatabaseConnection.ExtraOptionsOrder }
+   */
+  public DatabaseConnection.ExtraOptionsOrder getExtraOptionsOrder() {
+    return extraOptionsOrder;
+  }
+
+  /**
+   * Sets the value of the extraOptionsOrder property.
+   *
+   * @param value allowed object is {@link DatabaseConnection.ExtraOptionsOrder }
+   */
+  public void setExtraOptionsOrder( DatabaseConnection.ExtraOptionsOrder value ) {
+    this.extraOptionsOrder = value;
+  }
+
+  /**
    * Gets the value of the forcingIdentifiersToLowerCase property.
    */
   public boolean isForcingIdentifiersToLowerCase() {
@@ -566,7 +612,7 @@ public class DatabaseConnection {
    */
   public List<PartitionDatabaseMeta> getPartitioningInformation() {
     if ( partitioningInformation == null ) {
-      partitioningInformation = new ArrayList<PartitionDatabaseMeta>();
+      partitioningInformation = new ArrayList<>();
     }
     return this.partitioningInformation;
   }
@@ -682,392 +728,45 @@ public class DatabaseConnection {
   }
 
   /**
-   * <p/>
-   * Java class for anonymous complex type.
-   * <p/>
-   * <p/>
-   * The following schema fragment specifies the expected content contained within this class.
-   * <p/>
-   * <pre>
-   * &lt;complexType>
-   *   &lt;complexContent>
-   *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-   *       &lt;sequence>
-   *         &lt;element name="entry" maxOccurs="unbounded" minOccurs="0">
-   *           &lt;complexType>
-   *             &lt;complexContent>
-   *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-   *                 &lt;sequence>
-   *                   &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-   *                   &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-   *                 &lt;/sequence>
-   *               &lt;/restriction>
-   *             &lt;/complexContent>
-   *           &lt;/complexType>
-   *         &lt;/element>
-   *       &lt;/sequence>
-   *     &lt;/restriction>
-   *   &lt;/complexContent>
-   * &lt;/complexType>
-   * </pre>
+   * <p>Defining an inner class to support the attributes'Map object from the original class.</p>
+   * {@inheritDoc}
    */
-  @XmlAccessorType ( XmlAccessType.FIELD )
-  @XmlType ( name = "", propOrder = { "entry" } )
-  public static class Attributes {
-
-    protected List<DatabaseConnection.Attributes.Entry> entry;
-
-    /**
-     * Gets the value of the entry property.
-     * <p/>
-     * <p/>
-     * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you make to
-     * the returned list will be present inside the JAXB object. This is why there is not a <CODE>set</CODE> method for
-     * the entry property.
-     * <p/>
-     * <p/>
-     * For example, to add a new item, do as follows:
-     * <p/>
-     * <pre>
-     * getEntry().add( newItem );
-     * </pre>
-     * <p/>
-     * <p/>
-     * <p/>
-     * Objects of the following type(s) are allowed in the list {@link DatabaseConnection.Attributes.Entry }
-     */
-    public List<DatabaseConnection.Attributes.Entry> getEntry() {
-      if ( entry == null ) {
-        entry = new ArrayList<DatabaseConnection.Attributes.Entry>();
-      }
-      return this.entry;
-    }
-
-    /**
-     * <p/>
-     * Java class for anonymous complex type.
-     * <p/>
-     * <p/>
-     * The following schema fragment specifies the expected content contained within this class.
-     * <p/>
-     * <pre>
-     * &lt;complexType>
-     *   &lt;complexContent>
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-     *       &lt;sequence>
-     *         &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-     *         &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-     *       &lt;/sequence>
-     *     &lt;/restriction>
-     *   &lt;/complexContent>
-     * &lt;/complexType>
-     * </pre>
-     */
-    @XmlAccessorType ( XmlAccessType.FIELD )
-    @XmlType ( name = "", propOrder = { "key", "value" } )
-    public static class Entry {
-
-      protected String key;
-      protected String value;
-
-      /**
-       * Gets the value of the key property.
-       *
-       * @return possible object is {@link String }
-       */
-      public String getKey() {
-        return key;
-      }
-
-      /**
-       * Sets the value of the key property.
-       *
-       * @param value allowed object is {@link String }
-       */
-      public void setKey( String value ) {
-        this.key = value;
-      }
-
-      /**
-       * Gets the value of the value property.
-       *
-       * @return possible object is {@link String }
-       */
-      public String getValue() {
-        return value;
-      }
-
-      /**
-       * Sets the value of the value property.
-       *
-       * @param value allowed object is {@link String }
-       */
-      public void setValue( String value ) {
-        this.value = value;
-      }
-
-    }
-
+  public static class Attributes extends MapExport {
   }
 
   /**
-   * <p/>
-   * Java class for anonymous complex type.
-   * <p/>
-   * <p/>
-   * The following schema fragment specifies the expected content contained within this class.
-   * <p/>
-   * <pre>
-   * &lt;complexType>
-   *   &lt;complexContent>
-   *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-   *       &lt;sequence>
-   *         &lt;element name="entry" maxOccurs="unbounded" minOccurs="0">
-   *           &lt;complexType>
-   *             &lt;complexContent>
-   *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-   *                 &lt;sequence>
-   *                   &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-   *                   &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-   *                 &lt;/sequence>
-   *               &lt;/restriction>
-   *             &lt;/complexContent>
-   *           &lt;/complexType>
-   *         &lt;/element>
-   *       &lt;/sequence>
-   *     &lt;/restriction>
-   *   &lt;/complexContent>
-   * &lt;/complexType>
-   * </pre>
+   * <p>Defining an inner class to support the connectionPoolingProperties'Map object from the original class.</p>
+   * {@inheritDoc}
    */
-  @XmlAccessorType ( XmlAccessType.FIELD )
-  @XmlType ( name = "", propOrder = { "entry" } )
-  public static class ConnectionPoolingProperties {
-
-    protected List<DatabaseConnection.ConnectionPoolingProperties.Entry> entry;
-
-    /**
-     * Gets the value of the entry property.
-     * <p/>
-     * <p/>
-     * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you make to
-     * the returned list will be present inside the JAXB object. This is why there is not a <CODE>set</CODE> method for
-     * the entry property.
-     * <p/>
-     * <p/>
-     * For example, to add a new item, do as follows:
-     * <p/>
-     * <pre>
-     * getEntry().add( newItem );
-     * </pre>
-     * <p/>
-     * <p/>
-     * <p/>
-     * Objects of the following type(s) are allowed in the list {@link DatabaseConnection.ConnectionPoolingProperties
-     * .Entry
-     * }
-     */
-    public List<DatabaseConnection.ConnectionPoolingProperties.Entry> getEntry() {
-      if ( entry == null ) {
-        entry = new ArrayList<DatabaseConnection.ConnectionPoolingProperties.Entry>();
-      }
-      return this.entry;
-    }
-
-    /**
-     * <p/>
-     * Java class for anonymous complex type.
-     * <p/>
-     * <p/>
-     * The following schema fragment specifies the expected content contained within this class.
-     * <p/>
-     * <pre>
-     * &lt;complexType>
-     *   &lt;complexContent>
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-     *       &lt;sequence>
-     *         &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-     *         &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-     *       &lt;/sequence>
-     *     &lt;/restriction>
-     *   &lt;/complexContent>
-     * &lt;/complexType>
-     * </pre>
-     */
-    @XmlAccessorType ( XmlAccessType.FIELD )
-    @XmlType ( name = "", propOrder = { "key", "value" } )
-    public static class Entry {
-
-      protected String key;
-      protected String value;
-
-      /**
-       * Gets the value of the key property.
-       *
-       * @return possible object is {@link String }
-       */
-      public String getKey() {
-        return key;
-      }
-
-      /**
-       * Sets the value of the key property.
-       *
-       * @param value allowed object is {@link String }
-       */
-      public void setKey( String value ) {
-        this.key = value;
-      }
-
-      /**
-       * Gets the value of the value property.
-       *
-       * @return possible object is {@link String }
-       */
-      public String getValue() {
-        return value;
-      }
-
-      /**
-       * Sets the value of the value property.
-       *
-       * @param value allowed object is {@link String }
-       */
-      public void setValue( String value ) {
-        this.value = value;
-      }
-
-    }
-
+  public static class ConnectionPoolingProperties extends MapExport {
   }
 
   /**
-   * <p/>
-   * Java class for anonymous complex type.
-   * <p/>
-   * <p/>
-   * The following schema fragment specifies the expected content contained within this class.
-   * <p/>
-   * <pre>
-   * &lt;complexType>
-   *   &lt;complexContent>
-   *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-   *       &lt;sequence>
-   *         &lt;element name="entry" maxOccurs="unbounded" minOccurs="0">
-   *           &lt;complexType>
-   *             &lt;complexContent>
-   *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-   *                 &lt;sequence>
-   *                   &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-   *                   &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-   *                 &lt;/sequence>
-   *               &lt;/restriction>
-   *             &lt;/complexContent>
-   *           &lt;/complexType>
-   *         &lt;/element>
-   *       &lt;/sequence>
-   *     &lt;/restriction>
-   *   &lt;/complexContent>
-   * &lt;/complexType>
-   * </pre>
+   * <p>Defining an inner class to support the extraOptions'Map object from the original class.</p>
+   * {@inheritDoc}
    */
-  @XmlAccessorType ( XmlAccessType.FIELD )
-  @XmlType ( name = "", propOrder = { "entry" } )
-  public static class ExtraOptions {
-
-    protected List<DatabaseConnection.ExtraOptions.Entry> entry;
-
-    /**
-     * Gets the value of the entry property.
-     * <p/>
-     * <p/>
-     * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you make to
-     * the returned list will be present inside the JAXB object. This is why there is not a <CODE>set</CODE> method for
-     * the entry property.
-     * <p/>
-     * <p/>
-     * For example, to add a new item, do as follows:
-     * <p/>
-     * <pre>
-     * getEntry().add( newItem );
-     * </pre>
-     * <p/>
-     * <p/>
-     * <p/>
-     * Objects of the following type(s) are allowed in the list {@link DatabaseConnection.ExtraOptions.Entry }
-     */
-    public List<DatabaseConnection.ExtraOptions.Entry> getEntry() {
-      if ( entry == null ) {
-        entry = new ArrayList<DatabaseConnection.ExtraOptions.Entry>();
-      }
-      return this.entry;
-    }
-
-    /**
-     * <p/>
-     * Java class for anonymous complex type.
-     * <p/>
-     * <p/>
-     * The following schema fragment specifies the expected content contained within this class.
-     * <p/>
-     * <pre>
-     * &lt;complexType>
-     *   &lt;complexContent>
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-     *       &lt;sequence>
-     *         &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-     *         &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
-     *       &lt;/sequence>
-     *     &lt;/restriction>
-     *   &lt;/complexContent>
-     * &lt;/complexType>
-     * </pre>
-     */
-    @XmlAccessorType ( XmlAccessType.FIELD )
-    @XmlType ( name = "", propOrder = { "key", "value" } )
-    public static class Entry {
-
-      protected String key;
-      protected String value;
-
-      /**
-       * Gets the value of the key property.
-       *
-       * @return possible object is {@link String }
-       */
-      public String getKey() {
-        return key;
-      }
-
-      /**
-       * Sets the value of the key property.
-       *
-       * @param value allowed object is {@link String }
-       */
-      public void setKey( String value ) {
-        this.key = value;
-      }
-
-      /**
-       * Gets the value of the value property.
-       *
-       * @return possible object is {@link String }
-       */
-      public String getValue() {
-        return value;
-      }
-
-      /**
-       * Sets the value of the value property.
-       *
-       * @param value allowed object is {@link String }
-       */
-      public void setValue( String value ) {
-        this.value = value;
-      }
-
-    }
-
+  public static class ExtraOptions extends MapExport {
   }
 
+  /**
+   * <p>Defining an inner class to support the extraOptionsOrder'Map object from the original class.</p>
+   * {@inheritDoc}
+   */
+  public static class ExtraOptionsOrder extends MapExport {
+  }
+
+  /**
+   * An implementation of {@link XmlAdapter} that allows us to have passwords encrypted on serialization.
+   */
+  public static class PasswordEncryptionAdapter extends XmlAdapter<String, String> {
+    @Override
+    public String marshal( final String plainText ) throws Exception {
+      return Encr.encryptPassword( plainText );
+    }
+
+    @Override
+    public String unmarshal( final String encodedText ) throws Exception {
+      return Encr.decryptPassword( encodedText );
+    }
+  }
 }

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseType.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseType.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -52,23 +52,49 @@ import java.util.List;
  *         &lt;element name="shortName" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
  *         &lt;element name="supportedAccessTypes" type="{http://www.pentaho.com/schema/}databaseAccessType"
  * maxOccurs="unbounded" minOccurs="0"/>
+ *         &lt;element name="defaultDatabaseName" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *         &lt;element name="defaultOptions">
+ *           &lt;complexType>
+ *             &lt;complexContent>
+ *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 &lt;sequence>
+ *                   &lt;element name="entry" maxOccurs="unbounded" minOccurs="0">
+ *                     &lt;complexType>
+ *                       &lt;complexContent>
+ *                         &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                           &lt;sequence>
+ *                             &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *                             &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *                           &lt;/sequence>
+ *                         &lt;/restriction>
+ *                       &lt;/complexContent>
+ *                     &lt;/complexType>
+ *                   &lt;/element>
+ *                 &lt;/sequence>
+ *               &lt;/restriction>
+ *             &lt;/complexContent>
+ *           &lt;/complexType>
+ *         &lt;/element>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
  */
-@XmlAccessorType ( XmlAccessType.FIELD )
-@XmlType ( name = "databaseType", propOrder = { "defaultDatabasePort", "extraOptionsHelpUrl", "name", "shortName",
-    "supportedAccessTypes" } )
+@XmlAccessorType( XmlAccessType.FIELD )
+@XmlType( name = "databaseType", propOrder = { "defaultDatabasePort", "extraOptionsHelpUrl", "name", "shortName",
+  "supportedAccessTypes", "defaultDatabaseName", "defaultOptions" } )
 public class DatabaseType {
 
   protected int defaultDatabasePort;
   protected String extraOptionsHelpUrl;
   protected String name;
   protected String shortName;
-  @XmlElement ( nillable = true )
+  @XmlElement( nillable = true )
   protected List<DatabaseAccessType> supportedAccessTypes;
+  protected String defaultDatabaseName;
+  @XmlElement( required = true )
+  protected DatabaseType.DefaultOptions defaultOptions;
 
   /**
    * Gets the value of the defaultDatabasePort property.
@@ -159,9 +185,49 @@ public class DatabaseType {
    */
   public List<DatabaseAccessType> getSupportedAccessTypes() {
     if ( supportedAccessTypes == null ) {
-      supportedAccessTypes = new ArrayList<DatabaseAccessType>();
+      supportedAccessTypes = new ArrayList<>();
     }
     return this.supportedAccessTypes;
   }
 
+  /**
+   * Gets the value of the defaultDatabaseName property.
+   *
+   * @return possible object is {@link String }
+   */
+  public String getDefaultDatabaseName() {
+    return defaultDatabaseName;
+  }
+
+  /**
+   * Sets the value of the defaultDatabaseName property.
+   */
+  public void setDefaultDatabaseName( String value ) {
+    this.defaultDatabaseName = value;
+  }
+
+  /**
+   * Gets the value of the defaultOptions property.
+   *
+   * @return possible object is {@link DatabaseType.DefaultOptions }
+   */
+  public DatabaseType.DefaultOptions getDefaultOptions() {
+    return defaultOptions;
+  }
+
+  /**
+   * Sets the value of the defaultOptions property.
+   *
+   * @param value allowed object is {@link DatabaseType.DefaultOptions }
+   */
+  public void setDefaultOptions( DatabaseType.DefaultOptions value ) {
+    this.defaultOptions = value;
+  }
+
+  /**
+   * <p>Defining an inner class to support the DefaultOptions'Map object from the original class.</p>
+   * {@inheritDoc}
+   */
+  public static class DefaultOptions extends MapExport {
+  }
 }

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestDto.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/ExportManifestDto.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -27,7 +27,6 @@
 
 package org.pentaho.platform.plugin.services.importexport.exportManifest.bindings;
 
-import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.platform.plugin.services.importexport.ExportManifestUserSetting;
 import org.pentaho.platform.plugin.services.importexport.RoleExport;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
@@ -147,21 +146,21 @@ public class ExportManifestDto {
    */
   public List<ExportManifestMondrian> getExportManifestMondrian() {
     if ( exportManifestMondrian == null ) {
-      exportManifestMondrian = new ArrayList<ExportManifestMondrian>();
+      exportManifestMondrian = new ArrayList<>();
     }
     return this.exportManifestMondrian;
   }
 
   public List<UserExport> getExportManifestUser() {
     if ( exportManifestUser == null ) {
-      exportManifestUser = new ArrayList<UserExport>();
+      exportManifestUser = new ArrayList<>();
     }
     return this.exportManifestUser;
   }
 
   public List<RoleExport> getExportManifestRole() {
     if ( exportManifestRole == null ) {
-      exportManifestRole = new ArrayList<RoleExport>();
+      exportManifestRole = new ArrayList<>();
     }
     return this.exportManifestRole;
   }
@@ -187,7 +186,7 @@ public class ExportManifestDto {
    */
   public List<ExportManifestMetadata> getExportManifestMetadata() {
     if ( exportManifestMetadata == null ) {
-      exportManifestMetadata = new ArrayList<ExportManifestMetadata>();
+      exportManifestMetadata = new ArrayList<>();
     }
     return this.exportManifestMetadata;
   }
@@ -213,7 +212,7 @@ public class ExportManifestDto {
    */
   public List<JobScheduleRequest> getExportManifestSchedule() {
     if ( exportManifestSchedule == null ) {
-      exportManifestSchedule = new ArrayList<JobScheduleRequest>();
+      exportManifestSchedule = new ArrayList<>();
     }
     return this.exportManifestSchedule;
   }
@@ -239,7 +238,7 @@ public class ExportManifestDto {
    */
   public List<DatabaseConnection> getExportManifestDatasource() {
     if ( exportManifestDatasource == null ) {
-      exportManifestDatasource = new ArrayList<DatabaseConnection>();
+      exportManifestDatasource = new ArrayList<>();
     }
     return this.exportManifestDatasource;
   }
@@ -265,7 +264,7 @@ public class ExportManifestDto {
    */
   public List<ExportManifestEntityDto> getExportManifestEntity() {
     if ( exportManifestEntity == null ) {
-      exportManifestEntity = new ArrayList<ExportManifestEntityDto>();
+      exportManifestEntity = new ArrayList<>();
     }
     return this.exportManifestEntity;
   }

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/MapExport.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/MapExport.java
@@ -1,0 +1,153 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.importexport.exportManifest.bindings;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p> Java class for anonymous complex type.</p>
+ * <p>This class, to be used in the "Export" classes, supports the Map object from the original class.<br/>
+ * This exact code was being used in several places; to avoid duplication, it was extracted so that it can be
+ * reused.</p>
+ * <p>The following schema fragment specifies the expected content contained within this class.</p>
+ * <pre>
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="entry" maxOccurs="unbounded" minOccurs="0">
+ *           &lt;complexType>
+ *             &lt;complexContent>
+ *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *                 &lt;sequence>
+ *                   &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *                   &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *                 &lt;/sequence>
+ *               &lt;/restriction>
+ *             &lt;/complexContent>
+ *           &lt;/complexType>
+ *         &lt;/element>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ */
+@XmlAccessorType( XmlAccessType.FIELD )
+@XmlType( name = "", propOrder = { "entry" } )
+public class MapExport {
+
+  protected List<MapExport.Entry> entry;
+
+  /**
+   * Gets the value of the entry property.
+   * <p/>
+   * <p/>
+   * This accessor method returns a reference to the live list, not a snapshot. Therefore any modification you make to
+   * the returned list will be present inside the JAXB object. This is why there is not a <CODE>set</CODE> method for
+   * the entry property.
+   * <p/>
+   * <p/>
+   * For example, to add a new item, do as follows:
+   * <p/>
+   * <pre>
+   * getEntry().add( newItem );
+   * </pre>
+   * <p/>
+   * <p/>
+   * <p/>
+   * Objects of the following type(s) are allowed in the list {@link MapExport.Entry }
+   */
+  public List<MapExport.Entry> getEntry() {
+    if ( entry == null ) {
+      entry = new ArrayList<>();
+    }
+    return this.entry;
+  }
+
+  /**
+   * <p/>
+   * Java class for anonymous complex type.
+   * <p/>
+   * <p/>
+   * The following schema fragment specifies the expected content contained within this class.
+   * <p/>
+   * <pre>
+   * &lt;complexType>
+   *   &lt;complexContent>
+   *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+   *       &lt;sequence>
+   *         &lt;element name="key" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+   *         &lt;element name="value" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+   *       &lt;/sequence>
+   *     &lt;/restriction>
+   *   &lt;/complexContent>
+   * &lt;/complexType>
+   * </pre>
+   */
+  @XmlAccessorType( XmlAccessType.FIELD )
+  @XmlType( name = "", propOrder = { "key", "value" } )
+  public static class Entry {
+
+    protected String key;
+    protected String value;
+
+    /**
+     * Gets the value of the key property.
+     *
+     * @return possible object is {@link String }
+     */
+    public String getKey() {
+      return key;
+    }
+
+    /**
+     * Sets the value of the key property.
+     *
+     * @param value allowed object is {@link String }
+     */
+    public void setKey( String value ) {
+      this.key = value;
+    }
+
+    /**
+     * Gets the value of the value property.
+     *
+     * @return possible object is {@link String }
+     */
+    public String getValue() {
+      return value;
+    }
+
+    /**
+     * Sets the value of the value property.
+     *
+     * @param value allowed object is {@link String }
+     */
+    public void setValue( String value ) {
+      this.value = value;
+    }
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/exporter/PentahoPlatformExporterTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -24,7 +24,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.metastore.api.IMetaStore;
@@ -48,6 +47,7 @@ import org.pentaho.platform.plugin.services.importexport.ExportManifestUserSetti
 import org.pentaho.platform.plugin.services.importexport.RoleExport;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseConnection;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetaStore;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMondrian;
 import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
@@ -170,19 +170,19 @@ public class PentahoPlatformExporterTest {
     String tenantPath = "path";
     when( session.getAttribute( IPentahoSession.TENANT_ID_KEY ) ).thenReturn( tenantPath );
 
-    List<String> userList = new ArrayList<String>();
+    List<String> userList = new ArrayList<>();
     String user = "testUser";
     String role = "testRole";
 
     userList.add( user );
     when( mockDao.getAllUsers( any( ITenant.class ) ) ).thenReturn( userList );
 
-    List<String> roleList = new ArrayList<String>();
+    List<String> roleList = new ArrayList<>();
     roleList.add( role );
     when( mockDao.getAllRoles() ).thenReturn( roleList );
 
-    Map<String, List<String>> map = new HashMap<String, List<String>>();
-    List<String> permissions = new ArrayList<String>();
+    Map<String, List<String>> map = new HashMap<>();
+    List<String> permissions = new ArrayList<>();
     permissions.add( "read" );
     map.put( "testRole", permissions );
     RoleBindingStruct struct = mock( RoleBindingStruct.class );
@@ -200,7 +200,7 @@ public class PentahoPlatformExporterTest {
     when( userSettingService.getUserSettings( user ) ).thenReturn( settings );
     when( userSettingService.getGlobalUserSettings() ).thenReturn( settings );
 
-    List<GrantedAuthority> authList = new ArrayList<GrantedAuthority>();
+    List<GrantedAuthority> authList = new ArrayList<>();
     UserDetails userDetails = new User( "testUser", "testPassword", true, true, true, true, authList );
     when( userDetailsService.loadUserByUsername( anyString() ) ).thenReturn( userDetails );
 
@@ -240,7 +240,7 @@ public class PentahoPlatformExporterTest {
 
     Map<String, InputStream> inputMap = new HashMap<>();
     InputStream is = mock( InputStream.class );
-    when( is.read( any( ( new byte[] {} ).getClass() ) ) ).thenReturn( -1 );
+    when( is.read( any( byte[].class ) ) ).thenReturn( -1 );
     inputMap.put( "test1", is );
 
     doReturn( inputMap ).when( exporterSpy ).getDomainFilesData( "test1" );
@@ -260,7 +260,8 @@ public class PentahoPlatformExporterTest {
     exporterSpy.setDatasourceMgmtService( svc );
 
     List<IDatabaseConnection> datasources = new ArrayList<>();
-    IDatabaseConnection conn = mock( DatabaseConnection.class );
+    IDatabaseConnection conn = mock( org.pentaho.database.model.DatabaseConnection.class );
+    when( conn.getName() ).thenReturn( "aDatasourceName" );
     IDatabaseConnection icon = mock( IDatabaseConnection.class );
     datasources.add( conn );
     datasources.add( icon );
@@ -270,7 +271,8 @@ public class PentahoPlatformExporterTest {
     exporterSpy.exportDatasources();
 
     assertEquals( 1, exporterSpy.getExportManifest().getDatasourceList().size() );
-    assertEquals( conn, exporterSpy.getExportManifest().getDatasourceList().get( 0 ) );
+    DatabaseConnection exportedDatabaseConnection = exporterSpy.getExportManifest().getDatasourceList().get( 0 );
+    assertEquals( "aDatasourceName", exportedDatabaseConnection.getName() );
   }
 
   @Test
@@ -360,7 +362,7 @@ public class PentahoPlatformExporterTest {
 
     Map<String, InputStream> inputMap = new HashMap<>();
     InputStream is = mock( InputStream.class );
-    when( is.read( any( ( new byte[] {} ).getClass() ) ) ).thenReturn( -1 );
+    when( is.read( any( byte[].class ) ) ).thenReturn( -1 );
     inputMap.put( catalogName, is );
     when( mondrianCatalogRepositoryHelper.getModrianSchemaFiles( catalogName ) ).thenReturn( inputMap );
     exporterSpy.zos = mock( ZipOutputStream.class );

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/DatabaseConnectionConverterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/DatabaseConnectionConverterTest.java
@@ -1,0 +1,550 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2019-2020 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.importexport;
+
+import junit.framework.TestCase;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseAccessType;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseConnection;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseType;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.MapExport;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.PartitionDatabaseMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DatabaseConnectionConverterTest extends TestCase {
+
+  // Values to be used on the tests
+  private static final String CONNECT_SQL = "connectSql";
+  private static final org.pentaho.database.model.DatabaseAccessType DATABASE_ACCESS_TYPE_MODEL =
+    org.pentaho.database.model.DatabaseAccessType.OCI;
+  private static final DatabaseAccessType DATABASE_ACCESS_TYPE_EXPORT = DatabaseAccessType.OCI;
+  private static final org.pentaho.database.model.DatabaseAccessType SUPPORTED_DATABASE_ACCESS_TYPE_MODEL =
+    org.pentaho.database.model.DatabaseAccessType.JNDI;
+  private static final DatabaseAccessType SUPPORTED_DATABASE_ACCESS_TYPE_EXPORT = DatabaseAccessType.JNDI;
+  private static final String DATABASE_NAME = "databaseName";
+  private static final String DATABASE_PORT = "123456";
+
+  private static final boolean CHANGED = false;
+  private static final String DATABASE_TYPE_NAME = "databaseTypeName";
+  private static final String DATABASE_TYPE_SHORT_NAME = "databaseTypeShortName";
+  private static final String DATABASE_TYPE_DEFAULT_NAME = "databaseTypeDefaultName";
+  private static final int DATABASE_TYPE_DEFAULT_PORT = 9182;
+  private static final String DATABASE_TYPE_EXTRA_OPTIONS_HELP_URL = "databaseTypeExtraOptionsHelpUrl";
+
+  private static final String DUMMY_MAP_KEY = "dummyMapKey_";
+  private static final String DUMMY_MAP_VALUE = "dummyMapValue_";
+  private static final String DUMMY_EXPORT_KEY = "dummyExportKey_";
+  private static final String DUMMY_EXPORT_VALUE = "dummyExportValue_";
+
+  private static final String DATA_TABLESPACE = "dataTablespace";
+  private static final boolean FORCING_IDENTIFIERS_TO_LOWER_CASE = false;
+  private static final boolean FORCING_IDENTIFIERS_TO_UPPER_CASE = false;
+  private static final String HOSTNAME = "hostname";
+  private static final String ID = "id";
+  private static final String INDEX_TABLESPACE = "indexTablespace";
+  private static final String INFORMIX_SERVERNAME = "informixServername";
+  private static final int INITIAL_POOL_SIZE = 123;
+  private static final int MAXIMUM_POOL_SIZE = 321;
+  private static final String NAME = "name";
+  private static final boolean PARTITIONED = false;
+  private static final String PARTITIONING_INFORMATION_DATABASE_NAME = "partitioningInformationDatabaseName";
+  private static final String PARTITIONING_INFORMATION_HOSTNAME = "partitioningInformationHostname";
+  private static final String PARTITIONING_INFORMATION_PARTITION_ID = "partitioningInformationPartitionId";
+  private static final String PARTITIONING_INFORMATION_PASSWORD = "partitioningInformationPassword";
+  private static final String PARTITIONING_INFORMATION_PORT = "99887766";
+  private static final String PARTITIONING_INFORMATION_USERNAME = "partitioningInformationUsername";
+  private static final String PASSWORD = "password";
+  private static final boolean QUOTE_ALL_FIELDS = false;
+  private static final String SQL_SERVER_INSTANCE = "sqlServerInstance";
+  private static final boolean STREAMING_RESULTS = false;
+  private static final String USERNAME = "username";
+  private static final boolean USING_CONNECTION_POOL = false;
+  private static final boolean USING_DOUBLE_DECIMAL_AS_SCHEMA_TABLE_SEPARATOR = false;
+
+
+  public void testModel2export() throws Exception {
+
+    org.pentaho.database.model.IDatabaseConnection databaseConnection = buildDatabaseConnectionModel();
+
+    // Convert
+
+    DatabaseConnection databaseConnectionExport = DatabaseConnectionConverter.model2export( databaseConnection );
+
+
+    // Asserts
+
+    assertEquals( DATABASE_ACCESS_TYPE_EXPORT, databaseConnectionExport.getAccessType() );
+
+
+    assertMapEquals2model( databaseConnection.getAttributes(), databaseConnectionExport.getAttributes() );
+
+    assertEquals( CHANGED, databaseConnectionExport.isChanged() );
+
+    assertMapEquals2model( databaseConnection.getConnectionPoolingProperties(),
+      databaseConnectionExport.getConnectionPoolingProperties() );
+
+    assertEquals( databaseConnection.getConnectSql(), databaseConnectionExport.getConnectSql() );
+    assertEquals( databaseConnection.getDatabaseName(), databaseConnectionExport.getDatabaseName() );
+    assertEquals( databaseConnection.getDatabasePort(), databaseConnectionExport.getDatabasePort() );
+
+    assertDatabaseTypeEquals2model( databaseConnection.getDatabaseType(), databaseConnectionExport.getDatabaseType() );
+
+    assertEquals( databaseConnection.getDataTablespace(), databaseConnectionExport.getDataTablespace() );
+
+    // Note that the implementation of the "SQLServerInstance" uses the extraOptions map to store an information
+    assertMapEquals2model( databaseConnection.getExtraOptions(), databaseConnectionExport.getExtraOptions() );
+    assertMapEquals2model( databaseConnection.getExtraOptionsOrder(), databaseConnectionExport.getExtraOptionsOrder() );
+
+    assertEquals( databaseConnection.isForcingIdentifiersToLowerCase(),
+      databaseConnectionExport.isForcingIdentifiersToLowerCase() );
+    assertEquals( databaseConnection.isForcingIdentifiersToUpperCase(),
+      databaseConnectionExport.isForcingIdentifiersToUpperCase() );
+    assertEquals( databaseConnection.getHostname(), databaseConnectionExport.getHostname() );
+    assertEquals( databaseConnection.getId(), databaseConnectionExport.getId() );
+    assertEquals( databaseConnection.getIndexTablespace(), databaseConnectionExport.getIndexTablespace() );
+    assertEquals( databaseConnection.getInformixServername(), databaseConnectionExport.getInformixServername() );
+    assertEquals( databaseConnection.getInitialPoolSize(), databaseConnectionExport.getInitialPoolSize() );
+    assertEquals( databaseConnection.getMaximumPoolSize(), databaseConnectionExport.getMaximumPoolSize() );
+    assertEquals( databaseConnection.getName(), databaseConnectionExport.getName() );
+    assertEquals( databaseConnection.isPartitioned(), databaseConnectionExport.isPartitioned() );
+
+    assertPartitionDatabaseMetaEquals2model( databaseConnection.getPartitioningInformation(),
+      databaseConnectionExport.getPartitioningInformation() );
+
+    assertEquals( databaseConnection.getPassword(), databaseConnectionExport.getPassword() );
+    assertEquals( databaseConnection.isQuoteAllFields(), databaseConnectionExport.isQuoteAllFields() );
+    assertEquals( databaseConnection.getSQLServerInstance(), databaseConnectionExport.getSQLServerInstance() );
+    assertEquals( databaseConnection.isStreamingResults(), databaseConnectionExport.isStreamingResults() );
+    assertEquals( databaseConnection.getUsername(), databaseConnectionExport.getUsername() );
+    assertEquals( databaseConnection.isUsingDoubleDecimalAsSchemaTableSeparator(),
+      databaseConnectionExport.isUsingDoubleDecimalAsSchemaTableSeparator() );
+    assertEquals( databaseConnection.isUsingConnectionPool(), databaseConnectionExport.isUsingConnectionPool() );
+  }
+
+  public void testExport2model() throws Exception {
+
+    DatabaseConnection databaseConnection = buildDatabaseConnectionExport();
+
+    // Convert
+
+    org.pentaho.database.model.IDatabaseConnection databaseConnectionModel =
+      DatabaseConnectionConverter.export2model( databaseConnection );
+
+
+    // Asserts
+
+    assertEquals( DATABASE_ACCESS_TYPE_MODEL, databaseConnectionModel.getAccessType() );
+
+    assertMapEquals2export( databaseConnection.getAttributes(), databaseConnectionModel.getAttributes(), 0 );
+
+    assertEquals( databaseConnection.isChanged(), databaseConnection.isChanged() );
+
+    assertMapEquals2export( databaseConnection.getConnectionPoolingProperties(),
+      databaseConnectionModel.getConnectionPoolingProperties(), 0 );
+
+    assertEquals( databaseConnection.getConnectSql(), databaseConnectionModel.getConnectSql() );
+    assertEquals( databaseConnection.getDatabaseName(), databaseConnectionModel.getDatabaseName() );
+    assertEquals( databaseConnection.getDatabasePort(), databaseConnectionModel.getDatabasePort() );
+
+    assertDatabaseTypeEquals2export( databaseConnection.getDatabaseType(), databaseConnectionModel.getDatabaseType() );
+
+    assertEquals( databaseConnection.getDataTablespace(), databaseConnectionModel.getDataTablespace() );
+
+    // Note that the implementation of the "SQLServerInstance" uses the extraOptions map to store an information
+    assertMapEquals2export( databaseConnection.getExtraOptions(), databaseConnectionModel.getExtraOptions(), 1 );
+    assertMapEquals2export( databaseConnection.getExtraOptionsOrder(), databaseConnectionModel.getExtraOptionsOrder(),
+      0 );
+
+    assertEquals( databaseConnection.isForcingIdentifiersToLowerCase(),
+      databaseConnection.isForcingIdentifiersToLowerCase() );
+    assertEquals( databaseConnection.isForcingIdentifiersToUpperCase(),
+      databaseConnection.isForcingIdentifiersToUpperCase() );
+    assertEquals( databaseConnection.getHostname(), databaseConnectionModel.getHostname() );
+    assertEquals( databaseConnection.getId(), databaseConnectionModel.getId() );
+    assertEquals( databaseConnection.getIndexTablespace(), databaseConnectionModel.getIndexTablespace() );
+    assertEquals( databaseConnection.getInformixServername(), databaseConnectionModel.getInformixServername() );
+    assertEquals( databaseConnection.getInitialPoolSize(), databaseConnectionModel.getInitialPoolSize() );
+    assertEquals( databaseConnection.getMaximumPoolSize(), databaseConnectionModel.getMaximumPoolSize() );
+    assertEquals( databaseConnection.getName(), databaseConnectionModel.getName() );
+    assertEquals( databaseConnection.isPartitioned(), databaseConnection.isPartitioned() );
+
+    assertPartitionDatabaseMetaEquals2export( databaseConnection.getPartitioningInformation(),
+      databaseConnectionModel.getPartitioningInformation() );
+
+    assertEquals( databaseConnection.getPassword(), databaseConnectionModel.getPassword() );
+    assertEquals( databaseConnection.isQuoteAllFields(), databaseConnection.isQuoteAllFields() );
+    assertEquals( databaseConnection.getSQLServerInstance(), databaseConnectionModel.getSQLServerInstance() );
+    assertEquals( databaseConnection.isStreamingResults(), databaseConnection.isStreamingResults() );
+    assertEquals( databaseConnection.getUsername(), databaseConnectionModel.getUsername() );
+    assertEquals( databaseConnection.isUsingDoubleDecimalAsSchemaTableSeparator(),
+      databaseConnection.isUsingDoubleDecimalAsSchemaTableSeparator() );
+    assertEquals( databaseConnection.isUsingConnectionPool(), databaseConnection.isUsingConnectionPool() );
+  }
+
+  protected org.pentaho.database.model.IDatabaseConnection buildDatabaseConnectionModel() {
+    org.pentaho.database.model.IDatabaseConnection databaseConnection =
+      new org.pentaho.database.model.DatabaseConnection();
+
+    // "Simple" values
+    databaseConnection.setAccessType( DATABASE_ACCESS_TYPE_MODEL );
+    databaseConnection.setChanged( CHANGED );
+    databaseConnection.setConnectSql( CONNECT_SQL );
+    databaseConnection.setDatabaseName( DATABASE_NAME );
+    databaseConnection.setDatabasePort( DATABASE_PORT );
+    databaseConnection.setDataTablespace( DATA_TABLESPACE );
+    databaseConnection.setForcingIdentifiersToLowerCase( FORCING_IDENTIFIERS_TO_LOWER_CASE );
+    databaseConnection.setForcingIdentifiersToUpperCase( FORCING_IDENTIFIERS_TO_UPPER_CASE );
+    databaseConnection.setHostname( HOSTNAME );
+    databaseConnection.setId( ID );
+    databaseConnection.setIndexTablespace( INDEX_TABLESPACE );
+    databaseConnection.setInformixServername( INFORMIX_SERVERNAME );
+    databaseConnection.setInitialPoolSize( INITIAL_POOL_SIZE );
+    databaseConnection.setMaximumPoolSize( MAXIMUM_POOL_SIZE );
+    databaseConnection.setName( NAME );
+    databaseConnection.setPartitioned( PARTITIONED );
+    databaseConnection.setPassword( PASSWORD );
+    databaseConnection.setQuoteAllFields( QUOTE_ALL_FIELDS );
+    // Note that the implementation of the "SQLServerInstance" uses the extraOptions map to store an information
+    databaseConnection.setSQLServerInstance( SQL_SERVER_INSTANCE );
+    databaseConnection.setStreamingResults( STREAMING_RESULTS );
+    databaseConnection.setUsername( USERNAME );
+    databaseConnection.setUsingConnectionPool( USING_CONNECTION_POOL );
+    databaseConnection.setUsingDoubleDecimalAsSchemaTableSeparator( USING_DOUBLE_DECIMAL_AS_SCHEMA_TABLE_SEPARATOR );
+
+    // "Complex" values
+
+    Map<String, String> attributes = new HashMap<>();
+    generateMapEntries( attributes, 5 );
+    databaseConnection.setAttributes( attributes );
+
+    Map<String, String> connectionPoolingProperties = new HashMap<>();
+    generateMapEntries( connectionPoolingProperties, 2 );
+    databaseConnection.setConnectionPoolingProperties( connectionPoolingProperties );
+
+    List<org.pentaho.database.model.DatabaseAccessType> databaseTypeSupportedAccessTypes = new ArrayList<>();
+    databaseTypeSupportedAccessTypes.add( SUPPORTED_DATABASE_ACCESS_TYPE_MODEL );
+    org.pentaho.database.model.IDatabaseType databaseType =
+      new org.pentaho.database.model.DatabaseType( DATABASE_TYPE_NAME, DATABASE_TYPE_SHORT_NAME,
+        databaseTypeSupportedAccessTypes,
+        DATABASE_TYPE_DEFAULT_PORT, DATABASE_TYPE_EXTRA_OPTIONS_HELP_URL );
+    Map<String, String> databaseTypeDefaultOptions = new HashMap<>();
+    generateMapEntries( databaseTypeDefaultOptions, 3 );
+    databaseType.setDefaultOptions( databaseTypeDefaultOptions );
+    databaseConnection.setDatabaseType( databaseType );
+
+    // Note that the implementation of the "SQLServerInstance" uses the extraOptions map to store an information
+    // Testing if the map already exists!
+    Map<String, String> extraOptions = databaseConnection.getExtraOptions();
+    // Create a new only if non-existent
+    extraOptions = null != extraOptions ? extraOptions : new HashMap<>();
+    generateMapEntries( extraOptions, 3 );
+    databaseConnection.setExtraOptions( extraOptions );
+
+    Map<String, String> extraOptionsOrder = new HashMap<>();
+    generateMapEntries( extraOptionsOrder, 2 );
+    databaseConnection.setExtraOptionsOrder( extraOptionsOrder );
+
+    org.pentaho.database.model.PartitionDatabaseMeta partitioningInformation =
+      new org.pentaho.database.model.PartitionDatabaseMeta();
+    partitioningInformation.setDatabaseName( PARTITIONING_INFORMATION_DATABASE_NAME );
+    partitioningInformation.setHostname( PARTITIONING_INFORMATION_HOSTNAME );
+    partitioningInformation.setPartitionId( PARTITIONING_INFORMATION_PARTITION_ID );
+    partitioningInformation.setPassword( PARTITIONING_INFORMATION_PASSWORD );
+    partitioningInformation.setPort( PARTITIONING_INFORMATION_PORT );
+    partitioningInformation.setUsername( PARTITIONING_INFORMATION_USERNAME );
+    List<org.pentaho.database.model.PartitionDatabaseMeta> partitioningInformationList = new ArrayList<>();
+    partitioningInformationList.add( partitioningInformation );
+    databaseConnection.setPartitioningInformation( partitioningInformationList );
+
+    return databaseConnection;
+  }
+
+  protected DatabaseConnection buildDatabaseConnectionExport() {
+    DatabaseConnection databaseConnection = new DatabaseConnection();
+
+    // "Simple" values
+    databaseConnection.setAccessType( DATABASE_ACCESS_TYPE_EXPORT );
+    databaseConnection.setChanged( CHANGED );
+    databaseConnection.setConnectSql( CONNECT_SQL );
+    databaseConnection.setDatabaseName( DATABASE_NAME );
+    databaseConnection.setDatabasePort( DATABASE_PORT );
+    databaseConnection.setDataTablespace( DATA_TABLESPACE );
+    databaseConnection.setForcingIdentifiersToLowerCase( FORCING_IDENTIFIERS_TO_LOWER_CASE );
+    databaseConnection.setForcingIdentifiersToUpperCase( FORCING_IDENTIFIERS_TO_UPPER_CASE );
+    databaseConnection.setHostname( HOSTNAME );
+    databaseConnection.setId( ID );
+    databaseConnection.setIndexTablespace( INDEX_TABLESPACE );
+    databaseConnection.setInformixServername( INFORMIX_SERVERNAME );
+    databaseConnection.setInitialPoolSize( INITIAL_POOL_SIZE );
+    databaseConnection.setMaximumPoolSize( MAXIMUM_POOL_SIZE );
+    databaseConnection.setName( NAME );
+    databaseConnection.setPartitioned( PARTITIONED );
+    databaseConnection.setPassword( PASSWORD );
+    databaseConnection.setQuoteAllFields( QUOTE_ALL_FIELDS );
+    databaseConnection.setSQLServerInstance( SQL_SERVER_INSTANCE );
+    databaseConnection.setStreamingResults( STREAMING_RESULTS );
+    databaseConnection.setUsername( USERNAME );
+    databaseConnection.setUsingConnectionPool( USING_CONNECTION_POOL );
+    databaseConnection.setUsingDoubleDecimalAsSchemaTableSeparator( USING_DOUBLE_DECIMAL_AS_SCHEMA_TABLE_SEPARATOR );
+
+    // "Complex" values
+
+    DatabaseConnection.Attributes attributes = new DatabaseConnection.Attributes();
+    generateMapExportEntries( attributes, 6 );
+    databaseConnection.setAttributes( attributes );
+
+    DatabaseConnection.ConnectionPoolingProperties connectionPoolingProperties =
+      new DatabaseConnection.ConnectionPoolingProperties();
+    generateMapExportEntries( connectionPoolingProperties, 10 );
+    databaseConnection.setConnectionPoolingProperties( connectionPoolingProperties );
+
+    DatabaseType databaseType = new DatabaseType();
+    databaseType.setDefaultDatabaseName( DATABASE_TYPE_DEFAULT_NAME );
+    databaseType.setDefaultDatabasePort( DATABASE_TYPE_DEFAULT_PORT );
+    DatabaseType.DefaultOptions databaseTypeDefaultOptions = new DatabaseType.DefaultOptions();
+    generateMapExportEntries( databaseTypeDefaultOptions, 5 );
+    databaseType.setDefaultOptions( databaseTypeDefaultOptions );
+    databaseType.setExtraOptionsHelpUrl( DATABASE_TYPE_EXTRA_OPTIONS_HELP_URL );
+    databaseType.setName( DATABASE_TYPE_NAME );
+    databaseType.setShortName( DATABASE_TYPE_SHORT_NAME );
+    databaseType.getSupportedAccessTypes().add( SUPPORTED_DATABASE_ACCESS_TYPE_EXPORT );
+    databaseConnection.setDatabaseType( databaseType );
+
+    DatabaseConnection.ExtraOptions extraOptions = new DatabaseConnection.ExtraOptions();
+    generateMapExportEntries( extraOptions, 2 );
+    databaseConnection.setExtraOptions( extraOptions );
+
+    DatabaseConnection.ExtraOptionsOrder extraOptionsOrder = new DatabaseConnection.ExtraOptionsOrder();
+    generateMapExportEntries( extraOptionsOrder, 1 );
+    databaseConnection.setExtraOptionsOrder( extraOptionsOrder );
+
+    PartitionDatabaseMeta partitioningInformation = new PartitionDatabaseMeta();
+    partitioningInformation.setDatabaseName( PARTITIONING_INFORMATION_DATABASE_NAME );
+    partitioningInformation.setHostname( PARTITIONING_INFORMATION_HOSTNAME );
+    partitioningInformation.setPartitionId( PARTITIONING_INFORMATION_PARTITION_ID );
+    partitioningInformation.setPassword( PARTITIONING_INFORMATION_PASSWORD );
+    partitioningInformation.setPort( PARTITIONING_INFORMATION_PORT );
+    partitioningInformation.setUsername( PARTITIONING_INFORMATION_USERNAME );
+    databaseConnection.getPartitioningInformation().add( partitioningInformation );
+
+    return databaseConnection;
+  }
+
+  protected void generateMapEntries( Map<String, String> map, int entries ) {
+    for ( int i = 0; i < entries; ++i ) {
+      String entryNumber = String.valueOf( i );
+      map.put( DUMMY_MAP_KEY + entryNumber, DUMMY_MAP_VALUE + entryNumber );
+    }
+  }
+
+  protected void generateMapExportEntries( MapExport mapExport, int entries ) {
+    for ( int i = 0; i < entries; ++i ) {
+      String entryNumber = String.valueOf( i );
+      MapExport.Entry exportEntry = new MapExport.Entry();
+      exportEntry.setKey( DUMMY_EXPORT_KEY + entryNumber );
+      exportEntry.setValue( DUMMY_EXPORT_VALUE + entryNumber );
+      mapExport.getEntry().add( exportEntry );
+    }
+  }
+
+  /**
+   * Method to assert that the information on the DatabaseType that existed on the Model was correctly exported
+   *
+   * @param databaseTypeModel  model instance that contains the original information
+   * @param databaseTypeExport export instance that should contain the information
+   */
+  protected void assertDatabaseTypeEquals2model( org.pentaho.database.model.IDatabaseType databaseTypeModel,
+                                                 DatabaseType databaseTypeExport ) {
+    assertNotNull( databaseTypeExport );
+    assertEquals( databaseTypeModel.getName(), databaseTypeExport.getName() );
+    assertEquals( databaseTypeModel.getShortName(), databaseTypeExport.getShortName() );
+    List<DatabaseAccessType> supportedDatabaseAccessTypesExport = databaseTypeExport.getSupportedAccessTypes();
+    assertNotNull( supportedDatabaseAccessTypesExport );
+    assertEquals( databaseTypeModel.getSupportedAccessTypes().size(),
+      supportedDatabaseAccessTypesExport.size() );
+    // Check that all original values are present.
+    for ( org.pentaho.database.model.DatabaseAccessType databaseAccessType : databaseTypeModel
+      .getSupportedAccessTypes() ) {
+      boolean found = false;
+      for ( DatabaseAccessType databaseAccessTypeExport : supportedDatabaseAccessTypesExport ) {
+        if ( databaseAccessType.getName().equals( databaseAccessTypeExport.name() )
+          && databaseAccessType.getValue().equals( databaseAccessTypeExport.value() ) ) {
+          found = true;
+          break;
+        }
+      }
+      assertTrue( found );
+    }
+    assertEquals( databaseTypeModel.getDefaultDatabasePort(), databaseTypeExport.getDefaultDatabasePort() );
+    assertEquals( databaseTypeModel.getExtraOptionsHelpUrl(), databaseTypeExport.getExtraOptionsHelpUrl() );
+
+    assertMapEquals2model( databaseTypeModel.getDefaultOptions(), databaseTypeExport.getDefaultOptions() );
+  }
+
+  /**
+   * Method to assert that the information on the DatabaseType that existed on the Export was correctly imported
+   *
+   * @param databaseTypeExport export instance that contains the original information
+   * @param databaseTypeModel  model instance that should contain the information
+   */
+  protected void assertDatabaseTypeEquals2export( DatabaseType databaseTypeExport,
+                                                  org.pentaho.database.model.IDatabaseType databaseTypeModel ) {
+    assertNotNull( databaseTypeModel );
+    assertEquals( databaseTypeExport.getName(), databaseTypeModel.getName() );
+    assertEquals( databaseTypeExport.getShortName(), databaseTypeModel.getShortName() );
+    List<org.pentaho.database.model.DatabaseAccessType> supportedDatabaseAccessTypesModel =
+      databaseTypeModel.getSupportedAccessTypes();
+    assertNotNull( supportedDatabaseAccessTypesModel );
+    assertEquals( databaseTypeExport.getSupportedAccessTypes().size(),
+      supportedDatabaseAccessTypesModel.size() );
+    // Check that all original values are present.
+    for ( DatabaseAccessType databaseAccessType : databaseTypeExport
+      .getSupportedAccessTypes() ) {
+      boolean found = false;
+      for ( org.pentaho.database.model.DatabaseAccessType databaseAccessTypeModel :
+        supportedDatabaseAccessTypesModel ) {
+        if ( databaseAccessType.name().equals( databaseAccessTypeModel.getName() )
+          && databaseAccessType.value().equals( databaseAccessTypeModel.getValue() ) ) {
+          found = true;
+          break;
+        }
+      }
+      assertTrue( found );
+    }
+    assertEquals( databaseTypeExport.getDefaultDatabasePort(), databaseTypeModel.getDefaultDatabasePort() );
+    assertEquals( databaseTypeExport.getExtraOptionsHelpUrl(), databaseTypeModel.getExtraOptionsHelpUrl() );
+    assertMapEquals2export( databaseTypeExport.getDefaultOptions(), databaseTypeModel.getDefaultOptions(), 0 );
+  }
+
+  /**
+   * Method to assert that the information on the DatabaseType that existed on the Model was correctly exported
+   *
+   * @param partitionDatabaseMetaModelList  model instance that contains the original information
+   * @param partitionDatabaseMetaExportList export instance that should contain the information
+   */
+  protected void assertPartitionDatabaseMetaEquals2model(
+    List<org.pentaho.database.model.PartitionDatabaseMeta> partitionDatabaseMetaModelList,
+    List<PartitionDatabaseMeta> partitionDatabaseMetaExportList ) {
+
+    assertNotNull( partitionDatabaseMetaModelList );
+    assertEquals( partitionDatabaseMetaExportList.size(), partitionDatabaseMetaModelList.size() );
+
+    // Check that all original values are present.
+    for ( PartitionDatabaseMeta partitionDatabaseMetaExport : partitionDatabaseMetaExportList ) {
+      boolean found = false;
+      for ( org.pentaho.database.model.PartitionDatabaseMeta partitionDatabaseMetaModel :
+        partitionDatabaseMetaModelList ) {
+        if ( partitionDatabaseMetaExport.getDatabaseName().equals( partitionDatabaseMetaModel.getDatabaseName() ) ) {
+          assertEquals( partitionDatabaseMetaExport.getHostname(), partitionDatabaseMetaModel.getHostname() );
+          assertEquals( partitionDatabaseMetaExport.getPartitionId(), partitionDatabaseMetaModel.getPartitionId() );
+          assertEquals( partitionDatabaseMetaExport.getPassword(), partitionDatabaseMetaModel.getPassword() );
+          assertEquals( partitionDatabaseMetaExport.getPort(), partitionDatabaseMetaModel.getPort() );
+          assertEquals( partitionDatabaseMetaExport.getUsername(), partitionDatabaseMetaModel.getUsername() );
+          found = true;
+          break;
+        }
+      }
+      assertTrue( found );
+    }
+  }
+
+  /**
+   * Method to assert that the information on the DatabaseType that existed on the Export was correctly imported
+   *
+   * @param partitionDatabaseMetaExportList export instance that contains the original information
+   * @param partitionDatabaseMetaModelList  model instance that should contain the information
+   */
+  protected void assertPartitionDatabaseMetaEquals2export(
+    List<PartitionDatabaseMeta> partitionDatabaseMetaExportList,
+    List<org.pentaho.database.model.PartitionDatabaseMeta> partitionDatabaseMetaModelList ) {
+
+    assertNotNull( partitionDatabaseMetaModelList );
+    assertEquals( partitionDatabaseMetaExportList.size(), partitionDatabaseMetaModelList.size() );
+
+    // Check that all original values are present.
+    for ( PartitionDatabaseMeta partitionDatabaseMetaExport : partitionDatabaseMetaExportList ) {
+      boolean found = false;
+      for ( org.pentaho.database.model.PartitionDatabaseMeta partitionDatabaseMetaModel :
+        partitionDatabaseMetaModelList ) {
+        if ( partitionDatabaseMetaExport.getDatabaseName().equals( partitionDatabaseMetaModel.getDatabaseName() ) ) {
+          assertEquals( partitionDatabaseMetaExport.getHostname(), partitionDatabaseMetaModel.getHostname() );
+          assertEquals( partitionDatabaseMetaExport.getPartitionId(), partitionDatabaseMetaModel.getPartitionId() );
+          assertEquals( partitionDatabaseMetaExport.getPassword(), partitionDatabaseMetaModel.getPassword() );
+          assertEquals( partitionDatabaseMetaExport.getPort(), partitionDatabaseMetaModel.getPort() );
+          assertEquals( partitionDatabaseMetaExport.getUsername(), partitionDatabaseMetaModel.getUsername() );
+          found = true;
+          break;
+        }
+      }
+      assertTrue( found );
+    }
+  }
+
+  /**
+   * Method to assert that the information on a map that existed on the Model was correctly exported
+   *
+   * @param modelMap  model instance that contains the original information
+   * @param exportMap export instance that should contain the information
+   */
+  protected void assertMapEquals2model( Map<String, String> modelMap, MapExport exportMap ) {
+    assertNotNull( exportMap );
+    List<MapExport.Entry> exportList = exportMap.getEntry();
+    assertNotNull( exportList );
+    assertEquals( modelMap.size(), exportList.size() );
+    for ( Map.Entry<String, String> mapEntry : modelMap.entrySet() ) {
+      boolean found = false;
+      for ( MapExport.Entry exportEntry : exportList ) {
+        if ( mapEntry.getKey().equals( exportEntry.getKey() ) && mapEntry.getValue()
+          .equals( exportEntry.getValue() ) ) {
+          found = true;
+          break;
+        }
+      }
+      assertTrue( found );
+    }
+  }
+
+  /**
+   * Method to assert that the information on a map that existed on the Export was correctly imported
+   *
+   * @param exportMap    export instance that contains the original information
+   * @param modelMap     model instance that should contain the information
+   * @param extraEntries value to add to the expected size (in certain cases there're extra entries)
+   */
+  protected void assertMapEquals2export( MapExport exportMap, Map<String, String> modelMap, int extraEntries ) {
+    assertNotNull( modelMap );
+    assertEquals( extraEntries + exportMap.getEntry().size(), modelMap.size() );
+    for ( MapExport.Entry mapEntry : exportMap.getEntry() ) {
+      boolean found = false;
+      for ( Map.Entry<String, String> exportEntry : modelMap.entrySet() ) {
+        if ( exportEntry.getKey().equals( mapEntry.getKey() ) && exportEntry.getValue()
+          .equals( mapEntry.getValue() ) ) {
+          found = true;
+          break;
+        }
+      }
+      assertTrue( found );
+    }
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/ExporterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/ExporterTest.java
@@ -14,11 +14,11 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
-package org.pentaho.test.platform.plugin.services.importexport;
+package org.pentaho.platform.plugin.services.importexport;
 
 import java.io.File;
 import java.io.IOException;

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifestTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifestTest.java
@@ -14,53 +14,43 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.plugin.services.importexport.exportManifest;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.List;
-
-import javax.xml.bind.JAXBException;
-
-import org.junit.Test;
-import org.pentaho.database.model.DatabaseAccessType;
-import org.pentaho.database.model.DatabaseConnection;
-import org.pentaho.database.model.DatabaseType;
+import junit.framework.TestCase;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAce;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
+import org.pentaho.platform.api.scheduler2.Job;
 import org.pentaho.platform.plugin.services.importexport.ExportManifestUserSetting;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseAccessType;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseConnection;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseType;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestDto;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetadata;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMondrian;
 import org.pentaho.platform.web.http.api.resources.JobScheduleRequest;
 
-import junit.framework.TestCase;
+import javax.xml.bind.JAXBException;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
 
 public class ExportManifestTest extends TestCase {
-  ExportManifest exportManifest;
-  RepositoryFile repoDir2;
-  RepositoryFile repoFile3;
-  RepositoryFileAcl repoDir1Acl;
-  RepositoryFileAcl repoDir2Acl;
-  RepositoryFileAcl repoFile3Acl;
-  ExportManifestEntity entity1;
-  ExportManifestEntity entity2;
-  ExportManifestEntity entity3;
-  private ExportManifest importManifest;
+  private ExportManifest exportManifest;
 
   public ExportManifestTest() {
     String rootFolder = "/dir1/";
@@ -70,20 +60,20 @@ public class ExportManifestTest extends TestCase {
     exportManifestInformation.setExportDate( "2013-01-01" );
     exportManifestInformation.setRootFolder( rootFolder );
 
-    List<RepositoryFileAce> aces1 = new ArrayList<RepositoryFileAce>();
+    List<RepositoryFileAce> aces1 = new ArrayList<>();
     aces1.add( createMockAce( "admin-/pentaho/tenant0", "USER", RepositoryFilePermission.READ,
-        RepositoryFilePermission.WRITE ) );
+      RepositoryFilePermission.WRITE ) );
     aces1.add( createMockAce( "TenantAdmin-/pentaho/tenant0", "ROLE", RepositoryFilePermission.READ ) );
-    repoDir2 = createMockRepositoryFile( "/dir1/dir2", true );
-    repoDir2Acl = createMockRepositoryAcl( "acl2", "admin", false, aces1 );
-    repoFile3 = createMockRepositoryFile( "/dir1/dir2/file1", false );
+    RepositoryFile repoDir2 = createMockRepositoryFile( "/dir1/dir2", true );
+    RepositoryFileAcl repoDir2Acl = createMockRepositoryAcl( "acl2", "admin", false, aces1 );
+    RepositoryFile repoFile3 = createMockRepositoryFile( "/dir1/dir2/file1", false );
     RepositoryFile badRepoFile = createMockRepositoryFile( "/baddir/dir2/file1", false );
 
     try {
       exportManifest.add( repoDir2, repoDir2Acl );
       exportManifest.add( repoFile3, null );
     } catch ( Exception e ) {
-      fail( e.getStackTrace().toString() );
+      fail( e.toString() );
     }
 
     try {
@@ -93,9 +83,9 @@ public class ExportManifestTest extends TestCase {
       //ignored
     }
 
-    entity2 = exportManifest.getExportManifestEntity( "dir2" );
+    ExportManifestEntity entity2 = exportManifest.getExportManifestEntity( "dir2" );
     assertNotNull( entity2 );
-    entity3 = exportManifest.getExportManifestEntity( "dir2/file1" );
+    ExportManifestEntity entity3 = exportManifest.getExportManifestEntity( "dir2/file1" );
     assertNotNull( entity3 );
 
     // Mondrian
@@ -114,8 +104,21 @@ public class ExportManifestTest extends TestCase {
     metadata.setDomainId( "testDomain" );
     metadata.setFile( "testMetadata.xml" );
     exportManifest.addMetadata( metadata );
-    exportManifest.addSchedule( new JobScheduleRequest() );
 
+    // JobScheduleRequest
+    JobScheduleRequest jobScheduleRequest = new JobScheduleRequest();
+    HashMap<String, String> pdiParameters = new HashMap<>();
+    pdiParameters.put( "parm1", "val1" );
+    jobScheduleRequest.setPdiParameters( pdiParameters );
+    jobScheduleRequest.setJobName( "jobName" );
+    jobScheduleRequest.setJobState( Job.JobState.UNKNOWN );
+    jobScheduleRequest.setActionClass( "actionClass" );
+    jobScheduleRequest.setDuration( 3600 );
+    jobScheduleRequest.setTimeZone( "someTimeZone" );
+    jobScheduleRequest.setJobId( "jobId" );
+    exportManifest.addSchedule( jobScheduleRequest );
+
+    // Datasource
     DatabaseConnection connection = new DatabaseConnection();
     connection.setAccessType( DatabaseAccessType.NATIVE );
     connection.setDatabaseName( "SampleData" );
@@ -123,14 +126,24 @@ public class ExportManifestTest extends TestCase {
     DatabaseType type = new DatabaseType();
     type.setName( "Hypersonic" );
     type.setShortName( "HYPERSONIC" );
+    type.setDefaultDatabaseName( "defaultDatabaseName" );
+    type.setDefaultDatabasePort( 8888 );
+    type.setExtraOptionsHelpUrl( "extraOptionsHelpUrl" );
+    DatabaseType.DefaultOptions defaultOptions = new DatabaseType.DefaultOptions();
+    DatabaseType.DefaultOptions.Entry e = new DatabaseType.DefaultOptions.Entry();
+    e.setKey( "someKey" );
+    e.setValue( "someValue" );
+    defaultOptions.getEntry().add( e );
+    type.setDefaultOptions( defaultOptions );
     connection.setDatabaseType( type );
     connection.setHostname( "localhost" );
     connection.setUsername( "pentaho_user" );
-    connection.setPassword( "password" );
+    connection.setPassword( null );
     connection.setMaximumPoolSize( 20 );
 
     exportManifest.addDatasource( connection );
 
+    // UserExport
     UserExport user = new UserExport();
     user.setUsername( "pentaho" );
     user.setRole( "open source champion" );
@@ -141,14 +154,12 @@ public class ExportManifestTest extends TestCase {
     exportManifest.addGlobalUserSetting( new ExportManifestUserSetting( "viewHiddenFiles", "false" ) );
   }
 
-  @Test
   public void testEntityAccess() {
     ExportManifestEntity entityR1 = exportManifest.getExportManifestEntity( "dir2" );
     assertNotNull( entityR1 );
     assertEquals( "Path value", "dir2", entityR1.getPath() );
   }
 
-  @Test
   public void testMarshal() {
     try {
       exportManifest.toXml( System.out );
@@ -157,7 +168,6 @@ public class ExportManifestTest extends TestCase {
     }
   }
 
-  @Test
   public void testUnMarshal() {
     String xml = XmlToString();
     ExportManifest importManifest = null;
@@ -179,6 +189,9 @@ public class ExportManifestTest extends TestCase {
     assertTrue( fileEntity.getEntityMetaData().isIsFolder() );
 
     RepositoryFile r = fileEntity.getRepositoryFile();
+    assertEquals( "dir2", r.getPath() );
+    assertTrue( r.isFolder() );
+
     try {
       RepositoryFileAcl rfa = fileEntity.getRepositoryFileAcl();
       assertNotNull( rfa.getAces() );
@@ -187,34 +200,83 @@ public class ExportManifestTest extends TestCase {
       fail( "Could not un-marshal to RepositoryFileAcl" );
     }
 
-    assertEquals( 1, importManifest.getMetadataList().size() );
-    assertEquals( 1, importManifest.getMondrianList().size() );
+    // JobScheduleRequest
+    assertNotNull( importManifest.getScheduleList() );
     assertEquals( 1, importManifest.getScheduleList().size() );
-    assertEquals( 1, importManifest.getDatasourceList().size() );
+    JobScheduleRequest jobScheduleRequest = importManifest.getScheduleList().get( 0 );
+    assertNotNull( jobScheduleRequest );
+    assertNotNull( jobScheduleRequest.getPdiParameters() );
+    assertEquals( 1, jobScheduleRequest.getPdiParameters().size() );
+    assertEquals( "val1", jobScheduleRequest.getPdiParameters().get( "parm1" ) );
+    assertEquals( "jobName", jobScheduleRequest.getJobName() );
+    assertEquals( Job.JobState.UNKNOWN, jobScheduleRequest.getJobState() );
+    assertEquals( "actionClass", jobScheduleRequest.getActionClass() );
+    assertEquals( 3600, jobScheduleRequest.getDuration() );
+    assertEquals( "someTimeZone", jobScheduleRequest.getTimeZone() );
+    assertEquals( "jobId", jobScheduleRequest.getJobId() );
 
+    // Mondrian
+    assertNotNull( importManifest.getMondrianList() );
+    assertEquals( 1, importManifest.getMondrianList().size() );
     ExportManifestMondrian mondrian1 = importManifest.getMondrianList().get( 0 );
+    assertNotNull( mondrian1 );
     assertEquals( "cat1", mondrian1.getCatalogName() );
     assertTrue( mondrian1.getParameters().containsKey( "testKey" ) );
     assertEquals( "testValue", mondrian1.getParameters().get( "testKey" ) );
     assertEquals( "testMondrian.xml", mondrian1.getFile() );
 
+    // Metadata
+    assertNotNull( importManifest.getMetadataList() );
+    assertEquals( 1, importManifest.getMetadataList().size() );
     ExportManifestMetadata metadata1 = importManifest.getMetadataList().get( 0 );
+    assertNotNull( metadata1 );
     assertEquals( "testDomain", metadata1.getDomainId() );
     assertEquals( "testMetadata.xml", metadata1.getFile() );
 
+    // Datasource
+    assertNotNull( importManifest.getDatasourceList() );
+    assertEquals( 1, importManifest.getDatasourceList().size() );
     DatabaseConnection connection = importManifest.getDatasourceList().get( 0 );
+    assertNotNull( connection );
     assertEquals( "SampleData", connection.getDatabaseName() );
     assertEquals( "9001", connection.getDatabasePort() );
     assertEquals( "Hypersonic", connection.getDatabaseType().getName() );
     assertEquals( "HYPERSONIC", connection.getDatabaseType().getShortName() );
+    assertEquals( "defaultDatabaseName", connection.getDatabaseType().getDefaultDatabaseName() );
+    assertEquals( 8888, connection.getDatabaseType().getDefaultDatabasePort() );
+    assertEquals( "extraOptionsHelpUrl", connection.getDatabaseType().getExtraOptionsHelpUrl() );
+    assertNotNull( connection.getDatabaseType().getDefaultOptions() );
+    assertNotNull( connection.getDatabaseType().getDefaultOptions().getEntry() );
+    assertEquals( 1, connection.getDatabaseType().getDefaultOptions().getEntry().size() );
+    assertNotNull( connection.getDatabaseType().getDefaultOptions().getEntry().get( 0 ) );
+    assertEquals( "someKey", connection.getDatabaseType().getDefaultOptions().getEntry().get( 0 ).getKey() );
+    assertEquals( "someValue", connection.getDatabaseType().getDefaultOptions().getEntry().get( 0 ).getValue() );
     assertEquals( "localhost", connection.getHostname() );
     assertEquals( "pentaho_user", connection.getUsername() );
-    assertEquals( "password", connection.getPassword() );
     assertEquals( 20, connection.getMaximumPoolSize() );
 
+    // UserExport
+    assertNotNull( importManifest.getUserExports() );
+    assertEquals( 1, importManifest.getUserExports().size() );
+    UserExport userExport = importManifest.getUserExports().get( 0 );
+    assertNotNull( userExport );
+    assertEquals( "pentaho", userExport.getUsername() );
+    assertEquals( "123456", userExport.getPassword() );
+    List<String> userRoles = userExport.getRoles();
+    assertNotNull( userRoles );
+    assertEquals( 1, userRoles.size() );
+    assertEquals( "open source champion", userRoles.get( 0 ) );
+    assertNotNull( userExport.getUserSettings() );
+    assertEquals( 2, userExport.getUserSettings().size() );
+    List<ExportManifestUserSetting> userSettings = userExport.getUserSettings();
+    assertEquals( 2, userSettings.size() );
+    userSettings.stream().filter( exportManifestUserSetting -> "theme".equals( exportManifestUserSetting.getName() ) )
+      .forEach( exportManifestUserSetting -> assertEquals( "crystal", exportManifestUserSetting.getValue() ) );
+    userSettings.stream()
+      .filter( exportManifestUserSetting -> "language".equals( exportManifestUserSetting.getName() ) )
+      .forEach( exportManifestUserSetting -> assertEquals( "en_US", exportManifestUserSetting.getValue() ) );
   }
 
-  @Test
   public void testXmlToString() {
     String s = XmlToString();
     assertNotNull( s );
@@ -237,15 +299,13 @@ public class ExportManifestTest extends TestCase {
     Date lockDate = new Date();
     Date deletedDate = new Date();
     String baseName = path.substring( path.lastIndexOf( "/" ) + 1 );
-    RepositoryFile mockRepositoryFile =
-        new RepositoryFile( "12345", baseName, isFolder, false, false, false, "versionId", path, createdDate,
-            lastModeDate,
-            false, "lockOwner", "lockMessage", lockDate, "en_US", "title", "description",
-            "/original/parent/folder/path", deletedDate, 4096, "creatorId", null );
-    return mockRepositoryFile;
+    return
+      new RepositoryFile( "12345", baseName, isFolder, false, false, false, "versionId", path, createdDate,
+        lastModeDate,
+        false, "lockOwner", "lockMessage", lockDate, "en_US", "title", "description",
+        "/original/parent/folder/path", deletedDate, 4096, "creatorId", null );
   }
 
-  @Test
   public void testToXml_XmlUnsafeManifestParameters() {
     final String keyFirst = "DataSource";
     final String keySecond = "DynamicSchemaProcessor";
@@ -277,7 +337,7 @@ public class ExportManifestTest extends TestCase {
         }
         List<ExportManifestMondrian> catalogs = ex.getMondrianList();
         assertNotNull( catalogs );
-        assertTrue( !catalogs.isEmpty() );
+        assertFalse( catalogs.isEmpty() );
 
         ExportManifestMondrian mondrianCatalog = null;
 
@@ -290,22 +350,21 @@ public class ExportManifestTest extends TestCase {
         assertNotNull( mondrianCatalog );
         Parameters parameters = mondrianCatalog.getParameters();
         assertNotNull( parameters );
-        assertTrue( !parameters.isEmpty() );
+        assertFalse( parameters.isEmpty() );
 
         String parameter = parameters.get( keyFirst );
         assertNotNull( parameter );
-        assertTrue( valueFirst.equals( parameter ) );
+        assertEquals( valueFirst, parameter );
 
         parameter = parameters.get( keySecond );
         assertNotNull( parameter );
-        assertTrue( valueSecond.equals( parameter ) );
+        assertEquals( valueSecond, parameter );
       }
     } catch ( Exception e ) {
       fail( e.toString() );
     }
   }
 
-  @Test
   public void testToXml_XmlUnsafeEscaped() {
     final String keyFirst = "DataSource";
     final String keySecond = "DynamicSchemaProcessor";
@@ -332,7 +391,7 @@ public class ExportManifestTest extends TestCase {
     try ( ByteArrayOutputStream out = new ByteArrayOutputStream() ) {
       exportManifest.toXml( out );
       try ( ByteArrayInputStream inputStream = new ByteArrayInputStream( out.toByteArray() );
-           BufferedReader reader = new BufferedReader( new InputStreamReader( inputStream ) )
+            BufferedReader reader = new BufferedReader( new InputStreamReader( inputStream ) )
       ) {
         String line;
         while ( ( line = reader.readLine() ) != null ) {
@@ -357,13 +416,13 @@ public class ExportManifestTest extends TestCase {
   }
 
   private RepositoryFileAcl createMockRepositoryAcl( Serializable id, String owner, boolean entriesInheriting,
-      List<RepositoryFileAce> aces ) {
+                                                     List<RepositoryFileAce> aces ) {
     RepositoryFileSid ownerSid = new RepositoryFileSid( owner );
     return new RepositoryFileAcl( id, ownerSid, entriesInheriting, aces );
   }
 
   private RepositoryFileAce createMockAce( String recipientName, String recipientType, RepositoryFilePermission first,
-      RepositoryFilePermission... rest ) {
+                                           RepositoryFilePermission... rest ) {
     RepositoryFileSid.Type type = RepositoryFileSid.Type.valueOf( recipientType );
     RepositoryFileSid recipient = new RepositoryFileSid( recipientName, type );
     return new RepositoryFileAce( recipient, EnumSet.of( first, rest ) );

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseTypeTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseTypeTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -22,6 +22,7 @@ package org.pentaho.platform.plugin.services.importexport.exportManifest.binding
 
 import org.junit.Test;
 
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSettersExcluding;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
@@ -39,9 +40,21 @@ public class DatabaseTypeTest {
   }
 
   @Test
+  public void testInnerEntryClasses() throws Exception {
+    assertThat( DatabaseType.DefaultOptions.Entry.class, hasValidGettersAndSetters() );
+  }
+
+  @Test
   public void testGetSupportedAccessTypes() throws Exception {
     DatabaseType dbType = new DatabaseType();
     assertNotNull( dbType.getSupportedAccessTypes() );
     assertEquals( 0, dbType.getSupportedAccessTypes().size() );
+  }
+
+  @Test
+  public void testAttributes() throws Exception {
+    DatabaseType.DefaultOptions defaultOptions = new DatabaseType.DefaultOptions();
+    assertNotNull( defaultOptions.getEntry() );
+    assertEquals( 0, defaultOptions.getEntry().size() );
   }
 }


### PR DESCRIPTION
Original PRs:
- [#4620](https://github.com/pentaho/pentaho-platform/pull/4620)
- [#4648](https://github.com/pentaho/pentaho-platform/pull/4648)

Don't forget to squash the commits.


@pentaho-lmartins @ssamora @ppatricio @bcostahitachivantara 