### PR TITLE
[BISERVER-14418]

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-ldap.xml
@@ -58,6 +58,17 @@
     </property>
   </bean>
 
+  <!-- Uncomment below and update ldapAuthenticationProvider to enable local caching of LDAP credentials; reduces LDAP
+       traffic when running numerous spoon/pan/kitchen jobs against a repository. -->
+  <!--
+  <bean id="cachingAuthenticator"
+        class="org.pentaho.platform.plugin.services.security.userrole.ldap.PentahoCachingLdapAuthenticator">
+    <constructor-arg ref="authenticator" />
+    <property name="cacheRegionName" value="ldapAuthenticatorCache" />
+    <property name="passwordHashMethod" value="SHA-256" />
+  </bean>
+  -->
+
   <bean id="contextSource" class="org.springframework.security.ldap.DefaultSpringSecurityContextSource">
     <constructor-arg value="${ldap.contextSource.providerUrl}"/>
     <property name="userDn" value="${ldap.contextSource.userDn}"/>
@@ -89,6 +100,15 @@
     <property name="searchSubtree" value="${ldap.populator.searchSubtree}" />
     <property name="defaultRole" ref="defaultRole" />
   </bean>
+
+  <!-- Uncomment below and update ldapAuthenticationProvider to enable local caching of LDAP credentials; reduces LDAP
+       traffic when running numerous spoon/pan/kitchen jobs against a repository. -->
+  <!--
+  <bean id="cachingPopulator" class="org.pentaho.platform.plugin.services.security.userrole.ldap.PentahoCachingLdapAuthoritiesPopulator">
+    <constructor-arg ref="populator" />
+    <property name="cacheRegionName" value="ldapPopulatorCache" />
+  </bean>
+  -->
 
   <bean id="ldapUserDetailsService0"
         class="org.pentaho.platform.plugin.services.security.userrole.ldap.DefaultLdapUserDetailsService">

--- a/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/ehcache.xml
+++ b/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/ehcache.xml
@@ -299,6 +299,26 @@
       timeToLiveSeconds="600"
       diskPersistent="false"/>
 
+  <!-- Caches for the PentahoCachingLdap* classes. Only enable if they are in use. -->
+  <!--
+  <cache
+      name="ldapPopulatorCache"
+      maxEntriesLocalHeap="2000"
+      eternal="false"
+      overflowToDisk="false"
+      timeToIdleSeconds="300"
+      timeToLiveSeconds="600"
+      diskPersistent="false"/>
+  <cache
+      name="ldapAuthenticatorCache"
+      maxEntriesLocalHeap="2000"
+      eternal="false"
+      overflowToDisk="false"
+      timeToIdleSeconds="300"
+      timeToLiveSeconds="600"
+      diskPersistent="false"/>
+  -->
+
   <!-- Cache backing the CachingRepositoryFactory which creates PDI Repository instances in the platform -->
   <cache
       name="pdi-repository-cache"

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ldap/PentahoCachingLdapAuthenticator.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ldap/PentahoCachingLdapAuthenticator.java
@@ -1,0 +1,130 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2020 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.security.userrole.ldap;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.ICacheManager;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.ldap.authentication.LdapAuthenticator;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Random;
+
+public class PentahoCachingLdapAuthenticator implements LdapAuthenticator {
+  private static final Log logger = LogFactory.getLog( PentahoCachingLdapAuthenticator.class );
+  private static final String REGION_DEFAULT_NAME = "ldapAuthenticatorCache";
+  private static final String PASSWORD_HASH_METHOD = "SHA-256";
+
+  private String cacheRegionName = REGION_DEFAULT_NAME;
+  private String passwordHashMethod = PASSWORD_HASH_METHOD;
+
+  private MessageDigest messageDigest;
+  private final LdapAuthenticator delegate;
+  private final ICacheManager cacheManager = PentahoSystem.getCacheManager( null );
+  private static final String ROLES_BY_USER = "AuthenticatorCache_";
+  private static final int HASH_SALT = ( new Random() ).nextInt();
+
+  public PentahoCachingLdapAuthenticator( LdapAuthenticator delegate ) {
+    if ( delegate == null ) {
+      throw new IllegalArgumentException( "delegate LdapAuthenticator cannot be null" );
+    }
+    this.delegate = delegate;
+    if ( !this.cacheManager.cacheEnabled( cacheRegionName ) ) {
+      this.cacheManager.addCacheRegion( cacheRegionName );
+    }
+
+    try {
+      this.messageDigest = MessageDigest.getInstance( PASSWORD_HASH_METHOD );
+    } catch ( NoSuchAlgorithmException e ) {
+      throw new IllegalArgumentException( "Issue trying to create a messageDigest for MD5" );
+    }
+  }
+
+  private interface DelegateOperation {
+    DirContextOperations perform();
+  }
+
+  private DirContextOperations performOperation( Authentication authentication, DelegateOperation operation ) {
+    DirContextOperations results = null;
+    Object fromRegionCache = null;
+
+    String cacheEntry = ROLES_BY_USER + hashUserAndPassword( authentication );
+    if ( logger.isTraceEnabled() ) {
+      logger.trace( "cacheEntry:" + cacheEntry );
+    }
+    fromRegionCache = cacheManager.getFromRegionCache( cacheRegionName, cacheEntry );
+
+    if ( fromRegionCache instanceof DirContextOperations ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "Cache Hit for " + authentication.getPrincipal() );
+      }
+      results = (DirContextOperations) fromRegionCache;
+    } else {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "Cache miss for " + authentication.getPrincipal() );
+      }
+      results = operation.perform();
+      cacheManager.putInRegionCache( cacheRegionName, cacheEntry, results );
+    }
+    return results;
+  }
+
+  @Override
+  public DirContextOperations authenticate( Authentication authentication ) {
+    return performOperation( authentication, () -> delegate.authenticate( authentication ) );
+  }
+
+  protected String hashUserAndPassword( Authentication authentication ) {
+    String stringToEncrypt = HASH_SALT + ":" + authentication.getPrincipal() + ":" + authentication.getCredentials();
+    String encryptedString = new String( messageDigest.digest( stringToEncrypt.getBytes() ) );
+
+    //To protect from Odd characters in the CACHE KEY, we will convert to base64
+    return new String( Base64.getEncoder().encode( encryptedString.getBytes() ) );
+  }
+
+  public String getCacheRegionName() {
+    return cacheRegionName;
+  }
+
+  public void setCacheRegionName( String cacheRegionName ) {
+    this.cacheRegionName = cacheRegionName;
+  }
+
+  public String getPasswordHashMethod() {
+    return passwordHashMethod;
+  }
+
+  public void setPasswordHashMethod( String passwordHashMethod ) {
+    this.passwordHashMethod = passwordHashMethod;
+
+    try {
+      this.messageDigest = MessageDigest.getInstance( passwordHashMethod );
+    } catch ( NoSuchAlgorithmException e ) {
+      throw new IllegalArgumentException( "hashMethod NoSuchAlgorithmException, default is SHA-256" );
+    }
+  }
+
+}

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ldap/PentahoCachingLdapAuthoritiesPopulator.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ldap/PentahoCachingLdapAuthoritiesPopulator.java
@@ -1,0 +1,92 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2020 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.security.userrole.ldap;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.ICacheManager;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class PentahoCachingLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator {
+  private static final Log logger = LogFactory.getLog( PentahoCachingLdapAuthoritiesPopulator.class );
+  private static final String REGION_DEFAULT_NAME = "ldapPopulatorCache";
+
+  private String cacheRegionName = REGION_DEFAULT_NAME;
+
+  private final LdapAuthoritiesPopulator delegate;
+  private final ICacheManager cacheManager = PentahoSystem.getCacheManager( null );
+  private static final String ROLES_BY_USER = "GrantedAuthority by user ";
+
+  public PentahoCachingLdapAuthoritiesPopulator( LdapAuthoritiesPopulator delegate ) {
+    if ( delegate == null ) {
+      throw new IllegalArgumentException( "delegate LdapAuthoritiesPopulator cannot be null" );
+    }
+    this.delegate = delegate;
+    if ( !this.cacheManager.cacheEnabled( cacheRegionName ) ) {
+      this.cacheManager.addCacheRegion( cacheRegionName );
+    }
+  }
+
+  @SuppressWarnings( "squid:S1452" )
+  private interface DelegateOperation {
+    Collection<? extends GrantedAuthority> perform();
+  }
+
+  @SuppressWarnings( "unchecked" )
+  private Collection<? extends GrantedAuthority> performOperation( String cacheEntry, DelegateOperation operation ) {
+    Collection<? extends GrantedAuthority> results = null;
+    Object fromRegionCache = cacheManager.getFromRegionCache( cacheRegionName, cacheEntry );
+    if ( fromRegionCache instanceof Collection ) {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "Cache Hit for  " + cacheEntry );
+      }
+      results = (Collection<GrantedAuthority>) fromRegionCache;
+    } else {
+      if ( logger.isDebugEnabled() ) {
+        logger.debug( "Cache miss for  " + cacheEntry );
+      }
+      results = operation.perform();
+      cacheManager.putInRegionCache( cacheRegionName, cacheEntry, results );
+    }
+    return new ArrayList<>( results );
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getGrantedAuthorities( DirContextOperations userData,
+                                                                       String username ) {
+    return performOperation( ROLES_BY_USER + username, () -> delegate.getGrantedAuthorities( userData, username ) );
+  }
+
+  public String getCacheRegionName() {
+    return cacheRegionName;
+  }
+
+  public void setCacheRegionName( String cacheRegionName ) {
+    this.cacheRegionName = cacheRegionName;
+  }
+
+}

--- a/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/ldap/PentahoCachingLdapAuthenticatorTest.java
+++ b/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/ldap/PentahoCachingLdapAuthenticatorTest.java
@@ -1,0 +1,102 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2020 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.test.platform.plugin.services.security.userrole.ldap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.platform.plugin.services.security.userrole.ldap.PentahoCachingLdapAuthenticator;
+import org.pentaho.platform.plugin.services.security.userrole.ldap.PentahoCachingLdapAuthoritiesPopulator;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.ldap.authentication.LdapAuthenticator;
+import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the <code>PentahoCachingLdapAuthoritiesPopulator</code> class.
+ * 
+ */
+@RunWith( MockitoJUnitRunner.class )
+public class PentahoCachingLdapAuthenticatorTest {
+
+  @Mock LdapAuthenticator mockAuthenticator;
+  @Mock Authentication mockAuthentication1;
+  @Mock Authentication mockAuthentication2;
+  @Mock DirContextOperations mockDirContextOperations1;
+  @Mock DirContextOperations mockDirContextOperations2;
+
+  @Test
+  public void testGetGrantedAuthorities() {
+    PentahoCachingLdapAuthenticator cachingLdapAuthenticator
+      = new PentahoCachingLdapAuthenticator( mockAuthenticator );
+
+    when( mockAuthenticator.authenticate( mockAuthentication1 ) ).thenReturn( mockDirContextOperations1 );
+    when( mockAuthenticator.authenticate( mockAuthentication2 ) ).thenReturn( mockDirContextOperations2 );
+    when( mockAuthentication1.getPrincipal() ).thenReturn( "fred" );
+    when( mockAuthentication2.getPrincipal() ).thenReturn( "barney" );
+
+    cachingLdapAuthenticator.authenticate( mockAuthentication1 );
+    cachingLdapAuthenticator.authenticate( mockAuthentication2 );
+    cachingLdapAuthenticator.authenticate( mockAuthentication1 );
+    cachingLdapAuthenticator.authenticate( mockAuthentication2 );
+    cachingLdapAuthenticator.authenticate( mockAuthentication2 );
+    cachingLdapAuthenticator.authenticate( mockAuthentication1 );
+
+    // ensure the cache catches subsequent calls for the same auth
+    verify( mockAuthenticator, times( 1 ) ).authenticate( mockAuthentication1 );
+    verify( mockAuthenticator, times( 1 ) ).authenticate( mockAuthentication2 );
+  }
+
+  @Test
+  public void testGetRegionName() {
+    PentahoCachingLdapAuthenticator cachingLdapAuthenticator
+      = new PentahoCachingLdapAuthenticator( mockAuthenticator );
+
+    cachingLdapAuthenticator.setCacheRegionName( "testRegionName" );
+
+    assertEquals( "testRegionName", cachingLdapAuthenticator.getCacheRegionName() );
+  }
+
+  @Test
+  public void testSetPasswordHashMethod() {
+    PentahoCachingLdapAuthenticator cachingLdapAuthenticator
+      = new PentahoCachingLdapAuthenticator( mockAuthenticator );
+
+    cachingLdapAuthenticator.setPasswordHashMethod( "SHA-1" );
+
+    assertEquals( "SHA-1", cachingLdapAuthenticator.getPasswordHashMethod() );
+  }
+}

--- a/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/ldap/PentahoCachingLdapAuthoritiesPopulatorTest.java
+++ b/extensions/src/test/java/org/pentaho/test/platform/plugin/services/security/userrole/ldap/PentahoCachingLdapAuthoritiesPopulatorTest.java
@@ -1,0 +1,79 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2020 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.test.platform.plugin.services.security.userrole.ldap;
+
+import org.apache.commons.logging.LogFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.security.userrole.ldap.PentahoCachingLdapAuthoritiesPopulator;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the <code>PentahoCachingLdapAuthoritiesPopulator</code> class.
+ * 
+ */
+@RunWith( MockitoJUnitRunner.class )
+public class PentahoCachingLdapAuthoritiesPopulatorTest {
+
+  @Mock LdapAuthoritiesPopulator mockPopulator;
+  @Mock DirContextOperations mockDirContextOperations;
+
+  @Test
+  public void testGetGrantedAuthorities() {
+    PentahoCachingLdapAuthoritiesPopulator cachingLdapAuthoritiesPopulator
+      = new PentahoCachingLdapAuthoritiesPopulator( mockPopulator );
+    SimpleGrantedAuthority role1 = new SimpleGrantedAuthority( "someRole" );
+    Collection<SimpleGrantedAuthority> authList = new HashSet<>();
+    authList.add( role1 );
+    doReturn( authList ).when( mockPopulator ).getGrantedAuthorities( any(), anyString() );
+
+    cachingLdapAuthoritiesPopulator.getGrantedAuthorities( mockDirContextOperations, "fred" );
+    cachingLdapAuthoritiesPopulator.getGrantedAuthorities( mockDirContextOperations, "fred" );
+    cachingLdapAuthoritiesPopulator.getGrantedAuthorities( mockDirContextOperations, "fred" );
+
+    verify( mockPopulator, times( 1 ) ).getGrantedAuthorities( any(), anyString() );
+  }
+
+  @Test
+  public void testGetRegionName() {
+    PentahoCachingLdapAuthoritiesPopulator cachingLdapAuthoritiesPopulator
+      = new PentahoCachingLdapAuthoritiesPopulator( mockPopulator );
+
+    cachingLdapAuthoritiesPopulator.setCacheRegionName( "testRegionName" );
+
+    assertEquals( "testRegionName", cachingLdapAuthoritiesPopulator.getCacheRegionName() );
+  }
+}


### PR DESCRIPTION
[BISERVER-14418] Add a caching LDAP authenticator to reduce traffic against an LDAP server when running frequent spoon/pan/kitchen jobs against the repo. Keeps the default behavior as the original non-caching authenticator, allowing the customer to enable as desired