### PR TITLE
[SP-5713] - Backport of BISERVER-14290 - Schedules created on the User Console runs twice if the user scheduling does not have "Create Content" permission. (9.0 Suite)

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryFileStreamProvider.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryFileStreamProvider.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryFileStreamProvider.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryFileStreamProvider.java
@@ -125,6 +125,7 @@ public class RepositoryFileStreamProvider implements IBackgroundExecutionStreamP
     RepositoryFileOutputStream outputStream =
         new RepositoryFileOutputStream( tempOutputFilePath, autoCreateUniqueFilename, true );
     outputStream.addListener( this );
+    outputStream.forceFlush( false );
     return outputStream;
   }
 

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/fileio/RepositoryFileOutputStream.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/fileio/RepositoryFileOutputStream.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -166,7 +166,14 @@ public class RepositoryFileOutputStream extends ByteArrayOutputStream implements
     }
     super.flush();
 
-    ByteArrayInputStream bis = new ByteArrayInputStream( toByteArray() );
+    byte[] data = toByteArray();
+
+    if ( data.length == 0 ) {
+      flushed = true;
+      return;
+    }
+
+    ByteArrayInputStream bis = new ByteArrayInputStream( data );
 
     // make an effort to determine the correct mime type, default to application/octet-stream
     String extension = RepositoryFilenameUtils.getExtension( path );

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/fileio/RepositoryFileOutputStream.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/fileio/RepositoryFileOutputStream.java
@@ -55,6 +55,7 @@ public class RepositoryFileOutputStream extends ByteArrayOutputStream implements
   protected boolean autoCreateDirStructure = false;
   protected boolean closed = false;
   protected boolean flushed = false;
+  protected boolean forceFlush = true;
   protected ArrayList<IStreamListener> listeners = new ArrayList<>();
 
   public RepositoryFileOutputStream( final String path, final boolean autoCreateUniqueFileName,
@@ -150,13 +151,9 @@ public class RepositoryFileOutputStream extends ByteArrayOutputStream implements
     return repository.getFile( parentPath );
   }
 
-  @Override
-  public void close() throws IOException {
-    if ( !closed ) {
-      flush();
-      closed = true;
-      reset();
-    }
+
+  public void forceFlush( boolean forceFlush ) {
+    this.forceFlush = forceFlush;
   }
 
   @Override
@@ -168,11 +165,10 @@ public class RepositoryFileOutputStream extends ByteArrayOutputStream implements
 
     byte[] data = toByteArray();
 
-    if ( data.length == 0 ) {
+    if ( !forceFlush && data.length == 0 ) {
       flushed = true;
       return;
     }
-
     ByteArrayInputStream bis = new ByteArrayInputStream( data );
 
     // make an effort to determine the correct mime type, default to application/octet-stream
@@ -292,6 +288,15 @@ public class RepositoryFileOutputStream extends ByteArrayOutputStream implements
       repository.updateFile( file, payload, "New File" ); //$NON-NLS-1$
     }
     flushed = true;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if ( !closed ) {
+      flush();
+      closed = true;
+      reset();
+    }
   }
 
   IRepositoryFileData convert( Converter converter, ByteArrayInputStream bis, String mimeType ) {

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/fileio/RepositoryFileIoTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/fileio/RepositoryFileIoTest.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -22,26 +22,22 @@ package org.pentaho.platform.repository2.unified.fileio;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
-import org.powermock.reflect.Whitebox;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 import static org.pentaho.platform.repository2.unified.UnifiedRepositoryTestUtils.hasData;
 import static org.pentaho.platform.repository2.unified.UnifiedRepositoryTestUtils.isLikeFile;
-import static org.powermock.reflect.Whitebox.getInternalState;
 
 @SuppressWarnings( { "nls" } )
 public class RepositoryFileIoTest {
@@ -80,7 +76,7 @@ public class RepositoryFileIoTest {
     writer.close();
 
     verify( repo ).updateFile( argThat( isLikeFile( existingFile ) ), argThat( hasData( "test123", "UTF-8",
-      "text/plain" ) ), anyString() );
+        "text/plain" ) ), anyString() );
   }
 
   @Test
@@ -90,7 +86,7 @@ public class RepositoryFileIoTest {
     IUnifiedRepository repo = mock( IUnifiedRepository.class );
     // simulate request for publicDir
     RepositoryFile publicDir =
-      new RepositoryFile.Builder( "123", ClientRepositoryPaths.getPublicFolderName() ).folder( true ).build();
+        new RepositoryFile.Builder( "123", ClientRepositoryPaths.getPublicFolderName() ).folder( true ).build();
     doReturn( publicDir ).when( repo ).getFile( publicDirPath );
     mp.defineInstance( IUnifiedRepository.class, repo );
 
@@ -99,7 +95,7 @@ public class RepositoryFileIoTest {
     writer.close();
 
     verify( repo ).createFile( eq( "123" ), argThat( isLikeFile( new RepositoryFile.Builder( fileName ).build() ) ),
-      argThat( hasData( "test123", "UTF-8", "text/plain" ) ), anyString() );
+        argThat( hasData( "test123", "UTF-8", "text/plain" ) ), anyString() );
   }
 
   @Test( expected = FileNotFoundException.class )
@@ -127,7 +123,7 @@ public class RepositoryFileIoTest {
     IUnifiedRepository repo = mock( IUnifiedRepository.class );
     // simulate request for publicDir
     RepositoryFile publicDir =
-      new RepositoryFile.Builder( "123", ClientRepositoryPaths.getPublicFolderName() ).folder( true ).build();
+        new RepositoryFile.Builder( "123", ClientRepositoryPaths.getPublicFolderName() ).folder( true ).build();
     doReturn( publicDir ).when( repo ).getFile( publicDirPath );
     mp.defineInstance( IUnifiedRepository.class, repo );
 
@@ -137,7 +133,7 @@ public class RepositoryFileIoTest {
     rfos.close();
 
     verify( repo ).createFile( eq( "123" ), argThat( isLikeFile( new RepositoryFile.Builder( fileName ).build() ) ),
-      argThat( hasData( expectedPayload, "application/octet-stream" ) ), anyString() );
+        argThat( hasData( expectedPayload, "application/octet-stream" ) ), anyString() );
   }
 
   @Test( expected = FileNotFoundException.class )
@@ -165,13 +161,12 @@ public class RepositoryFileIoTest {
     reader.close();
   }
 
-
   @Test( expected = FileNotFoundException.class )
   public void testReadDirectoryPath() throws IOException {
     IUnifiedRepository repo = mock( IUnifiedRepository.class );
     // simulate file exists but is a directory
     doReturn( new RepositoryFile.Builder( "123", ClientRepositoryPaths.getPublicFolderName() ).folder( true ).build() )
-      .when( repo ).getFile( ClientRepositoryPaths.getPublicFolderPath() );
+        .when( repo ).getFile( ClientRepositoryPaths.getPublicFolderPath() );
     mp.defineInstance( IUnifiedRepository.class, repo );
 
     RepositoryFileReader reader = new RepositoryFileReader( ClientRepositoryPaths.getPublicFolderPath() );
@@ -183,26 +178,11 @@ public class RepositoryFileIoTest {
     IUnifiedRepository repo = mock( IUnifiedRepository.class );
     // simulate file exists but is a directory
     doReturn( new RepositoryFile.Builder( "123", ClientRepositoryPaths.getPublicFolderName() ).folder( true ).build() )
-      .when( repo ).getFile( ClientRepositoryPaths.getPublicFolderPath() );
+        .when( repo ).getFile( ClientRepositoryPaths.getPublicFolderPath() );
     mp.defineInstance( IUnifiedRepository.class, repo );
 
     RepositoryFileWriter writer = new RepositoryFileWriter( ClientRepositoryPaths.getPublicFolderPath(), "UTF-8" );
-    writer.write( "dummy data" );
     writer.close();
-  }
-
-  @Test
-  public void testWriteDirectoryWithEmptyData() throws IOException {
-    IUnifiedRepository repo = mock( IUnifiedRepository.class );
-    // simulate file exists but is a directory
-    doReturn( new RepositoryFile.Builder( "123", ClientRepositoryPaths.getPublicFolderName() ).folder( true ).build() )
-      .when( repo ).getFile( ClientRepositoryPaths.getPublicFolderPath() );
-    mp.defineInstance( IUnifiedRepository.class, repo );
-
-    RepositoryFileOutputStream writer =
-      new RepositoryFileOutputStream( ClientRepositoryPaths.getPublicFolderPath(), "UTF-8" );
-    writer.close();
-    assertTrue( getInternalState( writer, "flushed" ) );
   }
 
   protected static String getSolutionPath() {

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/fileio/RepositoryFileOutputStreamTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/fileio/RepositoryFileOutputStreamTest.java
@@ -14,13 +14,12 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.repository2.unified.fileio;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.pentaho.platform.api.repository2.unified.Converter;
@@ -28,20 +27,29 @@ import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
 import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFileData;
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
 
-
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
 
 public class RepositoryFileOutputStreamTest {
 
   @Test
-  public void convertTest() throws Exception{
-    RepositoryFileOutputStream spy = Mockito.spy( new RepositoryFileOutputStream( "1.ktr", "UTF-8"  ) );
-    Converter converter = Mockito.mock( Converter.class);
-    ByteArrayInputStream bis = Mockito.mock( ByteArrayInputStream.class);
-    Mockito.doReturn( Mockito.mock( NodeRepositoryFileData.class ) ).when( converter ).convert( bis , "UTF-8", "");
-    IRepositoryFileData data = spy.convert( null , bis , "");
-    Assert.assertTrue( data instanceof SimpleRepositoryFileData );
-    data = spy.convert( converter , bis , "");
-    Assert.assertTrue( data instanceof NodeRepositoryFileData );
+  public void convertTest() throws Exception {
+    RepositoryFileOutputStream spy = Mockito.spy( new RepositoryFileOutputStream( "1.ktr", "UTF-8" ) );
+    Converter converter = Mockito.mock( Converter.class );
+    ByteArrayInputStream bis = Mockito.mock( ByteArrayInputStream.class );
+    Mockito.doReturn( Mockito.mock( NodeRepositoryFileData.class ) ).when( converter ).convert( bis, "UTF-8", "" );
+    IRepositoryFileData data = spy.convert( null, bis, "" );
+    assertTrue( data instanceof SimpleRepositoryFileData );
+    data = spy.convert( converter, bis, "" );
+    assertTrue( data instanceof NodeRepositoryFileData );
+  }
+
+  @Test
+  public void testFlushWithEmptyData() throws IOException {
+    RepositoryFileOutputStream repositoryFileOutputStream = new RepositoryFileOutputStream( "1.ktr" );
+    repositoryFileOutputStream.flush();
+    assertTrue( repositoryFileOutputStream.flushed );
   }
 }


### PR DESCRIPTION
@pentaho-lmartins 
@ssamora 
@ppatricio 
@smmribeiro 
