### PR TITLE
[BISERVER-5014] Adding new log4j category and extra information to web socket configurations

### DIFF
--- a/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/log4j.xml
+++ b/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/log4j.xml
@@ -279,6 +279,10 @@
       <priority value="DEBUG"/>
       <appender-ref ref="SESSION_DATA_ACCESS_LOG"/>
     </category>
+    <category name="pt.webdetails.cda.dataaccess.SimpleDataAccess" additivity="false">
+      <priority value="DEBUG"/>
+      <appender-ref ref="SESSION_DATA_ACCESS_LOG"/>
+    </category>
     -->
 
 </log4j:configuration>

--- a/core/src/main/java/org/pentaho/platform/engine/core/system/PentahoSystem.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/PentahoSystem.java
@@ -130,6 +130,10 @@ public class PentahoSystem {
 
   public static final String PENTAHO_SESSION_KEY = "pentaho-session-context"; //$NON-NLS-1$
 
+  public static final String PENTAHO_AUTH_KEY = "pentaho-auth-context";
+
+  public static final String PENTAHO_MDC_KEY = "pentaho-mdc-context";
+
   public static final String WAIT_SECONDS = "waitSeconds";
 
   public static final String CORS_REQUESTS_ALLOWED = "cors-requests-allowed";


### PR DESCRIPTION
@bennychow please review
/cc @jcarneirohv

- CDA uses the websocket feature of the pentaho platform but requires extra information to be injected into the websocket's ServerEndpointConfig to be able to replicate the Pentaho session and request context on the websocket session side. This information is required to properly log and audit the data access.l
