### PR TITLE
[PDI-19103] "java.lang.IllegalArgumentException: Last encoded charact…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <enunciate-jersey-rt.version>1.27</enunciate-jersey-rt.version>
     <pentaho-json.version>9.2.0.0-SNAPSHOT</pentaho-json.version>
     <poi.version>4.1.1</poi.version>
-    <commons-codec.version>1.13</commons-codec.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <curvesapi.version>1.06</curvesapi.version>
     <commons-compress.version>1.20</commons-compress.version>


### PR DESCRIPTION
…er (before the paddings if any)" after upgrading Pentaho Spoon to 8.3.0.16 and higher

@bcostahitachivantara @smmribeiro 
Related PRs:
https://github.com/pentaho/maven-parent-poms/pull/265 (Must be merged first)
pentaho/pentaho-analyzer#2158
pentaho/pentaho-reporting#1384