### PR TITLE
[SP-5908] Backport of PDI-19084 - Backward slash ( \ ) is not resolve…

### DIFF
--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/DefaultPathConversionHelper.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/DefaultPathConversionHelper.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -34,12 +34,14 @@ public class DefaultPathConversionHelper implements IPathConversionHelper {
   /**
    * Returns null if path is not at or under the tenant root.
    */
+  @Override
   public String absToRel( final String absPath ) {
     Assert.hasLength( absPath );
     Assert.isTrue( absPath.startsWith( RepositoryFile.SEPARATOR ) );
+    String convertedAbsPath = convertPathSlashes( absPath );
     if ( ( ServerRepositoryPaths.getTenantRootFolderPath() != null )
-        && absPath.startsWith( ServerRepositoryPaths.getTenantRootFolderPath() ) ) {
-      String tmpPath = absPath.substring( ServerRepositoryPaths.getTenantRootFolderPath().length() );
+        && convertedAbsPath.startsWith( ServerRepositoryPaths.getTenantRootFolderPath() ) ) {
+      String tmpPath = convertedAbsPath.substring( ServerRepositoryPaths.getTenantRootFolderPath().length() );
       if ( "".equals( tmpPath ) ) { //$NON-NLS-1$
         return RepositoryFile.SEPARATOR;
       } else {
@@ -54,11 +56,22 @@ public class DefaultPathConversionHelper implements IPathConversionHelper {
   /**
    * Unconditionally adds tenant root path to given path.
    */
+  @Override
   public String relToAbs( final String relPath ) {
     Assert.hasLength( relPath );
     Assert.isTrue( relPath.startsWith( RepositoryFile.SEPARATOR ) );
+    String convertedRelPath = convertPathSlashes( relPath );
     return ServerRepositoryPaths.getTenantRootFolderPath()
-        + ( RepositoryFile.SEPARATOR.equals( relPath ) ? "" : relPath ); //$NON-NLS-1$
+        + ( RepositoryFile.SEPARATOR.equals( convertedRelPath ) ? "" : convertedRelPath ); //$NON-NLS-1$
+  }
+
+  /**
+   * Converts a path string with backslashes into a path string with the repository separator
+   * @param path the path string
+   * @return a new path string with backslashes converted to repository separators
+   */
+  private String convertPathSlashes( final String path ) {
+    return path.replace( "\\", RepositoryFile.SEPARATOR );
   }
 
 }

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/DefaultPathConversionHelperTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/DefaultPathConversionHelperTest.java
@@ -1,0 +1,118 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ *
+ */
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.repository2.unified.ServerRepositoryPaths;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( ServerRepositoryPaths.class )
+public class DefaultPathConversionHelperTest {
+  private DefaultPathConversionHelper converter;
+
+
+  @Before
+  public void setup() {
+    converter = new DefaultPathConversionHelper();
+  }
+
+
+  @Test( expected = IllegalArgumentException.class )
+  public void absToRelEmptyTest() {
+    converter.absToRel( "" );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void absToRelNullTest() {
+    converter.absToRel( null );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void absToRelStartsWithSeparatorTest() {
+    converter.absToRel( "somepath/somefile" );
+  }
+
+  @Test
+  public void absToRelNullTenantRootFolderTest() {
+    PowerMockito.mockStatic( ServerRepositoryPaths.class );
+    when( ServerRepositoryPaths.getTenantRootFolderPath() ).thenReturn( null );
+    assertNull( converter.absToRel( "/somepath/somefile" ) );
+  }
+
+  @Test
+  public void absToRelWrongTenantRootFolderTest() {
+    PowerMockito.mockStatic( ServerRepositoryPaths.class );
+    when( ServerRepositoryPaths.getTenantRootFolderPath() ).thenReturn( "/somepath" );
+    assertNull( converter.absToRel( "/otherpath/somefile" ) );
+  }
+
+  @Test
+  public void absToRelRootFolderTest() {
+    PowerMockito.mockStatic( ServerRepositoryPaths.class );
+    when( ServerRepositoryPaths.getTenantRootFolderPath() ).thenReturn( "/somepath" );
+    assertEquals( RepositoryFile.SEPARATOR, converter.absToRel( "/somepath" ) );
+  }
+
+  @Test
+  public void absToRelTest() {
+    PowerMockito.mockStatic( ServerRepositoryPaths.class );
+    when( ServerRepositoryPaths.getTenantRootFolderPath() ).thenReturn( "/somepath" );
+    assertEquals( "/other/thefile", converter.absToRel( "/somepath/other\\thefile" ) );
+    assertEquals( "/other/filename", converter.absToRel( "/somepath/other\\filename" ) );
+    assertEquals( "/other/filename", converter.absToRel( "/somepath\\other\\filename" ) );
+    assertEquals( "/other/else/filename", converter.absToRel( "/somepath\\other\\else\\filename" ) );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void relToAbsEmptyTest() {
+    converter.relToAbs( "" );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void relToAbsNullTest() {
+    converter.relToAbs( null );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void relToAbsStartsWithSeparatorTest() {
+    converter.relToAbs( "somepath/somefile" );
+  }
+
+  @Test
+  public void relToAbsTest() {
+    PowerMockito.mockStatic( ServerRepositoryPaths.class );
+    when( ServerRepositoryPaths.getTenantRootFolderPath() ).thenReturn( "/somepath" );
+    assertEquals( "/somepath/somefile", converter.relToAbs( "/somefile" ) );
+    assertEquals( "/somepath/somefolder/other/somefile/", converter.relToAbs( "/somefolder\\other/somefile/" ) );
+    assertEquals( "/somepath/somefolder/other/somefile/", converter.relToAbs( "/somefolder\\other\\somefile\\" ) );
+    assertEquals( "/somepath", converter.relToAbs( "/" ) );
+  }
+
+}


### PR DESCRIPTION
…d in the transformation path after upgrading from 8.1 to 8.3 (9.1 Suite)

@bcostahitachivantara @smmribeiro 

cherry-pick of 2ba0f687b10949ade926d0645d7f07a3d4e3cfb8 (from PR https://github.com/pentaho/pentaho-platform/pull/4829)