### PR TITLE
[ANALYZER-3942] Add ability to set the locale via ProxyTrustingFilter

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/messages/LocaleHelper.java
+++ b/core/src/main/java/org/pentaho/platform/util/messages/LocaleHelper.java
@@ -20,6 +20,7 @@
 
 package org.pentaho.platform.util.messages;
 
+import org.apache.commons.lang.StringUtils;
 import org.pentaho.platform.util.logging.Logger;
 
 import java.io.UnsupportedEncodingException;
@@ -69,16 +70,16 @@ public class LocaleHelper {
 
   /**
    * BISERVER-9863 Check if override locale string contains language and country. If so, instantiate Locale with
-   * two parameters for language and country, instead of just language
-   * 
-   * @param localeOverride
+   * two parameters for language and country, instead of just language.
+   *
+   * @param localeOverride The new locale override, or {@code null} or an empty string, if none.
    */
   public static void parseAndSetLocaleOverride( final String localeOverride ) {
-    if ( localeOverride.contains( "_" ) ) {
+    if ( StringUtils.isEmpty( localeOverride ) ) {
+      setLocaleOverride( null );
+    } else if ( localeOverride.contains( "_" ) ) {
       String[] parts = localeOverride.split( "_" );
-      if ( parts.length >= 2 ) {
-        setLocaleOverride( new Locale( parts[0], parts[1] ) );
-      }
+      setLocaleOverride( new Locale( parts[0], parts[1] ) );
     } else {
       setLocaleOverride( new Locale( localeOverride ) );
     }

--- a/core/src/test/java/org/pentaho/test/platform/engine/core/BaseTestCase.java
+++ b/core/src/test/java/org/pentaho/test/platform/engine/core/BaseTestCase.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -180,5 +180,13 @@ public abstract class BaseTestCase extends TestCase {
 
   public String getFullyQualifiedServerURL() {
     return "http://localhost:8080/pentaho/"; //$NON-NLS-1$
+  }
+
+  public IPentahoSession getPentahoSession() {
+    return session;
+  }
+
+  public void setPentahoSession( IPentahoSession session ) {
+    this.session = session;
   }
 }

--- a/extensions/src/it/java/org/pentaho/test/platform/web/ProxyServletIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/ProxyServletIT.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -23,20 +23,33 @@ package org.pentaho.test.platform.web;
 import com.mockrunner.mock.web.MockHttpServletRequest;
 import com.mockrunner.mock.web.MockHttpServletResponse;
 import com.mockrunner.mock.web.MockHttpSession;
+import com.mockrunner.mock.web.MockServletConfig;
+import org.apache.http.client.utils.URIBuilder;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.StandaloneApplicationContext;
+import org.pentaho.platform.engine.core.system.StandaloneSession;
+import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.platform.web.servlet.ProxyServlet;
 import org.pentaho.test.platform.engine.core.BaseTestCase;
 import org.pentaho.test.platform.utils.TestResourceLocation;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for <code>org.pentaho.platform.web.servlet.ProxyServlet</code>.
- * 
+ *
  * @author mlowery
  */
 public class ProxyServletIT extends BaseTestCase {
@@ -47,8 +60,23 @@ public class ProxyServletIT extends BaseTestCase {
   }
 
   public void setUp() {
-    StandaloneApplicationContext applicationContext = new StandaloneApplicationContext( getSolutionPath(), "" ); //$NON-NLS-1$
+    // BaseTestCase constructor initializes the PentahoSystem.
+    if ( PentahoSystem.getInitializedStatus() == PentahoSystem.SYSTEM_INITIALIZED_OK ) {
+      PentahoSystem.shutdown();
+    }
+
+    PentahoSessionHolder.setSession( getPentahoSession() );
+
+    StandaloneApplicationContext applicationContext =
+      new StandaloneApplicationContext( getSolutionPath(), "" ); //$NON-NLS-1$
     PentahoSystem.init( applicationContext, getRequiredListeners() );
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    PentahoSystem.shutdown();
+    LocaleHelper.setLocaleOverride( null );
+    PentahoSessionHolder.setSession( null );
   }
 
   protected Map getRequiredListeners() {
@@ -57,7 +85,7 @@ public class ProxyServletIT extends BaseTestCase {
     return listeners;
   }
 
-  public void testService() throws ServletException, IOException {
+  public void testServiceWithNoConfig() throws ServletException, IOException {
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpSession session = new MockHttpSession();
     request.setSession( session );
@@ -68,4 +96,148 @@ public class ProxyServletIT extends BaseTestCase {
     servlet.service( request, response );
   }
 
+  // region init( config )
+  public void testServiceInitParameterProxyURL() throws ServletException {
+
+    MockServletConfig config = new MockServletConfig();
+    config.setInitParameter( "ProxyURL", "http://www.pentaho.org" );
+
+    ProxyServlet servlet = new ProxyServlet();
+    servlet.init( config );
+
+    assertEquals( servlet.getProxyURL(), "http://www.pentaho.org" );
+  }
+
+  public void testServiceInitParameterErrorURL() throws ServletException {
+
+    MockServletConfig config = new MockServletConfig();
+    config.setInitParameter( "ErrorURL", "http://www.pentaho.org" );
+
+    ProxyServlet servlet = new ProxyServlet();
+    servlet.init( config );
+
+    assertEquals( servlet.getErrorURL(), "http://www.pentaho.org" );
+  }
+
+  public void testServiceInitParameterErrorURLDefault() throws ServletException {
+
+    MockServletConfig config = new MockServletConfig();
+
+    ProxyServlet servlet = new ProxyServlet();
+    servlet.init( config );
+
+    assertNull( servlet.getErrorURL() );
+  }
+
+  public void testServiceInitParameterLocaleOverrideEnabled() throws ServletException {
+
+    MockServletConfig config = new MockServletConfig();
+    config.setInitParameter( "LocaleOverrideEnabled", "false" );
+
+    ProxyServlet servlet = new ProxyServlet();
+    servlet.init( config );
+
+    assertEquals( servlet.isLocaleOverrideEnabled(), false );
+  }
+
+  public void testServiceInitParameterLocaleOverrideEnabledDefault() throws ServletException {
+
+    MockServletConfig config = new MockServletConfig();
+
+    ProxyServlet servlet = new ProxyServlet();
+    servlet.init( config );
+
+    assertEquals( servlet.isLocaleOverrideEnabled(), true );
+  }
+  // endregion
+
+  // region service
+
+  // IT tests are not in the same package of classes being tested.
+  // One way of spying protected methods is to inherit from the class, locally.
+  // We're only stubbing the parts where network access would occur.
+  private class TestProxyServlet extends ProxyServlet {
+    @Override
+    protected void doProxyCore( URI requestUri, HttpServletResponse response ) {
+      // Do not access network.
+    }
+  }
+
+  public void testServiceTrustUserQueryParameter() throws ServletException, IOException, URISyntaxException {
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    request.setServletPath( "/pentaho" );
+
+    MockHttpSession session = new MockHttpSession();
+    request.setSession( session );
+
+    MockServletConfig config = new MockServletConfig();
+    config.setInitParameter( "ProxyURL", "http://foo.bar" );
+
+    URIBuilder uriBuilder = new URIBuilder( "http://foo.bar/pentaho" );
+    uriBuilder.addParameter( "_TRUST_USER_", "system" );
+
+    TestProxyServlet servlet = spy( new TestProxyServlet() );
+    servlet.init( config );
+
+    servlet.service( request, response );
+
+    verify( servlet ).doProxyCore( eq( uriBuilder.build() ), eq( response ) );
+  }
+
+  public void testServiceTrustLocaleOverrideQueryParameter() throws ServletException, IOException, URISyntaxException {
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    request.setServletPath( "/pentaho" );
+
+    MockHttpSession session = new MockHttpSession();
+    request.setSession( session );
+
+    MockServletConfig config = new MockServletConfig();
+    config.setInitParameter( "ProxyURL", "http://foo.bar" );
+
+    URIBuilder uriBuilder = new URIBuilder( "http://foo.bar/pentaho" );
+    uriBuilder.addParameter( "_TRUST_USER_", "system" );
+    uriBuilder.addParameter( "_TRUST_LOCALE_OVERRIDE_", "pt_PT" );
+
+
+    TestProxyServlet servlet = spy( new TestProxyServlet() );
+    servlet.init( config );
+
+    LocaleHelper.setLocaleOverride( Locale.forLanguageTag( "pt-PT" ) );
+
+    servlet.service( request, response );
+
+    verify( servlet ).doProxyCore( eq( uriBuilder.build() ), eq( response ) );
+  }
+
+  public void testServiceNoUserSessionQueryParameter() throws ServletException, IOException, URISyntaxException {
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    request.setServletPath( "/pentaho" );
+
+    MockHttpSession session = new MockHttpSession();
+    request.setSession( session );
+    
+    PentahoSessionHolder.setSession( new StandaloneSession( "" ) );
+    
+    MockServletConfig config = new MockServletConfig();
+    config.setInitParameter( "ProxyURL", "http://foo.bar" );
+    
+    URIBuilder uriBuilder = new URIBuilder( "http://foo.bar/pentaho" );
+
+    TestProxyServlet servlet = spy( new TestProxyServlet() );
+    servlet.init( config );
+
+    servlet.service( request, response );
+
+    verify( servlet ).doProxyCore( eq( uriBuilder.build() ), eq( response ) );
+  }
+  // endregion
 }

--- a/extensions/src/main/java/org/pentaho/platform/web/http/filters/HttpSessionPentahoSessionIntegrationFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/filters/HttpSessionPentahoSessionIntegrationFilter.java
@@ -199,15 +199,16 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
    * doing there in the first place. TODO mlowery move this somewhere else
    */
   protected void localeLeftovers( final HttpServletRequest httpRequest ) {
+
+    // Sync the thread static LocaleHelper's locale override with the value of the corresponding session attribute.
     HttpSession httpSession = httpRequest.getSession( false );
     if ( httpSession != null ) {
-      String localeOverride = (String) httpSession.getAttribute( "locale_override" ); //$NON-NLS-1$
-      if ( !StringUtils.isEmpty( localeOverride ) ) {
-        LocaleHelper.parseAndSetLocaleOverride( localeOverride );
-      } else {
-        LocaleHelper.setLocaleOverride( null );
-      }
+      String localeOverride = (String) httpSession.getAttribute( "locale_override" );
+      LocaleHelper.parseAndSetLocaleOverride( localeOverride );
     }
+
+    // Even if there is no session, or if it has no locale override,
+    // set the thread's fallback locale to that of the HTTP request.
     LocaleHelper.setLocale( httpRequest.getLocale() );
   }
 

--- a/extensions/src/main/java/org/pentaho/platform/web/http/filters/ProxyTrustingFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/filters/ProxyTrustingFilter.java
@@ -172,9 +172,6 @@ public class ProxyTrustingFilter implements Filter {
         String tok = st.nextToken().trim();
         if ( tok.length() > 0 ) {
           addrs.add( tok );
-          // getLogger().info(
-          // Messages.getString("ProxyTrustingFilter.DEBUG_0001_TRUSTING",
-          // tok ) ); 
         }
       }
       if ( addrs.size() > 0 ) { // Guarantee that its null or has at least 1
@@ -251,8 +248,6 @@ public class ProxyTrustingFilter implements Filter {
 
   public void doFilter( final ServletRequest request, final ServletResponse response, final FilterChain chain )
     throws IOException, ServletException {
-
-    // long startTime = System.currentTimeMillis();
 
     if ( ( trustedIpAddrs != null ) && ( request instanceof HttpServletRequest ) ) {
       final HttpServletRequest req = (HttpServletRequest) request;

--- a/extensions/src/main/java/org/pentaho/platform/web/http/filters/ProxyTrustingFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/filters/ProxyTrustingFilter.java
@@ -164,9 +164,9 @@ public class ProxyTrustingFilter implements Filter {
 
   protected void initParameterTrustedIpAddresses() {
     trustedIpAddrs = null;
-    String hostStr = filterConfig.getInitParameter( "TrustedIpAddrs" ); 
+    String hostStr = filterConfig.getInitParameter( "TrustedIpAddrs" );
     if ( hostStr != null ) {
-      StringTokenizer st = new StringTokenizer( hostStr, "," ); 
+      StringTokenizer st = new StringTokenizer( hostStr, "," );
       List<String> addrs = new ArrayList<String>();
       while ( st.hasMoreTokens() ) {
         String tok = st.nextToken().trim();
@@ -185,21 +185,21 @@ public class ProxyTrustingFilter implements Filter {
   }
 
   protected void initParameterCheckHeader() {
-    String checkHeaderString = filterConfig.getInitParameter( "CheckHeader" ); 
+    String checkHeaderString = filterConfig.getInitParameter( "CheckHeader" );
     if ( !isEmpty( checkHeaderString ) ) {
-      this.checkHeader = checkHeaderString.equalsIgnoreCase( "true" ); 
+      this.checkHeader = checkHeaderString.equalsIgnoreCase( "true" );
     }
   }
 
   protected void initParameterUser() {
-    String requestParameterSetting = filterConfig.getInitParameter( "RequestParameterName" ); 
+    String requestParameterSetting = filterConfig.getInitParameter( "RequestParameterName" );
     if ( !isEmpty( requestParameterSetting ) ) {
       this.requestParameterName = requestParameterSetting;
     } else {
       this.requestParameterName = ProxyTrustingFilter.DEFAULT_PARAMETER_NAME;
     }
 
-    String headerNameSetting = filterConfig.getInitParameter( "HeaderName" ); 
+    String headerNameSetting = filterConfig.getInitParameter( "HeaderName" );
     if ( !isEmpty( headerNameSetting ) ) {
       this.headerName = headerNameSetting;
     } else {
@@ -266,12 +266,6 @@ public class ProxyTrustingFilter implements Filter {
       }
     }
     chain.doFilter( request, response );
-
-    // long stopTime = System.currentTimeMillis();
-
-    // getLogger().debug( Messages.getString(
-    // Messages.getString("ProxyTrustingFilter.DEBUG_0004_REQUEST_TIME"),
-    // String.valueOf( stopTime - startTime ) ) );
   }
 
   protected void doFilterCore( HttpServletRequest request, String name ) throws ServletException {

--- a/extensions/src/main/java/org/pentaho/platform/web/http/filters/ProxyTrustingFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/filters/ProxyTrustingFilter.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -29,6 +29,7 @@ import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.UserSession;
 import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.util.messages.LocaleHelper;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.core.context.SecurityContext;
@@ -54,7 +55,6 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
- * 
  * This servlet is used to filter Servlet requests coming from another server for processing and sets authentication for
  * the user passed in by the parameter <b>_TRUST_USER_</b>. It will conditionally look for the parameter in the HTTP
  * Header too. It then passes the request down the servlet chain to be serviced. Only requests coming from a trusted
@@ -75,8 +75,11 @@ import java.util.regex.PatternSyntaxException;
  * </pre>
  * 
  * In the above example, when a request coming from IP addresses 192.168.10.60 and 192.168.10.61 has the parameter
- * _TRUST_USER_=<i>name</i> set, tha user <i>name</i> will be authenticated.
- * 
+ * _TRUST_USER_=<i>name</i> set, that user <i>name</i> will be authenticated.
+ *
+ * An additional parameter, <b>_TRUST_LOCALE_OVERRIDE_</b>, and, optionally, header, can be specified
+ * containing a locale override that the user session should use.
+ *
  * <p>
  * NOTES:
  * <p>
@@ -90,8 +93,10 @@ import java.util.regex.PatternSyntaxException;
  * The sending server should be using the ProxyServlet enabled to generate the requests.
  * <p>
  * 
- * The parameter that this filter looks for can be configured in the init parameters, as well as whether to check the
- * request headers. The following shows the defaults used if these settings aren't provided.
+ * The user and locale parameters that this filter looks for can be configured in the init parameters,
+ * as well as whether to check the request headers.
+ *
+ * The following shows the defaults used if these settings aren't provided.
  * 
  * <pre>
  *   &lt;init-param&gt;
@@ -106,6 +111,15 @@ import java.util.regex.PatternSyntaxException;
  *     &lt;param-name&gt;HeaderName&lt;/param-name&gt;
  *     &lt;param-value&gt;_TRUST_USER_&lt;/param-value&gt;
  *   &lt;/init-param&gt;
+ *   &lt;init-param&gt;
+ *   &lt;init-param&gt;
+ *     &lt;param-name&gt;LocaleOverrideParameterName&lt;/param-name&gt;
+ *     &lt;param-value&gt;_TRUST_LOCALE_OVERRIDE_&lt;/param-value&gt;
+ *   &lt;/init-param&gt;
+ *   &lt;init-param&gt;
+ *     &lt;param-name&gt;LocaleOverrideHeaderName&lt;/param-name&gt;
+ *     &lt;param-value&gt;_TRUST_LOCALE_OVERRIDE_&lt;/param-value&gt;
+ *   &lt;/init-param&gt;
  * </pre>
  * 
  * 
@@ -116,13 +130,19 @@ import java.util.regex.PatternSyntaxException;
 
 public class ProxyTrustingFilter implements Filter {
   FilterConfig filterConfig;
-  private static final String DefaultParameterName = "_TRUST_USER_"; //$NON-NLS-1$
+  private static final String DEFAULT_PARAMETER_NAME = "_TRUST_USER_";
+  private static final String DEFAULT_LOCALE_OVERRIDE_PARAMETER_NAME = "_TRUST_LOCALE_OVERRIDE_";
 
   String[] trustedIpAddrs = null;
   private boolean checkHeader = true;
+
   private String requestParameterName;
   private String headerName;
-  private Map<String, Pattern> ipPatterns = new HashMap<String, Pattern>();
+
+  private String localeOverrideParameterName;
+  private String localeOverrideHeaderName;
+
+  private final Map<String, Pattern> ipPatterns = new HashMap<>();
 
   private static final Log logger = LogFactory.getLog( ProxyTrustingFilter.class );
 
@@ -149,24 +169,41 @@ public class ProxyTrustingFilter implements Filter {
       }
       if ( addrs.size() > 0 ) { // Guarantee that its null or has at least 1
         // element
-        trustedIpAddrs = (String[]) addrs.toArray( new String[0] );
+        trustedIpAddrs = addrs.toArray( new String[0] );
       }
     }
+
     String checkHeaderString = filterConfig.getInitParameter( "CheckHeader" ); //$NON-NLS-1$
     if ( !isEmpty( checkHeaderString ) ) {
       this.checkHeader = checkHeaderString.equalsIgnoreCase( "true" ); //$NON-NLS-1$
     }
+
+    // User
     String requestParameterSetting = filterConfig.getInitParameter( "RequestParameterName" ); //$NON-NLS-1$
     if ( !isEmpty( requestParameterSetting ) ) {
       this.requestParameterName = requestParameterSetting;
     } else {
-      this.requestParameterName = ProxyTrustingFilter.DefaultParameterName;
+      this.requestParameterName = ProxyTrustingFilter.DEFAULT_PARAMETER_NAME;
     }
     String headerNameSetting = filterConfig.getInitParameter( "HeaderName" ); //$NON-NLS-1$
     if ( !isEmpty( headerNameSetting ) ) {
       this.headerName = headerNameSetting;
     } else {
-      this.headerName = ProxyTrustingFilter.DefaultParameterName;
+      this.headerName = ProxyTrustingFilter.DEFAULT_PARAMETER_NAME;
+    }
+
+    // Locale Override
+    String localeOverrideParameterSetting = filterConfig.getInitParameter( "LocaleOverrideParameterName" );
+    if ( !isEmpty( localeOverrideParameterSetting ) ) {
+      this.localeOverrideParameterName = localeOverrideParameterSetting;
+    } else {
+      this.localeOverrideParameterName = DEFAULT_LOCALE_OVERRIDE_PARAMETER_NAME;
+    }
+    String localeOverrideHeaderNameSetting = filterConfig.getInitParameter( "LocaleOverrideHeaderName" );
+    if ( !isEmpty( localeOverrideHeaderNameSetting ) ) {
+      this.localeOverrideHeaderName = localeOverrideHeaderNameSetting;
+    } else {
+      this.localeOverrideHeaderName = DEFAULT_LOCALE_OVERRIDE_PARAMETER_NAME;
     }
   }
 
@@ -208,30 +245,40 @@ public class ProxyTrustingFilter implements Filter {
       if ( isTrusted( remoteHost ) ) {
         String name = getTrustUser( req );
         if ( !isEmpty( name ) ) {
-
           try {
             becomeUser( name );
+
+            setSystemLocaleOverrideCode( getTrustLocaleOverrideCode( req ) );
+
+            // ---
+            // Update HTTP Session Attributes
+
             HttpSession httpSession = req.getSession();
+            // 1. Pentaho Session
             httpSession.setAttribute( PentahoSystem.PENTAHO_SESSION_KEY, PentahoSessionHolder.getSession() );
 
-            /**
-            * definition of anonymous inner class
-            */
+            // 2. Locale Override
+            //
+            // As currently configured by default, this filter is followed by HttpSessionPentahoSessionIntegrationFilter,
+            // which calls LocaleHelper.setLocaleOverride with the locale corresponding to
+            // the httpSession's "locale_override" attribute. So, the attribute needs to be set, as well.
+            // `locale_override` uses Java's legacy Locale.toString format, which uses underscores.
+            Locale localeOverride = LocaleHelper.getLocaleOverride();
+            httpSession.setAttribute( "locale_override", localeOverride != null ? localeOverride.toString() : null );
+
+            // 3. Spring Security Context attribute.
             SecurityContext authWrapper = new SecurityContext() {
-            /**
-              * 
-              */
               private static final long serialVersionUID = 1L;
               private Authentication authentication;
 
               public Authentication getAuthentication() {
                 return authentication;
-              };
+              }
 
               public void setAuthentication( Authentication authentication ) {
                 this.authentication = authentication;
-              };
-            }; // end anonymous inner class
+              }
+            };
 
             authWrapper.setAuthentication( SecurityContextHolder.getContext().getAuthentication() );
             httpSession.setAttribute( HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, authWrapper );
@@ -277,7 +324,21 @@ public class ProxyTrustingFilter implements Filter {
   }
 
   /**
-   * @return true if the filter should consult the http header for the trusted user
+   * Gets the name of the request header that will contain the trusted locale override
+   */
+  protected String getLocaleOverrideHeaderName() {
+    return this.localeOverrideHeaderName;
+  }
+
+  /**
+   * Gets the name of the request parameter that will contain the trusted locale override.
+   */
+  protected String getLocaleOverrideParameterName() {
+    return this.localeOverrideParameterName;
+  }
+
+  /**
+   * @return true if the filter should consult the http header for the trusted user and trusted locale override
    */
   protected boolean checkHeader() {
     return checkHeader;
@@ -297,6 +358,22 @@ public class ProxyTrustingFilter implements Filter {
     }
 
     return name;
+  }
+
+  /**
+   * Gets the trusted locale code override from the request, and optionally from the HTTP header.
+   *
+   * @param request
+   *          The HttpServletRequest to examine for the trusted information
+   * @return The specified trusted locale code, if any; {@code null}, otherwise.
+   */
+  protected String getTrustLocaleOverrideCode( HttpServletRequest request ) {
+    String localeOverrideCode = request.getParameter( getLocaleOverrideParameterName() );
+    if ( checkHeader() && isEmpty( localeOverrideCode ) ) {
+      localeOverrideCode = request.getHeader( normalizeHeaderName( getLocaleOverrideHeaderName() ) );
+    }
+
+    return localeOverrideCode;
   }
 
   public boolean isEmpty( String str ) {
@@ -327,5 +404,14 @@ public class ProxyTrustingFilter implements Filter {
     Authentication auth = SecurityHelper.getInstance().createAuthentication( principalName );
     SecurityContextHolder.getContext().setAuthentication( auth );
     PentahoSystem.sessionStartup( PentahoSessionHolder.getSession(), null );
+  }
+
+  /**
+   * Sets the system's locale override.
+   *
+   * @param localeOverrideCode The locale override code.
+   */
+  protected void setSystemLocaleOverrideCode( String localeOverrideCode ) {
+    LocaleHelper.parseAndSetLocaleOverride( localeOverrideCode );
   }
 }

--- a/extensions/src/main/resources/org/pentaho/platform/web/servlet/messages/messages.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/web/servlet/messages/messages.properties
@@ -85,6 +85,7 @@ ProxyServlet.DEBUG_0001_OUTPUT_URL=>>>>>>>>>>>>>> PROXY:  {0}
 ProxyServlet.ERROR_0003_REMOTE_HTTP_CALL_FAILED=HTTP call to URL failed: {0}
 ProxyServlet.ERROR_0004_PROTOCOL_FAILURE=Fatal protocol violation
 ProxyServlet.ERROR_0005_TRANSPORT_FAILURE=Fatal transport error
+ProxyServlet.ERROR_0006_URI_SYNTAX_EXCEPTION=Invalid proxy base URL: {0}
 
 AdhocWebService.USER_REPORT_SAVED=Your report has been saved.
 AdhocWebService.USER_DELETE_SUCCESSFUL=The repository file has been deleted.

--- a/user-console/src/main/resources/org/pentaho/mantle/public/Mantle.jsp
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/Mantle.jsp
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
 --%>
 
 <!DOCTYPE html>
@@ -25,7 +25,6 @@
             java.util.Locale,
             java.net.URL,
             java.net.URLClassLoader,
-            java.util.ArrayList,
             java.util.Iterator,
             java.util.LinkedHashMap,
             java.util.List,
@@ -38,13 +37,12 @@
   boolean hasDataAccessPlugin = PentahoSystem.get( IPluginManager.class, PentahoSessionHolder.getSession() ).getRegisteredPlugins().contains( "data-access" );
 
   Locale effectiveLocale = request.getLocale();
-  if ( !StringUtils.isEmpty( request.getParameter( "locale" ) ) ) {
-    request.getSession().setAttribute( "locale_override", request.getParameter( "locale" ) );
-    LocaleHelper.parseAndSetLocaleOverride( request.getParameter( "locale" ) );
-  } else {
-    request.getSession().setAttribute( "locale_override", null );
-    LocaleHelper.setLocaleOverride( null );
-  }
+
+  // Handle the `locale` request parameter.
+  request.getSession().setAttribute(
+      "locale_override",
+      StringUtils.defaultIfEmpty( request.getParameter( "locale" ), null ) );
+  LocaleHelper.parseAndSetLocaleOverride( request.getParameter( "locale" ) );
 
   URLClassLoader loader = new URLClassLoader( new URL[] { application.getResource( "/mantle/messages/" ) } );
   ResourceBundle properties = ResourceBundle.getBundle( "mantleMessages", request.getLocale(), loader );

--- a/user-console/src/main/resources/org/pentaho/mantle/public/MantleDebug.jsp
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/MantleDebug.jsp
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+* Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
 --%>
 
 <!DOCTYPE html>
@@ -26,14 +26,11 @@
 
 <%
   Locale effectiveLocale = request.getLocale();
-  if ( !StringUtils.isEmpty( request.getParameter( "locale" ) ) ) {
-    effectiveLocale = new Locale( request.getParameter( "locale" ) );
-    request.getSession().setAttribute( "locale_override", request.getParameter( "locale" ) );
-    LocaleHelper.setLocaleOverride( effectiveLocale );
-  } else {
-    request.getSession().setAttribute( "locale_override", null );
-    LocaleHelper.setLocaleOverride( null );
-  }
+  // Handle the `locale` request parameter.
+  request.getSession().setAttribute(
+      "locale_override",
+      StringUtils.defaultIfEmpty( request.getParameter( "locale" ), null ) );
+  LocaleHelper.parseAndSetLocaleOverride( request.getParameter( "locale" ) );
 
   URLClassLoader loader = new URLClassLoader( new URL[] { application.getResource( "/mantle/messages/" ) } );
   ResourceBundle properties = ResourceBundle.getBundle( "mantleMessages", request.getLocale(), loader );


### PR DESCRIPTION
- `ProxyServlet`, `ProxyTrustingFilter` - send and receive the new `_TRUST_LOCALE_OVERRIDE_` argument
- `LocaleHelper.parseAndSetLocaleOverride` now accepts `null` or empty, simplifying some use cases
  - `Mantle.jsp`, `MantleDebug.jsp`, `HttpSessionPentahoSessionIntegrationFilter` - simplified to use the new interface of `LocaleHelper.parseAndSetLocaleOverride`

These changes allow CGG to request localized resources, via the `/i18n` service (the address of the platform's `LocalizationServlet`). The `/i18n` address is configured to allow being proxied/fetched from _localhost_ ([web.xml configuration of localhost](https://github.com/pentaho/pentaho-platform/blob/master/assemblies/pentaho-war/src/main/webapp/WEB-INF/web.xml#L86-L88) and [web.xml configuration of i18n](https://github.com/pentaho/pentaho-platform/blob/master/assemblies/pentaho-war/src/main/webapp/WEB-INF/web.xml#L127-L130)).

CGG is performing these HTTP requests to the server itself in [WebResourceLoader](https://github.com/webdetails/cgg/blob/master/pentaho/src/main/java/pt/webdetails/cgg/scripts/WebResourceLoader.java#L67-L69). See the corresponding proposed changes in the CGG PR: https://github.com/webdetails/cgg/pull/148.

CGG does not use the provided `ProxyServlet`. However, to maintain capability symmetry with `ProxyTrustingFilter`, I added the locale override capability to `ProxyServlet` as well. The new/improved integration tests test its use.

@bennychow please review.
/cc @jcarneirohv 