### PR TITLE
[ANALYZER-3942] Several Locale handling improvements

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/engine/IPentahoSession.java
+++ b/api/src/main/java/org/pentaho/platform/api/engine/IPentahoSession.java
@@ -20,6 +20,8 @@
 
 package org.pentaho.platform.api.engine;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.util.Iterator;
 import java.util.Locale;
 
@@ -43,6 +45,14 @@ public interface IPentahoSession extends ILogger, IAuditable {
    * Roles that are authorized in current session.
    */
   public static final String SESSION_ROLES = "roles"; //$NON-NLS-1$
+
+  /**
+   * The name of the session attribute where the session locale override is stored.
+   *
+   * The format of the locale override attribute is Java's legacy {@link Locale#toString()} format,
+   * which uses underscores.
+   */
+  public static final String ATTRIBUTE_LOCALE_OVERRIDE = "locale_override";
 
   /**
    * Gets the name for this session, for example if this is an authenticated HTTP or Portlet session, the name will be
@@ -119,10 +129,48 @@ public interface IPentahoSession extends ILogger, IAuditable {
 
   /**
    * Gets the locale of the session.
+   *
+   * This is the <i>initial</i> session locale, defined at construction.
    * 
    * @return Returns the locale of the session.
    */
   public Locale getLocale();
+
+  /**
+   * Gets the locale override of the session.
+   *
+   * The format of the locale override attribute should be that returned by {@link Locale#toString()}.
+   *
+   * If the stored locale is empty, {@code null} is returned instead.
+   *
+   * The locale override string is stored in the session attribute named {@link #ATTRIBUTE_LOCALE_OVERRIDE}.
+   *
+   * @return The locale override, if any; {@code null}, otherwise.
+   *
+   * @see #getAttribute(String)
+   * @see #setAttribute
+   */
+  public default String getAttributeLocaleOverride() {
+    return StringUtils.defaultIfEmpty( (String) getAttribute( ATTRIBUTE_LOCALE_OVERRIDE ), null );
+  }
+
+  /**
+   * Sets the locale override of the session.
+   *
+   * If the given locale is empty, it is converted to {@code null}.
+   *
+   * The format of the locale override attribute should be that returned by {@link Locale#toString()}.
+   *
+   * The locale override string is stored in the session attribute named {@link #ATTRIBUTE_LOCALE_OVERRIDE}.
+   *
+   * @param locale The locale override.
+   *
+   * @see #getAttribute(String)
+   * @see #setAttribute
+   */
+  public default void setAttributeLocaleOverride( String locale ) {
+    setAttribute( ATTRIBUTE_LOCALE_OVERRIDE, StringUtils.defaultIfEmpty( locale, null ) );
+  }
 
   /**
    * Gets whether the session is known to be authenticated or not.

--- a/core/src/main/java/org/pentaho/platform/engine/core/system/PentahoSystem.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/PentahoSystem.java
@@ -287,9 +287,6 @@ public class PentahoSystem {
       Logger.debug( PentahoSystem.class, "Setting property path" ); //$NON-NLS-1$
     }
     System.setProperty( "pentaho.solutionpath", "solution:" ); //$NON-NLS-1$
-    if ( LocaleHelper.getLocale() == null ) {
-      LocaleHelper.setLocale( Locale.getDefault() );
-    }
 
     if ( PentahoSystem.systemSettingsService != null ) {
       if ( debug ) {
@@ -1091,9 +1088,6 @@ public class PentahoSystem {
   public static void shutdown() {
     serverStatusProvider.setStatus( IServerStatusProvider.ServerStatus.STOPPING );
 
-    if ( LocaleHelper.getLocale() == null ) {
-      LocaleHelper.setLocale( Locale.getDefault() );
-    }
     if ( debug ) {
       Logger.debug( PentahoSystem.class, "Shutdown Listeners" ); //$NON-NLS-1$
     }

--- a/core/src/main/java/org/pentaho/platform/util/DateMath.java
+++ b/core/src/main/java/org/pentaho/platform/util/DateMath.java
@@ -151,10 +151,7 @@ public class DateMath {
 
     target = DateMath.calculateDate( date, expression );
 
-    myLocale = ( locale == null ) ? LocaleHelper.getLocale() : locale;
-    if ( myLocale == null ) {
-      myLocale = LocaleHelper.getDefaultLocale();
-    }
+    myLocale = locale == null ? LocaleHelper.getLocale() : locale;
 
     if ( pattern != null ) {
       format = new SimpleDateFormat( pattern, myLocale );

--- a/core/src/main/java/org/pentaho/platform/util/messages/LocaleHelper.java
+++ b/core/src/main/java/org/pentaho/platform/util/messages/LocaleHelper.java
@@ -194,7 +194,11 @@ public class LocaleHelper {
    * @param newLocale The new thread locale override. Can be {@code null}.
    */
   public static void setThreadLocaleOverride( final Locale newLocale ) {
-    LocaleHelper.threadLocalesOverride.set( newLocale );
+    if ( newLocale == null ) {
+      LocaleHelper.threadLocalesOverride.remove();
+    } else {
+      LocaleHelper.threadLocalesOverride.set( newLocale );
+    }
   }
 
   /**
@@ -238,7 +242,11 @@ public class LocaleHelper {
    * @param newLocale The new base locale. Can be {@code null}.
    */
   public static void setThreadLocaleBase( final Locale newLocale ) {
-    LocaleHelper.threadLocalesBase.set( newLocale );
+    if ( newLocale == null ) {
+      LocaleHelper.threadLocalesBase.remove();
+    } else {
+      LocaleHelper.threadLocalesBase.set( newLocale );
+    }
   }
 
   /**

--- a/core/src/main/java/org/pentaho/platform/util/messages/LocaleHelper.java
+++ b/core/src/main/java/org/pentaho/platform/util/messages/LocaleHelper.java
@@ -153,6 +153,7 @@ public class LocaleHelper {
    *
    * @deprecated Use a combination of {@link #parseLocale(String)} and {@link #setThreadLocaleOverride(Locale)} instead.
    */
+  @Deprecated
   public static void parseAndSetLocaleOverride( final String localeOverride ) {
     setThreadLocaleOverride( parseLocale( localeOverride ) );
   }
@@ -163,6 +164,7 @@ public class LocaleHelper {
    * @param newLocale The new override locale. Can be {@code null}.
    * @deprecated Use {@link #setThreadLocaleOverride(Locale)} instead.
    */
+  @Deprecated
   public static void setLocaleOverride( final Locale newLocale ) {
     setThreadLocaleOverride( newLocale );
   }
@@ -173,6 +175,7 @@ public class LocaleHelper {
    * @return The locale override, if set; {@code null}, otherwise.
    * @deprecated Use {@link #getThreadLocaleOverride()} instead.
    */
+  @Deprecated
   public static Locale getLocaleOverride() {
     return getThreadLocaleOverride();
   }
@@ -213,6 +216,7 @@ public class LocaleHelper {
    *
    * @deprecated Use {@link #setThreadLocaleBase(Locale)} instead.
    */
+  @Deprecated
   public static void setLocale( final Locale newLocale ) {
     setThreadLocaleBase( newLocale );
   }

--- a/core/src/main/java/org/pentaho/platform/util/messages/LocaleHelper.java
+++ b/core/src/main/java/org/pentaho/platform/util/messages/LocaleHelper.java
@@ -1,5 +1,4 @@
 /*!
- *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU General Public License, version 2 as published by the Free Software
  * Foundation.
@@ -13,14 +12,14 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
  *
- *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
- *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.platform.util.messages;
 
 import org.apache.commons.lang.StringUtils;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.util.logging.Logger;
 
 import java.io.UnsupportedEncodingException;
@@ -34,8 +33,13 @@ import java.util.Locale;
 
 public class LocaleHelper {
 
-  private static final ThreadLocal<Locale> threadLocales = new ThreadLocal<Locale>();
-  private static final ThreadLocal<Locale> threadLocaleOverride = new ThreadLocal<Locale>();
+  /**
+   * The default locale that is used when even the Java VM's {@link Locale#getDefault()} is {@code null}.
+   */
+  private static final Locale DEFAULT_LOCALE = Locale.US;
+
+  private static final ThreadLocal<Locale> threadLocalesBase = new ThreadLocal<>();
+  private static final ThreadLocal<Locale> threadLocalesOverride = new ThreadLocal<>();
 
   public static final int FORMAT_SHORT = DateFormat.SHORT;
 
@@ -59,58 +63,246 @@ public class LocaleHelper {
 
   public static final String USER_LOCALE_PARAM = "user_locale";
 
-  public static void setDefaultLocale( final Locale newLocale ) {
+  static {
+    setDefaultLocale( null );
+  }
+
+  // region Locale
+
+  /**
+   * Parses a locale string, taking into account if it is composed of several parts, separated by {@code _} characters.
+   * <p>
+   * If the given locale string is {@code null} or empty, then {@code null} is returned.
+   * <p>
+   * If the locale string has at least two parts, language and country, it creates and returns a locale using the first
+   * two parts as first and second arguments of the locale constructor {@link Locale(String, String)}, and ignoring the
+   * remaining parts.
+   * <p>
+   * Otherwise, it creates and returns a locale in which the whole string is passed to {@link Locale(String)}.
+   * <p>
+   * See BISERVER-9863 for more information.
+   *
+   * @param locale The locale string.
+   * @return The new locale or {@code null}.
+   */
+  public static Locale parseLocale( final String locale ) {
+    if ( StringUtils.isEmpty( locale ) ) {
+      return null;
+    }
+
+    if ( locale.contains( "_" ) ) {
+      String[] parts = locale.split( "_" );
+      return new Locale( parts[ 0 ], parts[ 1 ] );
+    }
+
+    return new Locale( locale );
+  }
+
+  // region 3 - Default Locale
+
+  /**
+   * Sets the default locale.
+   * <p>
+   * The default locale applies to any session or thread.
+   * <p>
+   * When {@code null}, the locale assumes the Java VM's current default locale,
+   * as given by {@link Locale#getDefault()}.
+   * In the rare cases that this may be {@code null}, it is initialized to {@link Locale#US}.
+   * <p>
+   * In the Pentaho server, the default locale is initialized by the
+   * {@code org.pentaho.platform.web.http.context.SolutionContextListener}.
+   * When the {@code web.xml} server parameters {@code locale-language} and {@code locale-country} are both specified
+   * and match an available locale, as given by {@link Locale#getAvailableLocales()}, it sets the default locale to
+   * that.
+   *
+   * @param newLocale The new default locale, possibly {@code null}.
+   */
+  public static void setDefaultLocale( Locale newLocale ) {
+    if ( newLocale == null ) {
+      newLocale = Locale.getDefault();
+    }
+
+    if ( newLocale == null ) {
+      newLocale = DEFAULT_LOCALE;
+    }
 
     LocaleHelper.defaultLocale = newLocale;
   }
 
+  /**
+   * Gets the default locale.
+   * <p>
+   * The default locale applies to any session or thread.
+   * <p>
+   * The default locale is always defined; it's never {@code null}.
+   *
+   * @return The default locale.
+   */
   public static Locale getDefaultLocale() {
     return LocaleHelper.defaultLocale;
   }
+  // endregion
+
+  // region 1 - Thread Locale Override
 
   /**
-   * BISERVER-9863 Check if override locale string contains language and country. If so, instantiate Locale with
-   * two parameters for language and country, instead of just language.
+   * BISERVER-9863 Check if override locale string contains language and country. If so, instantiate Locale with two
+   * parameters for language and country, instead of just language.
    *
    * @param localeOverride The new locale override, or {@code null} or an empty string, if none.
+   *
+   * @deprecated Use a combination of {@link #parseLocale(String)} and {@link #setThreadLocaleOverride(Locale)} instead.
    */
   public static void parseAndSetLocaleOverride( final String localeOverride ) {
-    if ( StringUtils.isEmpty( localeOverride ) ) {
-      setLocaleOverride( null );
-    } else if ( localeOverride.contains( "_" ) ) {
-      String[] parts = localeOverride.split( "_" );
-      setLocaleOverride( new Locale( parts[0], parts[1] ) );
-    } else {
-      setLocaleOverride( new Locale( localeOverride ) );
-    }
+    setThreadLocaleOverride( parseLocale( localeOverride ) );
   }
 
-  public static void setLocaleOverride( final Locale localeOverride ) {
-    LocaleHelper.threadLocaleOverride.set( localeOverride );
+  /**
+   * Sets the locale <i>override</i> of the current thread.
+   *
+   * @param newLocale The new override locale. Can be {@code null}.
+   * @deprecated Use {@link #setThreadLocaleOverride(Locale)} instead.
+   */
+  public static void setLocaleOverride( final Locale newLocale ) {
+    setThreadLocaleOverride( newLocale );
   }
 
+  /**
+   * Gets the locale <i>override</i> of the current thread.
+   *
+   * @return The locale override, if set; {@code null}, otherwise.
+   * @deprecated Use {@link #getThreadLocaleOverride()} instead.
+   */
   public static Locale getLocaleOverride() {
-    return LocaleHelper.threadLocaleOverride.get();
+    return getThreadLocaleOverride();
   }
 
+  /**
+   * Sets the locale <i>override</i> of the current thread.
+   * <p>
+   * A thread's locale <i>override</i> is the most specific locale, as returned by {@link #getLocale()}.
+   * <p>
+   * The Pentaho server sets the thread locale override, of threads handling HTTP requests,
+   * to the locale override of the Pentaho session of the corresponding request,
+   * as given by {@link IPentahoSession#getAttributeLocaleOverride()}.
+   * This is done by the {@code org.pentaho.platform.web.http.filters.HttpSessionPentahoSessionIntegrationFilter}
+   * filter.
+   *
+   * @param newLocale The new thread locale override. Can be {@code null}.
+   */
+  public static void setThreadLocaleOverride( final Locale newLocale ) {
+    LocaleHelper.threadLocalesOverride.set( newLocale );
+  }
+
+  /**
+   * Gets the locale <i>override</i> of the current thread.
+   *
+   * @return The locale override, if set; {@code null}, otherwise.
+   */
+  public static Locale getThreadLocaleOverride() {
+    return LocaleHelper.threadLocalesOverride.get();
+  }
+  // endregion
+
+  // region 2 - Thread Locale Base
+
+  /**
+   * Sets the <i>base</i> locale of the current thread.
+   *
+   * @param newLocale The new base locale. Can be {@code null}.
+   *
+   * @deprecated Use {@link #setThreadLocaleBase(Locale)} instead.
+   */
   public static void setLocale( final Locale newLocale ) {
-    LocaleHelper.threadLocales.set( newLocale );
+    setThreadLocaleBase( newLocale );
   }
 
+  /**
+   * Sets the <i>base</i> locale of the current thread.
+   * <p>
+   * The Pentaho server sets the base locale of threads handling HTTP requests
+   * to the corresponding request's locale, as given by {@code javax.servlet.http.HttpServletRequest#getLocale()}.
+   * This is done by the
+   * {@code org.pentaho.platform.web.http.filters.HttpSessionPentahoSessionIntegrationFilter}
+   * filter.
+   * <p>
+   * In this manner, according to the rules of {@link #getLocale()},
+   * and unless a web user has explicitly set their Pentaho session's locale override
+   * (or the thread's override locale is set by some other means),
+   * the effective locale will be the web browser's preferred language.
+   *
+   * @param newLocale The new base locale. Can be {@code null}.
+   */
+  public static void setThreadLocaleBase( final Locale newLocale ) {
+    LocaleHelper.threadLocalesBase.set( newLocale );
+  }
+
+  /**
+   * Gets the <i>base</i> locale of the current thread.
+   *
+   * @return The base locale, if any; {@code null}, otherwise.
+   */
+  public static Locale getThreadLocaleBase() {
+    return LocaleHelper.threadLocalesBase.get();
+  }
+  // endregion
+
+  // region Effective Locale
+
+  /**
+   * Gets the <i>effective</i> locale of the current thread.
+   * <p>
+   * The effective locale is the value of the first non-{@code null}, among the following:
+   * <ol>
+   *   <li>
+   *     The current thread's locale override, {@link #getThreadLocaleOverride()}
+   *   </li>
+   *   <li>
+   *     The current thread's base locale, {@link #getThreadLocaleBase()}
+   *   </li>
+   *   <li>
+   *     The default locale, {@link #getDefaultLocale()}
+   *   </li>
+   * </ol>
+   * <p>
+   * The effective locale is never {@code null}.
+   *
+   * @return The effective locale.
+   */
   public static Locale getLocale() {
-    Locale override = LocaleHelper.threadLocaleOverride.get();
-    if ( override != null ) {
-      return override;
+    // 1
+    Locale locale = getThreadLocaleOverride();
+    if ( locale != null ) {
+      return locale;
     }
-    Locale rtn = LocaleHelper.threadLocales.get();
-    if ( rtn != null ) {
-      return rtn;
-    }
-    LocaleHelper.defaultLocale = Locale.getDefault();
-    LocaleHelper.setLocale( LocaleHelper.defaultLocale );
-    return LocaleHelper.defaultLocale;
-  }
 
+    // 2
+    locale = getThreadLocaleBase();
+    if ( locale != null ) {
+      return locale;
+    }
+
+    // 3
+    return getDefaultLocale();
+  }
+  // endregion
+
+  /**
+   * Sets the locale override of the current session, if any.
+   *
+   * @see PentahoSessionHolder#getSession()
+   * @see IPentahoSession#setAttributeLocaleOverride(String)
+   */
+  public static void setSessionLocaleOverride( Locale locale ) {
+    IPentahoSession session = PentahoSessionHolder.getSession();
+    if ( session != null ) {
+      String localeCode = locale != null ? locale.toString() : null;
+      session.setAttributeLocaleOverride( localeCode );
+    }
+  }
+  // endregion
+
+  // region Encoding, Conversion, TextDirection
   public static void setSystemEncoding( final String encoding ) {
 
     Charset platformCharset = Charset.forName( encoding );
@@ -118,7 +310,7 @@ public class LocaleHelper {
 
     if ( platformCharset.compareTo( defaultCharset ) != 0 ) {
       Logger.warn( LocaleHelper.class.getName(), Messages.getInstance().getString(
-          "LocaleHelper.WARN_CHARSETS_DONT_MATCH", platformCharset.name(), defaultCharset.name() ) );
+        "LocaleHelper.WARN_CHARSETS_DONT_MATCH", platformCharset.name(), defaultCharset.name() ) );
     }
 
     LocaleHelper.encoding = encoding;
@@ -139,9 +331,9 @@ public class LocaleHelper {
   }
 
   /**
-   * This method is called to convert strings from ISO-8859-1 (post/get parameters for example) into the default
-   * system locale.
-   * 
+   * This method is called to convert strings from ISO-8859-1 (post/get parameters for example) into the default system
+   * locale.
+   *
    * @param isoString
    * @return Re-encoded string
    */
@@ -151,7 +343,7 @@ public class LocaleHelper {
 
   /**
    * This method converts strings from a known encoding into a string encoded by the system default encoding.
-   * 
+   *
    * @param fromEncoding
    * @param encodedStr
    * @return Re-encoded string
@@ -162,7 +354,7 @@ public class LocaleHelper {
 
   /**
    * This method converts an ISO-8859-1 encoded string to a UTF-8 encoded string.
-   * 
+   *
    * @param isoString
    * @return Re-encoded string
    */
@@ -172,7 +364,7 @@ public class LocaleHelper {
 
   /**
    * This method converts a UTF8-encoded string to ISO-8859-1
-   * 
+   *
    * @param utf8String
    * @return Re-encoded string
    */
@@ -182,7 +374,7 @@ public class LocaleHelper {
 
   /**
    * This method converts strings between various encodings.
-   * 
+   *
    * @param sourceString
    * @param sourceEncoding
    * @param targetEncoding
@@ -235,7 +427,9 @@ public class LocaleHelper {
     }
     return false;
   }
+  // endregion
 
+  // region Date and Number Formatting
   public static DateFormat getDateFormat( final int dateFormat, final int timeFormat ) {
 
     if ( ( dateFormat != LocaleHelper.FORMAT_IGNORE ) && ( timeFormat != LocaleHelper.FORMAT_IGNORE ) ) {
@@ -305,6 +499,7 @@ public class LocaleHelper {
   public static NumberFormat getCurrencyFormat() {
     return NumberFormat.getCurrencyInstance( LocaleHelper.getLocale() );
   }
+  // endregion
 
   public static String getClosestLocale( String locale, String[] locales ) {
     // see if this locale is supported
@@ -312,7 +507,7 @@ public class LocaleHelper {
       return locale;
     }
     if ( locale == null || locale.length() == 0 ) {
-      return locales[0];
+      return locales[ 0 ];
     }
     String localeLanguage = locale.substring( 0, 2 );
     String localeCountry = ( locale.length() > 4 ) ? locale.substring( 0, 5 ) : localeLanguage;
@@ -320,12 +515,12 @@ public class LocaleHelper {
     int closeMatch = -1;
     int exactMatch = -1;
     for ( int idx = 0; idx < locales.length; idx++ ) {
-      if ( locales[idx].equals( locale ) ) {
+      if ( locales[ idx ].equals( locale ) ) {
         exactMatch = idx;
         break;
-      } else if ( locales[idx].length() > 1 && locales[idx].substring( 0, 2 ).equals( localeLanguage ) ) {
+      } else if ( locales[ idx ].length() > 1 && locales[ idx ].substring( 0, 2 ).equals( localeLanguage ) ) {
         looseMatch = idx;
-      } else if ( locales[idx].length() > 4 && locales[idx].substring( 0, 5 ).equals( localeCountry ) ) {
+      } else if ( locales[ idx ].length() > 4 && locales[ idx ].substring( 0, 5 ).equals( localeCountry ) ) {
         closeMatch = idx;
       }
     }
@@ -333,12 +528,12 @@ public class LocaleHelper {
     if ( exactMatch != -1 ) {
       // do nothing we have an exact match
     } else if ( closeMatch != -1 ) {
-      locale = locales[closeMatch];
+      locale = locales[ closeMatch ];
     } else if ( looseMatch != -1 ) {
-      locale = locales[looseMatch];
+      locale = locales[ looseMatch ];
     } else {
       // no locale is close , just go with the first?
-      locale = locales[0];
+      locale = locales[ 0 ];
     }
     return locale;
   }

--- a/core/src/test/java/org/pentaho/platform/engine/services/SystemSettingsTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/services/SystemSettingsTest.java
@@ -86,7 +86,7 @@ public class SystemSettingsTest extends TestCase {
     File fileTest = new File( SOLUTION_PATH + PENTAHO_XML_PATH );
     if ( fileTest.exists() ) {
       System.out.println( "system test File exist returning " + SOLUTION_PATH );
-      LocaleHelper.setLocale( Locale.getDefault() );
+      LocaleHelper.setThreadLocaleBase( Locale.getDefault() );
       Assert.assertNotNull( SystemSettingsTest.SOLUTION_PATH );
       Assert.assertNotSame( "", SystemSettingsTest.SOLUTION_PATH ); //$NON-NLS-1$
 
@@ -101,7 +101,7 @@ public class SystemSettingsTest extends TestCase {
 
     } else {
       System.out.println( "system test File does not exist returning " + ALT_SOLUTION_PATH );
-      LocaleHelper.setLocale( Locale.getDefault() );
+      LocaleHelper.setThreadLocaleBase( Locale.getDefault() );
       Assert.assertNotNull( SystemSettingsTest.ALT_SOLUTION_PATH );
       Assert.assertNotSame( "", SystemSettingsTest.ALT_SOLUTION_PATH ); //$NON-NLS-1$
 

--- a/core/src/test/java/org/pentaho/platform/engine/services/solution/SolutionPublisherTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/services/solution/SolutionPublisherTest.java
@@ -51,7 +51,8 @@ public class SolutionPublisherTest extends BaseTest {
   public void testSolutionPublishI18N() {
     startTest();
 
-    Locale tmpLocale = LocaleHelper.getLocale();
+    Locale tmpLocale = LocaleHelper.getThreadLocaleBase();
+
     // Try a different locale from the default
     String localeLanguage = "fr"; //$NON-NLS-1$
     String localeCountry = "FR"; //$NON-NLS-1$
@@ -59,7 +60,7 @@ public class SolutionPublisherTest extends BaseTest {
     if ( locales != null ) {
       for ( int i = 0; i < locales.length; i++ ) {
         if ( locales[i].getLanguage().equals( localeLanguage ) && locales[i].getCountry().equals( localeCountry ) ) {
-          LocaleHelper.setLocale( locales[i] );
+          LocaleHelper.setThreadLocaleBase( locales[i] );
           break;
         }
       }
@@ -68,11 +69,12 @@ public class SolutionPublisherTest extends BaseTest {
     SolutionPublisher publisher = new SolutionPublisher();
     publisher.setLoggingLevel( getLoggingLevel() );
     StandaloneSession session =
-        new StandaloneSession( Messages.getInstance().getString( "BaseTest.DEBUG_JUNIT_SESSION" ) );
+      new StandaloneSession( Messages.getInstance().getString( "BaseTest.DEBUG_JUNIT_SESSION" ) );
     String result = publisher.publish( session, getLoggingLevel() );
     assertEquals( Messages.getInstance().getString( "SolutionPublisher.USER_SOLUTION_REPOSITORY_UPDATED" ), result );
+
     // now set the locale back again
-    LocaleHelper.setLocale( tmpLocale );
+    LocaleHelper.setThreadLocaleBase( tmpLocale );
     finishTest();
   }
 }

--- a/core/src/test/java/org/pentaho/platform/util/LocaleHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/LocaleHelperTest.java
@@ -14,14 +14,19 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.text.DateFormat;
 import java.text.NumberFormat;
@@ -30,6 +35,8 @@ import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.util.messages.LocaleHelper;
 
 public class LocaleHelperTest {
@@ -37,7 +44,7 @@ public class LocaleHelperTest {
   @Test
   public void testLocaleHelper() {
     LocaleHelper helper = new LocaleHelper();
-    Assert.assertNotNull( helper );
+    assertNotNull( helper );
 
     Locale myLocale = Locale.US;
     Locale newLocale = Locale.FRANCE;
@@ -60,59 +67,58 @@ public class LocaleHelperTest {
 
     DateFormat dateFormat = LocaleHelper.getDateFormat( LocaleHelper.FORMAT_MEDIUM, LocaleHelper.FORMAT_MEDIUM );
     String format = dateFormat.format( new Date() );
-    Assert.assertNotNull( format );
+    assertNotNull( format );
 
     DateFormat fullDateFormat0 = LocaleHelper.getFullDateFormat( false, false );
-    Assert.assertNull( fullDateFormat0 );
+    assertNull( fullDateFormat0 );
 
     DateFormat fullDateFormat = LocaleHelper.getFullDateFormat( true, true );
     String format1 = fullDateFormat.format( new Date() );
-    Assert.assertNotNull( format1 );
+    assertNotNull( format1 );
 
     DateFormat fullDateFormat1 = LocaleHelper.getFullDateFormat( true, false );
     String format2 = fullDateFormat1.format( new Date() );
-    Assert.assertNotNull( format2 );
+    assertNotNull( format2 );
 
     DateFormat fullDateFormat2 = LocaleHelper.getFullDateFormat( false, true );
     String format3 = fullDateFormat2.format( new Date() );
-    Assert.assertNotNull( format3 );
+    assertNotNull( format3 );
 
     DateFormat longDateFormat = LocaleHelper.getLongDateFormat( true, true );
     String format4 = longDateFormat.format( new Date() );
-    Assert.assertNotNull( format4 );
+    assertNotNull( format4 );
 
     DateFormat longDateFormat1 = LocaleHelper.getLongDateFormat( true, false );
     String format5 = longDateFormat1.format( new Date() );
-    Assert.assertNotNull( format5 );
+    assertNotNull( format5 );
 
     DateFormat longDateFormat2 = LocaleHelper.getLongDateFormat( false, true );
     String format6 = longDateFormat2.format( new Date() );
-    Assert.assertNotNull( format6 );
+    assertNotNull( format6 );
 
     DateFormat mediumDateFormat = LocaleHelper.getMediumDateFormat( true, true );
     String format7 = mediumDateFormat.format( new Date() );
-    Assert.assertNotNull( format7 );
+    assertNotNull( format7 );
 
     DateFormat mediumDateFormat1 = LocaleHelper.getMediumDateFormat( true, false );
     String format8 = mediumDateFormat1.format( new Date() );
-    Assert.assertNotNull( format8 );
+    assertNotNull( format8 );
 
     DateFormat mediumDateFormat2 = LocaleHelper.getMediumDateFormat( false, true );
     String format9 = mediumDateFormat2.format( new Date() );
-    Assert.assertNotNull( format9 );
+    assertNotNull( format9 );
 
     DateFormat shortDateFormat = LocaleHelper.getShortDateFormat( true, true );
     String format10 = shortDateFormat.format( new Date() );
-    Assert.assertNotNull( format10 );
+    assertNotNull( format10 );
 
     DateFormat shortDateFormat1 = LocaleHelper.getMediumDateFormat( true, false );
     String format11 = shortDateFormat1.format( new Date() );
-    Assert.assertNotNull( format11 );
+    assertNotNull( format11 );
 
     DateFormat shortDateFormat2 = LocaleHelper.getMediumDateFormat( false, true );
     String format12 = shortDateFormat2.format( new Date() );
-    Assert.assertNotNull( format12 );
-
+    assertNotNull( format12 );
   }
 
   @Test
@@ -149,28 +155,338 @@ public class LocaleHelperTest {
     LocaleHelper.setSystemEncoding( "Shift_JIS" );
   }
 
+  // region parseLocale
   @Test
   public void testParseAndSetLocaleOverride() {
+    Locale initiaLocaleOverride = LocaleHelper.getThreadLocaleOverride();
     final String TEST_LOCALE_LANG = "en";
     final String TEST_LOCALE_COUNTRY = "US";
-    LocaleHelper.parseAndSetLocaleOverride( TEST_LOCALE_LANG + "_" + TEST_LOCALE_COUNTRY );
+    try {
+      LocaleHelper.parseAndSetLocaleOverride( TEST_LOCALE_LANG + "_" + TEST_LOCALE_COUNTRY );
 
-    assertTrue( LocaleHelper.getLocale().equals( new Locale( TEST_LOCALE_LANG, TEST_LOCALE_COUNTRY ) ) );
-
-    // reset override to not break other tests
-    LocaleHelper.setThreadLocaleOverride( null );
+      assertEquals( LocaleHelper.getLocale(), new Locale( TEST_LOCALE_LANG, TEST_LOCALE_COUNTRY ) );
+    } finally {
+      LocaleHelper.setThreadLocaleOverride( initiaLocaleOverride );
+    }
   }
+
+  @Test
+  public void testParseLocaleReturnsNullWhenGivenNull() {
+
+    Locale locale = LocaleHelper.parseLocale( null );
+
+    assertNull( locale );
+  }
+
+  @Test
+  public void testParseLocaleReturnsNullWhenGivenEmpty() {
+
+    Locale locale = LocaleHelper.parseLocale( "" );
+
+    assertNull( locale );
+  }
+
+  @Test
+  public void testParseLocaleHandlesLocalesWithOneSection() {
+    final String TEST_LOCALE_LANG = "en";
+
+    Locale locale = LocaleHelper.parseLocale( TEST_LOCALE_LANG );
+
+    assertEquals( locale, new Locale( TEST_LOCALE_LANG ) );
+  }
+
+  @Test
+  public void testParseLocaleHandlesLocalesWithTwoSections() {
+    final String TEST_LOCALE_LANG = "en";
+    final String TEST_LOCALE_COUNTRY = "US";
+
+    Locale locale = LocaleHelper.parseLocale( TEST_LOCALE_LANG + "_" + TEST_LOCALE_COUNTRY );
+
+    assertEquals( locale, new Locale( TEST_LOCALE_LANG, TEST_LOCALE_COUNTRY ) );
+  }
+
+  // NOTE: this test was written to match the existing implementation,
+  // but it is not clear if this behavior was intentional or a bug.
+  @Test
+  public void testParseLocaleSimplifiesLocalesWithMoreThanTwoSections() {
+    final String TEST_LOCALE_LANG = "en";
+    final String TEST_LOCALE_COUNTRY = "US";
+    final String TEST_LOCALE_VARIANT = "Foo";
+
+    Locale locale = LocaleHelper.parseLocale(
+      TEST_LOCALE_LANG +
+        "_" +
+        TEST_LOCALE_COUNTRY +
+        "_" +
+        TEST_LOCALE_VARIANT);
+
+    assertEquals( locale, new Locale( TEST_LOCALE_LANG, TEST_LOCALE_COUNTRY ) );
+    assertNotEquals( locale, new Locale( TEST_LOCALE_LANG, TEST_LOCALE_COUNTRY, TEST_LOCALE_VARIANT ) );
+  }
+
+  @Test
+  public void testParseLocaleHandlesAndNormalizesLocalesWithMixedCasingSections() {
+
+    Locale locale = LocaleHelper.parseLocale( "eN_Us" );
+
+    assertEquals( locale, new Locale( "en", "US" ) );
+
+    locale = LocaleHelper.parseLocale( "En_us" );
+
+    assertEquals( locale, new Locale( "en", "US" ) );
+  }
+
+  // NOTE: again, not a requirement per se, afaict, but it's how it's working.
+  @Test
+  public void testParseLocaleAcceptsSectionsOfAnyLength() {
+
+    Locale locale = LocaleHelper.parseLocale( "foo_guru" );
+
+    assertEquals( locale, new Locale( "foo", "GURU" ) );
+  }
+
+  // NOTE: again, not a requirement per se, afaict, but it's how it's working.
+  // Notably, see SystemResource#setLocaleOverride( . ) which also supports sections separated
+  // by "-" or "|". Additionally, it then uses org.apache.commons.lang3.LocaleUtils.toLocale
+  // to parse the locale, instead of LocaleHelper.parseLocale.
+  @Test
+  public void testParseLocaleDoesNotSeparateSectionsByHyphen() {
+
+    Locale locale = LocaleHelper.parseLocale( "foo-guru" );
+
+    assertEquals( locale, new Locale( "foo-guru" ) );
+  }
+  // endregion
+
+  // region Default Locale
+
+  // Cannot test the case where Locale.getDefault() would be null with this kind of test,
+  // because that would possibly only happen if `java` were passed a non-available locale parameter...
+
+  @Test
+  public void testDefaultLocaleIsJVMLocale() {
+    assertEquals( Locale.getDefault(), LocaleHelper.getDefaultLocale() );
+  }
+
+  @Test
+  public void testDefaultLocaleFallsbackToJVMLocaleWhenSetToNull() {
+    Locale initialLocale = Locale.getDefault();
+    Locale customLocale = Locale.forLanguageTag( "de-POSIX-x-URP-lvariant-Abc-Def" );
+    Locale.setDefault( customLocale );
+    try {
+      LocaleHelper.setDefaultLocale( null );
+      assertEquals( customLocale, LocaleHelper.getDefaultLocale() );
+    } finally {
+      Locale.setDefault( initialLocale );
+    }
+  }
+
+  @Test
+  public void testDefaultLocaleIsRespectedWhenSetToNonNull() {
+    Locale initialDefaultLocale = LocaleHelper.getDefaultLocale();
+    Locale customLocale = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Def");
+    try {
+      LocaleHelper.setDefaultLocale( customLocale );
+      assertEquals( customLocale, LocaleHelper.getDefaultLocale() );
+    } finally {
+      LocaleHelper.setDefaultLocale( initialDefaultLocale );
+    }
+  }
+  // endregion
+
+  // region Thread Locale Base
+  @Test
+  public void testThreadLocaleBaseDefaultsToNull() {
+    assertNull( LocaleHelper.getThreadLocaleBase() );
+  }
+
+  @Test
+  public void testThreadLocaleBaseRemembersBeingSetToNonNullValue() {
+    Locale initialLocale = LocaleHelper.getThreadLocaleBase();
+    Locale customLocale = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Def");
+
+    try {
+      LocaleHelper.setThreadLocaleBase( customLocale );
+
+      assertEquals( customLocale, LocaleHelper.getThreadLocaleBase() );
+    } finally {
+      LocaleHelper.setThreadLocaleBase( initialLocale );
+    }
+  }
+
+  @Test
+  public void testThreadLocaleBaseCanBeSetToNullValue() {
+    Locale initialLocale = LocaleHelper.getThreadLocaleBase();
+
+    try {
+      LocaleHelper.setThreadLocaleBase( Locale.ENGLISH );
+      assertNotNull( LocaleHelper.getThreadLocaleBase() );
+
+      LocaleHelper.setThreadLocaleBase( null );
+      assertNull( LocaleHelper.getThreadLocaleBase() );
+    } finally {
+      LocaleHelper.setThreadLocaleBase( initialLocale );
+    }
+  }
+  // endregion
+
+  // region Thread Locale Override
+  @Test
+  public void testThreadLocaleOverrideDefaultsToNull() {
+    assertNull( LocaleHelper.getThreadLocaleOverride() );
+  }
+
+  @Test
+  public void testThreadLocaleOverrideRemembersBeingSetToNonNullValue() {
+    Locale initialLocale = LocaleHelper.getThreadLocaleOverride();
+    Locale customLocale = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Def");
+
+    try {
+      LocaleHelper.setThreadLocaleOverride( customLocale );
+
+      assertEquals( customLocale, LocaleHelper.getThreadLocaleOverride() );
+    } finally {
+      LocaleHelper.setThreadLocaleOverride( initialLocale );
+    }
+  }
+
+  @Test
+  public void testThreadLocaleOverrideCanBeSetToNullValue() {
+    Locale initialLocale = LocaleHelper.getThreadLocaleOverride();
+
+    try {
+      LocaleHelper.setThreadLocaleOverride( Locale.ENGLISH );
+      assertNotNull( LocaleHelper.getThreadLocaleOverride() );
+
+      LocaleHelper.setThreadLocaleOverride( null );
+      assertNull( LocaleHelper.getThreadLocaleOverride() );
+    } finally {
+      LocaleHelper.setThreadLocaleOverride( initialLocale );
+    }
+  }
+  // endregion
+
+  // region (Effective) Locale
+  @Test
+  public void testEffectiveLocaleIsTheDefaultLocaleIfNoThreadBaseOrOverride() {
+    Locale initialDefaultLocale = LocaleHelper.getDefaultLocale();
+    Locale initialThreadLocaleBase = LocaleHelper.getThreadLocaleBase();
+    Locale initialThreadLocaleOverride = LocaleHelper.getThreadLocaleOverride();
+
+    Locale customLocale = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Def");
+    try {
+      LocaleHelper.setDefaultLocale( customLocale );
+      LocaleHelper.setThreadLocaleBase( null );
+      LocaleHelper.setThreadLocaleOverride( null );
+
+      assertEquals( customLocale, LocaleHelper.getLocale() );
+    } finally {
+      LocaleHelper.setDefaultLocale( initialDefaultLocale );
+      LocaleHelper.setThreadLocaleBase( initialThreadLocaleBase );
+      LocaleHelper.setThreadLocaleOverride( initialThreadLocaleOverride );
+    }
+  }
+
+  @Test
+  public void testEffectiveLocaleIsTheThreadLocaleBaseIfSetAndNoThreadOverride() {
+    Locale initialDefaultLocale = LocaleHelper.getDefaultLocale();
+    Locale initialThreadLocaleBase = LocaleHelper.getThreadLocaleBase();
+    Locale initialThreadLocaleOverride = LocaleHelper.getThreadLocaleOverride();
+
+    Locale customLocale1 = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Def");
+    Locale customLocale2 = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Ghi");
+    try {
+      LocaleHelper.setDefaultLocale( customLocale1 );
+      LocaleHelper.setThreadLocaleBase( customLocale2 );
+      LocaleHelper.setThreadLocaleOverride( null );
+
+      assertEquals( customLocale2, LocaleHelper.getLocale() );
+    } finally {
+      LocaleHelper.setDefaultLocale( initialDefaultLocale );
+      LocaleHelper.setThreadLocaleBase( initialThreadLocaleBase );
+      LocaleHelper.setThreadLocaleOverride( initialThreadLocaleOverride );
+    }
+  }
+
+  @Test
+  public void testEffectiveLocaleIsTheThreadLocaleOverrideIfSet() {
+    Locale initialDefaultLocale = LocaleHelper.getDefaultLocale();
+    Locale initialThreadLocaleBase = LocaleHelper.getThreadLocaleBase();
+    Locale initialThreadLocaleOverride = LocaleHelper.getThreadLocaleOverride();
+
+    Locale customLocale1 = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Def");
+    Locale customLocale2 = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Ghi");
+    Locale customLocale3 = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Jkl");
+    try {
+      LocaleHelper.setDefaultLocale( customLocale1 );
+      LocaleHelper.setThreadLocaleBase( customLocale2 );
+      LocaleHelper.setThreadLocaleOverride( customLocale3 );
+
+      assertEquals( customLocale3, LocaleHelper.getLocale() );
+    } finally {
+      LocaleHelper.setDefaultLocale( initialDefaultLocale );
+      LocaleHelper.setThreadLocaleBase( initialThreadLocaleBase );
+      LocaleHelper.setThreadLocaleOverride( initialThreadLocaleOverride );
+    }
+  }
+  // endregion
+
+  // region Session Locale Override
+
+  @Test
+  public void testSessionLocaleOverrideIsNoOpIfNoSession() {
+    IPentahoSession initialSession = PentahoSessionHolder.getSession();
+
+    Locale customLocale = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Def");
+    try {
+      LocaleHelper.setSessionLocaleOverride( customLocale );
+    } finally {
+      PentahoSessionHolder.setSession( initialSession );
+    }
+  }
+
+  @Test
+  public void testSessionLocaleOverrideSetsCurrentSessionLocaleOverrideWithLocaleToString() {
+    IPentahoSession initialSession = PentahoSessionHolder.getSession();
+    IPentahoSession customSession = mock( IPentahoSession.class );
+    Locale customLocale = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Def");
+    try {
+      PentahoSessionHolder.setSession( customSession );
+
+      LocaleHelper.setSessionLocaleOverride( customLocale );
+
+      verify( customSession, times( 1 )).setAttributeLocaleOverride( customLocale.toString() );
+    } finally {
+      PentahoSessionHolder.setSession( initialSession );
+    }
+  }
+
+  @Test
+  public void testSessionLocaleOverrideSetsCurrentSessionLocaleOverrideWithNullLocale() {
+    IPentahoSession initialSession = PentahoSessionHolder.getSession();
+    IPentahoSession customSession = mock( IPentahoSession.class );
+    try {
+      PentahoSessionHolder.setSession( customSession );
+
+      LocaleHelper.setSessionLocaleOverride( null );
+
+      verify( customSession, times( 1 )).setAttributeLocaleOverride( null );
+    } finally {
+      PentahoSessionHolder.setSession( initialSession );
+    }
+  }
+  // endregion
 
   @Test
   public void testGetNumberFormat() {
     NumberFormat nfmt = LocaleHelper.getNumberFormat();
-    Assert.assertNotNull( nfmt );
+    assertNotNull( nfmt );
   }
 
   @Test
   public void testGetCurrencyFormat() {
     NumberFormat cfmt = LocaleHelper.getCurrencyFormat();
-    Assert.assertNotNull( cfmt );
+    assertNotNull( cfmt );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/platform/util/LocaleHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/LocaleHelperTest.java
@@ -422,12 +422,15 @@ public class LocaleHelperTest {
 
   // region Session Locale Override
 
-  @Test
+  // The Test.None.class ensures that SonarQube does not complain that there are no assertions in the test case.
+  @SuppressWarnings( "DefaultAnnotationParam" )
+  @Test( expected = Test.None.class )
   public void testSessionLocaleOverrideIsNoOpIfNoSession() {
     IPentahoSession initialSession = PentahoSessionHolder.getSession();
 
     Locale customLocale = Locale.forLanguageTag("de-POSIX-x-URP-lvariant-Abc-Def");
     try {
+      PentahoSessionHolder.setSession( null );
       LocaleHelper.setSessionLocaleOverride( customLocale );
     } finally {
       PentahoSessionHolder.setSession( initialSession );

--- a/core/src/test/java/org/pentaho/platform/util/LocaleHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/LocaleHelperTest.java
@@ -46,7 +46,7 @@ public class LocaleHelperTest {
     Locale myDefaultLocale = LocaleHelper.getDefaultLocale();
     Assert.assertEquals( myDefaultLocale, myLocale );
 
-    LocaleHelper.setLocale( newLocale );
+    LocaleHelper.setThreadLocaleBase( newLocale );
     Locale myNewLocale = LocaleHelper.getLocale();
     Assert.assertEquals( myNewLocale, newLocale );
 
@@ -158,7 +158,7 @@ public class LocaleHelperTest {
     assertTrue( LocaleHelper.getLocale().equals( new Locale( TEST_LOCALE_LANG, TEST_LOCALE_COUNTRY ) ) );
 
     // reset override to not break other tests
-    LocaleHelper.setLocaleOverride( null );
+    LocaleHelper.setThreadLocaleOverride( null );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/platform/util/LocaleHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/LocaleHelperTest.java
@@ -46,17 +46,6 @@ public class LocaleHelperTest {
     LocaleHelper helper = new LocaleHelper();
     assertNotNull( helper );
 
-    Locale myLocale = Locale.US;
-    Locale newLocale = Locale.FRANCE;
-
-    LocaleHelper.setDefaultLocale( myLocale );
-    Locale myDefaultLocale = LocaleHelper.getDefaultLocale();
-    Assert.assertEquals( myDefaultLocale, myLocale );
-
-    LocaleHelper.setThreadLocaleBase( newLocale );
-    Locale myNewLocale = LocaleHelper.getLocale();
-    Assert.assertEquals( myNewLocale, newLocale );
-
     LocaleHelper.setSystemEncoding( "UTF8" ); //$NON-NLS-1$
     String systemEncoding = LocaleHelper.getSystemEncoding();
     Assert.assertEquals( systemEncoding, "UTF8" ); //$NON-NLS-1$

--- a/extensions/src/it/java/org/pentaho/test/platform/web/LocalizationServletIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/LocalizationServletIT.java
@@ -140,12 +140,12 @@ public class LocalizationServletIT {
   public void getBundle_es() {
     LocalizationServlet ls = new LocalizationServlet();
     try {
-      LocaleHelper.setLocale( new Locale( "es" ) );
+      LocaleHelper.setThreadLocaleBase( new Locale( "es" ) );
       String json = ls.getJSONBundle( TestPluginProvider.TEST_PLUGIN, "messages/messages" );
       assertNotNull( json );
       assertTrue( json.contains( "\"2\":\"dos\"" ) );
     } finally {
-      LocaleHelper.setLocale( null );
+      LocaleHelper.setThreadLocaleBase( null );
     }
   }
 

--- a/extensions/src/it/java/org/pentaho/test/platform/web/ProxyServletIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/ProxyServletIT.java
@@ -75,7 +75,7 @@ public class ProxyServletIT extends BaseTestCase {
   @Override
   protected void tearDown() throws Exception {
     PentahoSystem.shutdown();
-    LocaleHelper.setLocaleOverride( null );
+    LocaleHelper.setThreadLocaleOverride( null );
     PentahoSessionHolder.setSession( null );
   }
 
@@ -208,7 +208,7 @@ public class ProxyServletIT extends BaseTestCase {
     TestProxyServlet servlet = spy( new TestProxyServlet() );
     servlet.init( config );
 
-    LocaleHelper.setLocaleOverride( Locale.forLanguageTag( "pt-PT" ) );
+    LocaleHelper.setThreadLocaleOverride( Locale.forLanguageTag( "pt-PT" ) );
 
     servlet.service( request, response );
 

--- a/extensions/src/main/java/org/pentaho/platform/plugin/action/olap/impl/OlapServiceImpl.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/action/olap/impl/OlapServiceImpl.java
@@ -910,11 +910,6 @@ public class OlapServiceImpl implements IOlapService {
   }
 
   private static Locale getLocale() {
-    final Locale locale = LocaleHelper.getLocale();
-    if ( locale != null ) {
-      return locale;
-    } else {
-      return Locale.getDefault();
-    }
+    return LocaleHelper.getLocale();
   }
 }

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifestEntity.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/ExportManifestEntity.java
@@ -131,9 +131,7 @@ public class ExportManifestEntity {
 
   private void createEntityMetaData( File file, String userId, String projectId, Boolean isFolder, Boolean isHidden,
       Boolean isSchedulable ) {
-    if ( LocaleHelper.getLocale() == null ) {
-      LocaleHelper.setLocale( Locale.getDefault() );
-    }
+
     entityMetaData = new EntityMetaData();
     entityMetaData.setCreatedBy( userId );
     entityMetaData.setCreatedDate( XmlGregorianCalendarConverter.asXMLGregorianCalendar( new Date() ) );
@@ -150,9 +148,7 @@ public class ExportManifestEntity {
 
   private void createEntityMetaData( String rootFolder, RepositoryFile repositoryFile )
     throws ExportManifestFormatException {
-    if ( LocaleHelper.getLocale() == null ) {
-      LocaleHelper.setLocale( Locale.getDefault() );
-    }
+
     entityMetaData = new EntityMetaData();
     entityMetaData.setCreatedBy( repositoryFile.getCreatorId() );
     entityMetaData.setCreatedDate( XmlGregorianCalendarConverter.asXMLGregorianCalendar( repositoryFile

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/SystemResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/SystemResource.java
@@ -31,10 +31,8 @@ import org.pentaho.platform.api.engine.IConfiguration;
 import org.pentaho.platform.api.engine.IContentInfo;
 import org.pentaho.platform.api.engine.IPluginManager;
 import org.pentaho.platform.api.engine.ISystemConfig;
-import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.IPluginOperation;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
-import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.api.repository2.unified.webservices.ExecutableFileTypeDto;
 import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
@@ -182,7 +180,7 @@ public class SystemResource extends AbstractJaxRSResource {
 
     if ( !StringUtils.isEmpty( locale ) ) {
       // Clean up "en-US" and "en/GB".
-      String localeNormalized = locale.replaceAll( "-|/", "_" );
+      String localeNormalized = locale.replaceAll( "[-/]", "_" );
       try {
         sessionLocale = LocaleUtils.toLocale( localeNormalized );
       } catch ( IllegalArgumentException ex ) {

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/SystemResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/SystemResource.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -178,24 +178,20 @@ public class SystemResource extends AbstractJaxRSResource {
   @Path( "/locale" )
   @Facet ( name = "Unsupported" )
   public Response setLocaleOverride( String locale ) {
-    IPentahoSession session = PentahoSessionHolder.getSession();
-    if ( session != null ) {
-      if ( !StringUtils.isEmpty( locale ) ) {
-        String localeTmp = locale.replaceAll( "-|/", "_" ); // Clean up "en-US" and "en/GB"
-        try {
-          Locale newLocale = LocaleUtils.toLocale( localeTmp );
-          session.setAttribute( "locale_override", localeTmp );
-          LocaleHelper.setLocaleOverride( newLocale );
-        } catch ( IllegalArgumentException ex ) {
-          return Response.serverError().entity( ex.getMessage() ).build();
-        }
-      } else {
-        session.setAttribute( "locale_override", null ); // empty string or null passed in, unset locale_override variable.
-        LocaleHelper.setLocaleOverride( null );
+    Locale sessionLocale = null;
+
+    if ( !StringUtils.isEmpty( locale ) ) {
+      // Clean up "en-US" and "en/GB".
+      String localeNormalized = locale.replaceAll( "-|/", "_" );
+      try {
+        sessionLocale = LocaleUtils.toLocale( localeNormalized );
+      } catch ( IllegalArgumentException ex ) {
+        return Response.serverError().entity( ex.getMessage() ).build();
       }
-    } else {
-      LocaleHelper.setLocaleOverride( null );
     }
+
+    LocaleHelper.setSessionLocaleOverride( sessionLocale );
+    LocaleHelper.setThreadLocaleOverride( sessionLocale );
 
     return getLocale();
   }

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserConsoleResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserConsoleResource.java
@@ -29,9 +29,9 @@ import org.pentaho.platform.api.engine.IContentInfo;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.IPluginManager;
 import org.pentaho.platform.api.engine.IPluginOperation;
-import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.api.engine.ISystemConfig;
 import org.pentaho.platform.config.PropertiesFileConfiguration;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.action.mondrian.catalog.IMondrianCatalogService;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCube;
@@ -50,7 +50,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.StringTokenizer;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -58,9 +57,9 @@ import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 
 /**
- * The {@code UserConsoleResource} service provides both shared and user-specific state or settings related
- * with the use of the Pentaho User Console.
- *
+ * The {@code UserConsoleResource} service provides both shared and user-specific state or settings related with the use
+ * of the Pentaho User Console.
+ * <p>
  * The following operations provide access to User Console system settings (shared by all users):
  * <ul>
  *   <li>{@link UserConsoleResource#getAdminContent()}</li>
@@ -68,24 +67,24 @@ import static javax.ws.rs.core.Response.Status.FORBIDDEN;
  *   <li>{@link UserConsoleResource#getMondrianCatalogs()}</li>
  *   <li>{@link UserConsoleResource#registeredPlugins()}</li>
  * </ul>
- *
+ * <p>
  * The {@code UserConsoleResource} exposes operations to access and manage <i>user session variables</i>.
  * User session variables are unique per user session and reset to their default values at every user session creation.
  * Contrast session variables with <i>user settings</i>, accessed via {@link UserSettingsResource},
  * which are persisted across user sessions and shared by all active sessions of a user.
- *
+ * <p>
  * One last characteristic of session variables is that only those declared in the properties
  * {@code userConsoleResource.getSessionVarWhiteList} and {@code userConsoleResource.setSessionVarWhiteList}
  * of the system file {@code system/restConfig.properties}, can be read or modified via this class.
  * By default, these are {@code scheduler_folder} and {@code showOverrideDialog}.
- *
+ * <p>
  * Generic user session variables are accessed and managed via the operations:
  * <ul>
  *   <li>{@link UserConsoleResource#setSessionVariable(String, String)}</li>
  *   <li>{@link UserConsoleResource#getSessionVariable(String)}</li>
  *   <li>{@link UserConsoleResource#clearSessionVariable(String)}</li>
  * </ul>
- *
+ * <p>
  * The following operations expose specific (non-generic) user session information:
  * <ul>
  *   <li>{@link UserConsoleResource#isAuthenticated()}</li>
@@ -98,7 +97,7 @@ import static javax.ws.rs.core.Response.Status.FORBIDDEN;
  *     and {@link org.pentaho.platform.util.messages.LocaleHelper#setThreadLocaleOverride(Locale)}
  *   </li>
  * </ul>
- *
+ * <p>
  * The state changing operations of this service,
  * with the notable exception of {@link UserConsoleResource#setLocaleOverride(String)},
  * are protected against CSRF attacks, and thus require a CSRF token to be called.

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserConsoleResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserConsoleResource.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.StringTokenizer;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -57,7 +58,55 @@ import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 
 /**
- * The UserConsoleResource service provides the ability to check whether the current user is authenticated and/or is an administrator.
+ * The {@code UserConsoleResource} service provides both shared and user-specific state or settings related
+ * with the use of the Pentaho User Console.
+ *
+ * The following operations provide access to User Console system settings (shared by all users):
+ * <ul>
+ *   <li>{@link UserConsoleResource#getAdminContent()}</li>
+ *   <li>{@link UserConsoleResource#getMantleSettings()}</li>
+ *   <li>{@link UserConsoleResource#getMondrianCatalogs()}</li>
+ *   <li>{@link UserConsoleResource#registeredPlugins()}</li>
+ * </ul>
+ *
+ * The {@code UserConsoleResource} exposes operations to access and manage <i>user session variables</i>.
+ * User session variables are unique per user session and reset to their default values at every user session creation.
+ * Contrast session variables with <i>user settings</i>, accessed via {@link UserSettingsResource},
+ * which are persisted across user sessions and shared by all active sessions of a user.
+ *
+ * One last characteristic of session variables is that only those declared in the properties
+ * {@code userConsoleResource.getSessionVarWhiteList} and {@code userConsoleResource.setSessionVarWhiteList}
+ * of the system file {@code system/restConfig.properties}, can be read or modified via this class.
+ * By default, these are {@code scheduler_folder} and {@code showOverrideDialog}.
+ *
+ * Generic user session variables are accessed and managed via the operations:
+ * <ul>
+ *   <li>{@link UserConsoleResource#setSessionVariable(String, String)}</li>
+ *   <li>{@link UserConsoleResource#getSessionVariable(String)}</li>
+ *   <li>{@link UserConsoleResource#clearSessionVariable(String)}</li>
+ * </ul>
+ *
+ * The following operations expose specific (non-generic) user session information:
+ * <ul>
+ *   <li>{@link UserConsoleResource#isAuthenticated()}</li>
+ *   <li>{@link UserConsoleResource#isAdministrator()}</li>
+ *   <li>{@link UserConsoleResource#getLocale()} - gets the effective locale of the user session</li>
+ *   <li>
+ *     {@link UserConsoleResource#setLocaleOverride(String)} -
+ *     sets the locale of the user session,
+ *     via {@link org.pentaho.platform.util.messages.LocaleHelper#setSessionLocaleOverride(Locale)}
+ *     and {@link org.pentaho.platform.util.messages.LocaleHelper#setThreadLocaleOverride(Locale)}
+ *   </li>
+ * </ul>
+ *
+ * The state changing operations of this service,
+ * with the notable exception of {@link UserConsoleResource#setLocaleOverride(String)},
+ * are protected against CSRF attacks, and thus require a CSRF token to be called.
+ * This resolves to:
+ * <ul>
+ *   <li>{@link UserConsoleResource#setSessionVariable(String, String)}</li>
+ *   <li>{@link UserConsoleResource#clearSessionVariable(String)}</li>
+ * </ul>
  */
 @Path ( "/mantle/" )
 public class UserConsoleResource extends AbstractJaxRSResource {

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserSettingsResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/UserSettingsResource.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -42,9 +42,16 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 
 /**
- * This resource manages the user settings of the platform
- * 
+ * This resource manages the user settings of the platform.
  *
+ * User settings are persisted across user sessions and shared by all active sessions of a user.
+ * Contrast this with <i>user session variables</i>, accessed via {@link UserConsoleResource},
+ * which are reset at every new user session, and are local to each user session.
+ *
+ * The state changing operations of this service are protected against CSRF attacks,
+ * and thus require a CSRF token to be called.
+ *
+ * @see UserConsoleResource
  */
 @Path( "/user-settings" )
 @Facet( name = "Unsupported" )

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
@@ -105,6 +105,7 @@ import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurity
 import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
+import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.platform.web.http.api.resources.SessionResource;
 import org.pentaho.platform.web.http.api.resources.Setting;
 import org.pentaho.platform.web.http.api.resources.StringListWrapper;
@@ -1797,7 +1798,7 @@ public class FileService {
   }
 
   protected Collator getCollatorInstance() {
-    return Collator.getInstance( PentahoSessionHolder.getSession().getLocale() );
+    return Collator.getInstance( LocaleHelper.getLocale() );
   }
 
   public class RepositoryFileToStreamWrapper {
@@ -1890,7 +1891,7 @@ public class FileService {
   }
 
   protected Collator getCollator( int strength ) {
-    Collator collator = Collator.getInstance( PentahoSessionHolder.getSession().getLocale() );
+    Collator collator = getCollatorInstance();
     collator.setStrength( strength ); // ignore case
     return collator;
   }

--- a/extensions/src/main/java/org/pentaho/platform/web/http/context/SolutionContextListener.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/context/SolutionContextListener.java
@@ -1,5 +1,4 @@
 /*!
- *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -13,9 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
- *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.platform.web.http.context;
@@ -72,26 +69,24 @@ public class SolutionContextListener implements ServletContextListener {
       LocaleHelper.setTextDirection( textDirection );
     }
 
+    Locale defaultLocale = null;
     String localeLanguage = getServerParameter( "locale-language" ); //$NON-NLS-1$
     String localeCountry = getServerParameter( "locale-country" ); //$NON-NLS-1$
-    boolean localeSet = false;
     if ( !StringUtils.isEmpty( localeLanguage ) && !StringUtils.isEmpty( localeCountry ) ) {
       Locale[] locales = Locale.getAvailableLocales();
-      if ( locales != null ) {
-        for ( Locale element : locales ) {
-          if ( element.getLanguage().equals( localeLanguage ) && element.getCountry().equals( localeCountry ) ) {
-            LocaleHelper.setLocale( element );
-            localeSet = true;
-            break;
-          }
+      for ( Locale element : locales ) {
+        if ( element.getLanguage().equals( localeLanguage ) && element.getCountry().equals( localeCountry ) ) {
+          defaultLocale = element;
+          break;
         }
       }
     }
-    if ( !localeSet ) {
-      // do this thread in the default locale
-      LocaleHelper.setLocale( Locale.getDefault() );
-    }
-    LocaleHelper.setDefaultLocale( LocaleHelper.getLocale() );
+
+    LocaleHelper.setDefaultLocale( defaultLocale );
+
+    // do this thread in the default locale
+    LocaleHelper.setThreadLocaleBase( LocaleHelper.getDefaultLocale() );
+
     // log everything that goes on here
     logger.info( Messages.getInstance().getString( "SolutionContextListener.INFO_INITIALIZING" ) ); //$NON-NLS-1$
     logger.info( Messages.getInstance().getString( "SolutionContextListener.INFO_SERVLET_CONTEXT", context ) ); //$NON-NLS-1$
@@ -282,9 +277,7 @@ public class SolutionContextListener implements ServletContextListener {
   public void contextDestroyed( final ServletContextEvent event ) {
 
     PentahoSystem.shutdown();
-    if ( LocaleHelper.getLocale() == null ) {
-      LocaleHelper.setLocale( Locale.getDefault() );
-    }
+
     // log everything that goes on here
     logger.info( Messages.getInstance().getString(
       "SolutionContextListener.INFO_SYSTEM_EXITING" ) ); //$NON-NLS-1$

--- a/extensions/src/main/java/org/pentaho/platform/web/http/filters/HttpSessionPentahoSessionIntegrationFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/filters/HttpSessionPentahoSessionIntegrationFilter.java
@@ -1,5 +1,4 @@
 /*!
- *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -13,15 +12,12 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- *
  * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
- *
  */
 
 package org.pentaho.platform.web.http.filters;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.engine.IPentahoSession;
@@ -48,17 +44,18 @@ import javax.servlet.http.HttpServletResponseWrapper;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Populates the {@link PentahoSessionHolder} with information obtained from the <code>HttpSession</code>.
- * 
+ *
  * <p>
  * Originally this functionality existed in PentahoHttpRequestListener but has been moved here. Javadoc for that class:
  * </p>
- * 
+ *
  * <blockquote> In a J2EE environment, sets the Hitachi Vantara session statically per request so the session can be retrieved
  * by other consumers within the same request without having it passed to them explicitly. -- aphillips </blockquote>
- * 
+ *
  * <p>
  * There are two reasons that this is a {@link Filter} and not a {@code ServletRequestListener}:
  * </p>
@@ -66,11 +63,11 @@ import java.util.List;
  * <li>Filters are compatible with Servlet 2.3 web applications.</li>
  * <li>Filters can be ordered.</li>
  * </ul>
- * 
+ *
  * <p>
  * This implementation is based on {@code org.springframework.security.context.HttpSessionContextIntegrationFilter}.
  * </p>
- * 
+ *
  * <p>
  * The <code>HttpSession</code> will be queried to retrieve the <code>IPentahoSession</code> that should be stored
  * against the <code>PentahoSessiontHolder</code> for the duration of the web request. At the end of the web request,
@@ -154,7 +151,7 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
 
   /**
    * Does nothing. We use IoC container lifecycle services instead.
-   * 
+   *
    * @param filterConfig
    *          ignored
    * @throws ServletException
@@ -172,25 +169,29 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
   public void afterPropertiesSet() throws Exception {
     if ( forceEagerSessionCreation && !allowSessionCreation ) {
       throw new IllegalArgumentException(
-          "If using forceEagerSessionCreation, you must set allowSessionCreation to also be true" );
+        "If using forceEagerSessionCreation, you must set allowSessionCreation to also be true" );
     }
   }
 
   protected IPentahoSession generatePentahoSession( final HttpServletRequest httpRequest ) {
+    IPentahoSession pentahoSession;
+
     HttpSession httpSession = httpRequest.getSession( false );
-    IPentahoSession pentahoSession = null;
     if ( httpSession != null ) {
       pentahoSession = new PentahoHttpSession( null, httpSession, httpRequest.getLocale(), null );
     } else {
       pentahoSession = new NoDestroyStandaloneSession( null );
     }
+
     if ( callSetAuthenticatedForAnonymousUsers ) {
       pentahoSession.setAuthenticated( getAnonymousUser() );
     }
+
     ITempFileDeleter deleter = PentahoSystem.get( ITempFileDeleter.class, pentahoSession );
     if ( deleter != null ) {
       pentahoSession.setAttribute( ITempFileDeleter.DELETER_SESSION_VARIABLE, deleter );
     }
+
     return pentahoSession;
   }
 
@@ -200,16 +201,12 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
    */
   protected void localeLeftovers( final HttpServletRequest httpRequest ) {
 
-    // Sync the thread static LocaleHelper's locale override with the value of the corresponding session attribute.
-    HttpSession httpSession = httpRequest.getSession( false );
-    if ( httpSession != null ) {
-      String localeOverride = (String) httpSession.getAttribute( "locale_override" );
-      LocaleHelper.parseAndSetLocaleOverride( localeOverride );
-    }
+    // Sync the thread static LocaleHelper's locale override with that stored in the session, if any.
+    LocaleHelper.setThreadLocaleOverride( readLocaleOverrideFromHttpSession( httpRequest ) );
 
     // Even if there is no session, or if it has no locale override,
     // set the thread's fallback locale to that of the HTTP request.
-    LocaleHelper.setLocale( httpRequest.getLocale() );
+    LocaleHelper.setThreadLocaleBase( httpRequest.getLocale() );
   }
 
   public void doFilter( ServletRequest request, ServletResponse response, FilterChain chain ) throws IOException,
@@ -230,7 +227,6 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
     if ( httpRequest.getAttribute( FILTER_APPLIED ) != null ) {
       // ensure that filter is only applied once per request
       chain.doFilter( httpRequest, httpResponse );
-
       return;
     }
 
@@ -257,7 +253,7 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
     } else {
       if ( logger.isDebugEnabled() ) {
         logger.debug( "Obtained a valid IPentahoSession from HTTP session to "
-            + "associate with PentahoSessionHolder: '" + pentahoSessionBeforeChainExecution + "'" );
+          + "associate with PentahoSessionHolder: '" + pentahoSessionBeforeChainExecution + "'" );
       }
     }
 
@@ -267,7 +263,7 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
     // if anything in the chain does a sendError() or sendRedirect().
 
     OnRedirectUpdateSessionResponseWrapper responseWrapper =
-        new OnRedirectUpdateSessionResponseWrapper( httpResponse, httpRequest, httpSessionExistedAtStartOfRequest );
+      new OnRedirectUpdateSessionResponseWrapper( httpResponse, httpRequest, httpSessionExistedAtStartOfRequest );
 
     // Proceed with chain
 
@@ -285,12 +281,12 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
 
       httpRequest.removeAttribute( FILTER_APPLIED );
 
-      // storePentahoSessionInHttpSession() might already be called by the response wrapper
+      // storePentahoSessionInHttpSession() might already have been called by the response wrapper
       // if something in the chain called sendError() or sendRedirect(). This ensures we only call it
       // once per request.
       if ( !responseWrapper.isSessionUpdateDone() ) {
         storePentahoSessionInHttpSession( pentahoSessionAfterChainExecution, httpRequest,
-            httpSessionExistedAtStartOfRequest );
+          httpSessionExistedAtStartOfRequest );
       }
 
       if ( logger.isDebugEnabled() ) {
@@ -304,7 +300,7 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
    * <p/>
    * If the HTTP session is null or the Hitachi Vantara session is null it will return null.
    * <p/>
-   * 
+   *
    * @param httpSession
    *          the session obtained from the request.
    */
@@ -320,7 +316,7 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
     // HTTP session exists, so try to obtain a Hitachi Vantara session from it.
 
     IPentahoSession pentahoSessionFromHttpSession =
-        (IPentahoSession) httpSession.getAttribute( PentahoSystem.PENTAHO_SESSION_KEY );
+      (IPentahoSession) httpSession.getAttribute( PentahoSystem.PENTAHO_SESSION_KEY );
 
     if ( pentahoSessionFromHttpSession == null ) {
       if ( logger.isDebugEnabled() ) {
@@ -335,7 +331,7 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
 
   /**
    * Stores the supplied Hitachi Vantara session in the HTTP session (if available).
-   * 
+   *
    * @param pentahoSession
    *          the Hitachi Vantara session obtained from the PentahoSessionHolder after the request has been processed by the
    *          filter chain. PentahoSessionHolder.getSession() cannot be used to obtain the Pentaho session as it has
@@ -345,18 +341,18 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
    * @param httpSessionExistedAtStartOfRequest
    *          indicates whether there was a session in place before the filter chain executed. If this is true, and the
    *          session is found to be null, this indicates that it was invalidated during the request and a new session
-   *          will now be created.
+   *                                           will now be created.
    * 
    */
   private void storePentahoSessionInHttpSession( IPentahoSession pentahoSession, HttpServletRequest request,
-      boolean httpSessionExistedAtStartOfRequest ) {
+                                                 boolean httpSessionExistedAtStartOfRequest ) {
     HttpSession httpSession = safeGetSession( request, false );
 
     if ( httpSession == null ) {
       if ( httpSessionExistedAtStartOfRequest ) {
         if ( logger.isDebugEnabled() ) {
           logger.debug( "HttpSession is now null, but was not null at start of request; "
-              + "session was invalidated, so do not create a new session" );
+            + "session was invalidated, so do not create a new session" );
         }
       } else {
         // Generate a HttpSession only if we need to
@@ -364,9 +360,9 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
         if ( !allowSessionCreation ) {
           if ( logger.isDebugEnabled() ) {
             logger.debug( "The HttpSession is currently null, and the " + this.getClass().getSimpleName()
-                + " is prohibited from creating an HttpSession "
-                + "(because the allowSessionCreation property is false) - Pentaho session thus not "
-                + "stored for next request" );
+              + " is prohibited from creating an HttpSession "
+              + "(because the allowSessionCreation property is false) - Pentaho session thus not "
+              + "stored for next request" );
           }
         } else if ( pentahoSession != null ) {
           if ( logger.isDebugEnabled() ) {
@@ -378,7 +374,7 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
         } else {
           if ( logger.isDebugEnabled() ) {
             logger.debug( "HttpSession is null, and Pentaho session is null; "
-                + "not creating HttpSession or storing SecurityContextHolder contents" );
+              + "not creating HttpSession or storing SecurityContextHolder contents" );
           }
         }
       }
@@ -456,6 +452,13 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
     }
   }
 
+  private Locale readLocaleOverrideFromHttpSession( HttpServletRequest httpRequest ) {
+    HttpSession httpSession = httpRequest.getSession( false );
+    return httpSession != null
+      ? LocaleHelper.parseLocale( (String) httpSession.getAttribute( IPentahoSession.ATTRIBUTE_LOCALE_OVERRIDE ) )
+      : null;
+  }
+
   private HttpSession safeGetSession( HttpServletRequest request, boolean allowCreate ) {
     try {
       return request.getSession( allowCreate );
@@ -523,11 +526,11 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
     /**
      * Takes the parameters required to call <code>storePentahoSessionInHttpSession()</code> in addition to the response
      * object we are wrapping.
-     * 
+     *
      * @see #storePentahoSessionInHttpSession(IPentahoSession, HttpServletRequest, boolean)
      */
     public OnRedirectUpdateSessionResponseWrapper( HttpServletResponse response, HttpServletRequest request,
-        boolean httpSessionExistedAtStartOfRequest ) {
+                                                   boolean httpSessionExistedAtStartOfRequest ) {
       super( response );
       this.request = request;
       this.httpSessionExistedAtStartOfRequest = httpSessionExistedAtStartOfRequest;
@@ -581,9 +584,9 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
   /**
    * An {@code StandaloneSession} that does nothing in its destroy implementation.
    * {@code InheritableThreadLocalPentahoSessionHolderStrategy} has the following code in {@code removeSession}:
-   * 
+   *
    * <pre>
-   * {@code 
+   * {@code
    * if (sess instanceof StandaloneSession)
    *   ((StandaloneSession) sess).destroy();
    * }
@@ -594,7 +597,7 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
    * and does not store the session.
    * 
    * Until now, Standalone sessions were only used for scheduled jobs. This is a new use for StandaloneSessions.
-   * 
+   *
    * @author mlowery
    */
   private static class NoDestroyStandaloneSession extends StandaloneSession {

--- a/extensions/src/main/java/org/pentaho/platform/web/http/filters/HttpSessionPentahoSessionIntegrationFilter.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/filters/HttpSessionPentahoSessionIntegrationFilter.java
@@ -209,6 +209,11 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
     LocaleHelper.setThreadLocaleBase( httpRequest.getLocale() );
   }
 
+  private void localeReset() {
+    LocaleHelper.setThreadLocaleOverride( null );
+    LocaleHelper.setThreadLocaleBase( null );
+  }
+
   public void doFilter( ServletRequest request, ServletResponse response, FilterChain chain ) throws IOException,
     ServletException {
 
@@ -288,6 +293,8 @@ public class HttpSessionPentahoSessionIntegrationFilter implements Filter, Initi
         storePentahoSessionInHttpSession( pentahoSessionAfterChainExecution, httpRequest,
           httpSessionExistedAtStartOfRequest );
       }
+
+      localeReset();
 
       if ( logger.isDebugEnabled() ) {
         logger.debug( "PentahoSessionHolder now cleared, as request processing completed" );

--- a/extensions/src/main/java/org/pentaho/platform/web/http/session/PentahoHttpSessionListener.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/session/PentahoHttpSessionListener.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -43,9 +43,12 @@ public class PentahoHttpSessionListener implements HttpSessionListener {
   private static final Map<String, String[]> sessionMap = new ConcurrentHashMap<String, String[]>();
 
   public void sessionCreated( final HttpSessionEvent event ) {
-    // we can't find out what the locale of the request is so we go with the
+    // We can't find out what the locale of the request is so we go with the
     // default for now...
-    LocaleHelper.setLocale( Locale.getDefault() );
+    // Proper handling is done "ahead" by
+    // HttpSessionPentahoSessionIntegrationFilter#localeLeftovers( HttpServletRequest )
+    LocaleHelper.setThreadLocaleOverride( Locale.getDefault() );
+
     String sessionId = event.getSession().getId();
     if ( PentahoHttpSessionListener.debug ) {
       Logger.debug( this, Messages.getInstance().getString( "HttpSessionListener.DEBUG_SESSION_CREATED", sessionId ) ); //$NON-NLS-1$
@@ -54,7 +57,6 @@ public class PentahoHttpSessionListener implements HttpSessionListener {
     // AuditHelper.audit( instanceId, String userId, String actionName,
     // String objectType, MessageTypes.PROCESS_ID_SESSION,
     // MessageTypes.SESSION_CREATE, "http session", "", 0, null );
-
   }
 
   public void sessionDestroyed( final HttpSessionEvent event ) {

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/ProxyServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/ProxyServlet.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -204,10 +204,7 @@ public class ProxyServlet extends ServletBase {
       queryParams.add( new BasicNameValuePair( TRUST_USER_PARAM, userName ) );
 
       if ( isLocaleOverrideEnabled ) {
-        Locale localeOverride = getProxyLocaleOverride();
-        if ( localeOverride != null ) {
-          queryParams.add( new BasicNameValuePair( TRUST_LOCALE_OVERRIDE_PARAM, localeOverride.toString() ) );
-        }
+        queryParams.add( new BasicNameValuePair( TRUST_LOCALE_OVERRIDE_PARAM, LocaleHelper.getLocale().toString() ) );
       }
     }
 
@@ -262,17 +259,6 @@ public class ProxyServlet extends ServletBase {
     if ( header != null ) {
       response.setHeader( headerStr, header.getValue() );
     }
-  }
-
-  /**
-   * Gets the locale override to send to the proxy url.
-   * <p>
-   * Mostly, supports unit testing.
-   *
-   * @return The locale override, or {@code null}, if none.
-   */
-  protected Locale getProxyLocaleOverride() {
-    return LocaleHelper.getLocale();
   }
 
   @Override

--- a/extensions/src/main/resources/org/pentaho/platform/web/http/messages/messages_en.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/web/http/messages/messages_en.properties
@@ -1,0 +1,151 @@
+#
+# Copyright 2006 - 2021 Hitachi Vantara.  All rights reserved.
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+# Foundation.
+#
+# You should have received a copy of the GNU Lesser General Public License along with this
+# program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+# or from the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+HttpSessionListener.DEBUG_SESSION_CREATED=Session {0} created
+HttpSessionListener.ERROR_0001_ERROR_DESTROYING_SESSION=Error destroying session
+HtmlMenuProvider.ERROR_0001_COULD_NOT_CREATE_XUL_LOADER=HtmlXulLoader could not be created
+
+PentahoSystem.USER_SYSTEM_TITLE=Pentaho Business Intelligence Platform
+PentahoSystem.ERROR_0003_SUBSCRIPTION_REPOSITORY_NOT_INITIALIZED=
+Scheduler.ERROR_0001_SCHEDULER_CANNOT_CANCEL=Could not cancel: {0}
+
+SolutionContextListener.ERROR_0001_NO_ROOT_PATH=Solution path is invalid
+SolutionContextListener.INFO_CONTEXT_PATH=contextPath={0}
+SolutionContextListener.INFO_INITIALIZING=Pentaho BI Platform Initializing
+SolutionContextListener.INFO_ROOT_PATH=rootPath={0}
+SolutionContextListener.INFO_SERVLET_CONTEXT=ServletContext={0}
+SolutionContextListener.INFO_SYSTEM_EXITING=Pentaho BI Platform Exiting
+SolutionContextListener.INFO_SYSTEM_NOT_READY=Pentaho BI Platform server failed to properly initialize. The system will not be available for requests. {0} Fully Qualified Server Url = {1}, Solution Path = {2}
+SolutionContextListener.INFO_SYSTEM_READY=Pentaho BI Platform server is ready. {0} Fully Qualified Server Url = {1}, Solution Path = {2}
+SolutionContextListener.ERROR_0002_BAD_OBJECT_FACTORY=Failed to create object factory of type: {0}
+SolutionContextListener.WARN_WEB_XML_PARAM_DEPRECATED=Parameter {0} found in web.xml has been deprecated.  Please set "{0}={1}" in file server.properties instead.
+
+
+#[BIerver 7887] XAction parameter messages
+HttpWebService.PARAMETER_GROUP_SYSTEM=System Parameters
+HttpWebService.PARAMETER_GROUP_USER=Parameters
+
+SolutionManagerUIComponent.INFO_0001_FILE_SAVED=FileSaved to:
+
+UI.ERROR_0001_BAD_TEMPLATE=Template could not be loaded: {0}
+
+UI.USER_ABOUT=About
+UI.USER_COPYRIGHT=Copyright &copy; 2004 - 2009 
+UI.USER_ADMIN=Admin
+UI.USER_CANCEL=Cancel
+UI.USER_CLOSE=Close
+UI.USER_DELETE=Delete
+UI.USER_DEMOS=Demos...
+UI.USER_DOWNLOADS=Downloads...
+UI.USER_FILE_CACHE=My Workspace
+UI.USER_FORUMS=Forums...
+UI.USER_HOME=Home
+UI.USER_LOGOUT=Logout
+UI.USER_NAVIGATE=Go
+UI.USER_NEW_CONTENT=*New Files*
+UI.USER_PENTAHO.COM=HitachiVantara.com...
+UI.USER_PORTAL=Portal
+UI.USER_SOLUTIONS=Solutions
+UI.USER_VIEW=View
+UI.USER_ERROR_0003_NO_BACKGROUND_EXECUTION=Background execution not defined in the pentaho.xml.
+
+XMLComponentFactory.ERROR_0001_Unable_To_Create_Class=Unable to create class:
+ 
+HttpSessionReuseDetectionFilter.DEBUG_PROCESS_AUTHN=Request is to process authentication
+HttpSessionReuseDetectionFilter.DEBUG_USER_ALREADY_LOGGED_IN=user "{0}" is already logged in
+HttpSessionReuseDetectionFilter.DEBUG_INVALIDATING_SESSION=invalidating session
+HttpSessionReuseDetectionFilter.DEBUG_REDIRECTING=redirecting to {0}
+HttpSessionReuseDetectionFilter.ERROR_0001_FILTERPROCESSESURL_NOT_SPECIFIED=filterProcessesUrl must be specified
+HttpSessionReuseDetectionFilter.ERROR_0002_SESSIONREUSEDETECTEDURL_NOT_SPECIFIED=sessionReuseDetectedUrl must be specified
+
+RequestParameterAuthenticationFilter.ERROR_0001_AUTHMGR_REQUIRED=An AuthenticationManager is required
+RequestParameterAuthenticationFilter.DEBUG_AUTH_USERID=Authorization userid: {0}
+RequestParameterAuthenticationFilter.DEBUG_AUTHENTICATION_REQUEST=Authentication request for user: {0} failed: {1}
+RequestParameterAuthenticationFilter.DEBUG_AUTH_SUCCESS=Authentication success: {0}
+RequestParameterAuthenticationFilter.ERROR_0002_AUTHM_ENTRYPT_REQUIRED=An AuthenticationEntryPoint is required
+RequestParameterAuthenticationFilter.ERROR_0003_USER_NAME_PARAMETER_MISSING=userNameParameter must be set to a valid request parameter name.
+RequestParameterAuthenticationFilter.ERROR_0004_PASSWORD_PARAMETER_MISSING=passwordParameter must be set to a valid request parameter name.
+RequestParameterAuthenticationFilter.ERROR_0005_HTTP_SERVLET_REQUEST_REQUIRED=Can only process HttpServletRequest
+RequestParameterAuthenticationFilter.ERROR_0006_HTTP_SERVLET_RESPONSE_REQUIRED=Can only process HttpServletResponse
+
+MessageFormatHelper.ERROR_PAGE_TITLE=MESSAGE_TBD
+MessageFormatHelper.USER_START_ACTION=Pentaho BI Platform - Start Action
+MessageFormatHelper.USER_ACTION_SUCCESSFUL=Action Successful
+MessageFormatHelper.USER_SERVER_VERSION=MESSAGE_TBD
+MessageFormatHelper.ERROR_0001_REQUEST_FAILED=MESSAGE_TBD
+MessageFormatHelper.ERROR_0002_COULD_NOT_PROCESS=MESSAGE_TBD
+
+PRO_SUBSCRIPTREP.ERROR_0005_GENERAL_ERROR=Error in Subscription Repository
+
+PentahoAwareCharacterEncodingFilter.ENCODING_IN_CTX=Encoding in context: {0}
+PentahoAwareCharacterEncodingFilter.ENCODING_IN_FILTER_INIT=Encoding in filter init: {0}
+PentahoAwareCharacterEncodingFilter.COULD_NOT_FIND_ENCODING=Could not find encoding. Using default encoding: {0}
+
+HttpOutputHandler.WARN_0001_VALUE_IS_NULL=The value to be output is null
+HttpOutputHandler.ERROR_0001_REDIRECT_FAILED=The redirection of the value: {0} failed
+
+MondrianCatalogPublisher.ERROR_0005_PUBLISH_EXCEPTION=Exception occurred while publishing
+
+UI.USER_FILE=File
+UI.USER_VIEW=View
+UI.USER_NIGHTLY=Nightly Builds..
+UI.USER_TRACKER=Issue Tracker..
+UI.USER_NEW_REPORT=New Ad Hoc Report..
+UI.USER_NEW_PIVOT=New Analysis View..
+WebTemplateHelperExperimental.ERROR_0001_COULD_NOT_CREATE_MENUBAR=Could not create menu system
+
+WebSpringPentahoObjectFactory.ERROR_0001_CONTEXT_NOT_SUPPORTED=This factory currently supports only {0} as a runtime context.  You have attempted to initialize with {1}
+CheckRefererFilter.ERROR_0001_REFERER_PREFIX_NOT_SPECIFIED=Initialization parameter refererPrefix must be specified.
+CheckRefererFilter.ERROR_0002_REDIRECT_NOT_SPECIFIED=Initialization parameter redirectTo must be specified.
+
+FileResource.IMPORT_SUCCESS=Import was Successful
+FileResource.ILLEGAL_PATHID=slashes removed from illegal pathId {0}
+FileResource.COPY_PREFIX=-Copy
+FileResource.DUPLICATE_INDICATOR=({0})
+FileResource.PARAM_FAILURE=parameter content generator failure: {0}
+FileResource.EXPORT_FAILED=Export failed: {0}
+FileResource.DESTINATION_PATH_UNKNOWN=Destination path not found: {0}
+FileResource.FILE_NOT_FOUND=File not found: {0}
+FileResource.FILE_MOVE_FAILED=Move failed for path: {0}
+FileResource.FILE_MOVE_ACCESS_DENIED=Access denied while moving files: {0}
+FileResource.FILE_COPY_ACCESS_DENIED=Access denied while copying files: {0}
+FileResource.FILE_RESTORE_FAILED=Restore failed for path: {0}
+FileResource.FILE_SET_CONTENT_CREATOR=Set Content Creator failed for path: {0}
+FileResource.FILE_GET_LOCALES=Get Locales failed for path: {0}
+FileResource.CAN_ADMINISTER=Checking if user has administration policies failed
+FileResource.WORKSPACE_FOLDER_NOT_FOUND=Workspace folder not found: {0}
+FileResource.GENERATED_CONTENT_FAILED=Getting generated content for {0} failed
+FileResource.GENERATED_CONTENT_FOR_USER_FAILED=Getting generated content for {0} by {1} failed
+FileResource.GENERATED_CONTENT_FOR_SCHEDULE_FAILED=Getting schedule generated content for {0} failed
+FileResource.CANNOT_GET_EXTENSION=Unable to get file extension
+FileResource.CANNOT_GET_MIMETYPE=Unable to get mime type for file
+FileResource.CANNOT_GET_CONVERTER=Unable to get converter for file
+FileResource.CANNOT_GET_INPUT_STREAM=Unable to get input stream for file
+FileResource.CANNOT_GET_FILE_DATA=Unable to get data for file
+FileOutputResource.XACTION_EXECUTION_FAILED=Failed to execute xaction {0}
+FileOutputResource.NO_CONTENT_GENERATOR=No content generator found for type {0}
+PluginFileResource.COULD_NOT_READ_FILE=Could not read file {0}
+PluginFileResource.UNDETERMINED_MIME_TYPE=Can't determine mime type for {0}, using *
+XactionUtil.HTML_OUTPUT_NOT_SUPPORTED=Unable to execute xaction as an html output
+XactionUtil.XML_OUTPUT_NOT_SUPPORTED=Unable to execute xaction as an xml output
+XactionUtil.CANNOT_REMOVE_OUTPUT_FILE=Unable to remove XAction output file {0}
+XactionUtil.SKIP_REMOVING_OUTPUT_FILE=File written by XActions must be cleaned up by external means: {0}
+
+SystemResource.GENERAL_ERROR=Error getting system resource
+
+HsqlDatabaseStartupListener.ERROR_0001_HSQLDB_ENTRY_MALFORMED=SQL to get databases is malformed
+HsqldbStartupListener.ERROR_0004_INVALID_PORT=Invalid port specified. Defaulting to {0}
+
+FileResource.INCORRECT_EXTENSION={0} has incorrect extension.

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/LocaleImportHandlerTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/LocaleImportHandlerTest.java
@@ -177,7 +177,7 @@ public class LocaleImportHandlerTest {
   @Test
   public void testImportLocalizedPropertiesFiles_fr() throws Exception {
 
-    LocaleHelper.setLocale( new Locale( "fr" ) );
+    LocaleHelper.setThreadLocaleBase( new Locale( "fr" ) );
 
     IUnifiedRepository mockUnifiedRepository = mock( IUnifiedRepository.class );
     RepositoryFileImportBundle mockLocale = mock( RepositoryFileImportBundle.class );
@@ -210,7 +210,7 @@ public class LocaleImportHandlerTest {
   @Test
   public void testImportLocalizedPropertiesFiles_en_us() throws Exception {
 
-    LocaleHelper.setLocale( new Locale( "en_US" ) );
+    LocaleHelper.setThreadLocaleBase( new Locale( "en_US" ) );
 
     IUnifiedRepository mockUnifiedRepository = mock( IUnifiedRepository.class );
     RepositoryFileImportBundle mockLocale = mock( RepositoryFileImportBundle.class );
@@ -243,7 +243,7 @@ public class LocaleImportHandlerTest {
   @Test
   public void testImportLocalizedPropertiesFiles_en_gb() throws Exception {
 
-    LocaleHelper.setLocale( new Locale( "en_GB" ) );
+    LocaleHelper.setThreadLocaleBase( new Locale( "en_GB" ) );
 
     IUnifiedRepository mockUnifiedRepository = mock( IUnifiedRepository.class );
     RepositoryFileImportBundle mockLocale = mock( RepositoryFileImportBundle.class );
@@ -369,7 +369,7 @@ public class LocaleImportHandlerTest {
   @Test
   public void testImportLocalizedWithFileExtensionPropertiesFiles_en_gb() throws Exception {
 
-    LocaleHelper.setLocale( new Locale( "en_GB" ) );
+    LocaleHelper.setThreadLocaleBase( new Locale( "en_GB" ) );
 
     IUnifiedRepository mockUnifiedRepository = mock( IUnifiedRepository.class );
     RepositoryFileImportBundle mockLocale = mock( RepositoryFileImportBundle.class );

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/olap/OlapServiceImplTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/olap/OlapServiceImplTest.java
@@ -845,11 +845,6 @@ public class OlapServiceImplTest {
   }
 
   private static Locale getLocale() {
-    final Locale locale = LocaleHelper.getLocale();
-    if ( locale != null ) {
-      return locale;
-    } else {
-      return Locale.getDefault();
-    }
+    return LocaleHelper.getLocale();
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/web/http/context/SolutionContextListenerTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/context/SolutionContextListenerTest.java
@@ -44,6 +44,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
@@ -125,30 +126,37 @@ public class SolutionContextListenerTest {
 
   @Test
   public void testShowInitializationMessage() throws Exception {
-    PentahoSystem.registerObjectFactory( objectFactory );
-    IVersionHelper versionHelper = mock( IVersionHelper.class );
-    PentahoSystem.registerObject( versionHelper );
-    when( versionHelper.getVersionInformation( PentahoSystem.class ) ).thenReturn( "version info" );
+    LocaleHelper.setThreadLocaleOverride( Locale.ENGLISH );
+    try {
+      PentahoSystem.registerObjectFactory( objectFactory );
+      IVersionHelper versionHelper = mock( IVersionHelper.class );
+      PentahoSystem.registerObject( versionHelper );
 
-    when( objectFactory.objectDefined( IVersionHelper.class.getSimpleName() ) ).thenReturn( true );
+      when( versionHelper.getVersionInformation( PentahoSystem.class ) ).thenReturn( "version info" );
 
-    solutionContextListener.solutionPath = "solution-path";
-    // it just prints out to standard out, nothing to verify
+      when( objectFactory.objectDefined( IVersionHelper.class.getSimpleName() ) ).thenReturn( true );
 
-    ByteArrayOutputStream captureStdOut = new ByteArrayOutputStream();
-    ByteArrayOutputStream captureStdErr = new ByteArrayOutputStream();
+      solutionContextListener.solutionPath = "solution-path";
+      // it just prints out to standard out, nothing to verify
 
-    System.setOut( new PrintStream( captureStdOut ) );
-    System.setErr( new PrintStream( captureStdErr ) );
+      ByteArrayOutputStream captureStdOut = new ByteArrayOutputStream();
+      ByteArrayOutputStream captureStdErr = new ByteArrayOutputStream();
 
-    solutionContextListener.showInitializationMessage( true, "http://localhost:8080/pentaho" );
-    assertTrue( captureStdOut.toString().contains( "Pentaho BI Platform server is ready. (version info) Fully Qualified Server Url = "
-        + "http://localhost:8080/pentaho, Solution Path = solution-path" ) );
+      System.setOut( new PrintStream( captureStdOut ) );
+      System.setErr( new PrintStream( captureStdErr ) );
 
-    solutionContextListener.showInitializationMessage( false, "http://localhost:8080/pentaho" );
-    assertTrue( captureStdErr.toString().contains( "Pentaho BI Platform server failed to properly initialize. The system will not be available for requests. "
-        + "(version info) Fully Qualified Server Url = http://localhost:8080/pentaho, Solution Path = solution-path" ) );
+      solutionContextListener.showInitializationMessage( true, "http://localhost:8080/pentaho" );
+      assertTrue( captureStdOut.toString()
+        .contains( "Pentaho BI Platform server is ready. (version info) Fully Qualified Server Url = "
+          + "http://localhost:8080/pentaho, Solution Path = solution-path" ) );
 
+      solutionContextListener.showInitializationMessage( false, "http://localhost:8080/pentaho" );
+      assertTrue( captureStdErr.toString().contains(
+        "Pentaho BI Platform server failed to properly initialize. The system will not be available for requests. "
+          + "(version info) Fully Qualified Server Url = http://localhost:8080/pentaho, Solution Path = solution-path" ) );
+    } finally {
+      LocaleHelper.setThreadLocaleOverride( null );
+    }
   }
 
   @Test

--- a/extensions/src/test/java/org/pentaho/platform/web/http/filters/PentahoWebContextFilterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/filters/PentahoWebContextFilterTest.java
@@ -321,8 +321,8 @@ public class PentahoWebContextFilterTest {
 
   @Test
   public void testWebContextDefinesSessionLocale() throws ServletException, IOException {
-    Locale previousLocaleOverride = LocaleHelper.getLocaleOverride();
-    LocaleHelper.setLocaleOverride( Locale.forLanguageTag( "pt-PT" ) );
+    Locale previousLocaleOverride = LocaleHelper.getThreadLocaleOverride();
+    LocaleHelper.setThreadLocaleOverride( Locale.forLanguageTag( "pt-PT" ) );
     try {
       final String response = executeWebContextFilter();
 
@@ -330,14 +330,14 @@ public class PentahoWebContextFilterTest {
         getWebContextVarDefinition( "SESSION_LOCALE", Locale.forLanguageTag( "pt-PT" ).toString() ) ) );
 
     } finally {
-      LocaleHelper.setLocaleOverride( previousLocaleOverride );
+      LocaleHelper.setThreadLocaleOverride( previousLocaleOverride );
     }
   }
 
   @Test
   public void testWebContextDefinesLocaleModule() throws ServletException, IOException {
-    Locale previousLocaleOverride = LocaleHelper.getLocaleOverride();
-    LocaleHelper.setLocaleOverride( Locale.forLanguageTag( "pt-PT" ) );
+    Locale previousLocaleOverride = LocaleHelper.getThreadLocaleOverride();
+    LocaleHelper.setThreadLocaleOverride( Locale.forLanguageTag( "pt-PT" ) );
     try {
       final String response = executeWebContextFilter();
 
@@ -348,7 +348,7 @@ public class PentahoWebContextFilterTest {
 
       assertTrue( response.contains( expected ) );
     } finally {
-      LocaleHelper.setLocaleOverride( previousLocaleOverride );
+      LocaleHelper.setThreadLocaleOverride( previousLocaleOverride );
     }
   }
 
@@ -431,9 +431,9 @@ public class PentahoWebContextFilterTest {
     String serverServices = escapeEnvironmentVariable( mockServerServices );
     String userHome = escapeEnvironmentVariable( "/home/" + this.sessionName );
 
-    Locale previousLocaleOverride = LocaleHelper.getLocaleOverride();
+    Locale previousLocaleOverride = LocaleHelper.getThreadLocaleOverride();
     try {
-      LocaleHelper.setLocaleOverride( Locale.forLanguageTag( "pt-PT" ) );
+      LocaleHelper.setThreadLocaleOverride( Locale.forLanguageTag( "pt-PT" ) );
 
       String application = "pentaho-test";
       when( this.mockRequest.getParameter( "application" ) ).thenReturn( application );
@@ -462,7 +462,7 @@ public class PentahoWebContextFilterTest {
 
       assertTrue( response.contains( environmentModuleConfig ) );
     } finally {
-      LocaleHelper.setLocaleOverride( previousLocaleOverride );
+      LocaleHelper.setThreadLocaleOverride( previousLocaleOverride );
     }
   }
 

--- a/extensions/src/test/java/org/pentaho/platform/web/http/filters/ProxyTrustingFilterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/filters/ProxyTrustingFilterTest.java
@@ -113,6 +113,7 @@ public class ProxyTrustingFilterTest {
     filter.init( cfg );
 
     MockHttpSession httpSession = (MockHttpSession) request.getSession( true );
+    assert httpSession != null;
 
     request.setRemoteHost( TRUSTED_IP );
     request.addParameter( filter.getParameterName(), "user" );
@@ -120,8 +121,9 @@ public class ProxyTrustingFilterTest {
     filter.doFilter( request, new MockHttpServletResponse(), new MockFilterChain() );
 
     verify( filter ).setSystemLocaleOverrideCode( null );
-    assertNull( LocaleHelper.getLocaleOverride() );
-    assertNull( httpSession.getAttribute( "locale_override" ) );
+
+    assertNull( httpSession.getAttribute( IPentahoSession.ATTRIBUTE_LOCALE_OVERRIDE ) );
+    assertNull( LocaleHelper.getThreadLocaleOverride() );
   }
 
   @Test
@@ -133,6 +135,7 @@ public class ProxyTrustingFilterTest {
     filter.init( cfg );
 
     MockHttpSession httpSession = (MockHttpSession) request.getSession( true );
+    assert httpSession != null;
 
     request.setRemoteHost( TRUSTED_IP );
     request.addParameter( filter.getParameterName(), "user" );
@@ -141,9 +144,9 @@ public class ProxyTrustingFilterTest {
     filter.doFilter( request, new MockHttpServletResponse(), new MockFilterChain() );
 
     verify( filter ).setSystemLocaleOverrideCode( "pt_PT" );
-    Locale locale = LocaleHelper.getLocaleOverride();
+    Locale locale = LocaleHelper.getThreadLocaleOverride();
     assertEquals( new Locale( "pt", "PT" ), locale );
-    assertEquals( locale.toString(), httpSession.getAttribute( "locale_override" ) );
+    assertEquals( locale.toString(), httpSession.getAttribute( IPentahoSession.ATTRIBUTE_LOCALE_OVERRIDE ) );
   }
 
   @Test
@@ -156,6 +159,7 @@ public class ProxyTrustingFilterTest {
     filter.init( cfg );
 
     MockHttpSession httpSession = (MockHttpSession) request.getSession( true );
+    assert httpSession != null;
 
     request.setRemoteHost( TRUSTED_IP );
     request.addParameter( filter.getParameterName(), "user" );
@@ -164,9 +168,9 @@ public class ProxyTrustingFilterTest {
     filter.doFilter( request, new MockHttpServletResponse(), new MockFilterChain() );
 
     verify( filter ).setSystemLocaleOverrideCode( "pt_PT" );
-    Locale locale = LocaleHelper.getLocaleOverride();
+    Locale locale = LocaleHelper.getThreadLocaleOverride();
     assertEquals( new Locale( "pt", "PT" ), locale );
-    assertEquals( locale.toString(), httpSession.getAttribute( "locale_override" ) );
+    assertEquals( locale.toString(), httpSession.getAttribute( IPentahoSession.ATTRIBUTE_LOCALE_OVERRIDE ) );
   }
 
   @Test
@@ -179,6 +183,7 @@ public class ProxyTrustingFilterTest {
     filter.init( cfg );
 
     MockHttpSession httpSession = (MockHttpSession) request.getSession( true );
+    assert httpSession != null;
 
     request.setRemoteHost( TRUSTED_IP );
     request.addParameter( filter.getParameterName(), "user" );
@@ -188,9 +193,9 @@ public class ProxyTrustingFilterTest {
     filter.doFilter( request, new MockHttpServletResponse(), new MockFilterChain() );
 
     verify( filter ).setSystemLocaleOverrideCode( "pt_PT" );
-    Locale locale = LocaleHelper.getLocaleOverride();
+    Locale locale = LocaleHelper.getThreadLocaleOverride();
     assertEquals( new Locale( "pt", "PT" ), locale );
-    assertEquals( locale.toString(), httpSession.getAttribute( "locale_override" ) );
+    assertEquals( locale.toString(), httpSession.getAttribute( IPentahoSession.ATTRIBUTE_LOCALE_OVERRIDE ) );
   }
 
   @Test
@@ -203,6 +208,7 @@ public class ProxyTrustingFilterTest {
     filter.init( cfg );
 
     MockHttpSession httpSession = (MockHttpSession) request.getSession( true );
+    assert httpSession != null;
 
     request.setRemoteHost( TRUSTED_IP );
     request.addParameter( filter.getParameterName(), "user" );
@@ -211,9 +217,9 @@ public class ProxyTrustingFilterTest {
     filter.doFilter( request, new MockHttpServletResponse(), new MockFilterChain() );
 
     verify( filter ).setSystemLocaleOverrideCode( "pt_PT" );
-    Locale locale = LocaleHelper.getLocaleOverride();
+    Locale locale = LocaleHelper.getThreadLocaleOverride();
     assertEquals( new Locale( "pt", "PT" ), locale );
-    assertEquals( locale.toString(), httpSession.getAttribute( "locale_override" ) );
+    assertEquals( locale.toString(), httpSession.getAttribute( IPentahoSession.ATTRIBUTE_LOCALE_OVERRIDE ) );
   }
 
   @Test
@@ -227,6 +233,7 @@ public class ProxyTrustingFilterTest {
     filter.init( cfg );
 
     MockHttpSession httpSession = (MockHttpSession) request.getSession( true );
+    assert httpSession != null;
 
     request.setRemoteHost( TRUSTED_IP );
     request.addParameter( filter.getParameterName(), "user" );
@@ -235,9 +242,9 @@ public class ProxyTrustingFilterTest {
     filter.doFilter( request, new MockHttpServletResponse(), new MockFilterChain() );
 
     verify( filter ).setSystemLocaleOverrideCode( "pt_PT" );
-    Locale locale = LocaleHelper.getLocaleOverride();
+    Locale locale = LocaleHelper.getThreadLocaleOverride();
     assertEquals( new Locale( "pt", "PT" ), locale );
-    assertEquals( locale.toString(), httpSession.getAttribute( "locale_override" ) );
+    assertEquals( locale.toString(), httpSession.getAttribute( IPentahoSession.ATTRIBUTE_LOCALE_OVERRIDE ) );
   }
   // endregion
 }

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -234,12 +234,7 @@ public class JcrRepositoryFileUtils {
 
     // Get default locale if null
     if ( pentahoLocale == null ) {
-      Locale currentLocale = LocaleHelper.getLocale();
-      if ( currentLocale != null ) {
-        pentahoLocale = new PentahoLocale( currentLocale );
-      } else {
-        pentahoLocale = new PentahoLocale();
-      }
+      pentahoLocale = new PentahoLocale( LocaleHelper.getLocale() );
     }
 
     // Not needed for content generators and the like
@@ -315,15 +310,12 @@ public class JcrRepositoryFileUtils {
     if ( session.getRootNode().isSame( node ) ) {
       return getRootFolder( session );
     }
+
     // Get default locale if null
     if ( pentahoLocale == null ) {
-      Locale currentLocale = LocaleHelper.getLocale();
-      if ( currentLocale != null ) {
-        pentahoLocale = new PentahoLocale( currentLocale );
-      } else {
-        pentahoLocale = new PentahoLocale();
-      }
+      pentahoLocale = new PentahoLocale( LocaleHelper.getLocale() );
     }
+
     return getRepositoryFileProxyFactory().getProxy( node, pentahoLocale );
   }
 

--- a/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
+++ b/scheduler/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
@@ -102,9 +102,9 @@ public class ActionRunner implements Callable<Boolean> {
 
     final Object locale = params.get( LocaleHelper.USER_LOCALE_PARAM );
     if ( locale instanceof Locale ) {
-      LocaleHelper.setLocaleOverride( (Locale) locale );
+      LocaleHelper.setThreadLocaleOverride( (Locale) locale );
     } else {
-      LocaleHelper.setLocaleOverride( new Locale( (String) locale ) );
+      LocaleHelper.setThreadLocaleOverride( new Locale( (String) locale ) );
     }
     // sync job params to the action bean
     ActionHarness actionHarness = new ActionHarness( actionBean );

--- a/user-console/src/main/java/org/pentaho/mantle/client/ui/xul/MantleController.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/ui/xul/MantleController.java
@@ -41,7 +41,9 @@ import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.Widget;
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
+import org.pentaho.gwt.widgets.client.menuitem.CheckBoxMenuItem;
 import org.pentaho.gwt.widgets.client.menuitem.PentahoMenuItem;
+import org.pentaho.gwt.widgets.client.utils.i18n.ResourceBundle;
 import org.pentaho.gwt.widgets.client.utils.string.StringTokenizer;
 import org.pentaho.mantle.client.admin.ContentCleanerPanel;
 import org.pentaho.mantle.client.admin.EmailAdminPanelController;
@@ -207,16 +209,22 @@ public class MantleController extends AbstractXulEventHandler {
     }
 
     // install language sub-menus
-    Map<String, String> supportedLanguages = Messages.getResourceBundle().getSupportedLanguages();
-    if ( supportedLanguages != null && supportedLanguages.keySet() != null && !supportedLanguages.isEmpty() ) {
+    ResourceBundle resourceBundle = Messages.getResourceBundle();
+    Map<String, String> supportedLanguages = resourceBundle.getSupportedLanguages();
+    if ( supportedLanguages != null && !supportedLanguages.isEmpty() ) {
+
+      String currentLanguage = resourceBundle.getLanguage();
+
       MenuBar langMenu = (MenuBar) languageMenu.getManagedObject();
       langMenu.insertSeparator( 0 );
       for ( String lang : supportedLanguages.keySet() ) {
-        MenuItem langMenuItem = new MenuItem( supportedLanguages.get( lang ), new SwitchLocaleCommand( lang ) );
-        langMenuItem.getElement().setId( supportedLanguages.get( lang ) + "_menu_item" ); //$NON-NLS-1$
+        CheckBoxMenuItem langMenuItem = new CheckBoxMenuItem( supportedLanguages.get( lang ), new SwitchLocaleCommand( lang ) );
+        langMenuItem.getElement().setId( supportedLanguages.get( lang ) + "_menu_item" );
+        langMenuItem.setChecked( lang.equalsIgnoreCase( currentLanguage ) );
         langMenu.insertItem( langMenuItem, 0 );
       }
     }
+
     buildFavoritesAndRecent( false );
 
     UserSettingsManager.getInstance().getUserSettings( new AsyncCallback<JsArray<JsSetting>>() {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/Mantle.jsp
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/Mantle.jsp
@@ -19,8 +19,7 @@
 <%@page pageEncoding="UTF-8" %>
 <%@
     page language="java"
-    import="org.apache.commons.lang.StringUtils,
-            org.owasp.encoder.Encode,
+    import="org.owasp.encoder.Encode,
             org.pentaho.platform.util.messages.LocaleHelper,
             java.util.Locale,
             java.net.URL,
@@ -37,12 +36,12 @@
   boolean hasDataAccessPlugin = PentahoSystem.get( IPluginManager.class, PentahoSessionHolder.getSession() ).getRegisteredPlugins().contains( "data-access" );
 
   // Handle the `locale` request parameter.
-  request.getSession().setAttribute(
-      "locale_override",
-      StringUtils.defaultIfEmpty( request.getParameter( "locale" ), null ) );
-  LocaleHelper.parseAndSetLocaleOverride( request.getParameter( "locale" ) );
+  Locale effectiveLocale = LocaleHelper.parseLocale( request.getParameter( "locale" ) );
+  LocaleHelper.setSessionLocaleOverride( effectiveLocale );
+  LocaleHelper.setThreadLocaleOverride( effectiveLocale );
 
-  Locale effectiveLocale = LocaleHelper.getLocale();
+  effectiveLocale = LocaleHelper.getLocale();
+
   URLClassLoader loader = new URLClassLoader( new URL[] { application.getResource( "/mantle/messages/" ) } );
   ResourceBundle properties = ResourceBundle.getBundle( "mantleMessages", effectiveLocale, loader );
 %>

--- a/user-console/src/main/resources/org/pentaho/mantle/public/MantleDebug.jsp
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/MantleDebug.jsp
@@ -16,7 +16,6 @@
 --%>
 
 <!DOCTYPE html>
-<%@page import="org.apache.commons.lang.StringUtils" %>
 <%@page import="org.owasp.encoder.Encode" %>
 <%@page import="org.pentaho.platform.util.messages.LocaleHelper" %>
 <%@page import="java.net.URL" %>
@@ -26,12 +25,12 @@
 
 <%
   // Handle the `locale` request parameter.
-  request.getSession().setAttribute(
-      "locale_override",
-      StringUtils.defaultIfEmpty( request.getParameter( "locale" ), null ) );
-  LocaleHelper.parseAndSetLocaleOverride( request.getParameter( "locale" ) );
+  Locale effectiveLocale = LocaleHelper.parseLocale( request.getParameter( "locale" ) );
+  LocaleHelper.setSessionLocaleOverride( effectiveLocale );
+  LocaleHelper.setThreadLocaleOverride( effectiveLocale );
 
-  Locale effectiveLocale = LocaleHelper.getLocale();
+  effectiveLocale = LocaleHelper.getLocale();
+
   URLClassLoader loader = new URLClassLoader( new URL[] { application.getResource( "/mantle/messages/" ) } );
   ResourceBundle properties = ResourceBundle.getBundle( "mantleMessages", effectiveLocale, loader );
 %>


### PR DESCRIPTION
* `IPentahoSession#{ATTRIBUTE_LOCALE_OVERRIDE, getAttributeLocaleOverride, setAttributeLocaleOverride}` - new members to legalize a well-known attribute
* `LocaleHelper#{setDefaultLocale, getDefaultLocale}` - can no longer be null; mimics the initialization previously done in `SolutionContextListener`
* `LocaleHelper#parseLocale` - parsing extracted from `parseAndSetLocaleOverride`, allowing independent parsing
* `LocaleHelper#{setLocale, parseAndSetLocaleOverride, setLocaleOverride, getLocaleOverride}` - deprecated in favor of a new clearer, more explicit naming scheme: `DefaultLocale`, `ThreadLocaleBase`, `ThreadLocaleOverride`. The *unadorned* `LocaleHelper#getLocale` returns the *effective* locale.
* `LocaleHelper#setSessionLocaleOverride` - new method to encapsulate setting the locale of the current Pentaho session, if any.
* Removed multiple, now unnecessary, checks for a `null` `LocaleHelper.getLocale()`.
* `FileService` - fixed file and folder sorting (`getCollatorInstance()`) only taking into account a session's *initial* locale
* Added documentation to `LocaleHelper`, `UserConsoleResource`, `UserSettingsResource`, `SystemResource` and elsewhere to clarify how the locale and user variables/settings work.
* Added missing `messages_en.properties` corresponding to the default locale, which caused tests to fail in non en-US machines (and would cause bugs in non en-US Pentaho servers as well)
* PUC Languages menu now checks/selects the current language

Depends on https://github.com/pentaho/pentaho-commons-gwt-modules/pull/793.