### PR TITLE
[BACKLOG-35002] Protecting GWT-RPC bridge against CSRF attacks

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-csrf.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-csrf.xml
@@ -5,10 +5,12 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
        xmlns:swm="http://www.hitachivantara.com/schema/security/web/model/spring"
+       xmlns:pen-gpc="http://www.pentaho.com/schema/pentaho-gwt-rpc-spring"
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="
           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
           http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd
+          http://www.pentaho.com/schema/pentaho-gwt-rpc-spring http://www.pentaho.com/schema/pentaho-gwt-rpc-spring.xsd
           http://www.hitachivantara.com/schema/security/web/model/spring http://www.hitachivantara.com/schema/security/web/model/spring/hv-swm-spring.xsd"
        default-lazy-init="true">
 
@@ -20,6 +22,8 @@
 
     <constructor-arg>
       <swm:or-request-matcher>
+        <!-- REST /api/* -->
+
         <!--
           POST /api/user-settings/recent
           POST /api/user-settings/favorites
@@ -44,6 +48,33 @@
           POST /api/repo/files/import
         -->
         <swm:regex-request-matcher pattern="^/api/repo/files/import\b.*" methods="POST" />
+
+        <!-- GWT-RPC ws/gwt/* -->
+
+        <!-- POST /ws/gwt/unifiedRepository (and body contains `createBinaryFile`, ... method call) -->
+        <pen-gpc:system-gwt-rpc-request-matcher pattern="^/ws/gwt/unifiedRepository\b.*"
+                                                methods="createBinaryFile
+                                                         createBinaryFileWithAcl
+                                                         updateBinaryFile
+                                                         copyFile
+                                                         moveFile
+                                                         lockFile
+                                                         unlockFile
+                                                         createFile
+                                                         createFileWithAcl
+                                                         updateFile
+                                                         createFolder
+                                                         createFolderWithAcl
+                                                         updateFolder
+                                                         deleteFile
+                                                         deleteFileWithPermanentFlag
+                                                         deleteFileAtVersion
+                                                         undeleteFile
+                                                         updateAcl
+                                                         restoreFileAtVersion
+                                                         setFileMetadata
+                                                         setLocalePropertiesForFileByFileId
+                                                         deleteLocalePropertiesForFile" />
       </swm:or-request-matcher>
     </constructor-arg>
   </bean>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -30,6 +30,12 @@
     <pentaho-chartbeans.version>9.3.0.0-SNAPSHOT</pentaho-chartbeans.version>
   </properties>
   <dependencies>
+    <!-- @Null, @Nullable annotations -->
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
@@ -2094,6 +2100,18 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <!-- region HV Web Security -->
+    <dependency>
+      <groupId>com.hitachivantara.security.web</groupId>
+      <artifactId>security-web-server-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.hitachivantara.security.web</groupId>
+      <artifactId>security-web-server-model-impl</artifactId>
+    </dependency>
+    <!-- endregion HV Web Security -->
+
     <dependency>
       <groupId>annogen</groupId>
       <artifactId>annogen</artifactId>

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/AbstractGwtRpc.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/AbstractGwtRpc.java
@@ -1,0 +1,528 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc;
+
+import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
+import com.google.gwt.user.client.rpc.SerializationException;
+import com.google.gwt.user.server.rpc.RPC;
+import com.google.gwt.user.server.rpc.RPCRequest;
+import com.google.gwt.user.server.rpc.RPCServletUtils;
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import com.google.gwt.user.server.rpc.SerializationPolicyLoader;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.web.gwt.rpc.impl.GwtRpcUtil;
+import org.pentaho.platform.web.gwt.rpc.util.ThrowingSupplier;
+import org.pentaho.platform.web.servlet.GwtRpcProxyException;
+import org.pentaho.platform.web.servlet.messages.Messages;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * The <code>AbstractGwtRpc</code> class is the base abstract class of classes that represent a GWT
+ * <b>Remote Procedure Call</b> which is made via HTTP.
+ * <p>
+ * One instance of this class is initialized with the {@link HttpServletRequest} instance which represents a GWT-RPC
+ * request.
+ * <p>
+ * The class exposes functionality to:
+ * <ol>
+ *   <li>
+ *     obtain the target object of the GWT-RPC request, via {@link #getTarget()};
+ *   </li>
+ *   <li>
+ *     obtain the class loader which should be current when the call is performed, via {@link #getTargetClassLoader()};
+ *   </li>
+ *   <li>
+ *     obtain the serialized request payload from the HTTP request, via {@link #getRequestPayload()};
+ *     this is useful for low-level integration with {@link com.google.gwt.user.server.rpc.RemoteServiceServlet};
+ *   </li>
+ *   <li>
+ *     obtain the parsed request, via {@link #getRequest()};
+ *   </li>
+ *   <li>
+ *     invoke the target method on the target object within its class loader and to return a serialized response.
+ *   </li>
+ * </ol>
+ * <p>
+ * Concrete specialized classes exist that can handle GWT-RPC requests for services of:
+ * <ul>
+ *   <li>
+ *     {@link PluginGwtRpc} - services of Pentaho Platform plugins, e.g. <code>/gwtrpc/serviceName</code>;
+ *   </li>
+ *   <li>
+ *     {@link SystemGwtRpc} - services of the Pentaho Platform itself, e.g. <code>/ws/gwt/serviceName</code>.
+ *   </li>
+ * </ul>
+ */
+public abstract class AbstractGwtRpc {
+
+  private static final Log logger = LogFactory.getLog( AbstractGwtRpc.class );
+
+  protected static final String HTTP_GWT_RPC_ATTRIBUTE = AbstractGwtRpc.class.getSimpleName();
+
+  @NonNull
+  private final HttpServletRequest httpRequest;
+
+  @Nullable
+  private Object target;
+
+  @Nullable
+  private String requestPayload;
+
+  @Nullable
+  private RPCRequest request;
+
+  @Nullable
+  private IGwtRpcSerializationPolicyCache serializationPolicyCache;
+
+  /**
+   * Creates an instance given an HTTP request.
+   *
+   * @param httpRequest An HTTP request.
+   */
+  protected AbstractGwtRpc( @NonNull HttpServletRequest httpRequest ) {
+    Objects.requireNonNull( httpRequest );
+    this.httpRequest = httpRequest;
+  }
+
+  /**
+   * Sets the serialization policy cache which will be used to load a serialization policy before creating one,
+   * or to store the created one if none exists.
+   * <p>
+   * The serialization policy is used to safely deserialize the GWT-RPC request and serialize the GWT-RPC response
+   * of this call.
+   *
+   * @param serializationPolicyCache A serialization policy cache instance, or <code>null</code>.
+   */
+  public void setSerializationPolicyCache( @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+    this.serializationPolicyCache = serializationPolicyCache;
+  }
+
+  /**
+   * Gets the serialization policy cache instance used by this GWT-RPC call.
+   *
+   * @return The serialization policy cache instance, if any; <code>null</code>, otherwise.
+   */
+  @Nullable
+  public IGwtRpcSerializationPolicyCache getSerializationPolicyCache() {
+    return serializationPolicyCache;
+  }
+
+  // region Servlet
+
+  /**
+   * Gets the associated HTTP request.
+   *
+   * @return An HTTP request.
+   */
+  @NonNull
+  public HttpServletRequest getServletRequest() {
+    return httpRequest;
+  }
+
+  /**
+   * Gets the associated servlet context.
+   * <p>
+   * Syntax-sugar method equivalent to <code>getServletRequest().getServletContext()</code>.
+   *
+   * @return A servlet context.
+   */
+  @NonNull
+  protected ServletContext getServletContext() {
+    return getServletRequest().getServletContext();
+  }
+
+  /**
+   * Gets the associated web app context path.
+   * <p>
+   * Syntax-sugar method equivalent to <code>getServletRequest().getContextPath()</code>.
+   * <p>
+   * Example value: <code>/pentaho</code>.
+   *
+   * @return The servlet context path.
+   */
+  @NonNull
+  protected String getAppContextPath() {
+    return httpRequest.getContextPath();
+  }
+
+  /**
+   * Gets the associated servlet context path.
+   * <p>
+   * Example value: <code>/gwt/rpc/serviceName?bar=foo</code>.
+   *
+   * @return The servlet context path.
+   */
+  @NonNull
+  protected String getServletContextPath() {
+    String path = httpRequest.getServletPath() + "/" + httpRequest.getPathInfo();
+    if ( path.contains( "//" ) ) {
+      path = path.replaceAll( "//", "/" );
+    }
+
+    return path;
+  }
+  // endregion
+
+  // region Target
+
+  /**
+   * Gets the target object on which the remote call will be made.
+   *
+   * @return The target object.
+   * @throws GwtRpcProxyException if the target object cannot be resolved.
+   */
+  @NonNull
+  public Object getTarget() {
+    if ( target == null ) {
+      try {
+        target = resolveTarget();
+      } catch ( GwtRpcProxyException ex ) {
+        logger.error( Messages.getInstance().getErrorString(
+          "AbstractGwtRpcProxyServlet.ERROR_0001_FAILED_TO_RESOLVE_DISPATCH_TARGET",
+          getServletContextPath() ), ex );
+        throw ex;
+      }
+    }
+
+    return target;
+  }
+
+  /**
+   * Gets the class loader which must be current to deserialize the request, invoke the method and
+   * serialize the response.
+   *
+   * @return The target class laoder.
+   * @throws GwtRpcProxyException if the target class loader cannot be resolved.
+   */
+  @NonNull
+  public ClassLoader getTargetClassLoader() {
+    return getTarget().getClass().getClassLoader();
+  }
+
+  /**
+   * Resolves the target object on which the remote call will be made.
+   *
+   * @return The target object.
+   * @throws GwtRpcProxyException if the target object cannot be resolved.
+   */
+  @NonNull
+  protected abstract Object resolveTarget();
+  // endregion
+
+  // region Request Payload, Decoding
+
+  /**
+   * Gets the serialized request payload which is present in the HTTP request.
+   *
+   * @return The serialized request payload.
+   * @throws GwtRpcProxyException if the request is not valid.
+   * @see RPCServletUtils#readContentAsGwtRpc(HttpServletRequest)
+   */
+  @NonNull
+  public String getRequestPayload() throws GwtRpcProxyException {
+    if ( requestPayload == null ) {
+      try {
+        requestPayload = RPCServletUtils.readContentAsGwtRpc( httpRequest );
+      } catch ( IOException | ServletException ex ) {
+        String message =
+          Messages.getInstance().getErrorString( "AbstractGwtRpcProxyServlet.ERROR_0002_RPC_INVALID_REQUEST" );
+        logger.error( message, ex );
+        throw new GwtRpcProxyException( message, ex );
+      }
+    }
+
+    return requestPayload;
+  }
+
+  // Based on RemoteServiceServlet#processPost(..)
+
+  /**
+   * Gets the processed GWT-RPC request object.
+   *
+   * @return The processed request.
+   * @throws GwtRpcProxyException if the request is invalid.
+   * @see RPC#decodeRequest(String, Class, com.google.gwt.user.server.rpc.SerializationPolicyProvider)
+   */
+  @NonNull
+  public RPCRequest getRequest() {
+    if ( request == null ) {
+
+      String requestPayload = getRequestPayload();
+
+      request = GwtRpcUtil.withClassLoader( getTargetClassLoader(), () -> getRequestCore( requestPayload ) );
+    }
+
+    return request;
+  }
+
+  // Visible For Testing
+  @NonNull
+  RPCRequest getRequestCore( @NonNull String requestPayload ) {
+    try {
+      return RPC.decodeRequest( requestPayload, null, this::getSerializationPolicy );
+    } catch ( IllegalArgumentException | IncompatibleRemoteServiceException ex ) {
+      String message =
+        Messages.getInstance().getErrorString( "AbstractGwtRpcProxyServlet.ERROR_0002_RPC_INVALID_REQUEST" );
+      logger.error( message, ex );
+      throw new GwtRpcProxyException( message, ex );
+    }
+  }
+  // endregion
+
+  // region Serialization Policy
+
+  /*
+   * Request path break down.
+   *
+   * Plugin Example
+   *
+   * - moduleBaseURL = 'http://localhost:8080/pentaho/content/data-access/resources/gwt/'
+   * - modulePath = '/pentaho/content/data-access/resources/gwt/'
+   * - appContextPath = '/pentaho'
+   * - moduleContextPath = '/content/data-access/resources/gwt/'
+   *
+   * System Example
+   *
+   * - moduleBaseURL = 'http://localhost:8080/pentaho/mantle/'
+   * - modulePath = '/pentaho/mantle/'
+   * - appContextPath = '/pentaho'
+   * - moduleContextPath = '/mantle/'
+   */
+
+  @NonNull
+  protected SerializationPolicy getSerializationPolicy( @Nullable String moduleBaseURL, @Nullable String strongName ) {
+    if ( serializationPolicyCache != null ) {
+      return serializationPolicyCache.getSerializationPolicy(
+        moduleBaseURL,
+        strongName,
+        this::getSerializationPolicyCore );
+    }
+
+    return getSerializationPolicyCore( moduleBaseURL, strongName );
+  }
+
+  @NonNull
+  private SerializationPolicy getSerializationPolicyCore( @Nullable String moduleBaseURL,
+                                                          @Nullable String strongName ) {
+    if ( moduleBaseURL == null ) {
+      logger.error( Messages.getInstance().getErrorString(
+        "GwtRpcPluginProxyServlet.ERROR_0004_MALFORMED_URL", "" ) );
+      return getDefaultSerializationPolicy();
+    }
+
+    String modulePath;
+    try {
+      modulePath = new URL( moduleBaseURL ).getPath();
+    } catch ( MalformedURLException ex ) {
+      logger.error( Messages.getInstance().getErrorString(
+        "GwtRpcPluginProxyServlet.ERROR_0004_MALFORMED_URL", moduleBaseURL ), ex );
+      return getDefaultSerializationPolicy();
+    }
+
+    String appContextPath = getAppContextPath();
+    modulePath = GwtRpcUtil.scrubWebAppRoot( modulePath, appContextPath );
+
+    if ( !modulePath.startsWith( appContextPath ) ) {
+      logger.error( Messages.getInstance().getErrorString(
+        "GwtRpcPluginProxyServlet.ERROR_0004_MALFORMED_URL", moduleBaseURL ) );
+      return getDefaultSerializationPolicy();
+    }
+
+    String moduleContextPath = modulePath.substring( appContextPath.length() );
+
+    SerializationPolicy serializationPolicy = loadSerializationPolicy( moduleContextPath, strongName );
+
+    return serializationPolicy != null ? serializationPolicy : getDefaultSerializationPolicy();
+  }
+
+  /**
+   * Loads the serialization policy having the given GWT module context path and strong name.
+   * <p>
+   * Typically, this method loads a serialization policy from a persistence medium.
+   *
+   * @param moduleContextPath The GWT module context path (e.g. <code>/content/data-access/resources/gwt/</code>).
+   * @param strongName        The serialization policy strong name.
+   * @return The associated serialization policy, if one can be loaded;
+   * <code>null</code>, otherwise, in which case the default serialization policy is assumed,
+   * as returned by {@link #getDefaultSerializationPolicy()}.
+   */
+  @Nullable
+  protected abstract SerializationPolicy loadSerializationPolicy( @NonNull String moduleContextPath,
+                                                                  @Nullable String strongName );
+
+  /**
+   * Gets a serialization policy to use when no specific serialization policy is available.
+   * <p>
+   * the default serialization policy is a legacy, 1.3.3 compatible, serialization policy and
+   * may result in {@link SerializationException}.
+   *
+   * @return The default serialization policy.
+   * @see RPC#getDefaultSerializationPolicy()
+   */
+  @NonNull
+  protected static SerializationPolicy getDefaultSerializationPolicy() {
+    return RPC.getDefaultSerializationPolicy();
+  }
+
+  /**
+   * Loads a serialization policy given an input stream whose content is in GWT-RPC
+   * serialization policy standard format.
+   * <p>
+   * Helper method for custom implementations.
+   *
+   * @param inputStreamSupplier         A supplier of an input stream of the serialization policy.
+   * @param serializationPolicyFileName The serialization policy file name; used for logging purposes, only.
+   * @return The loaded serialization policy, if successfully loaded; <code>null</code>, otherwise.
+   */
+  @Nullable
+  protected static SerializationPolicy loadSerializationPolicyFromInputStream(
+    @NonNull ThrowingSupplier<InputStream, IOException> inputStreamSupplier,
+    @NonNull String serializationPolicyFileName ) {
+
+    try ( InputStream rpcFileInputStream = inputStreamSupplier.get() ) {
+      if ( rpcFileInputStream != null ) {
+        return SerializationPolicyLoader.loadFromStream( rpcFileInputStream, null );
+      }
+
+      logger.error( Messages.getInstance().getErrorString(
+        "GwtRpcPluginProxyServlet.ERROR_0007_FAILED_TO_OPEN_FILE", serializationPolicyFileName ) );
+    } catch ( IOException e ) {
+      logger.error( Messages.getInstance().getErrorString(
+        "GwtRpcPluginProxyServlet.ERROR_0007_FAILED_TO_OPEN_FILE", serializationPolicyFileName ), e );
+    } catch ( ParseException e ) {
+      logger.error( Messages.getInstance().getErrorString(
+        "GwtRpcPluginProxyServlet.ERROR_0008_FAILED_TO_PARSE_FILE", serializationPolicyFileName ), e );
+    }
+
+    return null;
+  }
+  // endregion
+
+  // region Invocation
+
+  /**
+   * Makes the remote call on the target object and returns the serialized response.
+   *
+   * @return The serialized response.
+   * @throws GwtRpcProxyException if the call does not succeed.
+   */
+  @NonNull
+  public String invoke() {
+
+    Object target = getTarget();
+
+    Class<?> targetClass = target.getClass();
+
+    RPCRequest rpcRequest = getRequest();
+
+    try {
+      Method targetMethod = getTargetMethod( targetClass, rpcRequest );
+
+      return GwtRpcUtil.withClassLoaderThrowing(
+        // Making it this way, effectively repeating getTarget(), makes it easier to test.
+        getTargetClassLoader(),
+        () -> invokeCore( target, targetMethod, rpcRequest ) );
+
+    } catch ( NoSuchMethodException | SerializationException ex ) {
+      String message = Messages.getInstance().getErrorString(
+        "AbstractGwtRpcProxyServlet.ERROR_0003_RPC_INVOCATION_FAILED", targetClass.getName() );
+      logger.error( message, ex );
+      throw new GwtRpcProxyException( message, ex );
+    }
+  }
+
+  // Visible For Testing
+  @NonNull
+  Method getTargetMethod( @NonNull Class<?> targetClass, @NonNull RPCRequest rpcRequest )
+    throws NoSuchMethodException {
+
+    Method serviceInterfaceMethod = rpcRequest.getMethod();
+
+    // Don't require the target class to implement the service interface.
+    return targetClass.getMethod(
+      serviceInterfaceMethod.getName(),
+      serviceInterfaceMethod.getParameterTypes() );
+  }
+
+  // Visible For Testing
+  @NonNull
+  String invokeCore( @NonNull Object target, @NonNull Method targetMethod, @NonNull RPCRequest rpcRequest )
+    throws SerializationException {
+
+    return RPC.invokeAndEncodeResponse(
+      target,
+      targetMethod,
+      rpcRequest.getParameters(),
+      rpcRequest.getSerializationPolicy() );
+  }
+  // endregion
+
+  /**
+   * Gets the instance of a sub-class of {@link AbstractGwtRpc}, <code>R</code>,
+   * which is stored in the given HTTP request, if there is one already, or creates one and stores it if not.
+   * <p>
+   * The GWT-RPC instance is stored in an HTTP request attribute,
+   * as per {@link HttpServletRequest#getAttribute(String)} and {@link HttpServletRequest#setAttribute(String, Object)}.
+   * <p>
+   * Helper method for custom implementations.
+   *
+   * @param httpRequest              The HTTP request.
+   * @param factory                  A function which creates an instance of class <code>R</code> given an HTTP request.
+   * @param serializationPolicyCache A serialization policy cache instance to initialize a created instance with.
+   * @return The associated GWT-RPC instance.
+   * @see AbstractGwtRpc#setSerializationPolicyCache(IGwtRpcSerializationPolicyCache)
+   */
+  @NonNull
+  protected static <R extends AbstractGwtRpc> R getInstance(
+    @NonNull HttpServletRequest httpRequest,
+    @NonNull Function<HttpServletRequest, R> factory,
+    @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+
+    Objects.requireNonNull( httpRequest );
+    Objects.requireNonNull( factory );
+
+    @SuppressWarnings( "unchecked" )
+    R rpc = (R) httpRequest.getAttribute( HTTP_GWT_RPC_ATTRIBUTE );
+    if ( rpc == null ) {
+      rpc = factory.apply( httpRequest );
+      if ( rpc == null ) {
+        throw new RuntimeException( "Factory returned a null GwtRpc instance" );
+      }
+
+      rpc.setSerializationPolicyCache( serializationPolicyCache );
+
+      httpRequest.setAttribute( HTTP_GWT_RPC_ATTRIBUTE, rpc );
+    }
+
+    return rpc;
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/IGwtRpcSerializationPolicyCache.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/IGwtRpcSerializationPolicyCache.java
@@ -1,0 +1,42 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc;
+
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import com.google.gwt.user.server.rpc.SerializationPolicyProvider;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * The <code>IGwtRpcSerializationPolicyCache</code> interface represents a cached serialization policy provider.
+ *
+ * @see SerializationPolicyProvider
+ */
+public interface IGwtRpcSerializationPolicyCache {
+  /**
+   * Get a {@link SerializationPolicy} from cache or from the given provider.
+   *
+   * @param moduleBaseURL  The base URL of the GWT module.
+   * @param strongName     The strong name of the GWT module.
+   * @param sourceProvider The provider to use to obtain a missing policy. Cannot return <code>null</code>.
+   * @return A serialization policy.
+   */
+  @NonNull
+  SerializationPolicy getSerializationPolicy( @Nullable String moduleBaseURL, @Nullable String strongName,
+                                              @NonNull SerializationPolicyProvider sourceProvider );
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/PluginGwtRpc.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/PluginGwtRpc.java
@@ -1,0 +1,264 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc;
+
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import com.google.gwt.user.server.rpc.SerializationPolicyLoader;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.IPluginResourceLoader;
+import org.pentaho.platform.api.engine.IServiceManager;
+import org.pentaho.platform.api.engine.ServiceException;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.pluginmgr.PluginUtil;
+import org.pentaho.platform.web.gwt.rpc.util.ThrowingSupplier;
+import org.pentaho.platform.web.servlet.GwtRpcProxyException;
+import org.pentaho.platform.web.servlet.messages.Messages;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The <code>PluginGwtRpc</code> class is a specialized GWT-RPC which can be used
+ * to handle remote calls to services of Pentaho Platform plugins, e.g. <code>/gwtrpc/serviceName</code>.
+ * <p>
+ * Plugin GWT remote services must be registered in the current {@link IServiceManager} with the service type `gwt`.
+ * <p>
+ * Plugins can register a remote services in their <code>plugin.xml</code> file,
+ * using the <code>webservice</code> element, like in the following:
+ * <pre>
+ *
+ * &lt;webservice id="&lt;serviceName&gt;" type="gwt" class="&lt;my.remote.service.Class&gt;" /&gt;
+ * </pre>
+ * <p>
+ * This service would become exposed under the Pentaho context URL <code>/gwtrpc/&lt;serviceName&gt;</code>.
+ * The class <code>&lt;my.remote.service.Class&gt;</code> must be accessible in the plugin's class loader
+ * and should implement the {@link com.google.gwt.user.client.rpc.RemoteService} interface.
+ * <p>
+ * Plugin remote services handle GWT serialization policies in one of two ways:
+ * <p>
+ * A static serialization policy can be defined in the plugin's <code>plugin.spring.xml</code>,
+ * by registering with the Pentaho System a bean of a class extending from {@link SerializationPolicy},
+ * such as {@link org.pentaho.platform.web.servlet.PentahoSerializationPolicy}.
+ * This policy will be used whatever the <i>strong name</i> being requested.
+ * For example:
+ *
+ * <pre>
+ *   &lt;bean class="org.pentaho.platform.web.servlet.PentahoSerializationPolicy"&gt;
+ *     &lt;property name="whiteList"&gt;
+ *       &lt;util:list&gt;
+ *         &lt;value&gt;com.allen_sauer.gwt.dnd.client.DragHandlerCollection&lt;/value&gt;
+ *         ...
+ *       &lt;/util:list&gt;
+ *     &lt;/property&gt;
+ *     &lt;pen:publish as-type="CLASSES"&gt;
+ *       &lt;pen:attributes&gt;
+ *         &lt;pen:attr key="plugin" value="[my-plugin]"/&gt;
+ *       &lt;/pen:attributes&gt;
+ *     &lt;/pen:publish&gt;
+ *   &lt;/bean&gt;
+ * </pre>
+ *
+ * <p>
+ * In this example, the classes which are allowed to be exchanged between client and server must be specified in
+ * the property named <code>whiteList</code>.
+ * Moreover, instead of <code>[my-plugin]</code>, the identifier of the plugin should be used instead.
+ * <p>
+ * The second way to register serialization policies is by using the GWT-RPC files that GWT automatically
+ * creates when compiling GWT code. These files have a custom internal format,
+ * are named like <code>&lt;strong-name&gt;.gwt.rpc</code> and are placed in the same directory as the
+ * remaining compiled GWT code (e.g. <code>/content/data-access/resources/gwt/</code>).
+ * One such file could be named <code>825CCA5A63214CE13B23AAA2FCB5C8CA.gwt.rpc</code>.
+ * The serialization policy strong name is unique to it and is not necessarily shared with the strong name of a
+ * particular GWT module. This file is searched for <i>anywhere</i> in the plugin's file system,
+ * via {@link IPluginResourceLoader#findResources(ClassLoader, String)} and at least one file with such name must exist,
+ * or an error is logged and the loading fails. If more than one file exists, the first one found is used and
+ * a warning is logged.
+ */
+public class PluginGwtRpc extends AbstractGwtRpc {
+
+  private static final Log logger = LogFactory.getLog( PluginGwtRpc.class );
+
+  public PluginGwtRpc( @NonNull HttpServletRequest request ) {
+    super( request );
+  }
+
+  @NonNull @Override
+  protected Object resolveTarget() throws GwtRpcProxyException {
+
+    IServiceManager serviceManager = PentahoSystem.get( IServiceManager.class, PentahoSessionHolder.getSession() );
+
+    String key = getServiceKey();
+    if ( serviceManager.getServiceConfig( "gwt", key ) == null ) {
+      throw new GwtRpcProxyException( Messages.getInstance()
+        .getErrorString( "GwtRpcPluginProxyServlet.ERROR_0001_SERVICE_NOT_FOUND", key ) );
+    }
+
+    try {
+      return serviceManager.getServiceBean( "gwt", key );
+    } catch ( ServiceException e ) {
+      throw new GwtRpcProxyException( Messages.getInstance()
+        .getErrorString( "GwtRpcPluginProxyServlet.ERROR_0002_FAILED_TO_GET_BEAN_REFERENCE", key ), e );
+    }
+  }
+
+  @Nullable @Override
+  protected SerializationPolicy loadSerializationPolicy( @NonNull String moduleContextPath,
+                                                         @Nullable String strongName ) {
+    /*
+     * Plugin request path break down example.
+     *
+     * - moduleBaseURL = 'http://localhost:8080/pentaho/content/data-access/resources/gwt/'
+     * - modulePath = '/pentaho/content/data-access/resources/gwt/'
+     * - appContextPath = '/pentaho'
+     * - moduleContextPath = '/content/data-access/resources/gwt/'
+     * - pluginContextPath = '/data-access/resources/gwt/'
+     * - serializationPolicyFileName = '/data-access/resources/gwt/{strongName}.gwt.rpc'
+     */
+
+    // Special logic to use a spring defined SerializationPolicy for a plugin.
+    String pluginId = PluginUtil.getPluginIdFromPath( moduleContextPath );
+
+    SerializationPolicy serializationPolicy = PentahoSystem.get(
+      SerializationPolicy.class,
+      PentahoSessionHolder.getSession(),
+      Collections.singletonMap( "plugin", pluginId ) );
+    if ( serializationPolicy != null ) {
+      return serializationPolicy;
+    }
+
+    String serializationPolicyFileName = SerializationPolicyLoader.getSerializationPolicyFileName( strongName );
+    URL serializationPolicyUrl = getSerializationPolicyUrl( serializationPolicyFileName, moduleContextPath );
+
+    return serializationPolicyUrl != null
+      ? loadSerializationPolicyFromInputStream( getInputStreamSupplier( serializationPolicyUrl ),
+      serializationPolicyFileName )
+      : null;
+  }
+
+  // Visible For Testing
+  @NonNull
+  ThrowingSupplier<InputStream, IOException> getInputStreamSupplier( @NonNull URL inputStreamURL ) {
+    return inputStreamURL::openStream;
+  }
+
+  /**
+   * The request path is broken up for processing like so: Ex: given a request for serialization file at
+   * '/pentaho/content/data-access/resources/gwt/'
+   *
+   * @param serializationPolicyFilename the name of the serialization policy file that GWT is looking for
+   * @param moduleContextPath           according to the example url, this would be
+   *                                    '/content/data-access/resources/gwt/'
+   * @return a URL to the serialization policy file, or <code>null</code> if none applies, in which case the default
+   * serialization policy will apply
+   */
+  @Nullable
+  private URL getSerializationPolicyUrl( @NonNull String serializationPolicyFilename, String moduleContextPath ) {
+
+    ClassLoader serviceClassloader = PluginUtil.getClassLoaderForService( moduleContextPath );
+    if ( serviceClassloader == null ) {
+      // if we get here, then the service is not supplied by a plugin and thus we cannot hope to find
+      // the appropriate serialization policy.
+      logger.error( Messages.getInstance().getErrorString(
+        "GwtRpcPluginProxyServlet.ERROR_0005_FAILED_TO_FIND_PLUGIN", getAppContextPath() ) );
+      return null;
+    }
+
+    // We know what plugin is supposed to have the serialization policy file,
+    // now go find it in the plugin's filesystem.
+    IPluginResourceLoader resLoader =
+      PentahoSystem.get( IPluginResourceLoader.class, PentahoSessionHolder.getSession() );
+    List<URL> urls = resLoader.findResources( serviceClassloader, serializationPolicyFilename );
+    if ( urls.size() < 1 ) {
+      logger.error( Messages.getInstance().getErrorString(
+        "GwtRpcPluginProxyServlet.ERROR_0006_FAILED_TO_FIND_FILE", serializationPolicyFilename ) );
+      return null;
+    }
+
+    if ( urls.size() > 1 ) {
+      logger.warn( Messages.getInstance().getString(
+        "GwtRpcPluginProxyServlet.WARN_MULTIPLE_RESOURCES_FOUND", serializationPolicyFilename ) );
+    }
+
+    return urls.get( 0 );
+  }
+
+  /**
+   * Returns the dispatch key for this request. This name is the part of the request path beyond the servlet base path.
+   * I.e. if the GwtRpcPluginProxyServlet is mapped to the "/gwtrpc" context in web.xml, then this method will return
+   * "testservice" upon a request to "http://localhost:8080/pentaho/gwtrpc/testservice".
+   *
+   * @return the part of the request url used to dispatch the request
+   */
+  @NonNull
+  private String getServiceKey() {
+    // Path info will give us what we want with.
+    String requestPathInfo = getServletRequest().getPathInfo();
+    if ( requestPathInfo.startsWith( "/" ) ) {
+      requestPathInfo = requestPathInfo.substring( 1 );
+    }
+
+    if ( requestPathInfo.contains( "/" ) ) {
+      // if the request path happens to be multiple levels deep, return the last element in the path
+      String[] elements = requestPathInfo.split( "/" );
+      return elements[ elements.length - 1 ];
+    }
+
+    return requestPathInfo;
+  }
+
+  /**
+   * Gets the instance of {@link PluginGwtRpc} which is associated with the given HTTP request, creating one, if needed.
+   * <p>
+   * This method does not use a {@link IGwtRpcSerializationPolicyCache} which becomes associated to
+   * a created instance for retrieving the appropriate serialization policy.
+   * To specify a serialization policy cache, use the method
+   * {@link #getInstance(HttpServletRequest, IGwtRpcSerializationPolicyCache)}.
+   *
+   * @param httpRequest The HTTP request.
+   * @return The associated {@link PluginGwtRpc} instance.
+   */
+  @NonNull
+  public static PluginGwtRpc getInstance( @NonNull HttpServletRequest httpRequest ) {
+    return getInstance( httpRequest, null );
+  }
+
+  /**
+   * Gets the instance of {@link PluginGwtRpc} which is associated with the given HTTP request, creating one, if needed.
+   * <p>
+   * When the instance needs to be created, the given {@link IGwtRpcSerializationPolicyCache},
+   * via <code>serializationPolicyCache</code>, is associated with it.
+   *
+   * @param httpRequest              The HTTP request.
+   * @param serializationPolicyCache A serialization policy cache instance to initialize a created instance with.
+   * @return The associated {@link PluginGwtRpc} instance.
+   * @see AbstractGwtRpc#getInstance(HttpServletRequest, java.util.function.Function, IGwtRpcSerializationPolicyCache)
+   */
+  @NonNull
+  public static PluginGwtRpc getInstance( @NonNull HttpServletRequest httpRequest,
+                                          @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+    return getInstance( httpRequest, PluginGwtRpc::new, serializationPolicyCache );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/SystemGwtRpc.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/SystemGwtRpc.java
@@ -1,0 +1,194 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc;
+
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import com.google.gwt.user.server.rpc.SerializationPolicyLoader;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.services.messages.Messages;
+import org.pentaho.platform.web.servlet.GwtRpcProxyException;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.web.context.ConfigurableWebApplicationContext;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.web.context.support.XmlWebApplicationContext;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+
+/**
+ * The <code>SystemGwtRpc</code> class is a specialized GWT-RPC which can be used
+ * to handle remote calls to services of the Pentaho Platform itself, e.g. <code>/ws/gwt/serviceName</code>.
+ * <p>
+ * System GWT remote services must be registered in the Spring container file <code>pentahoServices.spring.xml</code>
+ * as a bean whose identifier has the structure: <code>ws-gwt-&lt;serviceName&gt;</code>.
+ * For example:
+ * <pre>
+ *
+ * &lt;bean id="ws-gwt-&lt;serviceName&gt;" /&gt;
+ * </pre>
+ * <p>
+ * This service would be exposed in the URL <code>/ws/gwt/&lt;serviceName&gt;</code>.
+ * <p>
+ * If the service name itself is composed of multiple sections, separated by <code>-</code>,
+ * these will be reflected in the service's URL.
+ * For example, if <code>&lt;serviceName&gt;</code> would be <code>products-manager</code>,
+ * then the remote service would be exposed in the URL <code>/ws/gwt/products/manager</code>.
+ * <p>
+ * System remote services load GWT serialization policies from the directory of the root class loader
+ * of the Pentaho web application.
+ * <p>
+ * For example, if the GWT module making the remote call lives at <code>/mantle</code>,
+ * then the serialization policy file name, given its strong name, would be:
+ * <code>/mantle/&lt;strongName&gt;.gwt.rpc</code>.
+ */
+public class SystemGwtRpc extends AbstractGwtRpc {
+
+  public SystemGwtRpc( @NonNull HttpServletRequest request ) {
+    super( request );
+  }
+
+  @NonNull @Override
+  protected Object resolveTarget() throws GwtRpcProxyException {
+
+    ApplicationContext beanFactory = createAppContext();
+
+    String beanId = getTargetBeanId();
+    if ( !beanFactory.containsBean( beanId ) ) {
+      throw new GwtRpcProxyException( Messages.getInstance()
+        .getErrorString( "GwtRpcProxyServlet.ERROR_0001_NO_BEAN_FOUND_FOR_SERVICE", beanId, getServletContextPath() ) );
+    }
+
+    try {
+      return beanFactory.getBean( beanId );
+    } catch ( BeansException ex ) {
+      throw new GwtRpcProxyException( Messages.getInstance()
+        .getErrorString( "GwtRpcProxyServlet.ERROR_0002_FAILED_TO_GET_BEAN_REFERENCE", beanId ), ex );
+    }
+  }
+
+  @Nullable @Override
+  protected SerializationPolicy loadSerializationPolicy( @NonNull String moduleContextPath,
+                                                         @Nullable String strongName ) {
+    /*
+     * System request path break down example.
+     *
+     * - moduleBaseURL = 'http://localhost:8080/pentaho/mantle/'
+     * - modulePath = '/pentaho/mantle/'
+     * - appContextPath = '/pentaho'
+     * - moduleContextPath = '/mantle/'
+     * - serializationPolicyFilePath = '/mantle/{strongName}.gwt.rpc'
+     */
+
+    String serializationPolicyFilePath = SerializationPolicyLoader.getSerializationPolicyFileName(
+      moduleContextPath + strongName );
+
+    return loadSerializationPolicyFromInputStream(
+      () -> getServletContext().getResourceAsStream( serializationPolicyFilePath ),
+      serializationPolicyFilePath );
+  }
+
+  // Visible For Testing
+  @NonNull
+  ApplicationContext createAppContext() {
+    WebApplicationContext parent = WebApplicationContextUtils.getRequiredWebApplicationContext( getServletContext() );
+
+    ConfigurableWebApplicationContext wac = new XmlWebApplicationContext() {
+      @Override
+      protected Resource getResourceByPath( @NonNull String path ) {
+        return new FileSystemResource( new File( path ) );
+      }
+    };
+
+    wac.setParent( parent );
+    wac.setServletContext( getServletContext() );
+
+    // This code was previously part of the GwtRpcProxyServlet class.
+    // There were/are really no known uses of this class.
+    // The only declared System, GWT-RPC service is /ws/gwt/unifiedRepository and is not used by any Pentaho code.
+    //
+
+    // No access to servlet config. Used to be passed, when this code was part of GwtRpcProxyServlet class.
+    // The GwtRpcProxyServlet servlet had no init parameters configured.
+    // wac.setServletConfig( getServletConfig() );
+
+    // J.I.C. Used to be created with getServerName(), in the GwtRpcProxyServlet class.
+    wac.setNamespace( "GwtRpcProxyServlet" );
+
+    String springFile = PentahoSystem.getApplicationContext()
+      .getSolutionPath( "system" + File.separator + "pentahoServices.spring.xml" );
+    wac.setConfigLocations( springFile );
+    wac.refresh();
+    return wac;
+  }
+
+  // Example
+  // servletContextPath = /ws/gwt/unifiedRepository
+  // targetBeanId = ws-gwt-unifiedRepository
+  @NonNull
+  private String getTargetBeanId() {
+    String servletContextPath = getServletContextPath();
+    if ( servletContextPath.startsWith( "/" ) ) {
+      servletContextPath = servletContextPath.substring( 1 );
+    }
+
+    return servletContextPath.replaceAll( "/", "-" );
+  }
+
+  /**
+   * Gets the instance of {@link SystemGwtRpc} which is associated with the given HTTP request,
+   * creating one, if needed.
+   * <p>
+   * This method does not use a {@link IGwtRpcSerializationPolicyCache} which becomes associated to
+   * a created instance for retrieving the appropriate serialization policy.
+   * To specify a serialization policy cache, use the method
+   * {@link #getInstance(HttpServletRequest, IGwtRpcSerializationPolicyCache)}.
+   *
+   * @param httpRequest The HTTP request.
+   * @return The associated {@link SystemGwtRpc} instance.
+   */
+  @NonNull
+  public static SystemGwtRpc getInstance( @NonNull HttpServletRequest httpRequest ) {
+    return getInstance( httpRequest, null );
+  }
+
+  /**
+   * Gets the instance of {@link SystemGwtRpc} which is associated with the given HTTP request,
+   * creating one, if needed.
+   * <p>
+   * When the instance needs to be created,
+   * the given {@link IGwtRpcSerializationPolicyCache}, via <code>serializationPolicyCache</code>,
+   * is associated with it.
+   *
+   * @param httpRequest              The HTTP request.
+   * @param serializationPolicyCache A serialization policy cache instance to initialize a
+   *                                 created instance with.
+   * @return The associated {@link SystemGwtRpc} instance.
+   * @see AbstractGwtRpc#getInstance(HttpServletRequest, java.util.function.Function, IGwtRpcSerializationPolicyCache)
+   */
+  @NonNull
+  public static SystemGwtRpc getInstance( @NonNull HttpServletRequest httpRequest,
+                                          @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+    return getInstance( httpRequest, SystemGwtRpc::new, serializationPolicyCache );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/impl/GwtRpcUtil.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/impl/GwtRpcUtil.java
@@ -1,0 +1,117 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.impl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.pentaho.platform.web.gwt.rpc.util.ThrowingSupplier;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Contains internal utility code that supports the implementation of the classes in the
+ * {@link org.pentaho.platform.web.gwt.rpc} namespace.
+ */
+public class GwtRpcUtil {
+  public static final String WEBAPP_ROOT_TOKEN = "WEBAPP_ROOT";
+  private static final Pattern WEBAPP_ROOT_PATH_PATTERN = Pattern.compile( "^/.*/WEBAPP_ROOT/" );
+
+  private GwtRpcUtil() {
+  }
+
+  /**
+   * Returns a new string which is equal to that specified in the <code>path</code> argument,
+   * except the first occurrence of <code>WEBAPP_ROOT</code> is replaced with the value of the
+   * <code>appContextPath</code> argument.
+   *
+   * @param path           The path in which to replace the web app token.
+   * @param appContextPath The value which replaces the web app token.
+   * @return A new string with the web app token replaced.
+   */
+  public static String scrubWebAppRoot( String path, String appContextPath ) {
+    if ( path.contains( WEBAPP_ROOT_TOKEN ) ) {
+      Matcher matcher = WEBAPP_ROOT_PATH_PATTERN.matcher( path );
+      if ( matcher.find() ) {
+        String garbagePathPart = matcher.group();
+        int index = path.indexOf( garbagePathPart );
+
+        return new StringBuffer( path )
+          .replace( index, index + garbagePathPart.length(), appContextPath )
+          .toString();
+      }
+    }
+
+    return path;
+  }
+
+  /**
+   * Calls a <code>supplier</code> having a given class loader, <code>classLoader</code>, as the current class loader
+   * of the current thread.
+   * <p>
+   * After calling the given supplier, the original current class loader of the current thread is restored,
+   * even in case the supplier throws an exception.
+   *
+   * @param classLoader The class loader.
+   * @param supplier    The supplier to call.
+   * @return The value returned by the supplier.
+   */
+  public static <T> T withClassLoader( @NonNull ClassLoader classLoader, @NonNull Supplier<T> supplier ) {
+    return withClassLoaderThrowing( classLoader, supplier::get );
+  }
+
+  /**
+   * Calls a throwing supplier, <code>supplier</code>, having a given class loader, <code>classLoader</code>, as the
+   * current class loader
+   * of the current thread.
+   * <p>
+   * After calling the given supplier, the original current class loader of the current thread is restored,
+   * even in case the supplier throws an exception.
+   *
+   * @param classLoader The class loader.
+   * @param supplier    The supplier to call.
+   * @return The value returned by the supplier.
+   * @throws E The exception thrown by the supplier, when called.
+   */
+  public static <T, E extends Throwable> T withClassLoaderThrowing( @NonNull ClassLoader classLoader,
+                                                                    @NonNull ThrowingSupplier<T, E> supplier )
+    throws E {
+
+    Objects.requireNonNull( classLoader );
+    Objects.requireNonNull( supplier );
+
+    ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      // Temporarily swap out the context classloader to the target class loader if
+      // the target has been loaded by one other than the context class loader.
+      // This is necessary, so the RPC class can do a Class.forName and find the service
+      // class specified in the request.
+      if ( classLoader != originalClassLoader ) {
+        Thread.currentThread().setContextClassLoader( classLoader );
+      }
+
+      return supplier.get();
+    } finally {
+      // Reset the context classloader, if necessary.
+      if ( ( classLoader != originalClassLoader ) && originalClassLoader != null ) {
+        Thread.currentThread().setContextClassLoader( originalClassLoader );
+      }
+    }
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/AbstractGwtRpcRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/AbstractGwtRpcRequestMatcher.java
@@ -1,0 +1,163 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.matcher;
+
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import com.hitachivantara.security.web.impl.model.matcher.RegexRequestMatcher;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.pentaho.platform.web.gwt.rpc.AbstractGwtRpc;
+import org.pentaho.platform.web.gwt.rpc.IGwtRpcSerializationPolicyCache;
+import org.pentaho.platform.web.servlet.GwtRpcProxyException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+/**
+ * The <code>AbstractGwtRpcRequestMatcher</code> class is the base class for GWT-RPC request matchers.
+ * <p>
+ * This request matcher class allows matching the GWT-RPC service method name of each request against a list of
+ * method names. The service method name is present in the request body, which is encoded in the GWT-RPC request format.
+ * <p>
+ * The abstract {@link #getGwtRpc(HttpServletRequest)} method is responsible for obtaining the {@link AbstractGwtRpc}
+ * object for the given request.
+ * <p>
+ * The service method name of the request is then obtained from the returned {@link AbstractGwtRpc} object.
+ * <p>
+ * Parsing the GWT-RPC request bodies requires a {@link SerializationPolicy} object, which is typically the result
+ * of loading a file from disk. To make this process performant, this class optionally accepts an instance of
+ * {@link IGwtRpcSerializationPolicyCache}, where these objects are stored and loaded from.
+ */
+public abstract class AbstractGwtRpcRequestMatcher extends RegexRequestMatcher {
+  /**
+   * The GWT RPC protocol only accepts POST requests. Let the other HTTP methods pass-through, because ultimately {@link
+   * com.google.gwt.user.server.rpc.RemoteServiceServlet} will reject the request. This also ensures that this class
+   * only tries to extract the method from the body when there's surely one.
+   */
+  private static final Collection<String> HTTP_METHODS_GWT_RPC = Collections.singletonList( HttpMethod.POST );
+
+  @NonNull
+  private final Collection<String> rpcMethodNames;
+
+  @Nullable
+  private final IGwtRpcSerializationPolicyCache serializationPolicyCache;
+
+  /**
+   * Constructs a GWT-RPC request matcher given a path pattern, collection of RPC method names,
+   * and a GWT-RPC serialization policy cache.
+   * <p>
+   * The request matcher created with this constructor applies matches the request path with the given pattern
+   * in a case-sensitive manner.
+   *
+   * @param pattern                  The request path pattern.
+   * @param rpcMethodNames           The collection of service method names
+   * @param serializationPolicyCache The serialization policy cache. Can be <code>null</code>,
+   *                                 in which case no caching occurs.
+   */
+  public AbstractGwtRpcRequestMatcher( @NonNull String pattern,
+                                       @NonNull Collection<String> rpcMethodNames,
+                                       @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+
+    super( pattern, HTTP_METHODS_GWT_RPC );
+
+    Objects.requireNonNull( rpcMethodNames );
+
+    this.rpcMethodNames = rpcMethodNames;
+    this.serializationPolicyCache = serializationPolicyCache;
+  }
+
+  /**
+   * Constructs a GWT-RPC request matcher given a path pattern, collection of RPC method names,
+   * and a GWT-RPC serialization policy cache.
+   *
+   * @param pattern                  The request path pattern.
+   * @param isCaseInsensitive        Indicates whether the request path pattern matches the given <code>pattern</code>
+   *                                 in a case-insensitive manner.
+   * @param rpcMethodNames           The collection of service method names
+   * @param serializationPolicyCache The serialization policy cache. Can be <code>null</code>,
+   *                                 in which case no caching occurs.
+   */
+  public AbstractGwtRpcRequestMatcher( @NonNull String pattern,
+                                       boolean isCaseInsensitive,
+                                       @NonNull Collection<String> rpcMethodNames,
+                                       @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+
+    super( pattern, HTTP_METHODS_GWT_RPC, isCaseInsensitive );
+
+    Objects.requireNonNull( rpcMethodNames );
+
+    this.rpcMethodNames = rpcMethodNames;
+    this.serializationPolicyCache = serializationPolicyCache;
+  }
+
+  /**
+   * Gets the serialization policy cache, if any.
+   */
+  @Nullable
+  public IGwtRpcSerializationPolicyCache getSerializationPolicyCache() {
+    return serializationPolicyCache;
+  }
+
+  /**
+   * Gets the collection of matching GWT-RPC service method names.
+   */
+  @NonNull
+  public Collection<String> getRpcMethodNames() {
+    return rpcMethodNames;
+  }
+
+  @Override
+  public boolean test( @NonNull HttpServletRequest httpRequest ) {
+    return super.test( httpRequest ) && rpcMethodNames.contains( getRpcMethodName( httpRequest ) );
+  }
+
+  /**
+   * Gets the {@link AbstractGwtRpc} instance associated with the given request,
+   * creating one if it has not yet been created.
+   *
+   * @param httpRequest The HTTP request.
+   * @return The associated {@link AbstractGwtRpc} instance.
+   * @throws GwtRpcProxyException if the {@link AbstractGwtRpc} instance fails to be created.
+   */
+  @NonNull
+  protected abstract AbstractGwtRpc getGwtRpc( @NonNull HttpServletRequest httpRequest );
+
+  // Visible For Testing
+  /**
+   * Obtains the GWT-RPC service method name associated with the given HTTP request.
+   *
+   * If calling {@link #getGwtRpc(HttpServletRequest)} fails with a {@link GwtRpcProxyException},
+   * then this method returns an empty string. This special method name cannot match any actual method.
+   *
+   * @param httpRequest The HTTP request.
+   * @return The service method name, if successful; an empty string, otherwise.
+   */
+  @NonNull
+  String getRpcMethodName( @NonNull HttpServletRequest httpRequest ) {
+    try {
+      return getGwtRpc( httpRequest ).getRequest().getMethod().getName();
+    } catch ( GwtRpcProxyException ex ) {
+      // Exception is already logged.
+      // Causes match to fail.
+      return "";
+    }
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/PluginGwtRpcRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/PluginGwtRpcRequestMatcher.java
@@ -36,14 +36,14 @@ import java.util.Collection;
 public class PluginGwtRpcRequestMatcher extends AbstractGwtRpcRequestMatcher {
 
   public PluginGwtRpcRequestMatcher( @NonNull String pattern,
-                                     @NonNull Collection<String> rpcMethods,
+                                     @Nullable Collection<String> rpcMethods,
                                      @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
     super( pattern, rpcMethods, serializationPolicyCache );
   }
 
   public PluginGwtRpcRequestMatcher( @NonNull String pattern,
                                      boolean isCaseInsensitive,
-                                     @NonNull Collection<String> rpcMethods,
+                                     @Nullable Collection<String> rpcMethods,
                                      @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
     super( pattern, isCaseInsensitive, rpcMethods, serializationPolicyCache );
   }

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/PluginGwtRpcRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/PluginGwtRpcRequestMatcher.java
@@ -15,7 +15,7 @@
  * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  */
 
-package org.pentaho.platform.web.servlet;
+package org.pentaho.platform.web.gwt.rpc.matcher;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -24,22 +24,32 @@ import org.pentaho.platform.web.gwt.rpc.IGwtRpcSerializationPolicyCache;
 import org.pentaho.platform.web.gwt.rpc.PluginGwtRpc;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Collection;
 
 /**
- * This is the plugin variant of the GwtRpcProxyServlet. This servlet routes incoming GWT RPC requests to POJOs found in
- * a plugin lib.
+ * The <code>PluginGwtRpcRequestMatcher</code> class is a specialized GWT-RPC request matcher
+ * which can be used to match URLs of GWT-RPC services of Pentaho Platform plugins (e.g.
+ * <code>/gwtrpc/serviceName</code>).
+ *
+ * @see PluginGwtRpc
  */
-public class GwtRpcPluginProxyServlet extends AbstractGwtRpcProxyServlet {
-  public GwtRpcPluginProxyServlet() {
-    super();
+public class PluginGwtRpcRequestMatcher extends AbstractGwtRpcRequestMatcher {
+
+  public PluginGwtRpcRequestMatcher( @NonNull String pattern,
+                                     @NonNull Collection<String> rpcMethods,
+                                     @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+    super( pattern, rpcMethods, serializationPolicyCache );
   }
 
-  public GwtRpcPluginProxyServlet( @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
-    super( serializationPolicyCache );
+  public PluginGwtRpcRequestMatcher( @NonNull String pattern,
+                                     boolean isCaseInsensitive,
+                                     @NonNull Collection<String> rpcMethods,
+                                     @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+    super( pattern, isCaseInsensitive, rpcMethods, serializationPolicyCache );
   }
-  
+
   @NonNull @Override
-  protected AbstractGwtRpc getRpc( @NonNull HttpServletRequest httpRequest ) {
+  protected AbstractGwtRpc getGwtRpc( @NonNull HttpServletRequest httpRequest ) {
     return PluginGwtRpc.getInstance( httpRequest, getSerializationPolicyCache() );
   }
 }

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/SystemGwtRpcRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/SystemGwtRpcRequestMatcher.java
@@ -15,7 +15,7 @@
  * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  */
 
-package org.pentaho.platform.web.servlet;
+package org.pentaho.platform.web.gwt.rpc.matcher;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -24,23 +24,32 @@ import org.pentaho.platform.web.gwt.rpc.IGwtRpcSerializationPolicyCache;
 import org.pentaho.platform.web.gwt.rpc.SystemGwtRpc;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Collection;
 
 /**
- * This servlet is the traffic cop for GWT services core to the BIServer. See pentahoServices.spring.xml for bean
- * definitions referenced by this servlet.
+ * The <code>SystemGwtRpcRequestMatcher</code> class is a specialized GWT-RPC request matcher
+ * which can be used to match URLs of GWT-RPC services of the Pentaho Platform itself (e.g.
+ * <code>/ws/gwt/serviceName</code>).
+ *
+ * @see SystemGwtRpc
  */
-public class GwtRpcProxyServlet extends AbstractGwtRpcProxyServlet {
+public class SystemGwtRpcRequestMatcher extends AbstractGwtRpcRequestMatcher {
 
-  public GwtRpcProxyServlet() {
-    super();
+  public SystemGwtRpcRequestMatcher( @NonNull String pattern,
+                                     @NonNull Collection<String> rpcMethods,
+                                     @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+    super( pattern, rpcMethods, serializationPolicyCache );
   }
 
-  public GwtRpcProxyServlet( @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
-    super( serializationPolicyCache );
+  public SystemGwtRpcRequestMatcher( @NonNull String pattern,
+                                     boolean isCaseInsensitive,
+                                     @NonNull Collection<String> rpcMethods,
+                                     @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+    super( pattern, isCaseInsensitive, rpcMethods, serializationPolicyCache );
   }
 
   @NonNull @Override
-  protected AbstractGwtRpc getRpc( @NonNull HttpServletRequest httpRequest ) {
+  protected AbstractGwtRpc getGwtRpc( @NonNull HttpServletRequest httpRequest ) {
     return SystemGwtRpc.getInstance( httpRequest, getSerializationPolicyCache() );
   }
 }

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/SystemGwtRpcRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/matcher/SystemGwtRpcRequestMatcher.java
@@ -36,14 +36,14 @@ import java.util.Collection;
 public class SystemGwtRpcRequestMatcher extends AbstractGwtRpcRequestMatcher {
 
   public SystemGwtRpcRequestMatcher( @NonNull String pattern,
-                                     @NonNull Collection<String> rpcMethods,
+                                     @Nullable Collection<String> rpcMethods,
                                      @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
     super( pattern, rpcMethods, serializationPolicyCache );
   }
 
   public SystemGwtRpcRequestMatcher( @NonNull String pattern,
                                      boolean isCaseInsensitive,
-                                     @NonNull Collection<String> rpcMethods,
+                                     @Nullable Collection<String> rpcMethods,
                                      @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
     super( pattern, isCaseInsensitive, rpcMethods, serializationPolicyCache );
   }

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/spring/xml/GwtRpcNamespaceHandler.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/spring/xml/GwtRpcNamespaceHandler.java
@@ -1,0 +1,28 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.spring.xml;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+public class GwtRpcNamespaceHandler extends NamespaceHandlerSupport {
+  @Override
+  public void init() {
+    registerBeanDefinitionParser( "plugin-gwt-rpc-request-matcher", new GwtRpcRequestMatcherParser( true ) );
+    registerBeanDefinitionParser( "system-gwt-rpc-request-matcher", new GwtRpcRequestMatcherParser( false ) );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/spring/xml/GwtRpcRequestMatcherParser.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/spring/xml/GwtRpcRequestMatcherParser.java
@@ -1,0 +1,75 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.spring.xml;
+
+import org.pentaho.platform.web.gwt.rpc.matcher.PluginGwtRpcRequestMatcher;
+import org.pentaho.platform.web.gwt.rpc.matcher.SystemGwtRpcRequestMatcher;
+import org.pentaho.platform.web.gwt.rpc.support.GwtRpcSerializationPolicyCache;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.w3c.dom.Element;
+
+import java.util.Arrays;
+import java.util.List;
+
+class GwtRpcRequestMatcherParser extends AbstractBeanDefinitionParser {
+
+  private final boolean isPlugin;
+
+  public GwtRpcRequestMatcherParser( boolean isPlugin ) {
+    this.isPlugin = isPlugin;
+  }
+
+  @Override
+  protected AbstractBeanDefinition parseInternal( Element element, ParserContext parserContext ) {
+
+    String pattern = element.getAttribute( "pattern" );
+    String rpcMethods = element.getAttribute( "methods" );
+
+    // Defaults to false, if not present.
+    boolean isCaseInsensitive = Boolean.parseBoolean( element.getAttribute( "insensitive" ) );
+
+    if ( pattern.equals( "" ) ) {
+      // throws
+      parserContext.getReaderContext().fatal(
+        "'pattern' attribute is empty or unspecified.",
+        element );
+    }
+
+    List<String> rpcMethodsList = null;
+    if ( !rpcMethods.equals( "" ) ) {
+      rpcMethodsList = Arrays.asList( rpcMethods.split( "\\s+" ) );
+    }
+
+    BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition( getBeanClass() );
+    builder.addConstructorArgValue( pattern );
+    builder.addConstructorArgValue( isCaseInsensitive );
+    builder.addConstructorArgValue( rpcMethodsList );
+
+    // TODO: Accepts a ref to a shared policy cache? Or, use a single, bounded cache?
+    builder.addConstructorArgValue( new GwtRpcSerializationPolicyCache() );
+
+    return builder.getBeanDefinition();
+  }
+
+  private Class<?> getBeanClass() {
+    return isPlugin ? PluginGwtRpcRequestMatcher.class : SystemGwtRpcRequestMatcher.class;
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/support/GwtRpcSerializationPolicyCache.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/support/GwtRpcSerializationPolicyCache.java
@@ -1,0 +1,59 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.support;
+
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import com.google.gwt.user.server.rpc.SerializationPolicyProvider;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.pentaho.platform.web.gwt.rpc.IGwtRpcSerializationPolicyCache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The <code>GwtRpcSerializationPolicyCache</code> class is a basic in-memory, multi-threaded implementation of
+ * the {@link IGwtRpcSerializationPolicyCache} interface.
+ */
+public class GwtRpcSerializationPolicyCache implements IGwtRpcSerializationPolicyCache {
+  @NonNull
+  private final Map<String, SerializationPolicy> serializationPolicyCache = new ConcurrentHashMap<>();
+
+  @NonNull @Override
+  public SerializationPolicy getSerializationPolicy( @Nullable String moduleBaseURL,
+                                                     @Nullable String strongName,
+                                                     @NonNull SerializationPolicyProvider sourceProvider ) {
+
+    String key = moduleBaseURL + strongName;
+
+    SerializationPolicy serializationPolicy = serializationPolicyCache.get( key );
+    if ( serializationPolicy != null ) {
+      return serializationPolicy;
+    }
+
+    serializationPolicy = sourceProvider.getSerializationPolicy( moduleBaseURL, strongName );
+    if ( serializationPolicy == null ) {
+      throw new RuntimeException(
+        "Serialization Policy Provider returned null for " + moduleBaseURL + " " + strongName + "." );
+    }
+
+    serializationPolicyCache.put( key, serializationPolicy );
+
+    return serializationPolicy;
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/util/ThrowingSupplier.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/gwt/rpc/util/ThrowingSupplier.java
@@ -1,0 +1,33 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.util;
+
+/**
+ * The <code>ThrowingSupplier</code> represents a supplier of a value, of type <code>T</code> which,
+ * when failing, throws an exception of type <code>E</code>.
+ * @param <T> The type of value returned.
+ * @param <E> The type of value thrown when it is not possible to obtain the value.
+ */
+public interface ThrowingSupplier<T, E extends Throwable> {
+  /**
+   * Gets the value.
+   * @return The value, possibly <code>null</code>.
+   * @throws E When it is not possible to obtain the value.
+   */
+  T get() throws E;
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/AbstractGwtRpcProxyServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/AbstractGwtRpcProxyServlet.java
@@ -1,5 +1,4 @@
 /*!
- *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -14,141 +13,93 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
- *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.platform.web.servlet;
 
-import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
 import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.gwt.user.server.rpc.RPC;
-import com.google.gwt.user.server.rpc.RPCRequest;
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
+import com.google.gwt.user.server.rpc.SerializationPolicy;
 import com.google.gwt.user.server.rpc.impl.StandardSerializationPolicy;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.pentaho.platform.web.servlet.messages.Messages;
+import org.pentaho.platform.web.gwt.rpc.AbstractGwtRpc;
+import org.pentaho.platform.web.gwt.rpc.support.GwtRpcSerializationPolicyCache;
+import org.pentaho.platform.web.gwt.rpc.IGwtRpcSerializationPolicyCache;
 
 import javax.servlet.http.HttpServletRequest;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings( "serial" )
 /**
- * Base class for GWT RPC proxying servlets, which allows developers to write GWT Services as Pojos and have 
- * the GWT client POST requests to subclasses of this class.
+ * Base class for GWT RPC proxying servlets, which allows developers to write GWT Services as Pojos and have the GWT
+ * client POST requests to subclasses of this class.
  */
 public abstract class AbstractGwtRpcProxyServlet extends RemoteServiceServlet {
 
   private static final Log logger = LogFactory.getLog( AbstractGwtRpcProxyServlet.class );
 
-  public AbstractGwtRpcProxyServlet() {
-    super();
+  @NonNull
+  private final IGwtRpcSerializationPolicyCache serializationPolicyCache;
+
+  protected AbstractGwtRpcProxyServlet() {
+    this( null );
   }
 
-  /**
-   * Resolve the target impl that ultimately handles the GWT RPC request, provided a key.
-   * 
-   * @param servletContextPath
-   *          the portion of the http request path beyond the servlet context, used to uniquely identify the target impl
-   * @return the object that handles the request
-   * @throws GwtRpcProxyException
-   *           if no target can be found
-   */
-  protected abstract Object resolveDispatchTarget( String servletContextPath );
+  protected AbstractGwtRpcProxyServlet( @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+    this.serializationPolicyCache = serializationPolicyCache != null
+      ? serializationPolicyCache
+      : new GwtRpcSerializationPolicyCache();
+  }
+
+  @NonNull
+  public IGwtRpcSerializationPolicyCache getSerializationPolicyCache() {
+    return serializationPolicyCache;
+  }
 
   protected void doUnexpectedFailure( Throwable e ) {
     super.doUnexpectedFailure( e );
     logger.error( e );
   }
 
-  /**
-   * Returns the dispatch key for this request. This name is the part of the request path beyond the servlet base path.
-   * I.e. if the GwtRpcPluginProxyServlet is mapped to the "/gwtrpc" context in web.xml, then this method will return
-   * "testservice" upon a request to "http://localhost:8080/pentaho/gwtrpc/testservice".
-   * 
-   * @return the part of the request url used to dispatch the request
-   */
-  protected String getDispatchKey() {
-    HttpServletRequest request = getThreadLocalRequest();
-    // path info will give us what we want with
-    String requestPathInfo = request.getPathInfo();
-    if ( requestPathInfo.startsWith( "/" ) ) { //$NON-NLS-1$
-      requestPathInfo = requestPathInfo.substring( 1 );
-    }
-    if ( requestPathInfo.contains( "/" ) ) { //$NON-NLS-1$
-      // if the request path happens to be multiple levels deep, return the last element in the path
-      String[] elements = requestPathInfo.split( "/" ); //$NON-NLS-1$
-      return elements[elements.length - 1];
-    }
-    return requestPathInfo;
-  }
+  @NonNull
+  protected abstract AbstractGwtRpc getRpc( @NonNull HttpServletRequest httpRequest );
 
-  @SuppressWarnings( "nls" )
-  protected String getServletContextPath() {
-    HttpServletRequest request = getThreadLocalRequest();
-    String path = request.getServletPath() + "/" + request.getPathInfo();
-    if ( path.contains( "//" ) ) {
-      path = path.replaceAll( "//", "/" );
-    }
-    return path;
+  @Override
+  protected String readContent( HttpServletRequest httpRequest ) {
+    return getRpc( httpRequest ).getRequestPayload();
   }
 
   @Override
-  public String processCall( String payload ) throws SerializationException {
-    Map<Class<?>, Boolean> whitelist = new HashMap<Class<?>, Boolean>();
-    whitelist.put( GwtRpcProxyException.class, Boolean.TRUE );
-    Map<Class<?>, String> obfuscatedTypeIds = new HashMap<Class<?>, String>();
-    StandardSerializationPolicy policy = new StandardSerializationPolicy( whitelist, whitelist, obfuscatedTypeIds );
+  public String processCall( String requestPayload ) throws SerializationException {
 
-    String servletContextPath = getServletContextPath();
+    checkPermutationStrongName();
 
-    Object target = null;
     try {
-      target = resolveDispatchTarget( servletContextPath );
+      return getRpc( getThreadLocalRequest() ).invoke();
     } catch ( GwtRpcProxyException ex ) {
-      logger.error( Messages.getInstance().getErrorString(
-          "AbstractGwtRpcProxyServlet.ERROR_0001_FAILED_TO_RESOLVE_DISPATCH_TARGET", servletContextPath ), ex ); //$NON-NLS-1$
-      return RPC.encodeResponseForFailure( null, ex, policy );
+      return RPC.encodeResponseForFailure( null, ex, getBasicSerializationPolicy() );
     }
+  }
 
-    final ClassLoader origLoader = Thread.currentThread().getContextClassLoader();
-    final ClassLoader altLoader = target.getClass().getClassLoader();
+  @Override
+  protected SerializationPolicy doGetSerializationPolicy( HttpServletRequest request,
+                                                          String moduleBaseURL,
+                                                          String strongName ) {
+    throw new UnsupportedOperationException( "Class is not being used as SerializationPolicyProvider" );
+  }
 
-    try {
-      // temporarily swap out the context classloader to an alternate classloader if
-      // the targetBean has been loaded by one other than the context classloader.
-      // This is necessary, so the RPC class can do a Class.forName and find the service
-      // class specified in the request
-      if ( altLoader != origLoader ) {
-        Thread.currentThread().setContextClassLoader( altLoader );
-      }
+  @NonNull
+  static StandardSerializationPolicy getBasicSerializationPolicy() {
+    Map<Class<?>, Boolean> whitelist = new HashMap<>();
+    whitelist.put( GwtRpcProxyException.class, Boolean.TRUE );
 
-      RPCRequest rpcRequest = RPC.decodeRequest( payload, null, this );
-      onAfterRequestDeserialized( rpcRequest );
-      // don't require the server side to implement the service interface
-      Method method = rpcRequest.getMethod();
-      try {
-        Method m = target.getClass().getMethod( method.getName(), method.getParameterTypes() );
-        if ( m != null ) {
-          method = m;
-        }
-      } catch ( Exception e ) {
-        e.printStackTrace();
-      }
-      return RPC.invokeAndEncodeResponse( target, method, rpcRequest.getParameters(), rpcRequest
-          .getSerializationPolicy() );
-    } catch ( IncompatibleRemoteServiceException ex ) {
-      logger.error( Messages.getInstance().getErrorString(
-          "AbstractGwtRpcProxyServlet.ERROR_0003_RPC_INVOCATION_FAILED", target.getClass().getName() ), ex ); //$NON-NLS-1$
-      return RPC.encodeResponseForFailure( null, ex );
-    } finally {
-      // reset the context classloader if necessary
-      if ( ( altLoader != origLoader ) && origLoader != null ) {
-        Thread.currentThread().setContextClassLoader( origLoader );
-      }
-    }
+    Map<Class<?>, String> obfuscatedTypeIds = new HashMap<>();
+
+    return new StandardSerializationPolicy( whitelist, whitelist, obfuscatedTypeIds );
   }
 }

--- a/extensions/src/main/resources/META-INF/spring.handlers
+++ b/extensions/src/main/resources/META-INF/spring.handlers
@@ -1,0 +1,1 @@
+http\://www.pentaho.com/schema/pentaho-gwt-rpc-spring=org.pentaho.platform.web.gwt.rpc.spring.xml.GwtRpcNamespaceHandler

--- a/extensions/src/main/resources/META-INF/spring.schemas
+++ b/extensions/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,2 @@
+http\://www.pentaho.com/schema/pentaho-gwt-rpc-spring.xsd=org/pentaho/platform/web/gwt/rpc/spring/schema-1.0.xsd
+http\://www.pentaho.com/schema/pentaho-gwt-rpc-spring-1.0.xsd=org/pentaho/platform/web/gwt/rpc/spring/schema-1.0.xsd

--- a/extensions/src/main/resources/org/pentaho/platform/web/gwt/rpc/spring/schema-1.0.xsd
+++ b/extensions/src/main/resources/org/pentaho/platform/web/gwt/rpc/spring/schema-1.0.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:pen-gpc="http://www.pentaho.com/schema/pentaho-gwt-rpc-spring"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:beans="http://www.springframework.org/schema/beans"
+            targetNamespace="http://www.pentaho.com/schema/pentaho-gwt-rpc-spring"
+            elementFormDefault="qualified">
+
+  <xsd:import namespace="http://www.springframework.org/schema/beans"/>
+
+  <!-- region Request Matchers -->
+  <!--
+    Example:
+    <pen-gpc:system-gwt-rpc-request-matcher
+        pattern="^/ws/gwt/unifiedRepository\b.*"
+        methods="deleteFile deleteFileAtVersion lockFile" />
+  -->
+  <xsd:element name="system-gwt-rpc-request-matcher" type="pen-gpc:TGwtRpcRequestMatcher" id="system-gwt-rpc-request-matcher"/>
+
+  <!--
+    Example:
+    <pen-gpc:plugin-gwt-rpc-request-matcher
+        pattern="^/gwtrpc/DatasourceService\b.*"
+        methods="deleteLogicalModel" />
+  -->
+  <xsd:element name="plugin-gwt-rpc-request-matcher" type="pen-gpc:TGwtRpcRequestMatcher" id="plugin-gwt-rpc-request-matcher"/>
+
+  <xsd:complexType name="TAbstractRequestMatcher" abstract="true">
+    <xsd:complexContent>
+      <xsd:extension base="beans:identifiedType">
+        <!-- Copied from Spring beans schema -->
+        <xsd:attribute name="name" type="xsd:string">
+          <xsd:annotation>
+            <xsd:documentation><![CDATA[
+  Can be used to create one or more aliases illegal in an (XML) id.
+  Multiple aliases can be separated by any number of spaces, commas,
+  or semi-colons (or indeed any mixture of the three).
+        ]]></xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TGwtRpcRequestMatcher">
+    <xsd:complexContent>
+      <xsd:extension base="pen-gpc:TAbstractRequestMatcher">
+        <xsd:attribute name="pattern" type="xsd:string" use="required"/>
+        <xsd:attribute name="methods" type="pen-gpc:TGwtRpcMethods" use="required"/>
+        <xsd:attribute name="insensitive" type="xsd:boolean"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <!--
+    Examples:
+    saveLocales
+  -->
+  <xsd:simpleType name="TGwtRpcMethod">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="\w+"/>
+      <xsd:whiteSpace value="replace"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="TGwtRpcMethods">
+    <xsd:restriction>
+      <xsd:simpleType>
+        <xsd:list itemType="pen-gpc:TGwtRpcMethod"/>
+      </xsd:simpleType>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- endregion Request Matchers -->
+
+</xsd:schema>

--- a/extensions/src/main/resources/org/pentaho/platform/web/servlet/messages/messages.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/web/servlet/messages/messages.properties
@@ -149,6 +149,7 @@ GenericServlet.ERROR_0004_RESOURCE_NOT_FOUND=Resource {1} not found in plugin {0
 GenericServlet.ERROR_0005_NO_RESOURCE_SPECIFIED=No resource specified at this URL
 
 AbstractGwtRpcProxyServlet.ERROR_0001_FAILED_TO_RESOLVE_DISPATCH_TARGET=Failed to find a dispatch target class for request context path {0}
+AbstractGwtRpcProxyServlet.ERROR_0002_RPC_INVALID_REQUEST=RPC request is invalid.
 AbstractGwtRpcProxyServlet.ERROR_0003_RPC_INVOCATION_FAILED=RPC invocation on target service {0} failed.
 GwtRpcPluginProxyServlet.ERROR_0004_MALFORMED_URL=Malformed moduleBaseURL {0}
 GwtRpcPluginProxyServlet.ERROR_0007_FAILED_TO_OPEN_FILE=Could not open serialization file {0}.
@@ -159,6 +160,7 @@ GwtRpcPluginProxyServlet.ERROR_0005_FAILED_TO_FIND_PLUGIN=Could not find a plugi
 GwtRpcPluginProxyServlet.ERROR_0006_FAILED_TO_FIND_FILE=failed to get serialization policy file {0} from the plugin resource loader.
 GwtRpcPluginProxyServlet.WARN_MULTIPLE_RESOURCES_FOUND=More than one serialization policy file found called {0}.  Using first one.
 GwtRpcProxyServlet.ERROR_0001_NO_BEAN_FOUND_FOR_SERVICE=No bean with id {0} found for service {1}
+GwtRpcProxyServlet.ERROR_0002_FAILED_TO_GET_BEAN_REFERENCE=Failed to get a reference to service bean {0}
 
 
 PentahoGeneral.USER_FEATURE_DISABLED=This feature is disabled.

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/AbstractGwtRpcTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/AbstractGwtRpcTest.java
@@ -1,0 +1,967 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc;
+
+import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.SerializationException;
+import com.google.gwt.user.server.rpc.RPC;
+import com.google.gwt.user.server.rpc.RPCRequest;
+import com.google.gwt.user.server.rpc.RPCServletUtils;
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import com.google.gwt.user.server.rpc.SerializationPolicyLoader;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.pentaho.platform.web.gwt.rpc.impl.GwtRpcUtil;
+import org.pentaho.platform.web.gwt.rpc.util.ThrowingSupplier;
+import org.pentaho.platform.web.servlet.GwtRpcProxyException;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.text.ParseException;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( {
+  RPCServletUtils.class,
+  RPC.class,
+  LogFactory.class,
+  AbstractGwtRpc.class,
+  GwtRpcUtil.class,
+  SerializationPolicyLoader.class } )
+public class AbstractGwtRpcTest {
+
+  private final String HTTP_GWT_RPC_ATTRIBUTE = AbstractGwtRpc.HTTP_GWT_RPC_ATTRIBUTE;
+
+  private static Log loggerMock;
+
+  // region Helpers
+  static class TestGwtRpc extends AbstractGwtRpc {
+
+    public TestGwtRpc( @NonNull HttpServletRequest httpRequest ) {
+      super( httpRequest );
+    }
+
+    @NonNull @Override
+    protected Object resolveTarget() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Nullable @Override
+    protected SerializationPolicy loadSerializationPolicy( @NonNull String moduleContextPath,
+                                                           @Nullable String strongName ) {
+      throw new UnsupportedOperationException();
+    }
+  }
+  // endregion
+
+  @BeforeClass
+  public static void beforeAll() {
+
+    mockStatic( LogFactory.class );
+
+    loggerMock = mock( Log.class );
+
+    when( LogFactory.getLog( AbstractGwtRpc.class ) ).thenReturn( loggerMock );
+  }
+
+  @After
+  public void afterEach() {
+    reset( loggerMock );
+  }
+
+  // region Servlet
+  @Test
+  public void testGetServletRequest() {
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    assertEquals( httpRequestMock, gwtRpc.getServletRequest() );
+  }
+
+  @Test
+  public void testGetServletContext() {
+    ServletContext servletContextMock = mock( ServletContext.class );
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    when( httpRequestMock.getServletContext() ).thenReturn( servletContextMock );
+
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    assertEquals( servletContextMock, gwtRpc.getServletContext() );
+  }
+
+  @Test
+  public void testGetAppContextPath() {
+    String appContextPath = "PATH";
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    when( httpRequestMock.getContextPath() ).thenReturn( appContextPath );
+
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    assertEquals( appContextPath, gwtRpc.getAppContextPath() );
+  }
+
+  @Test
+  public void testGetServletContextPath() {
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    when( httpRequestMock.getServletPath() ).thenReturn( "/A" );
+
+    // ---
+
+    when( httpRequestMock.getPathInfo() ).thenReturn( "/B" );
+    assertEquals( "/A/B", gwtRpc.getServletContextPath() );
+
+    when( httpRequestMock.getPathInfo() ).thenReturn( "B" );
+    assertEquals( "/A/B", gwtRpc.getServletContextPath() );
+  }
+  // endregion
+
+  // region SerializationPolicyCache
+  @Test
+  public void testDefaultSerializationPolicyCacheIsNull() {
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    assertNull( gwtRpc.getSerializationPolicyCache() );
+  }
+
+  @Test
+  public void testSetAndGetSerializationPolicyCache() {
+
+    IGwtRpcSerializationPolicyCache cache = mock( IGwtRpcSerializationPolicyCache.class );
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    gwtRpc.setSerializationPolicyCache( cache );
+
+    assertEquals( cache, gwtRpc.getSerializationPolicyCache() );
+  }
+  // endregion
+
+  // region Request Payload
+  @Test
+  public void testGetRequestPayloadFirstTime() throws ServletException, IOException {
+    String requestPayload = "REQUEST_PAYLOAD";
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    mockStatic( RPCServletUtils.class );
+    when( RPCServletUtils.readContentAsGwtRpc( any() ) ).thenReturn( requestPayload );
+
+    String result = gwtRpc.getRequestPayload();
+
+    assertEquals( requestPayload, result );
+  }
+
+  @Test
+  public void testGetRequestPayloadSecondTimeIsCached() throws ServletException, IOException {
+    String requestPayload = "REQUEST_PAYLOAD";
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    mockStatic( RPCServletUtils.class );
+    when( RPCServletUtils.readContentAsGwtRpc( any() ) ).thenReturn( requestPayload );
+
+    gwtRpc.getRequestPayload();
+
+    String result = gwtRpc.getRequestPayload();
+
+    assertEquals( requestPayload, result );
+
+    verifyStatic( times( 1 ) );
+    RPCServletUtils.readContentAsGwtRpc( any() );
+  }
+
+  @Test
+  public void testGetRequestPayloadLogsAndWrapsThrownIOException() throws ServletException, IOException {
+    IOException error = mock( IOException.class );
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    mockStatic( RPCServletUtils.class );
+    when( RPCServletUtils.readContentAsGwtRpc( any() ) ).thenThrow( error );
+
+    try {
+      gwtRpc.getRequestPayload();
+
+      fail();
+    } catch ( GwtRpcProxyException ex ) {
+      assertEquals( error, ex.getCause() );
+      verify( loggerMock, times( 1 ) ).error( anyString(), eq( error ) );
+    }
+  }
+
+  @Test
+  public void testGetRequestPayloadLogsAndWrapsThrownServletException() throws ServletException, IOException {
+    ServletException error = mock( ServletException.class );
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    mockStatic( RPCServletUtils.class );
+    when( RPCServletUtils.readContentAsGwtRpc( any() ) ).thenThrow( error );
+
+    try {
+      gwtRpc.getRequestPayload();
+
+      fail();
+    } catch ( GwtRpcProxyException ex ) {
+      assertEquals( error, ex.getCause() );
+      verify( loggerMock, times( 1 ) ).error( anyString(), eq( error ) );
+    }
+  }
+  // endregion
+
+  // region Target
+  @Test
+  public void testGetTargetFirstTime() {
+    Object target = new Object();
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( target ).when( gwtRpcSpy ).resolveTarget();
+
+    Object result = gwtRpcSpy.getTarget();
+
+    assertEquals( target, result );
+  }
+
+  @Test
+  public void testGetTargetSecondTimeIsCached() {
+    Object target = new Object();
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( target ).when( gwtRpcSpy ).resolveTarget();
+
+    gwtRpcSpy.getTarget();
+
+    Object result = gwtRpcSpy.getTarget();
+
+    assertEquals( target, result );
+
+    verify( gwtRpcSpy, times( 1 ) ).resolveTarget();
+  }
+
+  @Test
+  public void testGetTargetLogsAndRethrowsGwtRpcException() {
+    // Mocking the exception does not work with doThrow...
+    // Spies require doThrow instead of thenThrow.
+    // mock( GwtRpcProxyException.class );
+    GwtRpcProxyException error = new GwtRpcProxyException();
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doThrow( error ).when( gwtRpcSpy ).resolveTarget();
+    try {
+      gwtRpcSpy.getTarget();
+
+      fail();
+    } catch ( GwtRpcProxyException ex ) {
+      assertEquals( error, ex );
+      verify( loggerMock, times( 1 ) ).error( anyString(), eq( ex ) );
+    }
+  }
+
+  @Test
+  public void testGetTargetClassLoader() {
+    // new Object() would have a null class loader...
+    Object target = this;
+    ClassLoader classLoader = this.getClass().getClassLoader();
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( target ).when( gwtRpcSpy ).getTarget();
+
+    Object result = gwtRpcSpy.getTargetClassLoader();
+
+    assertEquals( classLoader, result );
+  }
+  // endregion
+
+  // region Request
+  @Test
+  public void testGetRequestFirstTime() {
+    String requestPayload = "REQUEST_PAYLOAD";
+    // new Object would have a null class loader!
+    Object target = this;
+    RPCRequest rpcRequest = new RPCRequest( null, null, null, 0 );
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( requestPayload ).when( gwtRpcSpy ).getRequestPayload();
+    doReturn( target ).when( gwtRpcSpy ).resolveTarget();
+
+    mockStatic( RPC.class );
+    when( RPC.decodeRequest( eq( requestPayload ), eq( null ), any() ) ).thenReturn( rpcRequest );
+
+    RPCRequest result = gwtRpcSpy.getRequest();
+
+    assertEquals( rpcRequest, result );
+  }
+
+  @Test
+  public void testGetRequestSecondTimeIsCached() {
+    String requestPayload = "REQUEST_PAYLOAD";
+    // new Object would have a null class loader!
+    Object target = this;
+    RPCRequest rpcRequest = new RPCRequest( null, null, null, 0 );
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( requestPayload ).when( gwtRpcSpy ).getRequestPayload();
+    doReturn( target ).when( gwtRpcSpy ).resolveTarget();
+
+    mockStatic( RPC.class );
+    when( RPC.decodeRequest( eq( requestPayload ), eq( null ), any() ) ).thenReturn( rpcRequest );
+
+    gwtRpcSpy.getRequest();
+
+    verify( gwtRpcSpy, times( 1 ) ).getRequestPayload();
+
+    RPCRequest result = gwtRpcSpy.getRequest();
+
+    verify( gwtRpcSpy, times( 1 ) ).getRequestPayload();
+
+    assertEquals( rpcRequest, result );
+  }
+
+  @Test
+  public void testGetRequestRunsWithTargetClassLoader() {
+    String requestPayload = "REQUEST_PAYLOAD";
+    ClassLoader targetClassLoader = mock( ClassLoader.class );
+    RPCRequest rpcRequest = new RPCRequest( null, null, null, 0 );
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( targetClassLoader ).when( gwtRpcSpy ).getTargetClassLoader();
+    doReturn( requestPayload ).when( gwtRpcSpy ).getRequestPayload();
+
+    // Stub getRequestCore with:
+    doAnswer( (Answer<RPCRequest>) invocationOnMock -> {
+      ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+
+      assertEquals( targetClassLoader, currentClassLoader );
+
+      return rpcRequest;
+    } ).when( gwtRpcSpy ).getRequestCore( requestPayload );
+
+    gwtRpcSpy.getRequest();
+
+    verify( gwtRpcSpy, times( 1 ) ).getRequestCore( requestPayload );
+  }
+
+  @Test
+  public void testGetRequestLogsAndWrapsThrownIllegalArgumentException() {
+    String requestPayload = "REQUEST_PAYLOAD";
+    // new Object would have a null class loader!
+    Object target = this;
+    IllegalArgumentException error = new IllegalArgumentException();
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( requestPayload ).when( gwtRpcSpy ).getRequestPayload();
+    doReturn( target ).when( gwtRpcSpy ).resolveTarget();
+
+    mockStatic( RPC.class );
+    when( RPC.decodeRequest( eq( requestPayload ), eq( null ), any() ) ).thenThrow( error );
+
+    try {
+      gwtRpcSpy.getRequest();
+      fail();
+    } catch ( GwtRpcProxyException ex ) {
+      assertEquals( error, ex.getCause() );
+      verify( loggerMock, times( 1 ) ).error( anyString(), eq( error ) );
+    }
+  }
+
+  @Test
+  public void testGetRequestLogsAndWrapsThrownIncompatibleRemoteServiceException() {
+    String requestPayload = "REQUEST_PAYLOAD";
+    // new Object would have a null class loader!
+    Object target = this;
+    IncompatibleRemoteServiceException error = new IncompatibleRemoteServiceException();
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( requestPayload ).when( gwtRpcSpy ).getRequestPayload();
+    doReturn( target ).when( gwtRpcSpy ).resolveTarget();
+
+    mockStatic( RPC.class );
+    when( RPC.decodeRequest( eq( requestPayload ), eq( null ), any() ) ).thenThrow( error );
+
+    try {
+      gwtRpcSpy.getRequest();
+      fail();
+    } catch ( GwtRpcProxyException ex ) {
+      assertEquals( error, ex.getCause() );
+      verify( loggerMock, times( 1 ) ).error( anyString(), eq( error ) );
+    }
+  }
+  // endregion
+
+  // region getSerializationPolicy
+  @Test
+  public void testGetSerializationPolicyUsesCacheIfSet() {
+
+    String moduleBaseURL = "http://localhost:8080/pentaho/content/data-access/resources/gwt/";
+    String strongName = "ABCDF12345";
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    SerializationPolicy policyMock = mock( SerializationPolicy.class );
+
+    IGwtRpcSerializationPolicyCache cache = mock( IGwtRpcSerializationPolicyCache.class );
+    when( cache.getSerializationPolicy( eq( moduleBaseURL ), eq( strongName ), any() ) ).thenReturn( policyMock );
+
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+    gwtRpc.setSerializationPolicyCache( cache );
+
+    SerializationPolicy result = gwtRpc.getSerializationPolicy( moduleBaseURL, strongName );
+
+    assertEquals( policyMock, result );
+  }
+
+  @Test
+  public void testGetSerializationPolicyLogsAndReturnsDefaultIfModuleBaseURLIsNull() {
+
+    String moduleBaseURL = null;
+    String strongName = "ABCDF12345";
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    SerializationPolicy defaultPolicyMock = mock( SerializationPolicy.class );
+
+    mockStatic( AbstractGwtRpc.class );
+    when( AbstractGwtRpc.getDefaultSerializationPolicy() ).thenReturn( defaultPolicyMock );
+
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    SerializationPolicy result = gwtRpc.getSerializationPolicy( moduleBaseURL, strongName );
+
+    assertEquals( defaultPolicyMock, result );
+
+    verify( loggerMock, times( 1 ) ).error( anyString() );
+  }
+
+  @Test
+  public void testGetSerializationPolicyLogsAndReturnsDefaultIfModuleBaseURLIsNotValidURL() {
+
+    String moduleBaseURL = "ht123_-tp:localhost:8080/pentaho/content/data-access/resources/gwt/";
+    String strongName = "ABCDF12345";
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    SerializationPolicy defaultPolicyMock = mock( SerializationPolicy.class );
+
+    mockStatic( AbstractGwtRpc.class );
+    when( AbstractGwtRpc.getDefaultSerializationPolicy() ).thenReturn( defaultPolicyMock );
+
+    TestGwtRpc gwtRpc = new TestGwtRpc( httpRequestMock );
+
+    SerializationPolicy result = gwtRpc.getSerializationPolicy( moduleBaseURL, strongName );
+
+    assertEquals( defaultPolicyMock, result );
+
+    verify( loggerMock, times( 1 ) ).error( anyString(), any() );
+  }
+
+  @Test
+  public void testGetSerializationPolicyReplacesWebAppRootToken() {
+
+    String moduleBaseURL = "http://localhost:8080/WEBAPP_ROOT//content/data-access/resources/gwt/";
+    String modulePath = "/WEBAPP_ROOT//content/data-access/resources/gwt/";
+    String modulePathScrubbed = "/pentaho/content/data-access/resources/gwt/";
+    String appContextPath = "/pentaho";
+    String moduleContextPath = "/content/data-access/resources/gwt/";
+    String strongName = "ABCDF12345";
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    SerializationPolicy policyMock = mock( SerializationPolicy.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( appContextPath ).when( gwtRpcSpy ).getAppContextPath();
+    doReturn( policyMock ).when( gwtRpcSpy ).loadSerializationPolicy( moduleContextPath, strongName );
+
+    mockStatic( GwtRpcUtil.class );
+    when( GwtRpcUtil.scrubWebAppRoot( modulePath, appContextPath ) ).thenReturn( modulePathScrubbed );
+
+    gwtRpcSpy.getSerializationPolicy( moduleBaseURL, strongName );
+
+    verifyStatic( times( 1 ) );
+    GwtRpcUtil.scrubWebAppRoot( modulePath, appContextPath );
+  }
+
+  @Test
+  public void testGetSerializationPolicyLogsAndReturnsDefaultIfModuleBaseURLIsNotPrefixByAppContextPath() {
+
+    String moduleBaseURL = "http://localhost:8080/pentaho/content/data-access/resources/gwt/";
+    String appContextPath = "/sixtaho";
+    String strongName = "ABCDF12345";
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    SerializationPolicy defaultPolicyMock = mock( SerializationPolicy.class );
+
+    mockStatic( AbstractGwtRpc.class );
+    when( AbstractGwtRpc.getDefaultSerializationPolicy() ).thenReturn( defaultPolicyMock );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( appContextPath ).when( gwtRpcSpy ).getAppContextPath();
+
+    SerializationPolicy result = gwtRpcSpy.getSerializationPolicy( moduleBaseURL, strongName );
+
+    assertEquals( defaultPolicyMock, result );
+
+    verify( loggerMock, times( 1 ) ).error( anyString() );
+  }
+
+  @Test
+  public void testGetSerializationPolicyCallsLoadSerializationPolicyWithModulePathAndStrongName() {
+
+    String moduleBaseURL = "http://localhost:8080/pentaho/content/data-access/resources/gwt/";
+    String appContextPath = "/pentaho";
+    String moduleContextPath = "/content/data-access/resources/gwt/";
+    String strongName = "ABCDF12345";
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    SerializationPolicy policyMock = mock( SerializationPolicy.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( appContextPath ).when( gwtRpcSpy ).getAppContextPath();
+    doReturn( policyMock ).when( gwtRpcSpy ).loadSerializationPolicy( moduleContextPath, strongName );
+
+    SerializationPolicy result = gwtRpcSpy.getSerializationPolicy( moduleBaseURL, strongName );
+
+    assertEquals( policyMock, result );
+  }
+
+  @Test
+  public void testGetSerializationPolicyCallsLoadSerializationPolicyReturnsDefaultIfItReturnsNull() {
+
+    String moduleBaseURL = "http://localhost:8080/pentaho/content/data-access/resources/gwt/";
+    String appContextPath = "/pentaho";
+    String moduleContextPath = "/content/data-access/resources/gwt/";
+    String strongName = "ABCDF12345";
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    SerializationPolicy defaultPolicyMock = mock( SerializationPolicy.class );
+
+    mockStatic( AbstractGwtRpc.class );
+    when( AbstractGwtRpc.getDefaultSerializationPolicy() ).thenReturn( defaultPolicyMock );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( appContextPath ).when( gwtRpcSpy ).getAppContextPath();
+    doReturn( null ).when( gwtRpcSpy ).loadSerializationPolicy( moduleContextPath, strongName );
+
+    SerializationPolicy result = gwtRpcSpy.getSerializationPolicy( moduleBaseURL, strongName );
+
+    assertEquals( defaultPolicyMock, result );
+  }
+  // endregion
+
+  // region static getDefaultSerializationPolicy
+  @Test
+  public void testGetDefaultSerializationPolicyDelegatesToRPCClass() {
+
+    SerializationPolicy defaultPolicyMock = mock( SerializationPolicy.class );
+
+    mockStatic( RPC.class );
+    when( RPC.getDefaultSerializationPolicy() ).thenReturn( defaultPolicyMock );
+
+    SerializationPolicy result = AbstractGwtRpc.getDefaultSerializationPolicy();
+
+    assertEquals( defaultPolicyMock, result );
+  }
+  // endregion
+
+  // region static loadSerializationPolicyFromInputStream
+  @Test
+  public void testLoadSerializationPolicyFromInputStreamSuccessfully() throws IOException, ParseException {
+    String serializationPolicyFileName = "ABCDF12345.gwt.rpc";
+    InputStream inputStreamMock = mock( InputStream.class );
+    ThrowingSupplier<InputStream, IOException> inputStreamSupplier = () -> inputStreamMock;
+    SerializationPolicy policyMock = mock( SerializationPolicy.class );
+
+    mockStatic( SerializationPolicyLoader.class );
+    when( SerializationPolicyLoader.loadFromStream( inputStreamMock, null ) ).thenReturn( policyMock );
+
+    SerializationPolicy result =
+      AbstractGwtRpc.loadSerializationPolicyFromInputStream( inputStreamSupplier, serializationPolicyFileName );
+
+    assertEquals( policyMock, result );
+  }
+
+  @Test
+  public void testLoadSerializationPolicyFromInputStreamLogsAndReturnsNullIfSupplierReturnsNull() {
+    String serializationPolicyFileName = "ABCDF12345.gwt.rpc";
+    ThrowingSupplier<InputStream, IOException> inputStreamSupplier = () -> null;
+
+    SerializationPolicy result =
+      AbstractGwtRpc.loadSerializationPolicyFromInputStream( inputStreamSupplier, serializationPolicyFileName );
+
+    assertNull( result );
+    verify( loggerMock, times( 1 ) ).error( anyString() );
+  }
+
+  @Test
+  public void testLoadSerializationPolicyFromInputStreamLogsAndReturnsNullIfSupplierThrowsIOException() {
+    String serializationPolicyFileName = "ABCDF12345.gwt.rpc";
+    IOException error = new IOException();
+    ThrowingSupplier<InputStream, IOException> inputStreamSupplier = () -> {
+      throw error;
+    };
+
+    SerializationPolicy result =
+      AbstractGwtRpc.loadSerializationPolicyFromInputStream( inputStreamSupplier, serializationPolicyFileName );
+
+    assertNull( result );
+    verify( loggerMock, times( 1 ) ).error( anyString(), eq( error ) );
+  }
+
+  @Test
+  public void testLoadSerializationPolicyFromInputStreamLogsAndReturnsNullAndClosesStreamIfLoadThrowsIOException()
+    throws IOException, ParseException {
+
+    String serializationPolicyFileName = "ABCDF12345.gwt.rpc";
+    InputStream inputStreamMock = mock( InputStream.class );
+    ThrowingSupplier<InputStream, IOException> inputStreamSupplier = () -> inputStreamMock;
+    IOException error = new IOException();
+
+    mockStatic( SerializationPolicyLoader.class );
+    when( SerializationPolicyLoader.loadFromStream( inputStreamMock, null ) ).thenThrow( error );
+
+    SerializationPolicy result =
+      AbstractGwtRpc.loadSerializationPolicyFromInputStream( inputStreamSupplier, serializationPolicyFileName );
+
+    assertNull( result );
+    verify( loggerMock, times( 1 ) ).error( anyString(), eq( error ) );
+    verify( inputStreamMock, times( 1 ) ).close();
+  }
+
+  @Test
+  public void testLoadSerializationPolicyFromInputStreamLogsAndReturnsNullAndClosesStreamIfLoadThrowsParseException()
+    throws IOException, ParseException {
+
+    String serializationPolicyFileName = "ABCDF12345.gwt.rpc";
+    InputStream inputStreamMock = mock( InputStream.class );
+    ThrowingSupplier<InputStream, IOException> inputStreamSupplier = () -> inputStreamMock;
+    ParseException error = new ParseException( "ABC", 0 );
+
+    mockStatic( SerializationPolicyLoader.class );
+    when( SerializationPolicyLoader.loadFromStream( inputStreamMock, null ) ).thenThrow( error );
+
+    SerializationPolicy result =
+      AbstractGwtRpc.loadSerializationPolicyFromInputStream( inputStreamSupplier, serializationPolicyFileName );
+
+    assertNull( result );
+    verify( loggerMock, times( 1 ) ).error( anyString(), eq( error ) );
+    verify( inputStreamMock, times( 1 ) ).close();
+  }
+
+  @Test
+  public void testLoadSerializationPolicyFromInputStreamDoesNotLogErrorAndClosesStreamWhenSuccessful()
+    throws IOException, ParseException {
+
+    String serializationPolicyFileName = "ABCDF12345.gwt.rpc";
+    InputStream inputStreamMock = mock( InputStream.class );
+    ThrowingSupplier<InputStream, IOException> inputStreamSupplier = () -> inputStreamMock;
+    SerializationPolicy policy = mock( SerializationPolicy.class );
+
+    mockStatic( SerializationPolicyLoader.class );
+    when( SerializationPolicyLoader.loadFromStream( inputStreamMock, null ) ).thenReturn( policy );
+
+    AbstractGwtRpc.loadSerializationPolicyFromInputStream( inputStreamSupplier, serializationPolicyFileName );
+
+
+    verify( loggerMock, times( 0 ) ).error( anyString(), any() );
+    verify( loggerMock, times( 0 ) ).error( anyString() );
+
+    verify( inputStreamMock, times( 1 ) ).close();
+  }
+  // endregion
+
+  // region Invocation
+  static class TestResponse {
+
+  }
+
+  interface ServiceInterface extends RemoteService {
+    TestResponse method( String id );
+
+    TestResponse methodSpecial( String id );
+  }
+
+  static class ServiceClassWhichDoesNotImplementInterface {
+    public TestResponse method( String id ) {
+      return new TestResponse();
+    }
+  }
+
+  @Test
+  public void testInvokeSuccessfully() throws NoSuchMethodException, SerializationException {
+    ServiceClassWhichDoesNotImplementInterface target = new ServiceClassWhichDoesNotImplementInterface();
+    Method targetMethod = target.getClass().getMethod( "method", String.class );
+    ClassLoader targetClassLoader = mock( ClassLoader.class );
+
+    Method serviceMethod = ServiceInterface.class.getMethod( "method", String.class );
+    Object[] rpcParameters = new Object[] { "id1" };
+    SerializationPolicy policy = mock( SerializationPolicy.class );
+    RPCRequest rpcRequest = new RPCRequest( serviceMethod, rpcParameters, policy, 0 );
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    String response = "rpc response";
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( target ).when( gwtRpcSpy ).getTarget();
+    doReturn( targetMethod ).when( gwtRpcSpy ).getTargetMethod( target.getClass(), rpcRequest );
+    doReturn( targetClassLoader ).when( gwtRpcSpy ).getTargetClassLoader();
+    doReturn( rpcRequest ).when( gwtRpcSpy ).getRequest();
+
+    mockStatic( RPC.class );
+    when( RPC.invokeAndEncodeResponse( target, targetMethod, rpcParameters, policy ) ).thenReturn( response );
+
+    String result = gwtRpcSpy.invoke();
+
+    assertEquals( response, result );
+
+    verifyStatic( times( 1 ) );
+    RPC.invokeAndEncodeResponse( target, targetMethod, rpcParameters, policy );
+  }
+
+  @Test
+  public void testInvokeServiceClassDoesNotNeedToImplementServiceInterface()
+    throws NoSuchMethodException, SerializationException {
+    ServiceClassWhichDoesNotImplementInterface target = new ServiceClassWhichDoesNotImplementInterface();
+    Method targetMethod = target.getClass().getMethod( "method", String.class );
+    ClassLoader targetClassLoader = mock( ClassLoader.class );
+
+    Method serviceMethod = ServiceInterface.class.getMethod( "method", String.class );
+    Object[] rpcParameters = new Object[] { "id1" };
+    SerializationPolicy policy = mock( SerializationPolicy.class );
+    RPCRequest rpcRequest = new RPCRequest( serviceMethod, rpcParameters, policy, 0 );
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    String response = "rpc response";
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( target ).when( gwtRpcSpy ).getTarget();
+    doReturn( targetClassLoader ).when( gwtRpcSpy ).getTargetClassLoader();
+    doReturn( rpcRequest ).when( gwtRpcSpy ).getRequest();
+
+    // Proven if the correct targetMethod is received at this call.
+    mockStatic( RPC.class );
+    when( RPC.invokeAndEncodeResponse( target, targetMethod, rpcParameters, policy ) ).thenReturn( response );
+
+    String result = gwtRpcSpy.invoke();
+
+    assertEquals( response, result );
+
+    verifyStatic( times( 1 ) );
+    RPC.invokeAndEncodeResponse( target, targetMethod, rpcParameters, policy );
+  }
+
+  @Test
+  public void testInvokeLogsAndThrowsIfServiceClassDoesNotHaveServiceInterfaceMethod() throws NoSuchMethodException {
+    ServiceClassWhichDoesNotImplementInterface target = new ServiceClassWhichDoesNotImplementInterface();
+    ClassLoader targetClassLoader = mock( ClassLoader.class );
+
+    Method serviceSpecialMethod = ServiceInterface.class.getMethod( "methodSpecial", String.class );
+    Object[] rpcParameters = new Object[] { "id1" };
+    SerializationPolicy policy = mock( SerializationPolicy.class );
+    RPCRequest rpcRequest = new RPCRequest( serviceSpecialMethod, rpcParameters, policy, 0 );
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( target ).when( gwtRpcSpy ).getTarget();
+    doReturn( targetClassLoader ).when( gwtRpcSpy ).getTargetClassLoader();
+    doReturn( rpcRequest ).when( gwtRpcSpy ).getRequest();
+
+    try {
+      gwtRpcSpy.invoke();
+      fail();
+    } catch ( GwtRpcProxyException ex ) {
+      assertTrue( ex.getCause() instanceof NoSuchMethodException );
+      verify( loggerMock, times( 1 ) ).error( anyString(), eq( ex.getCause() ) );
+    }
+  }
+
+  @Test
+  public void testInvokeServiceClassLogsAndThrowsIfRPCThrowsSerializationException()
+    throws NoSuchMethodException, SerializationException {
+    ServiceClassWhichDoesNotImplementInterface target = new ServiceClassWhichDoesNotImplementInterface();
+    Method targetMethod = target.getClass().getMethod( "method", String.class );
+    ClassLoader targetClassLoader = mock( ClassLoader.class );
+
+    Method serviceSpecialMethod = ServiceInterface.class.getMethod( "method", String.class );
+    Object[] rpcParameters = new Object[] { "id1" };
+    SerializationPolicy policy = mock( SerializationPolicy.class );
+    RPCRequest rpcRequest = new RPCRequest( serviceSpecialMethod, rpcParameters, policy, 0 );
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( target ).when( gwtRpcSpy ).getTarget();
+    doReturn( targetClassLoader ).when( gwtRpcSpy ).getTargetClassLoader();
+    doReturn( rpcRequest ).when( gwtRpcSpy ).getRequest();
+
+    SerializationException error = new SerializationException();
+    mockStatic( RPC.class );
+    when( RPC.invokeAndEncodeResponse( target, targetMethod, rpcParameters, policy ) ).thenThrow( error );
+
+    try {
+      gwtRpcSpy.invoke();
+      fail();
+    } catch ( GwtRpcProxyException ex ) {
+      assertEquals( error, ex.getCause() );
+      verify( loggerMock, times( 1 ) ).error( anyString(), eq( error ) );
+    }
+  }
+
+  @Test
+  public void testInvokeRunsInTargetClassLoader() throws NoSuchMethodException, SerializationException {
+    ServiceClassWhichDoesNotImplementInterface target = new ServiceClassWhichDoesNotImplementInterface();
+    Method targetMethod = target.getClass().getMethod( "method", String.class );
+    ClassLoader targetClassLoader = mock( ClassLoader.class );
+
+    Method serviceMethod = ServiceInterface.class.getMethod( "method", String.class );
+    Object[] rpcParameters = new Object[] { "id1" };
+    SerializationPolicy policy = mock( SerializationPolicy.class );
+    RPCRequest rpcRequest = new RPCRequest( serviceMethod, rpcParameters, policy, 0 );
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+
+    String response = "rpc response";
+
+    TestGwtRpc gwtRpcSpy = spy( new TestGwtRpc( httpRequestMock ) );
+    doReturn( target ).when( gwtRpcSpy ).getTarget();
+    doReturn( targetMethod ).when( gwtRpcSpy ).getTargetMethod( target.getClass(), rpcRequest );
+    doReturn( targetClassLoader ).when( gwtRpcSpy ).getTargetClassLoader();
+    doReturn( rpcRequest ).when( gwtRpcSpy ).getRequest();
+
+    // Stub invokeCore with:
+    doAnswer( (Answer<String>) invocationOnMock -> {
+      ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+
+      assertEquals( targetClassLoader, currentClassLoader );
+
+      return response;
+    } ).when( gwtRpcSpy ).invokeCore( target, targetMethod, rpcRequest );
+
+    gwtRpcSpy.invoke();
+
+    verify( gwtRpcSpy, times( 1 ) ).invokeCore( target, targetMethod, rpcRequest );
+  }
+
+  // endregion
+
+  // region getInstance
+  @Test
+  public void testGetInstanceFirstTimeCreatesSetsPolicyCacheAndStoresInRequest() {
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    when( httpRequestMock.getAttribute( HTTP_GWT_RPC_ATTRIBUTE ) ).thenReturn( null );
+
+    TestGwtRpc gwtRpcMock1 = mock( TestGwtRpc.class );
+    Function<HttpServletRequest, TestGwtRpc> factory = request -> gwtRpcMock1;
+
+    IGwtRpcSerializationPolicyCache cache = mock( IGwtRpcSerializationPolicyCache.class );
+
+    TestGwtRpc result1 = AbstractGwtRpc.getInstance( httpRequestMock, factory, cache );
+
+    assertEquals( gwtRpcMock1, result1 );
+
+    verify( gwtRpcMock1, times( 1 ) ).setSerializationPolicyCache( cache );
+
+    verify( httpRequestMock, Mockito.times( 1 ) ).getAttribute( HTTP_GWT_RPC_ATTRIBUTE );
+    verify( httpRequestMock, Mockito.times( 1 ) ).setAttribute( HTTP_GWT_RPC_ATTRIBUTE, gwtRpcMock1 );
+  }
+
+  @Test
+  public void testGetInstanceSecondTimeGetsFromRequest() {
+
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    TestGwtRpc gwtRpcMock1 = mock( TestGwtRpc.class );
+    when( httpRequestMock.getAttribute( HTTP_GWT_RPC_ATTRIBUTE ) ).thenReturn( gwtRpcMock1 );
+
+    Function<HttpServletRequest, TestGwtRpc> factory = httpServletRequest -> {
+      fail();
+      return null;
+    };
+
+    IGwtRpcSerializationPolicyCache cache = mock( IGwtRpcSerializationPolicyCache.class );
+
+    TestGwtRpc result2 = AbstractGwtRpc.getInstance( httpRequestMock, factory, cache );
+
+    assertEquals( gwtRpcMock1, result2 );
+
+    verify( gwtRpcMock1, times( 0 ) ).setSerializationPolicyCache( cache );
+    verify( httpRequestMock, Mockito.times( 1 ) ).getAttribute( HTTP_GWT_RPC_ATTRIBUTE );
+    verify( httpRequestMock, Mockito.times( 0 ) ).setAttribute( HTTP_GWT_RPC_ATTRIBUTE, gwtRpcMock1 );
+  }
+  // endregion
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/PluginGwtRpcTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/PluginGwtRpcTest.java
@@ -1,0 +1,503 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc;
+
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+import org.pentaho.platform.api.engine.IPluginResourceLoader;
+import org.pentaho.platform.api.engine.IServiceConfig;
+import org.pentaho.platform.api.engine.IServiceManager;
+import org.pentaho.platform.api.engine.ServiceException;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.pluginmgr.PluginUtil;
+import org.pentaho.platform.web.gwt.rpc.util.ThrowingSupplier;
+import org.pentaho.platform.web.servlet.GwtRpcProxyException;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( {
+  PentahoSystem.class,
+  PluginUtil.class,
+  PentahoSessionHolder.class,
+  LogFactory.class,
+  AbstractGwtRpc.class
+} )
+public class PluginGwtRpcTest {
+
+  private static Log loggerMock;
+
+  private IServiceManager setupServiceManagerMock( String serviceKey, Object serviceBean ) {
+    IServiceManager serviceManagerMock = mock( IServiceManager.class );
+
+    IServiceConfig serviceConfigMock = mock( IServiceConfig.class );
+    when( serviceManagerMock.getServiceConfig( "gwt", serviceKey ) ).thenReturn( serviceConfigMock );
+
+    mockStatic( PentahoSystem.class );
+    when( PentahoSystem.get( eq( IServiceManager.class ), any() ) ).thenReturn( serviceManagerMock );
+
+    try {
+      when( serviceManagerMock.getServiceBean( "gwt", serviceKey ) ).thenReturn( serviceBean );
+    } catch ( ServiceException e ) {
+      // Does not happen.
+    }
+
+    return serviceManagerMock;
+  }
+
+  private HttpServletRequest setupHttpRequest( String pathInfo ) {
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    when( httpRequestMock.getPathInfo() ).thenReturn( pathInfo );
+
+    return httpRequestMock;
+  }
+
+  @BeforeClass
+  public static void beforeAll() {
+
+    mockStatic( LogFactory.class );
+
+    // Must use this lazy form of mocking `LogFactory.log` because the literal reference to
+    // PentahoSessionHolder.class would trigger that class's initialization, which would request for the logger.
+
+    loggerMock = mock( Log.class );
+    Log sessionLogger = mock( Log.class );
+
+    doAnswer( (Answer<Log>) invocationOnMock -> {
+
+      Class<?> logClass = invocationOnMock.getArgumentAt( 0, Class.class );
+
+      if ( logClass.equals( PluginGwtRpc.class ) ) {
+        return loggerMock;
+      }
+
+      if ( logClass.equals( PentahoSessionHolder.class ) ) {
+        return sessionLogger;
+      }
+
+      return mock( Log.class );
+    } ).when( LogFactory.class );
+    LogFactory.getLog( any( Class.class ) );
+
+    // ---
+
+    // Static initialization of class requires LogFactory already configured, above.
+    mockStatic( PentahoSessionHolder.class );
+    when( PentahoSessionHolder.getSession() ).thenReturn( null );
+  }
+
+  @After
+  public void afterEach() {
+    reset( loggerMock );
+  }
+
+  // region HttpRequest
+  @Test
+  public void testGetServletRequest() {
+    String pathInfo = "/serviceName";
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+
+    PluginGwtRpc gwtRpc = new PluginGwtRpc( httpRequestMock );
+
+    HttpServletRequest result = gwtRpc.getServletRequest();
+
+    assertEquals( httpRequestMock, result );
+  }
+  // endregion
+
+  // region Target
+  @Test
+  public void testResolveTargetSuccessfully() {
+    String serviceKey = "serviceName";
+    String pathInfo = "/serviceName";
+    Object serviceTarget = new Object();
+
+    setupServiceManagerMock( serviceKey, serviceTarget );
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+
+    PluginGwtRpc gwtRpc = new PluginGwtRpc( httpRequestMock );
+
+    Object result = gwtRpc.resolveTarget();
+
+    assertEquals( serviceTarget, result );
+  }
+
+  @Test( expected = GwtRpcProxyException.class )
+  public void testResolveTargetThrowsWhenNotRegisteredServiceKey() {
+    String serviceKey = "serviceName";
+    String pathInfo = "/serviceName";
+    Object serviceTarget = null;
+
+    @SuppressWarnings( "ConstantConditions" )
+    IServiceManager serviceManagerMock = setupServiceManagerMock( serviceKey, serviceTarget );
+
+    // No Configuration
+    when( serviceManagerMock.getServiceConfig( "gwt", serviceKey ) ).thenReturn( null );
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+
+    PluginGwtRpc gwtRpc = new PluginGwtRpc( httpRequestMock );
+    gwtRpc.resolveTarget();
+  }
+
+  @Test( expected = GwtRpcProxyException.class )
+  public void testResolveTargetThrowsWhenServiceResolveThrowsServiceException() {
+    String serviceKey = "serviceName";
+    String pathInfo = "/serviceName";
+    Object serviceTarget = null;
+
+    @SuppressWarnings( "ConstantConditions" )
+    IServiceManager serviceManagerMock = setupServiceManagerMock( serviceKey, serviceTarget );
+    ServiceException error = new ServiceException();
+    try {
+      when( serviceManagerMock.getServiceBean( "gwt", serviceKey ) ).thenThrow( error );
+    } catch ( ServiceException ex ) {
+      // noop
+    }
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+
+    PluginGwtRpc gwtRpc = new PluginGwtRpc( httpRequestMock );
+    gwtRpc.resolveTarget();
+  }
+
+  @Test
+  public void testResolveTargetWithCompositeServiceNameUsesLastSegmentAsKey() {
+    String serviceKey = "Name";
+    String pathInfo = "/service/Name";
+    Object serviceTarget = new Object();
+
+    setupServiceManagerMock( serviceKey, serviceTarget );
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+
+    PluginGwtRpc gwtRpc = new PluginGwtRpc( httpRequestMock );
+
+    Object result = gwtRpc.resolveTarget();
+
+    assertEquals( serviceTarget, result );
+  }
+  // endregion
+
+  // region Serialization Policy
+  @Test
+  public void testLoadSerializationPolicySupportsPluginBean() {
+    String pathInfo = "/serviceName";
+    String pluginId = "data-access";
+    String moduleContextPath = "/content/data-access/resources/gwt/";
+    String strongName = "ABC";
+
+    // ---
+
+    mockStatic( PluginUtil.class );
+    when( PluginUtil.getPluginIdFromPath( moduleContextPath ) ).thenReturn( pluginId );
+
+    // ---
+
+    SerializationPolicy pluginPolicyMock = mock( SerializationPolicy.class );
+
+    mockStatic( PentahoSystem.class );
+    doAnswer( invocationOnMock -> {
+      @SuppressWarnings( "unchecked" )
+      Map<String, String> props = (Map<String, String>) invocationOnMock.getArguments()[ 2 ];
+      if ( pluginId.equals( props.get( "plugin" ) ) ) {
+        return pluginPolicyMock;
+      }
+
+      fail();
+      return mock( SerializationPolicy.class );
+    } ).when( PentahoSystem.class );
+    PentahoSystem.get( eq( SerializationPolicy.class ), eq( null ), anyMapOf( String.class, String.class ) );
+
+    // ---
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+    PluginGwtRpc gwtRpc = new PluginGwtRpc( httpRequestMock );
+
+    SerializationPolicy result = gwtRpc.loadSerializationPolicy( moduleContextPath, strongName );
+
+    assertEquals( pluginPolicyMock, result );
+  }
+
+  @Test
+  public void testLoadSerializationPolicyLogsErrorAndReturnsNullIfNoPluginClassLoader() {
+    String pathInfo = "/serviceName";
+    String pluginId = "data-access";
+    String moduleContextPath = "/content/data-access/resources/gwt/";
+    String strongName = "ABC";
+
+    // ---
+
+    mockStatic( PluginUtil.class );
+    when( PluginUtil.getPluginIdFromPath( moduleContextPath ) ).thenReturn( pluginId );
+
+    // ----
+
+    // There is no configured SP bean.
+    mockStatic( PentahoSystem.class );
+    when( PentahoSystem.get( eq( SerializationPolicy.class ), eq( null ), anyMapOf( String.class, String.class ) ) )
+      .thenReturn( null );
+
+    // ---
+
+    when( PluginUtil.getClassLoaderForService( moduleContextPath ) ).thenReturn( null );
+
+    // ---
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+    PluginGwtRpc gwtRpc = new PluginGwtRpc( httpRequestMock );
+
+    SerializationPolicy result = gwtRpc.loadSerializationPolicy( moduleContextPath, strongName );
+
+    assertNull( result );
+
+    verify( loggerMock, times( 1 ) ).error( anyString() );
+  }
+
+  @Test
+  public void testLoadSerializationPolicyLogsErrorAndReturnsNullIfNoPluginResource() {
+    String pathInfo = "/serviceName";
+    String pluginId = "data-access";
+    String moduleContextPath = "/content/data-access/resources/gwt/";
+    String strongName = "ABC";
+    String serializationPolicyFilename = strongName + ".gwt.rpc";
+
+    // ---
+
+    mockStatic( PluginUtil.class );
+    when( PluginUtil.getPluginIdFromPath( moduleContextPath ) ).thenReturn( pluginId );
+
+    // ----
+
+    // There is no configured SP bean.
+    mockStatic( PentahoSystem.class );
+    when( PentahoSystem.get( eq( SerializationPolicy.class ), eq( null ), anyMapOf( String.class, String.class ) ) )
+      .thenReturn( null );
+
+    // ---
+
+    ClassLoader pluginClassLoader = mock( ClassLoader.class );
+    when( PluginUtil.getClassLoaderForService( moduleContextPath ) ).thenReturn( pluginClassLoader );
+
+    // ---
+
+    // No serialization policy resource found.
+    IPluginResourceLoader resLoaderMock = mock( IPluginResourceLoader.class );
+    when( resLoaderMock.findResources( pluginClassLoader, serializationPolicyFilename ) )
+      .thenReturn( Collections.emptyList() );
+
+    when( PentahoSystem.get( eq( IPluginResourceLoader.class ), eq( null ) ) ).thenReturn( resLoaderMock );
+
+    // ---
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+    PluginGwtRpc gwtRpc = new PluginGwtRpc( httpRequestMock );
+
+    SerializationPolicy result = gwtRpc.loadSerializationPolicy( moduleContextPath, strongName );
+
+    assertNull( result );
+
+    verify( loggerMock, times( 1 ) ).error( anyString() );
+  }
+
+  @Test
+  public void testLoadSerializationPolicyLogsWarningAndReturnsFirstIfMoreThanOnePluginResource()
+    throws MalformedURLException {
+    String pathInfo = "/serviceName";
+    String pluginId = "data-access";
+    String moduleContextPath = "/content/data-access/resources/gwt/";
+    String strongName = "ABC";
+    String policyFilename = strongName + ".gwt.rpc";
+    URL policy1Url = new URL( "file:///resources/gwt/a/" + policyFilename );
+    URL policy2Url = new URL( "file:///resources/gwt/b/" + policyFilename );
+
+    // ---
+
+    mockStatic( PluginUtil.class );
+    when( PluginUtil.getPluginIdFromPath( moduleContextPath ) ).thenReturn( pluginId );
+
+    // ----
+
+    // There is no configured SP bean.
+    mockStatic( PentahoSystem.class );
+    when( PentahoSystem.get( eq( SerializationPolicy.class ), eq( null ), anyMapOf( String.class, String.class ) ) )
+      .thenReturn( null );
+
+    // ---
+
+    ClassLoader pluginClassLoader = mock( ClassLoader.class );
+    when( PluginUtil.getClassLoaderForService( moduleContextPath ) ).thenReturn( pluginClassLoader );
+
+    // ---
+
+    // More than one serialization policy resource found.
+    IPluginResourceLoader resLoaderMock = mock( IPluginResourceLoader.class );
+    when( resLoaderMock.findResources( pluginClassLoader, policyFilename ) )
+      .thenReturn( Arrays.asList( policy1Url, policy2Url ) );
+
+    when( PentahoSystem.get( eq( IPluginResourceLoader.class ), eq( null ) ) ).thenReturn( resLoaderMock );
+
+    // ---
+
+    InputStream pluginPolicyInputStreamMock = mock( InputStream.class );
+
+    // Spying requires a non-final class. Lambda expression is not suitable.
+    @SuppressWarnings( "Convert2Lambda" )
+    ThrowingSupplier<InputStream, IOException> pluginPolicyInputStreamSupplierSpy =
+      spy( new ThrowingSupplier<InputStream, IOException>() {
+        @Override public InputStream get() {
+          return pluginPolicyInputStreamMock;
+        }
+      } );
+
+    // ---
+
+    SerializationPolicy pluginPolicyMock = mock( SerializationPolicy.class );
+    mockStatic( AbstractGwtRpc.class );
+    when( AbstractGwtRpc.loadSerializationPolicyFromInputStream( pluginPolicyInputStreamSupplierSpy, policyFilename ) )
+      .thenReturn( pluginPolicyMock );
+
+    // ---
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+    PluginGwtRpc gwtRpcSpy = spy( new PluginGwtRpc( httpRequestMock ) );
+
+    doReturn( pluginPolicyInputStreamSupplierSpy ).when( gwtRpcSpy ).getInputStreamSupplier( policy1Url );
+
+    // ---
+
+    SerializationPolicy result = gwtRpcSpy.loadSerializationPolicy( moduleContextPath, strongName );
+
+    // ---
+
+    assertEquals( pluginPolicyMock, result );
+
+    verify( loggerMock, times( 1 ) ).warn( anyString() );
+  }
+
+  @Test
+  public void testLoadSerializationPolicyWhenPluginResource() throws MalformedURLException {
+    String pathInfo = "/serviceName";
+    String pluginId = "data-access";
+    String moduleContextPath = "/content/data-access/resources/gwt/";
+    String strongName = "ABC";
+    String policyFilename = strongName + ".gwt.rpc";
+    URL policy1Url = new URL( "file:///resources/gwt/a/" + policyFilename );
+
+    // ---
+
+    mockStatic( PluginUtil.class );
+    when( PluginUtil.getPluginIdFromPath( moduleContextPath ) ).thenReturn( pluginId );
+
+    // ----
+
+    // There is no configured SP bean.
+    mockStatic( PentahoSystem.class );
+    when( PentahoSystem.get( eq( SerializationPolicy.class ), eq( null ), anyMapOf( String.class, String.class ) ) )
+      .thenReturn( null );
+
+    // ---
+
+    ClassLoader pluginClassLoader = mock( ClassLoader.class );
+    when( PluginUtil.getClassLoaderForService( moduleContextPath ) ).thenReturn( pluginClassLoader );
+
+    // ---
+
+    // More than one serialization policy resource found.
+    IPluginResourceLoader resLoaderMock = mock( IPluginResourceLoader.class );
+    when( resLoaderMock.findResources( pluginClassLoader, policyFilename ) )
+      .thenReturn( Collections.singletonList( policy1Url ) );
+
+    when( PentahoSystem.get( eq( IPluginResourceLoader.class ), eq( null ) ) ).thenReturn( resLoaderMock );
+
+    // ---
+
+    InputStream pluginPolicyInputStreamMock = mock( InputStream.class );
+
+    // Spying requires a non-final class. Lambda expression is not suitable.
+    @SuppressWarnings( "Convert2Lambda" )
+    ThrowingSupplier<InputStream, IOException> pluginPolicyInputStreamSupplierSpy =
+      spy( new ThrowingSupplier<InputStream, IOException>() {
+        @Override public InputStream get() {
+          return pluginPolicyInputStreamMock;
+        }
+      } );
+
+    // ---
+
+    SerializationPolicy pluginPolicyMock = mock( SerializationPolicy.class );
+    mockStatic( AbstractGwtRpc.class );
+    when( AbstractGwtRpc.loadSerializationPolicyFromInputStream( pluginPolicyInputStreamSupplierSpy, policyFilename ) )
+      .thenReturn( pluginPolicyMock );
+
+    // ---
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( pathInfo );
+    PluginGwtRpc gwtRpcSpy = spy( new PluginGwtRpc( httpRequestMock ) );
+
+    doReturn( pluginPolicyInputStreamSupplierSpy ).when( gwtRpcSpy ).getInputStreamSupplier( policy1Url );
+
+    // ---
+
+    SerializationPolicy result = gwtRpcSpy.loadSerializationPolicy( moduleContextPath, strongName );
+
+    // ---
+
+    assertEquals( pluginPolicyMock, result );
+
+    verify( loggerMock, times( 0 ) ).error( anyString() );
+    verify( loggerMock, times( 0 ) ).warn( anyString() );
+  }
+
+  // endregion
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/SystemGwtRpcTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/SystemGwtRpcTest.java
@@ -1,0 +1,220 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc;
+
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.web.gwt.rpc.util.ThrowingSupplier;
+import org.pentaho.platform.web.servlet.GwtRpcProxyException;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( {
+  PentahoSystem.class,
+  WebApplicationContextUtils.class,
+  AbstractGwtRpc.class
+} )
+public class SystemGwtRpcTest {
+
+  private HttpServletRequest setupHttpRequest( String servletPath, String pathInfo ) {
+    HttpServletRequest httpRequestMock = mock( HttpServletRequest.class );
+    when( httpRequestMock.getServletPath() ).thenReturn( servletPath );
+    when( httpRequestMock.getPathInfo() ).thenReturn( pathInfo );
+
+    return httpRequestMock;
+  }
+
+  // region HttpRequest
+  @Test
+  public void testGetServletRequest() {
+    String servletPath = "/ws";
+    String pathInfo = "/gwt/serviceName";
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( servletPath, pathInfo );
+
+    SystemGwtRpc gwtRpc = new SystemGwtRpc( httpRequestMock );
+
+    HttpServletRequest result = gwtRpc.getServletRequest();
+
+    assertEquals( httpRequestMock, result );
+  }
+  // endregion
+
+  // region Target
+  @Test( expected = GwtRpcProxyException.class )
+  public void testResolveTargetThrowsWhenServiceIsNotDefined() {
+    String servletPath = "/ws";
+    String pathInfo = "/gwt/serviceName";
+    String serviceKey = "ws-gwt-serviceName";
+
+    // ---
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( servletPath, pathInfo );
+
+    // ---
+
+    ApplicationContext appContext = mock( ApplicationContext.class );
+    when( appContext.containsBean( serviceKey ) ).thenReturn( false );
+
+    // ---
+
+    SystemGwtRpc gwtRpc = spy( new SystemGwtRpc( httpRequestMock ) );
+    doReturn( appContext ).when( gwtRpc ).createAppContext();
+
+    // ---
+
+    gwtRpc.resolveTarget();
+  }
+
+  @Test( expected = GwtRpcProxyException.class )
+  public void testResolveTargetThrowsIfBeanResolveThrowsBeansException() {
+    String servletPath = "/ws";
+    String pathInfo = "/gwt/serviceName";
+    String serviceKey = "ws-gwt-serviceName";
+
+    // ---
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( servletPath, pathInfo );
+
+    // ---
+
+    BeansException error = mock( BeansException.class );
+
+    ApplicationContext appContext = mock( ApplicationContext.class );
+    when( appContext.containsBean( serviceKey ) ).thenReturn( true );
+    when( appContext.getBean( serviceKey ) ).thenThrow( error );
+
+    // ---
+
+    SystemGwtRpc gwtRpc = spy( new SystemGwtRpc( httpRequestMock ) );
+    doReturn( appContext ).when( gwtRpc ).createAppContext();
+
+    // ---
+
+    gwtRpc.resolveTarget();
+  }
+
+  @Test
+  public void testResolveTargetWithServiceDefined() {
+    String servletPath = "/ws";
+    String pathInfo = "/gwt/serviceName";
+    String serviceKey = "ws-gwt-serviceName";
+    Object serviceTarget = new Object();
+
+    // ---
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( servletPath, pathInfo );
+
+    // ---
+
+    ApplicationContext appContext = mock( ApplicationContext.class );
+    when( appContext.containsBean( serviceKey ) ).thenReturn( true );
+    when( appContext.getBean( serviceKey ) ).thenReturn( serviceTarget );
+
+    // ---
+
+    SystemGwtRpc gwtRpc = spy( new SystemGwtRpc( httpRequestMock ) );
+    doReturn( appContext ).when( gwtRpc ).createAppContext();
+
+    // ---
+
+    Object result = gwtRpc.resolveTarget();
+
+    assertEquals( serviceTarget, result );
+  }
+  // endregion
+
+  // region Serialization Policy
+  @Test
+  public void testLoadSerializationPolicy() {
+    String servletPath = "/ws";
+    String pathInfo = "/gwt/serviceName";
+
+    String moduleContextPath = "/mantle/";
+    String strongName = "ABC";
+    String policyFilePath = moduleContextPath + strongName + ".gwt.rpc";
+
+    // ---
+
+    InputStream systemPolicyInputStreamMock = mock( InputStream.class );
+    ServletContext servletContextMock = mock( ServletContext.class );
+
+    when( servletContextMock.getResourceAsStream( policyFilePath ) )
+      .thenReturn( systemPolicyInputStreamMock );
+
+    // ---
+
+    SerializationPolicy systemPolicyMock = mock( SerializationPolicy.class );
+
+    mockStatic( AbstractGwtRpc.class );
+    doAnswer( (Answer<SerializationPolicy>) invocationOnMock -> {
+      @SuppressWarnings( "unchecked" )
+      ThrowingSupplier<InputStream, IOException> inputStreamSupplier =
+        (ThrowingSupplier<InputStream, IOException>) invocationOnMock.getArguments()[ 0 ];
+
+      InputStream inputStream = inputStreamSupplier.get();
+      assertEquals( systemPolicyInputStreamMock, inputStream );
+
+      return systemPolicyMock;
+    } ).when( AbstractGwtRpc.class );
+    AbstractGwtRpc.loadSerializationPolicyFromInputStream( any(), eq( policyFilePath ) );
+
+    // ---
+
+    HttpServletRequest httpRequestMock = setupHttpRequest( servletPath, pathInfo );
+    SystemGwtRpc gwtRpcSpy = spy( new SystemGwtRpc( httpRequestMock ) );
+
+    doReturn( servletContextMock ).when( gwtRpcSpy ).getServletContext();
+
+    // ---
+
+    SerializationPolicy result = gwtRpcSpy.loadSerializationPolicy( moduleContextPath, strongName );
+
+    // ---
+
+    assertEquals( systemPolicyMock, result );
+
+    verifyStatic( times( 1 ) );
+    AbstractGwtRpc.loadSerializationPolicyFromInputStream( any(), eq( policyFilePath ) );
+  }
+  // endregion
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/impl/GwtRpcUtilTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/impl/GwtRpcUtilTest.java
@@ -1,0 +1,299 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.impl;
+
+import org.junit.Test;
+import org.pentaho.platform.web.gwt.rpc.util.ThrowingSupplier;
+
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class GwtRpcUtilTest {
+
+  // region scrubWebAppRoot( path , contextPath )
+  /*
+   * NOTE: These tests were written to match the existing implementation, even though much of the way it works
+   * doesn't seem to make much sense...
+   */
+
+  private static final String APP_CONTEXT = "/pentaho";
+
+  private void testScrubOne( String path, String expectedResult ) {
+    String result = GwtRpcUtil.scrubWebAppRoot( path, APP_CONTEXT );
+
+    assertEquals( expectedResult, result );
+  }
+
+  @Test
+  public void testScrubEmptyResultsInEmpty() {
+    testScrubOne( "", "" );
+  }
+
+  @Test
+  public void testScrubNotRootedPathReturnsSamePath() {
+    testScrubOne( "WEBAPP_ROOT", "WEBAPP_ROOT" );
+    testScrubOne( "WEBAPP_ROOT/", "WEBAPP_ROOT/" );
+    testScrubOne( "abc/WEBAPP_ROOT/", "abc/WEBAPP_ROOT/" );
+  }
+
+  @Test
+  public void testScrubRootedPathButNonTokenFolderReturnsSamePath() {
+    testScrubOne( "/WEBAPP_ROOT", "/WEBAPP_ROOT" );
+    testScrubOne( "/abc/WEBAPP_ROOT", "/abc/WEBAPP_ROOT" );
+  }
+
+  @Test
+  public void testScrubFirstLevelRootedAndFolderTokenReturnsSamePath() {
+    testScrubOne( "/WEBAPP_ROOT/", "/WEBAPP_ROOT/" );
+    testScrubOne( "/WEBAPP_ROOT/abc", "/WEBAPP_ROOT/abc" );
+  }
+
+  @Test
+  public void testScrubSecondLevelRootedAndFolderTokenReplacesToken() {
+    testScrubOne( "//WEBAPP_ROOT/", APP_CONTEXT );
+    testScrubOne( "//WEBAPP_ROOT//abc", APP_CONTEXT + "/abc" );
+
+    testScrubOne( "//WEBAPP_ROOT/", APP_CONTEXT );
+    testScrubOne( "/abc/WEBAPP_ROOT//cde", APP_CONTEXT + "/cde" );
+  }
+  // endregion scrubWebAppRoot
+
+  // region withClassLoader( classLoader, supplier )
+  public static class SupplierMock<T> implements Supplier<T> {
+
+    private final T value;
+    private final Runnable runnable;
+
+    public SupplierMock( T value, Runnable runnable ) {
+      this.value = value;
+      this.runnable = runnable;
+    }
+
+    @Override
+    public T get() {
+      if ( runnable != null ) {
+        runnable.run();
+      }
+
+      return value;
+    }
+  }
+
+  @Test
+  public void testWithClassLoaderSetsGivenClassLoaderInCurrentThread() {
+    ClassLoader classLoaderMock = mock( ClassLoader.class );
+
+    SupplierMock<Void> supplierSpy = spy( new SupplierMock<>( null,
+      () -> assertEquals( classLoaderMock, Thread.currentThread().getContextClassLoader() ) ) );
+
+    GwtRpcUtil.withClassLoader( classLoaderMock, supplierSpy );
+
+    // Make sure it was called.
+    verify( supplierSpy, times( 1 ) ).get();
+  }
+
+  @Test
+  public void testWithClassLoaderRestoresOriginalClassLoaderInCurrentThreadIfSupplierSucceeds() {
+    Thread currentThread = Thread.currentThread();
+    ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+    try {
+      ClassLoader beforeClassLoaderMock = mock( ClassLoader.class );
+      currentThread.setContextClassLoader( beforeClassLoaderMock );
+
+      ClassLoader duringClassLoaderMock = mock( ClassLoader.class );
+
+      // Cannot spy Supplier<T> directly.
+      SupplierMock<Void> supplierSpy = spy( new SupplierMock<>( null, null ) );
+
+      GwtRpcUtil.withClassLoader( duringClassLoaderMock, supplierSpy );
+
+      // Make sure it was called.
+      verify( supplierSpy, times( 1 ) ).get();
+
+      assertEquals( beforeClassLoaderMock, currentThread.getContextClassLoader() );
+
+    } finally {
+      if ( originalClassLoader != null ) {
+        currentThread.setContextClassLoader( originalClassLoader );
+      }
+    }
+  }
+
+  @Test
+  public void testWithClassLoaderRestoresOriginalClassLoaderInCurrentThreadIfSupplierThrows() {
+    Thread currentThread = Thread.currentThread();
+    ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+    try {
+      ClassLoader beforeClassLoaderMock = mock( ClassLoader.class );
+      currentThread.setContextClassLoader( beforeClassLoaderMock );
+
+      ClassLoader duringClassLoaderMock = mock( ClassLoader.class );
+
+      RuntimeException error = new RuntimeException();
+
+      // Cannot spy Supplier<T> directly.
+      SupplierMock<Void> supplierSpy = spy( new SupplierMock<>( null, () -> {
+        throw error;
+      } ) );
+
+      try {
+        GwtRpcUtil.withClassLoader( duringClassLoaderMock, supplierSpy );
+      } catch ( RuntimeException ex ) {
+        assertEquals( error, ex );
+      }
+
+      // Make sure it was called.
+      verify( supplierSpy, times( 1 ) ).get();
+
+      assertEquals( beforeClassLoaderMock, currentThread.getContextClassLoader() );
+
+    } finally {
+      if ( originalClassLoader != null ) {
+        currentThread.setContextClassLoader( originalClassLoader );
+      }
+    }
+  }
+
+  @Test
+  public void testWithClassLoaderReturnsSupplierValue() {
+    ClassLoader classLoaderMock = mock( ClassLoader.class );
+    Object supplied = new Object();
+    Object result = GwtRpcUtil.withClassLoader( classLoaderMock, new SupplierMock<>( supplied, null ) );
+
+    assertEquals( supplied, result );
+  }
+  // endregion withClassLoader
+
+  // region withClassLoaderThrowing( classLoader, throwingSupplier)
+  interface ThrowingRunnable<E extends Throwable> {
+    void run() throws E;
+  }
+
+  public static class ThrowingSupplierMock<T, E extends Throwable> implements ThrowingSupplier<T, E> {
+
+    private final T value;
+    private final ThrowingRunnable<E> runnable;
+
+    public ThrowingSupplierMock( T value, ThrowingRunnable<E> runnable ) {
+      this.value = value;
+      this.runnable = runnable;
+    }
+
+    @Override
+    public T get() throws E {
+      if ( runnable != null ) {
+        runnable.run();
+      }
+
+      return value;
+    }
+  }
+
+  @Test
+  public void testWithClassLoaderThrowingSetsGivenClassLoaderInCurrentThread() throws Exception {
+    ClassLoader classLoaderMock = mock( ClassLoader.class );
+
+    ThrowingSupplierMock<Void, Exception> supplierSpy = spy( new ThrowingSupplierMock<>( null,
+      () -> assertEquals( classLoaderMock, Thread.currentThread().getContextClassLoader() ) ) );
+
+    GwtRpcUtil.withClassLoaderThrowing( classLoaderMock, supplierSpy );
+
+    // Make sure it was called.
+    verify( supplierSpy, times( 1 ) ).get();
+  }
+
+  @Test
+  public void testWithClassLoaderThrowingRestoresOriginalClassLoaderInCurrentThreadIfSupplierSucceeds()
+    throws Exception {
+    Thread currentThread = Thread.currentThread();
+    ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+    try {
+      ClassLoader beforeClassLoaderMock = mock( ClassLoader.class );
+      currentThread.setContextClassLoader( beforeClassLoaderMock );
+
+      ClassLoader duringClassLoaderMock = mock( ClassLoader.class );
+
+      // Cannot spy Supplier<T> directly.
+      ThrowingSupplierMock<Void, Exception> supplierSpy = spy( new ThrowingSupplierMock<>( null, null ) );
+
+      GwtRpcUtil.withClassLoaderThrowing( duringClassLoaderMock, supplierSpy );
+
+      // Make sure it was called.
+      verify( supplierSpy, times( 1 ) ).get();
+
+      assertEquals( beforeClassLoaderMock, currentThread.getContextClassLoader() );
+
+    } finally {
+      if ( originalClassLoader != null ) {
+        currentThread.setContextClassLoader( originalClassLoader );
+      }
+    }
+  }
+
+  @Test
+  public void testWithClassLoaderThrowingRestoresOriginalClassLoaderInCurrentThreadIfSupplierThrows() throws Exception {
+    Thread currentThread = Thread.currentThread();
+    ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+    try {
+      ClassLoader beforeClassLoaderMock = mock( ClassLoader.class );
+      currentThread.setContextClassLoader( beforeClassLoaderMock );
+
+      ClassLoader duringClassLoaderMock = mock( ClassLoader.class );
+
+      Exception error = new Exception();
+
+      // Cannot spy Supplier<T> directly.
+      ThrowingSupplierMock<Void, Exception> supplierSpy = spy( new ThrowingSupplierMock<>( null, () -> {
+        throw error;
+      } ) );
+
+      try {
+        GwtRpcUtil.withClassLoaderThrowing( duringClassLoaderMock, supplierSpy );
+      } catch ( Exception ex ) {
+        assertEquals( error, ex );
+      }
+
+      // Make sure it was called.
+      verify( supplierSpy, times( 1 ) ).get();
+
+      assertEquals( beforeClassLoaderMock, currentThread.getContextClassLoader() );
+
+    } finally {
+      if ( originalClassLoader != null ) {
+        currentThread.setContextClassLoader( originalClassLoader );
+      }
+    }
+  }
+
+  @Test
+  public void testWithClassLoaderThrowingReturnsSupplierValue() throws Exception {
+    ClassLoader classLoaderMock = mock( ClassLoader.class );
+    Object supplied = new Object();
+    Object result = GwtRpcUtil.withClassLoaderThrowing(
+      classLoaderMock,
+      new ThrowingSupplierMock<Object, Exception>( supplied, null ) );
+
+    assertEquals( supplied, result );
+  }
+  // endregion
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/AbstractGwtRpcRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/AbstractGwtRpcRequestMatcherTest.java
@@ -1,0 +1,275 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.matcher;
+
+import com.google.gwt.user.server.rpc.RPCRequest;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.junit.Test;
+import org.pentaho.platform.web.gwt.rpc.AbstractGwtRpc;
+import org.pentaho.platform.web.gwt.rpc.IGwtRpcSerializationPolicyCache;
+import org.pentaho.platform.web.servlet.GwtRpcProxyException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class AbstractGwtRpcRequestMatcherTest {
+
+  private static final String TEST_PATH = "/ws/gwt/unifiedRepository";
+  private static final String TEST_PATH_ALTERNATE_CASE = "/ws/gwt/UnifiedRepository";
+  private static final String TEST_PATTERN = "^/ws/gwt/unifiedRepository\\b.*";
+  private static final String TEST_RPC_METHOD_1 = "methodSave";
+  private static final String TEST_RPC_METHOD_2 = "methodRead";
+  private static final Collection<String> TEST_RPC_METHODS_SINGLE = Collections.singletonList( TEST_RPC_METHOD_1 );
+  private static final Collection<String> TEST_RPC_METHODS_MULTIPLE =
+    Arrays.asList( TEST_RPC_METHOD_1, TEST_RPC_METHOD_2 );
+
+  // region Helpers
+  static class TestRequestMatcher extends AbstractGwtRpcRequestMatcher {
+
+    public TestRequestMatcher( @NonNull String pattern,
+                               @NonNull Collection<String> rpcMethods,
+                               @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+      super( pattern, rpcMethods, serializationPolicyCache );
+    }
+
+    public TestRequestMatcher( @NonNull String pattern,
+                               boolean isCaseInsensitive,
+                               @NonNull Collection<String> rpcMethods,
+                               @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
+      super( pattern, isCaseInsensitive, rpcMethods, serializationPolicyCache );
+    }
+
+    @NonNull @Override
+    protected AbstractGwtRpc getGwtRpc( @NonNull HttpServletRequest httpRequest ) {
+      // To be stubbed.
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  @NonNull
+  private HttpServletRequest createRequestMock( @NonNull String httpMethod, @NonNull String path ) {
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getMethod() ).thenReturn( httpMethod );
+    when( request.getServletPath() ).thenReturn( "" );
+    when( request.getPathInfo() ).thenReturn( path );
+    when( request.getQueryString() ).thenReturn( null );
+
+    return request;
+  }
+
+  // This method is used below to obtain a legitimate reflection Method instance.
+  // ~ TEST_RPC_METHOD_1
+  public void methodSave() {
+  }
+
+  // This method is used below to obtain a legitimate reflection Method instance.
+  // ~ TEST_RPC_METHOD_2
+  public void methodSaveSomething() {
+  }
+
+  @NonNull
+  private AbstractGwtRpc createGwtRpcMock( @NonNull String serviceMethodName ) throws NoSuchMethodException {
+
+    Method serviceMethodMock = this.getClass().getMethod( serviceMethodName );
+
+    RPCRequest rpcRequestMock = new RPCRequest( serviceMethodMock, new Object[] {}, null, 0 );
+
+    AbstractGwtRpc gwtRpcMock = mock( AbstractGwtRpc.class );
+    when( gwtRpcMock.getRequest() ).thenReturn( rpcRequestMock );
+
+    return gwtRpcMock;
+  }
+  // endregion
+
+  // region RpcMethods
+  @Test
+  public void testRpcMethodsSingleMatch() {
+    AbstractGwtRpcRequestMatcher matcher = spy( new TestRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, null ) );
+    assertEquals( TEST_RPC_METHODS_SINGLE, matcher.getRpcMethodNames() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
+    assertFalse( matcher.test( request ) );
+  }
+
+  @Test
+  public void testRpcMethodsMultipleMatch() {
+    AbstractGwtRpcRequestMatcher matcher =
+      spy( new TestRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_MULTIPLE, null ) );
+    assertEquals( TEST_RPC_METHODS_MULTIPLE, matcher.getRpcMethodNames() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_2 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
+    assertFalse( matcher.test( request ) );
+  }
+  // endregion
+
+  // region Path Case Sensitivity
+  @Test
+  public void testPathCaseInsensitiveMatch() {
+
+    AbstractGwtRpcRequestMatcher matcher = spy( new TestRequestMatcher(
+      TEST_PATTERN,
+      true,
+      TEST_RPC_METHODS_SINGLE,
+      null ) );
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH_ALTERNATE_CASE );
+    assertTrue( matcher.test( request ) );
+  }
+
+  @Test
+  public void testPathCaseSensitiveMatch() {
+
+    AbstractGwtRpcRequestMatcher matcher = spy( new TestRequestMatcher(
+      TEST_PATTERN,
+      false,
+      TEST_RPC_METHODS_SINGLE,
+      null ) );
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH_ALTERNATE_CASE );
+    assertFalse( matcher.test( request ) );
+
+    // ---
+    // Default is false
+
+    matcher = spy( new TestRequestMatcher(
+      TEST_PATTERN,
+      TEST_RPC_METHODS_SINGLE,
+      null ) );
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH_ALTERNATE_CASE );
+    assertFalse( matcher.test( request ) );
+  }
+  // endregion
+
+  // region Http Method
+  @Test
+  public void testHttpMethodMustBePOSTMatch() {
+
+    AbstractGwtRpcRequestMatcher matcher = spy( new TestRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, null ) );
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    request = createRequestMock( HttpMethod.GET, TEST_PATH );
+    assertFalse( matcher.test( request ) );
+  }
+  // endregion
+
+  // region getGwtRpc integration
+  @Test
+  public void testMatchWithMethodNameFromGwtRpc() throws NoSuchMethodException {
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    AbstractGwtRpcRequestMatcher matcher = spy( new TestRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, null ) );
+
+    // ---
+
+    AbstractGwtRpc gwtRpcMock = createGwtRpcMock( TEST_RPC_METHOD_1 );
+
+    doReturn( gwtRpcMock ).when( matcher ).getGwtRpc( any() );
+
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    gwtRpcMock = createGwtRpcMock( TEST_RPC_METHOD_1 + "Something" );
+
+    doReturn( gwtRpcMock ).when( matcher ).getGwtRpc( any() );
+
+    assertFalse( matcher.test( request ) );
+  }
+
+  @Test
+  public void testMatchFailsWhenGetGwtRpcThrows() {
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    AbstractGwtRpcRequestMatcher matcher = spy( new TestRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, null ) );
+
+    // ---
+
+    doThrow( GwtRpcProxyException.class ).when( matcher ).getGwtRpc( any() );
+
+    assertFalse( matcher.test( request ) );
+  }
+  // endregion
+
+  // region Serialization Policy Cache
+  @Test
+  public void testConstructWithSerializationPolicyCache() {
+    IGwtRpcSerializationPolicyCache cache = mock( IGwtRpcSerializationPolicyCache.class );
+
+    AbstractGwtRpcRequestMatcher matcher = new TestRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, cache );
+
+    assertEquals( cache, matcher.getSerializationPolicyCache() );
+  }
+  // endregion
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/AbstractGwtRpcRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/AbstractGwtRpcRequestMatcherTest.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -57,14 +58,14 @@ public class AbstractGwtRpcRequestMatcherTest {
   static class TestRequestMatcher extends AbstractGwtRpcRequestMatcher {
 
     public TestRequestMatcher( @NonNull String pattern,
-                               @NonNull Collection<String> rpcMethods,
+                               @Nullable Collection<String> rpcMethods,
                                @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
       super( pattern, rpcMethods, serializationPolicyCache );
     }
 
     public TestRequestMatcher( @NonNull String pattern,
                                boolean isCaseInsensitive,
-                               @NonNull Collection<String> rpcMethods,
+                               @Nullable Collection<String> rpcMethods,
                                @Nullable IGwtRpcSerializationPolicyCache serializationPolicyCache ) {
       super( pattern, isCaseInsensitive, rpcMethods, serializationPolicyCache );
     }
@@ -152,6 +153,24 @@ public class AbstractGwtRpcRequestMatcherTest {
 
     doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
     assertFalse( matcher.test( request ) );
+  }
+
+  @Test
+  public void testRpcMethodsAllMatch() {
+    AbstractGwtRpcRequestMatcher matcher = spy( new TestRequestMatcher( TEST_PATTERN, null, null ) );
+    assertNull( matcher.getRpcMethodNames() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
   }
   // endregion
 

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/PluginGwtRpcRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/PluginGwtRpcRequestMatcherTest.java
@@ -1,0 +1,215 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.matcher;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.junit.Test;
+import org.pentaho.platform.web.gwt.rpc.AbstractGwtRpc;
+import org.pentaho.platform.web.gwt.rpc.IGwtRpcSerializationPolicyCache;
+import org.pentaho.platform.web.gwt.rpc.PluginGwtRpc;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PluginGwtRpcRequestMatcherTest {
+  private static final String HTTP_GWT_RPC_ATTRIBUTE = AbstractGwtRpc.class.getSimpleName();
+
+  private static final String TEST_PATH = "/ws/gwt/unifiedRepository";
+  private static final String TEST_PATH_ALTERNATE_CASE = "/ws/gwt/UnifiedRepository";
+  private static final String TEST_PATTERN = "^/ws/gwt/unifiedRepository\\b.*";
+  private static final String TEST_RPC_METHOD_1 = "methodSave";
+  private static final String TEST_RPC_METHOD_2 = "methodRead";
+  private static final Collection<String> TEST_RPC_METHODS_SINGLE = Collections.singletonList( TEST_RPC_METHOD_1 );
+  private static final Collection<String> TEST_RPC_METHODS_MULTIPLE =
+    Arrays.asList( TEST_RPC_METHOD_1, TEST_RPC_METHOD_2 );
+
+  // region Helpers
+
+  @NonNull
+  private HttpServletRequest createRequestMock( @NonNull String httpMethod, @NonNull String path ) {
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getMethod() ).thenReturn( httpMethod );
+    when( request.getServletPath() ).thenReturn( "" );
+    when( request.getPathInfo() ).thenReturn( path );
+    when( request.getQueryString() ).thenReturn( null );
+
+    return request;
+  }
+  // endregion
+
+  // region RpcMethods
+  @Test
+  public void testRpcMethodsSingleMatch() {
+    PluginGwtRpcRequestMatcher matcher =
+      spy( new PluginGwtRpcRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, null ) );
+    assertEquals( TEST_RPC_METHODS_SINGLE, matcher.getRpcMethodNames() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
+    assertFalse( matcher.test( request ) );
+  }
+
+  @Test
+  public void testRpcMethodsMultipleMatch() {
+    PluginGwtRpcRequestMatcher matcher =
+      spy( new PluginGwtRpcRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_MULTIPLE, null ) );
+    assertEquals( TEST_RPC_METHODS_MULTIPLE, matcher.getRpcMethodNames() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_2 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
+    assertFalse( matcher.test( request ) );
+  }
+  // endregion
+
+  // region Path Case Sensitivity
+  @Test
+  public void testPathCaseInsensitiveMatch() {
+
+    PluginGwtRpcRequestMatcher matcher = spy( new PluginGwtRpcRequestMatcher(
+      TEST_PATTERN,
+      true,
+      TEST_RPC_METHODS_SINGLE,
+      null ) );
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH_ALTERNATE_CASE );
+    assertTrue( matcher.test( request ) );
+  }
+
+  @Test
+  public void testPathCaseSensitiveMatch() {
+
+    PluginGwtRpcRequestMatcher matcher = spy( new PluginGwtRpcRequestMatcher(
+      TEST_PATTERN,
+      false,
+      TEST_RPC_METHODS_SINGLE,
+      null ) );
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH_ALTERNATE_CASE );
+    assertFalse( matcher.test( request ) );
+
+    // ---
+    // Default is false
+
+    matcher = spy( new PluginGwtRpcRequestMatcher(
+      TEST_PATTERN,
+      TEST_RPC_METHODS_SINGLE,
+      null ) );
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH_ALTERNATE_CASE );
+    assertFalse( matcher.test( request ) );
+  }
+  // endregion
+
+  // region getGwtRpc integration
+  @Test
+  public void testGetGwtRpcReturnsAPluginGwtRpc() {
+
+    HttpServletRequest requestMock = createRequestMock( HttpMethod.POST, TEST_PATH );
+    IGwtRpcSerializationPolicyCache serializationPolicyCache = ( moduleBaseURL, strongName, sourceProvider ) -> {
+      throw new UnsupportedOperationException();
+    };
+
+    PluginGwtRpcRequestMatcher matcher =
+      spy( new PluginGwtRpcRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, serializationPolicyCache ) );
+
+    // ---
+
+    AbstractGwtRpc gwtRpc = matcher.getGwtRpc( requestMock );
+
+    assertNotNull( gwtRpc );
+    assertTrue( gwtRpc instanceof PluginGwtRpc );
+    assertEquals( requestMock, gwtRpc.getServletRequest() );
+    assertEquals( serializationPolicyCache, gwtRpc.getSerializationPolicyCache() );
+  }
+
+  @Test
+  public void testGetGwtRpcCachesPluginGwtRpcOnRequest() {
+
+    HttpServletRequest requestMock = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    PluginGwtRpcRequestMatcher matcher =
+      spy( new PluginGwtRpcRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, null ) );
+
+    // ---
+
+    AbstractGwtRpc gwtRpc1 = matcher.getGwtRpc( requestMock );
+
+    verify( requestMock, times( 1 ) ).getAttribute( HTTP_GWT_RPC_ATTRIBUTE );
+    verify( requestMock, times( 1 ) ).setAttribute( HTTP_GWT_RPC_ATTRIBUTE, gwtRpc1 );
+
+    // ---
+
+    when( requestMock.getAttribute( HTTP_GWT_RPC_ATTRIBUTE ) ).thenReturn( gwtRpc1 );
+
+    AbstractGwtRpc gwtRpc2 = matcher.getGwtRpc( requestMock );
+
+    assertEquals( gwtRpc1, gwtRpc2 );
+  }
+  // endregion
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/PluginGwtRpcRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/PluginGwtRpcRequestMatcherTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -109,6 +110,24 @@ public class PluginGwtRpcRequestMatcherTest {
 
     doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
     assertFalse( matcher.test( request ) );
+  }
+
+  @Test
+  public void testRpcMethodsAllMatch() {
+    PluginGwtRpcRequestMatcher matcher = spy( new PluginGwtRpcRequestMatcher( TEST_PATTERN, null, null ) );
+    assertNull( matcher.getRpcMethodNames() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
   }
   // endregion
 

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/SystemGwtRpcRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/SystemGwtRpcRequestMatcherTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -109,6 +110,24 @@ public class SystemGwtRpcRequestMatcherTest {
 
     doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
     assertFalse( matcher.test( request ) );
+  }
+
+  @Test
+  public void testRpcMethodsAllMatch() {
+    SystemGwtRpcRequestMatcher matcher = spy( new SystemGwtRpcRequestMatcher( TEST_PATTERN, null, null ) );
+    assertNull( matcher.getRpcMethodNames() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
   }
   // endregion
 

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/SystemGwtRpcRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/matcher/SystemGwtRpcRequestMatcherTest.java
@@ -1,0 +1,215 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.matcher;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.junit.Test;
+import org.pentaho.platform.web.gwt.rpc.AbstractGwtRpc;
+import org.pentaho.platform.web.gwt.rpc.IGwtRpcSerializationPolicyCache;
+import org.pentaho.platform.web.gwt.rpc.SystemGwtRpc;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SystemGwtRpcRequestMatcherTest {
+  private static final String HTTP_GWT_RPC_ATTRIBUTE = AbstractGwtRpc.class.getSimpleName();
+
+  private static final String TEST_PATH = "/ws/gwt/unifiedRepository";
+  private static final String TEST_PATH_ALTERNATE_CASE = "/ws/gwt/UnifiedRepository";
+  private static final String TEST_PATTERN = "^/ws/gwt/unifiedRepository\\b.*";
+  private static final String TEST_RPC_METHOD_1 = "methodSave";
+  private static final String TEST_RPC_METHOD_2 = "methodRead";
+  private static final Collection<String> TEST_RPC_METHODS_SINGLE = Collections.singletonList( TEST_RPC_METHOD_1 );
+  private static final Collection<String> TEST_RPC_METHODS_MULTIPLE =
+    Arrays.asList( TEST_RPC_METHOD_1, TEST_RPC_METHOD_2 );
+
+  // region Helpers
+
+  @NonNull
+  private HttpServletRequest createRequestMock( @NonNull String httpMethod, @NonNull String path ) {
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getMethod() ).thenReturn( httpMethod );
+    when( request.getServletPath() ).thenReturn( "" );
+    when( request.getPathInfo() ).thenReturn( path );
+    when( request.getQueryString() ).thenReturn( null );
+
+    return request;
+  }
+  // endregion
+
+  // region RpcMethods
+  @Test
+  public void testRpcMethodsSingleMatch() {
+    SystemGwtRpcRequestMatcher matcher =
+      spy( new SystemGwtRpcRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, null ) );
+    assertEquals( TEST_RPC_METHODS_SINGLE, matcher.getRpcMethodNames() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
+    assertFalse( matcher.test( request ) );
+  }
+
+  @Test
+  public void testRpcMethodsMultipleMatch() {
+    SystemGwtRpcRequestMatcher matcher =
+      spy( new SystemGwtRpcRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_MULTIPLE, null ) );
+    assertEquals( TEST_RPC_METHODS_MULTIPLE, matcher.getRpcMethodNames() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_2 ).when( matcher ).getRpcMethodName( any() );
+    assertTrue( matcher.test( request ) );
+
+    // ---
+
+    doReturn( TEST_RPC_METHOD_1 + "_SOMETHING" ).when( matcher ).getRpcMethodName( any() );
+    assertFalse( matcher.test( request ) );
+  }
+  // endregion
+
+  // region Path Case Sensitivity
+  @Test
+  public void testPathCaseInsensitiveMatch() {
+
+    SystemGwtRpcRequestMatcher matcher = spy( new SystemGwtRpcRequestMatcher(
+      TEST_PATTERN,
+      true,
+      TEST_RPC_METHODS_SINGLE,
+      null ) );
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH_ALTERNATE_CASE );
+    assertTrue( matcher.test( request ) );
+  }
+
+  @Test
+  public void testPathCaseSensitiveMatch() {
+
+    SystemGwtRpcRequestMatcher matcher = spy( new SystemGwtRpcRequestMatcher(
+      TEST_PATTERN,
+      false,
+      TEST_RPC_METHODS_SINGLE,
+      null ) );
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    HttpServletRequest request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH_ALTERNATE_CASE );
+    assertFalse( matcher.test( request ) );
+
+    // ---
+    // Default is false
+
+    matcher = spy( new SystemGwtRpcRequestMatcher(
+      TEST_PATTERN,
+      TEST_RPC_METHODS_SINGLE,
+      null ) );
+
+    doReturn( TEST_RPC_METHOD_1 ).when( matcher ).getRpcMethodName( any() );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH );
+    assertTrue( matcher.test( request ) );
+
+    request = createRequestMock( HttpMethod.POST, TEST_PATH_ALTERNATE_CASE );
+    assertFalse( matcher.test( request ) );
+  }
+  // endregion
+
+  // region getGwtRpc integration
+  @Test
+  public void testGetGwtRpcReturnsASystemGwtRpc() {
+
+    HttpServletRequest requestMock = createRequestMock( HttpMethod.POST, TEST_PATH );
+    IGwtRpcSerializationPolicyCache serializationPolicyCache = ( moduleBaseURL, strongName, sourceProvider ) -> {
+      throw new UnsupportedOperationException();
+    };
+
+    SystemGwtRpcRequestMatcher matcher =
+      spy( new SystemGwtRpcRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, serializationPolicyCache ) );
+
+    // ---
+
+    AbstractGwtRpc gwtRpc = matcher.getGwtRpc( requestMock );
+
+    assertNotNull( gwtRpc );
+    assertTrue( gwtRpc instanceof SystemGwtRpc );
+    assertEquals( requestMock, gwtRpc.getServletRequest() );
+    assertEquals( serializationPolicyCache, gwtRpc.getSerializationPolicyCache() );
+  }
+
+  @Test
+  public void testGetGwtRpcCachesSystemGwtRpcOnRequest() {
+
+    HttpServletRequest requestMock = createRequestMock( HttpMethod.POST, TEST_PATH );
+
+    SystemGwtRpcRequestMatcher matcher =
+      spy( new SystemGwtRpcRequestMatcher( TEST_PATTERN, TEST_RPC_METHODS_SINGLE, null ) );
+
+    // ---
+
+    AbstractGwtRpc gwtRpc1 = matcher.getGwtRpc( requestMock );
+
+    verify( requestMock, times( 1 ) ).getAttribute( HTTP_GWT_RPC_ATTRIBUTE );
+    verify( requestMock, times( 1 ) ).setAttribute( HTTP_GWT_RPC_ATTRIBUTE, gwtRpc1 );
+
+    // ---
+
+    when( requestMock.getAttribute( HTTP_GWT_RPC_ATTRIBUTE ) ).thenReturn( gwtRpc1 );
+
+    AbstractGwtRpc gwtRpc2 = matcher.getGwtRpc( requestMock );
+
+    assertEquals( gwtRpc1, gwtRpc2 );
+  }
+  // endregion
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/support/GwtRpcSerializationPolicyCacheTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/gwt/rpc/support/GwtRpcSerializationPolicyCacheTest.java
@@ -1,0 +1,115 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2021 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.gwt.rpc.support;
+
+import com.google.gwt.user.server.rpc.SerializationPolicy;
+import com.google.gwt.user.server.rpc.SerializationPolicyProvider;
+import org.junit.Test;
+import org.pentaho.platform.web.gwt.rpc.IGwtRpcSerializationPolicyCache;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GwtRpcSerializationPolicyCacheTest {
+
+  // region Helpers
+  private static void testSerializationPolicyIsNewAndCreated( IGwtRpcSerializationPolicyCache cache,
+                                                              String moduleBaseURL,
+                                                              String strongName,
+                                                              SerializationPolicy policy ) {
+
+    SerializationPolicyProvider sourceProviderMock = createProviderMock( moduleBaseURL, strongName, policy );
+
+    SerializationPolicy result = cache.getSerializationPolicy( moduleBaseURL, strongName, sourceProviderMock );
+
+    assertEquals( policy, result );
+
+    verify( sourceProviderMock, times( 1 ) ).getSerializationPolicy( moduleBaseURL, strongName );
+  }
+
+  private static SerializationPolicyProvider createProviderMock( String moduleBaseURL,
+                                                                 String strongName,
+                                                                 SerializationPolicy policy ) {
+    SerializationPolicyProvider sourceProviderMock = mock( SerializationPolicyProvider.class );
+    when( sourceProviderMock.getSerializationPolicy( moduleBaseURL, strongName ) )
+      .thenReturn( policy );
+
+    return sourceProviderMock;
+  }
+
+  private static void testSerializationPolicyIsInCache( IGwtRpcSerializationPolicyCache cache,
+                                                        String moduleBaseURL,
+                                                        String strongName,
+                                                        SerializationPolicy policy ) {
+
+    SerializationPolicyProvider sourceProviderMock = createProviderMock( moduleBaseURL, strongName, policy );
+
+    SerializationPolicy result = cache.getSerializationPolicy( moduleBaseURL, strongName, sourceProviderMock );
+
+    assertEquals( policy, result );
+
+    verify( sourceProviderMock, times( 0 ) ).getSerializationPolicy( any(), any() );
+  }
+  // endregion
+
+  @Test
+  public void testGetSerializationPolicyWithNullKeysIsSupported() {
+    GwtRpcSerializationPolicyCache cache = new GwtRpcSerializationPolicyCache();
+    SerializationPolicy policy = mock( SerializationPolicy.class );
+
+    testSerializationPolicyIsNewAndCreated( cache, null, null, policy );
+    testSerializationPolicyIsInCache( cache, null, null, policy );
+  }
+
+  @Test
+  public void testGetSerializationPolicyWithNormalKeyIsSupported() {
+    GwtRpcSerializationPolicyCache cache = new GwtRpcSerializationPolicyCache();
+    SerializationPolicy policy = mock( SerializationPolicy.class );
+
+    testSerializationPolicyIsNewAndCreated( cache, "url", "abc", policy );
+    testSerializationPolicyIsInCache( cache, "url", "abc", policy );
+  }
+
+  @Test
+  public void testGetSerializationPolicyWithMultipleKeysMaintainsCache() {
+    GwtRpcSerializationPolicyCache cache = new GwtRpcSerializationPolicyCache();
+    SerializationPolicy policy1 = mock( SerializationPolicy.class );
+    String moduleBaseURL1 = "url1";
+    String strongName1 = "abc1";
+
+    SerializationPolicy policy2 = mock( SerializationPolicy.class );
+    String moduleBaseURL2 = "url2";
+    String strongName2 = "abc2";
+
+    SerializationPolicy policy3 = mock( SerializationPolicy.class );
+    String moduleBaseURL3 = "url3";
+    String strongName3 = "abc3";
+
+    testSerializationPolicyIsNewAndCreated( cache, moduleBaseURL1, strongName1, policy1 );
+    testSerializationPolicyIsNewAndCreated( cache, moduleBaseURL2, strongName2, policy2 );
+    testSerializationPolicyIsNewAndCreated( cache, moduleBaseURL3, strongName3, policy3 );
+
+    testSerializationPolicyIsInCache( cache, moduleBaseURL1, strongName1, policy1 );
+    testSerializationPolicyIsInCache( cache, moduleBaseURL2, strongName2, policy2 );
+    testSerializationPolicyIsInCache( cache, moduleBaseURL3, strongName3, policy3 );
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,21 @@
     <hsqldb.version>2.3.2</hsqldb.version>
     <websocket-api.version>1.0</websocket-api.version>
     <encryption-support.version>9.3.0.0-SNAPSHOT</encryption-support.version>
+    <!-- @Null @Nullable annotations -->
+    <com.github.spotbugs.annotations.version>4.2.3</com.github.spotbugs.annotations.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- @Null, @Nullable annotations -->
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${com.github.spotbugs.annotations.version}</version>
+        <optional>true</optional>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>

--- a/user-console/src/main/java/org/pentaho/mantle/client/commands/CollapseBrowserCommand.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/commands/CollapseBrowserCommand.java
@@ -1,5 +1,4 @@
 /*!
- *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -13,9 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- *
- * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
- *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.mantle.client.commands;
@@ -23,10 +20,8 @@ package org.pentaho.mantle.client.commands;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestException;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.pentaho.mantle.client.EmptyRequestCallback;
-import org.pentaho.mantle.client.csrf.JsCsrfToken;
-import org.pentaho.mantle.client.csrf.CsrfUtil;
+import org.pentaho.mantle.client.csrf.CsrfRequestBuilder;
 import org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel;
 import org.pentaho.mantle.client.ui.PerspectiveManager;
 
@@ -44,32 +39,19 @@ public class CollapseBrowserCommand extends AbstractCommand {
 
   protected void performOperation( boolean feedback ) {
 
-    final String url = GWT.getHostPageBaseURL() + "api/user-settings/MANTLE_SHOW_NAVIGATOR"; //$NON-NLS-1$
+    final SolutionBrowserPanel solutionBrowserPerspective = SolutionBrowserPanel.getInstance();
+    if ( !solutionBrowserPerspective.isNavigatorShowing() ) {
+      PerspectiveManager.getInstance().setPerspective( PerspectiveManager.OPENED_PERSPECTIVE );
+    }
+    solutionBrowserPerspective.setNavigatorShowing( false );
 
-    CsrfUtil.getCsrfToken( url, new AsyncCallback<JsCsrfToken>() {
-
-      public void onFailure( Throwable caught ) {
-      }
-
-      public void onSuccess( JsCsrfToken token ) {
-
-        final SolutionBrowserPanel solutionBrowserPerspective = SolutionBrowserPanel.getInstance();
-        if ( !solutionBrowserPerspective.isNavigatorShowing() ) {
-          PerspectiveManager.getInstance().setPerspective( PerspectiveManager.OPENED_PERSPECTIVE );
-        }
-        solutionBrowserPerspective.setNavigatorShowing( false );
-
-        RequestBuilder builder = new RequestBuilder( RequestBuilder.POST, url );
-        try {
-          builder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
-          if ( token != null ) {
-            builder.setHeader( token.getHeader(), token.getToken() );
-          }
-          builder.sendRequest( "false", EmptyRequestCallback.getInstance() );
-        } catch ( RequestException e ) {
-          // showError(e);
-        }
-      }
-    } );
+    String url = GWT.getHostPageBaseURL() + "api/user-settings/MANTLE_SHOW_NAVIGATOR";
+    RequestBuilder builder = new CsrfRequestBuilder( RequestBuilder.POST, url );
+    try {
+      builder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
+      builder.sendRequest( "false", EmptyRequestCallback.getInstance() );
+    } catch ( RequestException e ) {
+      // showError(e);
+    }
   }
 }

--- a/user-console/src/main/java/org/pentaho/mantle/client/commands/ShowBrowserCommand.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/commands/ShowBrowserCommand.java
@@ -1,5 +1,4 @@
 /*!
- *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -13,9 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- *
- * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
- *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.mantle.client.commands;
@@ -24,10 +21,8 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestException;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.pentaho.mantle.client.EmptyRequestCallback;
-import org.pentaho.mantle.client.csrf.CsrfUtil;
-import org.pentaho.mantle.client.csrf.JsCsrfToken;
+import org.pentaho.mantle.client.csrf.CsrfRequestBuilder;
 import org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel;
 import org.pentaho.mantle.client.ui.PerspectiveManager;
 
@@ -46,32 +41,19 @@ public class ShowBrowserCommand implements Command {
   public void execute() {
     final SolutionBrowserPanel solutionBrowserPerspective = SolutionBrowserPanel.getInstance();
     solutionBrowserPerspective.setNavigatorShowing( state );
-    if ( solutionBrowserPerspective != null ) {
-      if ( PerspectiveManager.getInstance().getActivePerspective().getId().equalsIgnoreCase(
-          PerspectiveManager.OPENED_PERSPECTIVE ) ) {
-        PerspectiveManager.getInstance().setPerspective( PerspectiveManager.OPENED_PERSPECTIVE );
-      }
+
+    if ( PerspectiveManager.getInstance().getActivePerspective().getId().equalsIgnoreCase(
+        PerspectiveManager.OPENED_PERSPECTIVE ) ) {
+      PerspectiveManager.getInstance().setPerspective( PerspectiveManager.OPENED_PERSPECTIVE );
     }
 
-    final String url = GWT.getHostPageBaseURL() + "api/user-settings/MANTLE_SHOW_NAVIGATOR"; //$NON-NLS-1$
-
-    CsrfUtil.getCsrfToken( url, new AsyncCallback<JsCsrfToken>() {
-
-      public void onFailure( Throwable caught ) {
-      }
-
-      public void onSuccess( JsCsrfToken token ) {
-        RequestBuilder builder = new RequestBuilder( RequestBuilder.POST, url );
-        try {
-          builder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
-          if ( token != null ) {
-            builder.setHeader( token.getHeader(), token.getToken() );
-          }
-          builder.sendRequest( "" + state, EmptyRequestCallback.getInstance() );
-        } catch ( RequestException e ) {
-          // showError(e);
-        }
-      }
-    } );
+    String url = GWT.getHostPageBaseURL() + "api/user-settings/MANTLE_SHOW_NAVIGATOR";
+    RequestBuilder builder = new CsrfRequestBuilder( RequestBuilder.POST, url );
+    try {
+      builder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
+      builder.sendRequest( "" + state, EmptyRequestCallback.getInstance() );
+    } catch ( RequestException e ) {
+      // showError(e);
+    }
   }
 }

--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/filepicklist/AbstractFilePickList.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/filepicklist/AbstractFilePickList.java
@@ -1,5 +1,4 @@
 /*!
- *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -13,9 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- *
- * Copyright (c) 2002-2019 Hitachi Vantara. All rights reserved.
- *
+ * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.mantle.client.solutionbrowser.filepicklist;
@@ -29,11 +26,8 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
-
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
-import org.pentaho.mantle.client.csrf.CsrfUtil;
-import org.pentaho.mantle.client.csrf.JsCsrfToken;
+import org.pentaho.mantle.client.csrf.CsrfRequestBuilder;
 import org.pentaho.mantle.client.messages.Messages;
 
 import java.util.ArrayList;
@@ -92,9 +86,9 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
   }
 
   /**
-   * If the object is already in the list it will be removed first and the index adjusted accordingly. If maxSize
-   * is positive and adding the item would exceed maxSize, then the item will not be added.
-   * 
+   * If the object is already in the list it will be removed first and the index adjusted accordingly. If maxSize is
+   * positive and adding the item would exceed maxSize, then the item will not be added.
+   *
    * @param index
    * @param pickListItem
    */
@@ -164,7 +158,6 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
   }
 
   /**
-   * 
    * @return true if the list was truncated
    */
   private boolean truncateToMaxSize() {
@@ -196,8 +189,7 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
   }
 
   /**
-   * @param maxSize
-   *          Set Maximum number of entries in list, 0 = unlimited
+   * @param maxSize Set Maximum number of entries in list, 0 = unlimited
    */
   public void setMaxSize( int maxSize ) {
     this.maxSize = maxSize;
@@ -208,55 +200,40 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
 
   /**
    * Convert the FilePickList to JSON and save it to a user setting
-   * 
+   *
    * @param settingName
    */
   public void save( String settingName ) {
 
-    final String url = GWT.getHostPageBaseURL() + "api/user-settings/" + settingName; //$NON-NLS-1$
+    String url = GWT.getHostPageBaseURL() + "api/user-settings/" + settingName;
+    RequestBuilder builder = new CsrfRequestBuilder( RequestBuilder.POST, url );
+    try {
+      builder.setHeader( "accept", "application/json" );
+      builder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
+      builder.sendRequest( toJson().toString(), new RequestCallback() {
 
-    CsrfUtil.getCsrfToken( url, new AsyncCallback<JsCsrfToken>() {
-
-      public void onFailure( Throwable caught ) {
-        MessageDialogBox dialog = new MessageDialogBox(
-            Messages.getString( "error" ),
-            Messages.getString( "couldNotSetUserSettings" ),
-            true,
-            false,
-            true );
-        dialog.center();
-      }
-
-      public void onSuccess( JsCsrfToken token ) {
-        RequestBuilder builder = new RequestBuilder( RequestBuilder.POST, url );
-        try {
-          builder.setHeader( "accept", "application/json" );
-          builder.setHeader( "If-Modified-Since", "01 Jan 1970 00:00:00 GMT" );
-          if ( token != null ) {
-            builder.setHeader( token.getHeader(), token.getToken() );
-          }
-          builder.sendRequest( toJson().toString(), new RequestCallback() {
-
-            public void onError( Request request, Throwable exception ) {
-              MessageDialogBox dialog =
-                  new MessageDialogBox(
-                      Messages.getString( "error" ), Messages.getString( "couldNotSetUserSettings" ), true, false, true ); //$NON-NLS-1$ //$NON-NLS-2$
-              dialog.center();
-            }
-
-            public void onResponseReceived( Request request, Response response ) {
-              fireOnSavedEvent();
-            }
-          } );
-        } catch ( RequestException e ) {
-          // showError(e);
+        public void onError( Request request, Throwable exception ) {
+          MessageDialogBox dialog =
+            new MessageDialogBox(
+              Messages.getString( "error" ),
+              Messages.getString( "couldNotSetUserSettings" ),
+              true,
+              false,
+              true );
+          dialog.center();
         }
-      }
-    } );
+
+        public void onResponseReceived( Request request, Response response ) {
+          fireOnSavedEvent();
+        }
+      } );
+    } catch ( RequestException e ) {
+      // showError(e);
+    }
   }
 
   public void reloadFavorites( final T pickListItem, final String command ) {
-    final String url = GWT.getHostPageBaseURL() + "api/user-settings/favorites"; //$NON-NLS-1$
+    final String url = GWT.getHostPageBaseURL() + "api/user-settings/favorites";
 
     RequestBuilder builder = new RequestBuilder( RequestBuilder.GET, url );
     try {
@@ -303,7 +280,7 @@ public abstract class AbstractFilePickList<T extends IFilePickItem> {
   }
 
   public void reloadRecents( final T pickListItem, final String command ) {
-    final String url = GWT.getHostPageBaseURL() + "api/user-settings/recent"; //$NON-NLS-1$
+    final String url = GWT.getHostPageBaseURL() + "api/user-settings/recent";
 
     RequestBuilder builder = new RequestBuilder( RequestBuilder.GET, url );
     try {

--- a/user-console/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -1,5 +1,4 @@
 /*!
- *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
  * Foundation.
@@ -13,47 +12,9 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- *
  * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
- *
  */
 package org.pentaho.mantle.client.workspace;
-
-import static org.pentaho.mantle.client.workspace.SchedulesPerspectivePanel.PAGE_SIZE;
-
-import com.google.gwt.json.client.JSONArray;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import org.apache.http.protocol.HTTP;
-import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
-import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
-import org.pentaho.gwt.widgets.client.dialogs.PromptDialogBox;
-import org.pentaho.gwt.widgets.client.toolbar.Toolbar;
-import org.pentaho.gwt.widgets.client.toolbar.ToolbarButton;
-import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
-import org.pentaho.mantle.client.commands.RefreshSchedulesCommand;
-import org.pentaho.mantle.client.csrf.CsrfUtil;
-import org.pentaho.mantle.client.csrf.JsCsrfToken;
-import org.pentaho.mantle.client.dialogs.scheduling.NewScheduleDialog;
-import org.pentaho.mantle.client.dialogs.scheduling.OutputLocationUtils;
-import org.pentaho.mantle.client.events.EventBusUtil;
-import org.pentaho.mantle.client.events.GenericEvent;
-import org.pentaho.mantle.client.images.ImageUtil;
-import org.pentaho.mantle.client.messages.Messages;
-import org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel;
-import org.pentaho.mantle.client.ui.PerspectiveManager;
-import org.pentaho.mantle.client.ui.column.HtmlColumn;
-import org.pentaho.mantle.client.workspace.SchedulesPerspectivePanel.CellTableResources;
-
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.core.client.GWT;
@@ -70,6 +31,7 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.http.client.URL;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
+import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -93,6 +55,39 @@ import com.google.gwt.view.client.ProvidesKey;
 import com.google.gwt.view.client.Range;
 import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SelectionChangeEvent.Handler;
+import org.apache.http.protocol.HTTP;
+import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
+import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
+import org.pentaho.gwt.widgets.client.dialogs.PromptDialogBox;
+import org.pentaho.gwt.widgets.client.toolbar.Toolbar;
+import org.pentaho.gwt.widgets.client.toolbar.ToolbarButton;
+import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
+import org.pentaho.mantle.client.EmptyRequestCallback;
+import org.pentaho.mantle.client.commands.RefreshSchedulesCommand;
+import org.pentaho.mantle.client.csrf.CsrfRequestBuilder;
+import org.pentaho.mantle.client.dialogs.scheduling.NewScheduleDialog;
+import org.pentaho.mantle.client.dialogs.scheduling.OutputLocationUtils;
+import org.pentaho.mantle.client.events.EventBusUtil;
+import org.pentaho.mantle.client.events.GenericEvent;
+import org.pentaho.mantle.client.images.ImageUtil;
+import org.pentaho.mantle.client.messages.Messages;
+import org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel;
+import org.pentaho.mantle.client.ui.PerspectiveManager;
+import org.pentaho.mantle.client.ui.column.HtmlColumn;
+import org.pentaho.mantle.client.workspace.SchedulesPerspectivePanel.CellTableResources;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.pentaho.mantle.client.workspace.SchedulesPerspectivePanel.PAGE_SIZE;
 
 public class SchedulesPanel extends SimplePanel {
 
@@ -126,8 +121,7 @@ public class SchedulesPanel extends SimplePanel {
 
   private ArrayList<IJobFilter> filters = new ArrayList<IJobFilter>();
 
-  private CellTable<JsJob> table = new CellTable<JsJob>( PAGE_SIZE, (CellTableResources) GWT
-      .create( CellTableResources.class ) );
+  private CellTable<JsJob> table = new CellTable<JsJob>( PAGE_SIZE, (CellTableResources) GWT.create( CellTableResources.class ) );
 
   private ListDataProvider<JsJob> dataProvider = new ListDataProvider<JsJob>();
 
@@ -190,7 +184,7 @@ public class SchedulesPanel extends SimplePanel {
     }
   };
 
-  @SuppressWarnings ( "unchecked" )
+  @SuppressWarnings( "unchecked" )
   private Set<JsJob> getSelectedJobs() {
     return ( (MultiSelectionModel<JsJob>) table.getSelectionModel() ).getSelectedSet();
   }
@@ -381,7 +375,7 @@ public class SchedulesPanel extends SimplePanel {
     HtmlColumn<JsJob> resourceColumn = new HtmlColumn<JsJob>() {
       @Override
       public String getStringValue( JsJob job ) {
-        String name = job.getFullResourceName().split( "\\." )[0];
+        String name = job.getFullResourceName().split( "\\." )[ 0 ];
         return name.replaceAll( "/", "/<wbr/>" );
       }
     };
@@ -686,7 +680,7 @@ public class SchedulesPanel extends SimplePanel {
         Set<JsJob> selectedJobs = getSelectedJobs();
 
         if ( !selectedJobs.isEmpty() ) {
-          final JsJob job = selectedJobs.toArray( new JsJob[0] )[0];
+          final JsJob job = selectedJobs.toArray( new JsJob[ 0 ] )[ 0 ];
           updateJobScheduleButtonStyle( job.getState() );
 
           controlScheduleButton.setEnabled( isScheduler );
@@ -821,7 +815,7 @@ public class SchedulesPanel extends SimplePanel {
         Set<JsJob> selectedJobs = getSelectedJobs();
 
         if ( !selectedJobs.isEmpty() ) {
-          final JsJob job = selectedJobs.toArray( new JsJob[0] )[0];
+          final JsJob job = selectedJobs.toArray( new JsJob[ 0 ] )[ 0 ];
 
           boolean isRunning = JOB_STATE_NORMAL.equalsIgnoreCase( job.getState() );
 
@@ -841,7 +835,7 @@ public class SchedulesPanel extends SimplePanel {
         Set<JsJob> selectedJobs = getSelectedJobs();
 
         if ( !selectedJobs.isEmpty() ) {
-          final JsJob editJob = selectedJobs.toArray( new JsJob[0] )[0];
+          final JsJob editJob = selectedJobs.toArray( new JsJob[ 0 ] )[ 0 ];
 
           canAccessJobRequest( editJob, new RequestCallback() {
             public void onError( Request request, Throwable exception ) {
@@ -1117,32 +1111,13 @@ public class SchedulesPanel extends SimplePanel {
 
     PerspectiveManager.getInstance().setPerspective( PerspectiveManager.BROWSER_PERSPECTIVE );
 
-    final String url = GWT.getHostPageBaseURL() + "api/mantle/session-variable?key=scheduler_folder&value=" + outputLocation;
-
-    CsrfUtil.getCsrfToken( url, new AsyncCallback<JsCsrfToken>() {
-
-      public void onFailure( Throwable caught ) {
-      }
-
-      public void onSuccess( JsCsrfToken token ) {
-        RequestBuilder executableTypesRequestBuilder = new RequestBuilder( RequestBuilder.POST, url );
-        if ( token != null ) {
-          executableTypesRequestBuilder.setHeader( token.getHeader(), token.getToken() );
-        }
-
-        try {
-          executableTypesRequestBuilder.sendRequest( null, new RequestCallback() {
-            public void onError( Request request, Throwable exception ) {
-            }
-
-            public void onResponseReceived( Request request, Response response ) {
-            }
-          } );
-        } catch ( RequestException e ) {
-          //IGNORE
-        }
-      }
-    } );
+    String url = GWT.getHostPageBaseURL() + "api/mantle/session-variable?key=scheduler_folder&value=" + outputLocation;
+    RequestBuilder executableTypesRequestBuilder = new CsrfRequestBuilder( RequestBuilder.POST, url );
+    try {
+      executableTypesRequestBuilder.sendRequest( null, EmptyRequestCallback.getInstance() );
+    } catch ( RequestException e ) {
+      // IGNORE
+    }
 
     GenericEvent event = new GenericEvent();
     event.setEventSubType( "RefreshFolderEvent" );


### PR DESCRIPTION
Depends on https://github.com/pentaho/pentaho-commons-gwt-modules/pull/795.

Part of the PR group https://github.com/pentaho/data-access/pull/1116.

@bennychow, @ddiroma please review. You might want to read the following first, for context.

## GWT-RPC web-services 

### How these work and are currently implemented

There are currently three `Servlet` classes in the platform which take care of exposing GWT-RPC web-services. One common, abstract class, `AbstractGwtRpcProxyServlet`,  and two subclasses:
- `GwtRpcProxyServlet` — handles the **System** GWT-RPC web services, exposed under `/ws/gwt/*`;
- `GwtRpcPluginProxyServlet` — handles the **Plugins**' GWT-RPC web services, exposed under `/gwtrpc/*`.

which is transported in 
GWT-RPC web services use a custom serialization format in HTTP requests and responses. Specifically, the method name which is being called is not in the URL, but, instead, in the body of the HTTP request message.

These classes have the following main functions:

1. finding the _target/service object_ which will receive the remote call,
2. obtaining a _serialization policy_ which indicates the types which are allowed to be part of the request and response messages, and
3. setting up an appropriate "current" class loader for request message deserialization.

The target object is selected exclusively according to (the remainder of) the URL. It may be of any class, even of one which does not implement the interface that represents the service. The only requirement is that the methods which are _called remotely_ exist with same name and arguments — as in _duck typing_.

GWT supports a special serialization policy file format which contains the list of allowed classes. These files are generated automatically by the GWT compiler and placed besides the remaining compiled GWT resources (files with the `.gwt.rpc` extension).

The following describes the differences in the handling of System and Plugin web-services which justify the existence of the two sub-classes.

#### System web services

The path is mapped to a target bean which must be declared in `pentahoServices.spring.xml` (e.g. URL/Path: `ws/gwt/unifiedRepository`, Bean id.: `ws-gwt-unifiedRepository`).

The serialization policies are accepted only as standard policy files present in the Pentaho web app's `pentaho/mantle` folder. The classes present in the policy files must exist in the main class-loader. The code that deserializes request messages must execute having the main class-loader as _current_ in the current thread.

#### Plugin web services

The path is mapped to a target object which is declared in a plugin's `plugin.xml` file, via the special `<webservice type="gwt" id="serviceName" ... />` element.

The serialization policies can be provided as an explicit plugin bean of type `SerializationPolicy`, or by standard GWT serialization policy files, present anywhere within the plugin's "file system". The classes present in the serialization policy files must exist in the **plugin's** class-loader. The code that deserializes request messages must execute having the **plugin's** class-loader as current in the current thread.

### Adding CSRF protection

Protecting these services against CSRF would be straight forward if, like normal REST or SOAP services, the _service method_ being called was somehow indicated in the URL. The existing request matchers could then be used to configure security for the URLs of specific methods of a service.

Unfortunately, given that the _service method_ of the remote call is only present in the encoded body of the HTTP request, special request matcher classes had to be developed that know how to deserialize GWT-RPC bodies and test for the service method, for both the System and Plugins cases. Additionally, care had to be taken to minimize the harm to performance.

A new class, `AbstractGwtRpc`, was defined that represents a single remote service call, and which is associated with a single `HttpServletRequest` instance, from which the call is deserialized. The same GWT-RPC instance which is used by the request matcher, which is evaluated within the `CsrfGateFilter` filter, is used by the corresponding GWT-RPC servlet (`AbstractGwtRpcProxyServlet`) instance. Thus, the request is only deserialized once. The GWT-RPC instance is stored as an attribute of the HTTP request object.

Logically, two concrete sub-classes exist:
1. `SystemGwtRpc`
2. `PluginGwtRpc`

These three new classes now house most of the code which existed in the servlet classes. The request matcher classes and the servlet classes now delegate most of the work to these new shared objects.