### PR TITLE
[PDI-19163] Upgraded mongo java driver version from 3.10.2 to 3.12.10

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -262,7 +262,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
-      <version>3.10.2</version>
+      <version>3.12.10</version>
     </dependency>
     <dependency>
       <groupId>com.ibm.icu</groupId>


### PR DESCRIPTION
Upgrading java mongo driver to the latest possible version without many changes in the code.