### PR TITLE
[BACKLOG-35298] Fix requestParameterAuthenticationEnabled due to CSRF changes

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2109,6 +2109,10 @@
       <groupId>com.hitachivantara.security.web</groupId>
       <artifactId>security-web-server-model-impl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.hitachivantara.security.web</groupId>
+      <artifactId>security-web-server-service-impl</artifactId>
+    </dependency>
     <!-- endregion HV Web Security -->
 
     <dependency>

--- a/extensions/src/main/java/org/pentaho/platform/web/http/request/MultiReadHttpServletRequest.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/request/MultiReadHttpServletRequest.java
@@ -34,9 +34,13 @@ import java.io.InputStreamReader;
 
 /**
  * @author Rowell Belen
- *
+ * <p>
  * see http://stackoverflow.com/questions/10210645/http-servlet-request-lose-params-from-post-body-after-read-it-once
+ * @deprecated Please use {@link com.hitachivantara.security.web.impl.service.util.MultiReadHttpServletRequestWrapper}
+ * instead. It supports multi-part requests, including the new {@link HttpServletRequest#getPart(String)} and
+ * {@link HttpServletRequest#getParts()} methods.
  */
+@Deprecated
 public class MultiReadHttpServletRequest extends HttpServletRequestWrapper {
   private ByteArrayOutputStream cachedBytes;
 

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/JAXRSPluginServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/JAXRSPluginServlet.java
@@ -34,7 +34,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -50,8 +49,6 @@ import java.util.regex.Pattern;
  *
  * @author Aaron Phillips
  */
-// Activate request multi-part processing.
-@MultipartConfig
 public class JAXRSPluginServlet extends SpringServlet implements ApplicationContextAware {
 
   private static final long serialVersionUID = 457538570048660945L;

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/JAXRSServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/JAXRSServlet.java
@@ -52,7 +52,6 @@ import org.springframework.web.context.support.XmlWebApplicationContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.WebApplicationException;
@@ -82,8 +81,6 @@ import java.util.Map;
  *
  * @author Aaron Phillips
  */
-// Activate request multi-part processing.
-@MultipartConfig
 public class JAXRSServlet extends SpringServlet {
 
   private static final long serialVersionUID = 457538570048660945L;

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/UploadFileServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/UploadFileServlet.java
@@ -26,15 +26,12 @@ import org.pentaho.reporting.libraries.base.util.StringUtils;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
-import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
 import java.io.IOException;
 
-// Activate request multi-part processing.
-@MultipartConfig
 public class UploadFileServlet extends HttpServlet implements Servlet {
 
   private static final long serialVersionUID = 8305367618713715640L;


### PR DESCRIPTION
- Removed `@MultipartConfig` annotations which revealed unnecessary for the final `MultiReadHttpServletRequestWrapper` implementation.
- Deprecated the existing `MultiReadHttpServletRequest` class in favor of the improved `MultiReadHttpServletRequestWrapper`
- `RequestParameterAuthenticationFilter` now uses `MultiReadHttpServletRequestWrapper`, which integrates better with `CsrfGateFilter`, as a multi-read wrapper is only used if there isn't one already in the request wrapper chain. This also makes the filter more standard in that it will allow downstream use of the new `HttpServletRequest` `getPart` and `getParts` methods.

Very indirectly related with recent story: https://jira.pentaho.com/browse/BISERVER-14701.

Depends on: 
- https://github.com/pentaho/security-web/pull/11
- https://github.com/pentaho/maven-parent-poms/pull/305

@bennychow, @ddiroma please review and merge.