### PR TITLE
[BACKLOG-35436] Not able to create a Data Source from CSV File using Wizard

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/UploadFileServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/UploadFileServlet.java
@@ -26,12 +26,15 @@ import org.pentaho.reporting.libraries.base.util.StringUtils;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
+import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
 import java.io.IOException;
 
+// Activate request multi-part processing; enable use of Request#getPart API.
+@MultipartConfig
 public class UploadFileServlet extends HttpServlet implements Servlet {
 
   private static final long serialVersionUID = 8305367618713715640L;


### PR DESCRIPTION
This annotation is required to be able to use the `Request#getPart` API. It would work when CSRF was enabled, because, then, the request would be an instance of the `MultiReadHttpServletRequestWrapper` which does not have this requirement.

@bennychow please review and merge.