### PR TITLE
[SP-6106] backport of BISERVER-14720 - Upgrade log4j2

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -30,7 +30,6 @@
     <kafka-clients.version>0.10.2.1</kafka-clients.version>
     <paho.version>1.2.0</paho.version>
     <rxjava.version>2.2.3</rxjava.version>
-    <apache-log4j-extras>1.2.17</apache-log4j-extras>
     <snowflake-jdbc.version>3.6.28</snowflake-jdbc.version>
   </properties>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,6 @@
     <itext.version>2.1.7</itext.version>
     <mondrian.version>8.3.0.0-SNAPSHOT</mondrian.version>
     <mockito-all.version>1.10.19</mockito-all.version>
-    <log4j.version>1.2.17</log4j.version>
     <wsdl4j-qname.version>1.6.1</wsdl4j-qname.version>
     <rome.version>1.0</rome.version>
     <javatar.version>2.5</javatar.version>
@@ -230,7 +229,6 @@
     <quartz.version>1.7.2</quartz.version>
     <hibernate-jpa-2.0-api.version>1.0.1.Final</hibernate-jpa-2.0-api.version>
     <hsqldb.version>2.3.2</hsqldb.version>
-    <apache-log4j-extras>1.2.17</apache-log4j-extras>
     <websocket-api.version>1.0</websocket-api.version>
   </properties>
   <build>


### PR DESCRIPTION
Remove old log4j version references that exist on the 8.3 branch.


@smaring @rmansoor 