### PR TITLE
[SP-6106] [BACKLOG-35556] Ensure logs from sqoop jobs get their own

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/util/LogUtil.java
+++ b/api/src/main/java/org/pentaho/platform/api/util/LogUtil.java
@@ -1,16 +1,36 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2022 Hitachi Vantara. All rights reserved.
+ *
+ */
+
 package org.pentaho.platform.api.util;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.WriterAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.appender.WriterAppender;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 
 import java.io.StringWriter;
@@ -33,6 +53,10 @@ public class LogUtil {
    *          - Set to null if appender should log all events
    */
   public static void addAppender( Appender appender, Logger logger, Level level ) {
+    addAppender( appender, logger, level, null );
+  }
+
+  public static void addAppender( Appender appender, Logger logger, Level level, Filter filter ) {
     LoggerContext ctx = (LoggerContext) LogManager.getContext( false );
     Configuration config = ctx.getConfiguration();
     appender.start();
@@ -53,7 +77,7 @@ public class LogUtil {
       config.addLogger( logger.getName(), specificConfig );
     }
 
-    specificConfig.addAppender( appender, level, null );
+    specificConfig.addAppender( appender, level, filter );
     ctx.updateLoggers();
   }
 


### PR DESCRIPTION
appenders bridging them to the kettle log system to avoid mixing log
messages from separate processes together.
This commit is a cherry-pick from master 6bdb815a65