### PR TITLE
[BACKLOG-35701] Removing security-constraint http-methods because whe…

### DIFF
--- a/assemblies/pentaho-war/src/main/webapp/WEB-INF/web.xml
+++ b/assemblies/pentaho-war/src/main/webapp/WEB-INF/web.xml
@@ -555,8 +555,6 @@
     <web-resource-collection>
       <web-resource-name>Portlet Directory</web-resource-name>
       <url-pattern>/jsp/*</url-pattern>
-      <http-method>GET</http-method>
-      <http-method>POST</http-method>
     </web-resource-collection>
     <auth-constraint>
       <role-name>PENTAHO_ADMIN</role-name>

--- a/user-console/build-resources/WEB-INF/web.xml
+++ b/user-console/build-resources/WEB-INF/web.xml
@@ -335,8 +335,6 @@
     <web-resource-collection>
       <web-resource-name>Portlet Directory</web-resource-name>
       <url-pattern>/jsp/*</url-pattern>
-      <http-method>GET</http-method>
-      <http-method>POST</http-method>
     </web-resource-collection>
     <auth-constraint>
       <role-name>PENTAHO_ADMIN</role-name>


### PR DESCRIPTION
…n no HTTP methods are named, all are protected, including PUT, DELETE, ...