### PR TITLE
[BACKLOG-35003] Change security-web to latest version

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-csrf.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-csrf.xml
@@ -6,9 +6,11 @@
        xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
        xmlns:swm="http://www.hitachivantara.com/schema/security/web/model/spring"
        xmlns:pen-gpc="http://www.pentaho.com/schema/pentaho-gwt-rpc-spring"
+       xmlns:util="http://www.springframework.org/schema/util"
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="
           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+          http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.3.xsd
           http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd
           http://www.pentaho.com/schema/pentaho-gwt-rpc-spring http://www.pentaho.com/schema/pentaho-gwt-rpc-spring.xsd
           http://www.hitachivantara.com/schema/security/web/model/spring http://www.hitachivantara.com/schema/security/web/model/spring/hv-swm-spring.xsd"
@@ -17,7 +19,7 @@
   <!-- region CSRF Configurations -->
 
   <!-- CSRF protected system endpoints -->
-  <bean class="com.hitachivantara.security.web.impl.model.csrf.CsrfRequestSetConfigurationPojo">
+  <bean class="com.hitachivantara.security.web.impl.model.csrf.PartialCsrfConfigurationPojo">
     <pen:publish as-type="INTERFACES" />
 
     <constructor-arg>
@@ -140,9 +142,13 @@
     </constructor-arg>
   </bean>
 
-  <!-- Aggregates all registered CSRF request set configurations, from the system and plugins -->
-  <bean id="aggregatedCsrfConfiguration"
-        class="com.hitachivantara.security.web.impl.model.csrf.AggregatedRequestSetCsrfConfiguration">
+  <!-- endregion configurations -->
+
+  <!-- region CSRF Services -->
+
+  <!-- Aggregates all registered partial CSRF configurations, from the system and plugins -->
+  <bean id="csrfConfiguration"
+        class="com.hitachivantara.security.web.impl.model.csrf.AggregatedCsrfConfiguration">
 
     <!-- Needed by CsrfTokenService in another app context -->
     <pen:publish as-type="INTERFACES" />
@@ -150,20 +156,45 @@
     <!-- Read `csrf-protection-enabled` configuration from `system.properties` or `pentaho.xml` -->
     <property name="enabled" value="${system.csrf-protection-enabled:false}" />
 
-    <property name="requestSetConfigurations">
-      <pen:list class="com.hitachivantara.security.web.model.csrf.CsrfRequestSetConfiguration" />
+    <property name="partialConfigurations">
+      <pen:list class="com.hitachivantara.security.web.model.csrf.PartialCsrfConfiguration" />
     </property>
   </bean>
 
-  <!-- endregion configurations -->
+  <bean id="csrfTokenRepository" class="org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository">
+    <!-- Needed by CsrfTokenService in another app context -->
+    <pen:publish as-type="INTERFACES" />
+  </bean>
 
-  <!-- region CSRF Services -->
+  <bean id="csrfHelper" class="com.hitachivantara.security.web.impl.service.csrf.servlet.DefaultCsrfHelper">
+    <!-- Possibly needed in other app contexts -->
+    <pen:publish as-type="INTERFACES" />
+
+    <constructor-arg>
+      <util:set>
+        <value>X-Requested-With</value>
+        <!-- Temporary. To be removed once all uses of sending the CSRF token as a header are converted. -->
+        <value>X-CSRF-TOKEN</value>
+      </util:set>
+    </constructor-arg>
+  </bean>
+
+  <!-- CSRF Processor -->
+  <bean id="csrfProcessor" class="com.hitachivantara.security.web.impl.service.csrf.servlet.DefaultCsrfProcessor">
+    <!-- Possibly needed in other app contexts -->
+    <pen:publish as-type="INTERFACES" />
+
+    <constructor-arg ref="csrfConfiguration" />
+    <constructor-arg ref="csrfTokenRepository" />
+
+    <property name="helper" ref="csrfHelper" />
+  </bean>
 
   <!-- Servlet Filter that checks that requests to protected endpoints specify a CSRF token.
        Should be the first filter. See `filterChainProxy` in `applicationContext-spring-security.xml`.
     -->
   <bean id="csrfGateFilter" class="com.hitachivantara.security.web.impl.service.csrf.servlet.CsrfGateFilter">
-    <constructor-arg ref="aggregatedCsrfConfiguration" />
+    <constructor-arg ref="csrfProcessor" />
   </bean>
 
   <!-- JAX-RS Resource for obtaining a CSRF token.

--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
@@ -23,12 +23,11 @@
     <constructor-arg>
       <util:list>
         <sec:filter-chain pattern="/api/csrf/token"
-                          filters="csrfGateFilter,
-                                   corsFilter" />
+                          filters="corsFilter" />
 
         <sec:filter-chain pattern="/webservices/**"
-                          filters="csrfGateFilter,
-                                   corsFilter,
+                          filters="corsFilter,
+                                   csrfGateFilter,
                                    securityContextHolderAwareRequestFilterForWS,
                                    httpSessionPentahoSessionContextIntegrationFilter,
                                    httpSessionContextIntegrationFilter,
@@ -40,8 +39,8 @@
                                    filterInvocationInterceptorForWS" />
 
         <sec:filter-chain pattern="/api/repos/**"
-                          filters="csrfGateFilter,
-                                   corsFilter,
+                          filters="corsFilter,
+                                   csrfGateFilter,
                                    securityContextHolderAwareRequestFilterForWS,
                                    httpSessionPentahoSessionContextIntegrationFilter,
                                    httpSessionContextIntegrationFilter,
@@ -55,8 +54,8 @@
                                    preFlightFilter" />
 
         <sec:filter-chain pattern="/api/**"
-                          filters="csrfGateFilter,
-                                   corsFilter,
+                          filters="corsFilter,
+                                   csrfGateFilter,
                                    securityContextHolderAwareRequestFilterForWS,
                                    httpSessionPentahoSessionContextIntegrationFilter,
                                    httpSessionContextIntegrationFilter,
@@ -69,8 +68,8 @@
                                    filterInvocationInterceptorForWS" />
 
         <sec:filter-chain pattern="/plugin/reporting/api/jobs/**"
-                          filters="csrfGateFilter,
-                                   corsFilter,
+                          filters="corsFilter,
+                                   csrfGateFilter,
                                    securityContextHolderAwareRequestFilterForWS,
                                    httpSessionPentahoSessionContextIntegrationFilter,
                                    httpSessionContextIntegrationFilter,
@@ -84,8 +83,8 @@
                                    preFlightFilter" />
 
         <sec:filter-chain pattern="/plugin/**"
-                          filters="csrfGateFilter,
-                                   corsFilter,
+                          filters="corsFilter,
+                                   csrfGateFilter,
                                    securityContextHolderAwareRequestFilterForWS,
                                    httpSessionPentahoSessionContextIntegrationFilter,
                                    httpSessionContextIntegrationFilter,
@@ -98,8 +97,8 @@
                                    filterInvocationInterceptorForWS" />
 
         <sec:filter-chain pattern="/**"
-                          filters="csrfGateFilter,
-                                   corsFilter,
+                          filters="corsFilter,
+                                   csrfGateFilter,
                                    securityContextHolderAwareRequestFilter,
                                    httpSessionPentahoSessionContextIntegrationFilter,
                                    httpSessionContextIntegrationFilter,

--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/pentahoServices.spring.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/pentahoServices.spring.xml
@@ -167,11 +167,16 @@
   <bean class="org.pentaho.platform.web.http.api.resources.PasswordResource" scope="request"/>
   <bean class="org.pentaho.platform.web.http.api.resources.ServiceResource" scope="request"/>
 
+  <!-- See also, corresponding CORS configuration in applicationContext-spring-security-csrf.xml -->
   <bean class="com.hitachivantara.security.web.impl.service.csrf.jaxrs.CsrfTokenService" scope="request">
     <constructor-arg>
       <pen:bean class="com.hitachivantara.security.web.model.csrf.CsrfConfiguration"/>
     </constructor-arg>
+    <constructor-arg>
+      <pen:bean class="org.springframework.security.web.csrf.CsrfTokenRepository"/>
+    </constructor-arg>
   </bean>
+
   <bean class="org.pentaho.platform.web.http.api.resources.MantleResource" scope="request"/>
 
 </beans>

--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
@@ -63,11 +63,14 @@ csrf-protection-enabled=false
 cors-root-config-is-abstract=false
 
 # Allowed HTTP methods for all cross-origin requests:
-cors-requests-allowed-methods=GET,HEAD,POST
+cors-requests-allowed-methods=GET,HEAD,POST,PUT,DELETE
 
 # Allowed request HTTP headers for all cross-origin requests:
-# (note: CONTENT-TYPE and X-CSRF-TOKEN are required for proper CSRF operation)
-cors-requests-allowed-headers=CONTENT-TYPE,X-CSRF-TOKEN
+# Notes:
+# - X-REQUESTED-WITH: is used for CSRF operation
+# - AUTHORIZATION: is required for the (Basic) HTTP Authentication mechanism
+# - X-CSRF-TOKEN: is temporary; to be removed once all uses of sending the CSRF token as a header are converted.
+cors-requests-allowed-headers=CONTENT-TYPE,X-REQUESTED-WITH,AUTHORIZATION,X-CSRF-TOKEN
 
 # Allow credentials for all cross-origin requests?
 cors-requests-allow-credentials=true


### PR DESCRIPTION
- `AggregatedRequestSetCsrfConfiguration` -> `AggregatedCsrfConfiguration`
- `CsrfRequestSetConfiguration` -> `PartialCsrfConfiguration`
- Using the new `DefaultCsrfProcessor` class
- Using the new `DefaultCsrfHelper` class
- Switched the order of CSRF and CORS filters; CORS filter first.
- Removed CSRF filter from the CSRF token service endpoint

Please see main PR: https://github.com/pentaho/maven-parent-poms/pull/336.