### PR TITLE
[PDI - 18988]: Fixed Username and Password exposed in cleartext on Server logs when adding or importing Hadoop Cluster

### DIFF
--- a/assemblies/pentaho-server/pom.xml
+++ b/assemblies/pentaho-server/pom.xml
@@ -281,7 +281,7 @@
 
               <!-- Replace the classname with the custom class name -->
               <token>&lt;Valve className="org.apache.catalina.valves.AccessLogValve"</token>
-              <value>&lt;Valve className="org.pentaho.tomcat.logs.FilteredAccessLogValve"</value>
+              <value>&lt;Valve className="org.pentaho.tomcat.logvalve.FilteredAccessLogValve"</value>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -291,17 +291,6 @@
       </modules>
     </profile>
     <profile>
-      <id>tomcat-logs</id>
-      <activation>
-        <property>
-          <name>!skipDefault</name>
-        </property>
-      </activation>
-      <modules>
-        <module>tomcat-logs</module>
-      </modules>
-    </profile>
-    <profile>
       <id>platform-base</id>
       <activation>
         <property>
@@ -313,6 +302,7 @@
         <module>repository</module>
         <module>scheduler</module>
         <module>extensions</module>
+        <module>tomcat-logs</module>
       </modules>
     </profile>
     <profile>

--- a/tomcat-logs/src/main/java/org/pentaho/tomcat/logvalve/FilteredAccessLogValve.java
+++ b/tomcat-logs/src/main/java/org/pentaho/tomcat/logvalve/FilteredAccessLogValve.java
@@ -1,0 +1,44 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright (c) 2022 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.tomcat.logvalve;
+
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import org.apache.catalina.valves.AccessLogValve;
+
+/**
+ * This class makes sure that the passwords visible in the tomcat server access logs are masked
+ *
+ * @author samhithavootkoor
+ */
+public class FilteredAccessLogValve extends AccessLogValve {
+
+  @Override
+  public void log( CharArrayWriter message ) {
+    try ( CharArrayWriter caw = new CharArrayWriter() ) {
+      // Mask the user password
+      caw.write( message.toString().replaceAll( "j_password=[^&^ ]*", "j_password=***" ) );
+      super.log( caw );
+    } catch ( IOException e ) {
+      e.printStackTrace();
+    }
+  }
+} 


### PR DESCRIPTION
[PDI - 18988]: Fixed Username and Password exposed in cleartext on Server logs when adding or importing Hadoop Cluster