### PR TITLE
[SP-6148] - Backport of BISERVER-14682 - Database connections from different pools mixed up when using SQL Server (8.3 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DynamicallyPooledOrJndiDatasourceService.java
+++ b/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DynamicallyPooledOrJndiDatasourceService.java
@@ -39,7 +39,7 @@ public class DynamicallyPooledOrJndiDatasourceService extends NonPooledOrJndiDat
     throws DBDatasourceServiceException {
     return databaseConnection.isUsingConnectionPool()
           ? getPooledDatasourceService().resolveDatabaseConnection( databaseConnection )
-          : getNonPooledDatasourceService().getDataSource( requestedDatasourceName );
+          : getNonPooledDatasourceService().getDataSource( databaseConnection.getName() );
   }
 
 

--- a/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/NonPooledOrJndiDatasourceService.java
+++ b/core/src/main/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/NonPooledOrJndiDatasourceService.java
@@ -36,12 +36,9 @@ public class NonPooledOrJndiDatasourceService extends BaseDatasourceService {
 
   private static final Log log = LogFactory.getLog( NonPooledOrJndiDatasourceService.class );
 
-  String requestedDatasourceName = null;
-
   @Override
   protected DataSource retrieve( String dsName ) throws DBDatasourceServiceException {
     DataSource ds = null;
-    requestedDatasourceName = dsName;
 
     try {
       IDatasourceMgmtService datasourceMgmtSvc = getDatasourceMgmtService();

--- a/core/src/test/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DynamicConnectionDatasourceServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/DynamicConnectionDatasourceServiceTest.java
@@ -65,6 +65,7 @@ public class DynamicConnectionDatasourceServiceTest {
     mockConnection = mock( IDatabaseConnection.class );
 
     // Set it up - this is a NATIVE connection
+    dsName = mockConnection.getName();
     when( mockConnection.getAccessType() ).thenReturn( DatabaseAccessType.NATIVE );
     when( mockConnection.getDatabaseName() ).thenReturn( dsName );
 


### PR DESCRIPTION
@andreramos89 
@bcostahitachivantara 
@smmribeiro 

Original PR:
  - https://github.com/pentaho/pentaho-platform/pull/5073/