### PR TITLE
[BACKLOG-36137] ServicePluginLoader required in order to make services

### DIFF
--- a/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/kettle-registry-extensions.xml
+++ b/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/kettle-registry-extensions.xml
@@ -8,4 +8,11 @@
     <version-browser-classname/>
   </registry-extension>
 
+  <registry-extension id="ServicePluginRegistry">
+    <description>Used to init the service plugin type</description>
+    <classname>org.pentaho.di.core.service.PluginServiceLoaderRegistryExtension</classname>
+    <meta-classname/>
+    <version-browser-classname/>
+  </registry-extension>
+
 </registry-extensions>


### PR DESCRIPTION
provided by kettle plugins available to other plugins.