### PR TITLE
[SP-6176] Backport of [BISERVER-14811] Microsoft Excel steps ( Input/…

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -528,18 +528,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho.weka</groupId>
-      <artifactId>pdm-ce</artifactId>
-      <version>${weka.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
       <version>${cglib.version}</version>


### PR DESCRIPTION
…Output/Writer ) broken after upgrading server to 8.3.0.25/8.3.0.26/9.2.0.2 removing unnecessary dependency for pentaho data mining - 8.3 suite