### PR TITLE
[SP-6181][PDI-18988]:Fixed Username and Password exposed in cleartext on Server logs when adding or importing Hadoop Cluster

### DIFF
--- a/assemblies/pentaho-server/pom.xml
+++ b/assemblies/pentaho-server/pom.xml
@@ -137,6 +137,11 @@
       <type>zip</type>
     </dependency>
     <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-tomcat-logs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>
@@ -273,6 +278,10 @@
               <file>${tomcat.directory}/conf/server.xml</file>
               <token>&lt;Connector</token>
               <value>&lt;Connector URIEncoding="UTF-8" relaxedPathChars="[]|" relaxedQueryChars="^{}[]|<![CDATA[&amp;]]>" maxHttpHeaderSize="65536"</value>
+
+              <!-- Replace the classname with the custom class name -->
+              <token>&lt;Valve className="org.apache.catalina.valves.AccessLogValve"</token>
+              <value>&lt;Valve className="org.pentaho.tomcat.logvalve.FilteredAccessLogValve"</value>
             </configuration>
           </execution>
         </executions>

--- a/assemblies/pentaho-server/src/assembly/assembly.xml
+++ b/assemblies/pentaho-server/src/assembly/assembly.xml
@@ -159,6 +159,15 @@
       <useTransitiveDependencies>false</useTransitiveDependencies>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
+    <dependencySet>
+      <includes>
+        <include>pentaho:pentaho-tomcat-logs:jar</include>
+      </includes>
+      <outputDirectory>tomcat/lib</outputDirectory>
+      <outputFileNameMapping>pentaho-tomcat-logs.${artifact.extension}</outputFileNameMapping>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
 
     <!-- copy third party tools to third-party-tools/wkhtmltoimage -->
     <dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
+    <parent>
     <groupId>org.pentaho</groupId>
     <artifactId>pentaho-ce-jar-parent-pom</artifactId>
     <version>9.3.0.0-SNAPSHOT</version>
@@ -302,6 +302,7 @@
         <module>repository</module>
         <module>scheduler</module>
         <module>extensions</module>
+        <module>tomcat-logs</module>
       </modules>
     </profile>
     <profile>

--- a/tomcat-logs/pom.xml
+++ b/tomcat-logs/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>pentaho-platform-ce-parent</artifactId>
+        <groupId>pentaho</groupId>
+        <version>9.4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pentaho-tomcat-logs</artifactId>
+    <version>9.4.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tomcat-logs/src/main/java/org/pentaho/tomcat/logvalve/FilteredAccessLogValve.java
+++ b/tomcat-logs/src/main/java/org/pentaho/tomcat/logvalve/FilteredAccessLogValve.java
@@ -1,0 +1,44 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright (c) 2022 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.tomcat.logvalve;
+
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import org.apache.catalina.valves.AccessLogValve;
+
+/**
+ * This class makes sure that the passwords visible in the tomcat server access logs are masked
+ *
+ * @author samhithavootkoor
+ */
+public class FilteredAccessLogValve extends AccessLogValve {
+
+  @Override
+  public void log( CharArrayWriter message ) {
+    try ( CharArrayWriter caw = new CharArrayWriter() ) {
+      // Mask the user password
+      caw.write( message.toString().replaceAll( "j_password=[^&^ ]*", "j_password=***" ) );
+      super.log( caw );
+    } catch ( IOException e ) {
+      e.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
Fixed Username and Password exposed in cleartext on Server logs when adding or importing Hadoop Cluster

(cherry picked from commit 65147a695e3135277bd5859c970ce3324bdd4ac2)