### PR TITLE
[BACKLOG-36079] Improve Metadata Domain Repository Performance By Kee…

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
@@ -18,6 +18,9 @@ hideUserHomeFolderOnCreate=false
 # Default folder to open or save file(s) in case user's home folder is hidden
 defaultFolderWhenHomeFolderIsHidden=/public
 
+# Default number of threads for caching domains
+number-threads=3
+
 ## CSRF ##
 
 # Enables CSRF (Cross-Site Request Forgery) protection for the server.

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/IDataSourceAwareMetadataDomainRepository.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/IDataSourceAwareMetadataDomainRepository.java
@@ -1,0 +1,45 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2022 Hitachi Vantara.  All rights reserved.
+ */
+
+package org.pentaho.platform.plugin.services.metadata;
+
+import org.pentaho.metadata.repository.IMetadataDomainRepository;
+
+import java.util.Set;
+
+/**
+ * This interface defines a metadata domain repository, used to maintain a system-wide set of metadata domains.
+ * Includes the ability to retrieve Domains based on data source type.
+ */
+public interface IDataSourceAwareMetadataDomainRepository extends IMetadataDomainRepository {
+
+    /**
+     * Retrieve a list of all the domain ids in the repository of the data source type Metadata.
+     * See {@link #getDomainIds()} for similar functionality.
+     *
+     * @return the metadata domain Ids.
+     */
+    public Set<String> getMetadataDomainIds();
+
+    /**
+     * Retrieve a list of all the domain ids in the repository of the data source type DataSourceWizard.
+     * See {@link #getDomainIds()} for similar functionality.
+     *
+     * @return the data source wizard domain Ids.
+     */
+    public Set<String> getDataSourceWizardDomainIds();
+}

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoDataSourceType.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoDataSourceType.java
@@ -1,0 +1,40 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2022 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.metadata;
+
+/**
+ * Datasource Type
+ */
+public enum PentahoDataSourceType {
+    METADATA( "metadata" ),
+    DATA_SOURCE_WIZARD( "dsw" );
+
+    private String type;
+
+    private PentahoDataSourceType( String type ) {
+        this.type = type;
+    }
+
+    @Override
+    public  String toString() {
+        return type;
+    }
+}

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoDataSourceTypeMap.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoDataSourceTypeMap.java
@@ -1,0 +1,94 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2022 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.metadata;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Holder of information relating to the mappings between Pentaho Metadata Domain datasource types and
+ * Pentaho Metadata Domain IDs.
+ * <p></p>
+ * Map :{
+ *    "TYPE-1 ": ["domain-7", "domain-34"]
+ *    "TYPE-2" : ["domain-W", "domain-V", "domain-"F"]
+ *    }
+ *
+ */
+class PentahoDataSourceTypeMap {
+  private static final Log log = LogFactory.getLog( PentahoDataSourceTypeMap.class );
+
+  /**
+   * Store mappings for datasource type -> collections of domain Ids
+   */
+  private Map<String, Set<String>> mapDataSourceTypeToDomainIds = new HashMap<>();
+
+  /**
+   * Remove all domain Ids from datasource types.
+   */
+  public void reset() {
+    log.debug( "reset()" );
+    mapDataSourceTypeToDomainIds.clear();
+  }
+
+  /**
+   * Add domain Id to a datasource type.
+   * @param datasourceType
+   * @param domainId
+   */
+  public void addDatasourceType( String datasourceType, final String domainId ) {
+    log.debug( String.format( "addDatasourceType( datasourceType: %s, domainId: %s )", datasourceType, domainId ) );
+    Set<String> setDomainIds = mapDataSourceTypeToDomainIds.get( datasourceType );
+    if ( setDomainIds == null ) {
+      setDomainIds = new HashSet<>();
+    }
+    setDomainIds.add( domainId );
+    mapDataSourceTypeToDomainIds.put( datasourceType, setDomainIds );
+  }
+
+  /**
+   * Remove a single domain Id.
+   * @param domainId
+   */
+  public void deleteDomainId( final String domainId ) {
+    log.debug( String.format( "deleteDomainId( domainId: %s )", domainId ) );
+    mapDataSourceTypeToDomainIds.values().stream().forEach( setDomainIds -> setDomainIds.remove( domainId ) );
+  }
+
+  /**
+   * Retrieve all domain Ids for a specific datasource type
+   * @param datasourceType
+   * @return
+   */
+  public Set<String> getDatasourceType( String datasourceType ) {
+    log.debug( String.format( "getDatasourceType( datasourceType: %s )", datasourceType ) );
+    return mapDataSourceTypeToDomainIds.containsKey( datasourceType )
+            ? mapDataSourceTypeToDomainIds.get( datasourceType )
+            : Collections.emptySet();
+  }
+
+}

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoDataSourceTypeMapTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoDataSourceTypeMapTest.java
@@ -1,0 +1,219 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2022 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.plugin.services.metadata;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class PentahoDataSourceTypeMapTest {
+
+    PentahoDataSourceTypeMap testInstance = new PentahoDataSourceTypeMap();
+
+    private static final String TYPE_1 = "TYPE-1";
+
+    private static final String TYPE_2 = "TYPE-2";
+
+    @Before
+    public void setup() {
+        testInstance = createInstanceWithTestData();
+    }
+
+    @Test
+    public void testReset() {
+
+        // sanity check
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).isEmpty() );
+        assertFalse( testInstance.getDatasourceType( TYPE_2 ).isEmpty() );
+
+        // execute
+        testInstance.reset();
+
+        // verify
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).isEmpty() );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).isEmpty() );
+    }
+
+    @Test
+    public void testAddDatasourceType() {
+
+        // execute
+        testInstance.addDatasourceType( TYPE_2, "domain-XY" );
+        testInstance.addDatasourceType( TYPE_1, "domain-555" );
+        testInstance.addDatasourceType( TYPE_1, "domain-001" );
+        testInstance.addDatasourceType( TYPE_2, "domain-HE" );
+
+        //verify
+        assertEquals( 4, testInstance.getDatasourceType( TYPE_1 ).size() );
+        assertEquals( 5, testInstance.getDatasourceType( TYPE_2 ).size() );
+
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-555" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-001" ) );
+
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-W" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-V" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-F" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-XY" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-HE" ) );
+
+    }
+
+    @Test
+    public void testDeleteDomainId_InvalidInputs() {
+
+        // testing deleting domain Id that should not exist
+        testInstance.deleteDomainId( null );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+
+        // testing deleting domain Id that should not exist
+        testInstance.deleteDomainId( "       " );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+
+        // testing deleting domain Id that should not exist
+        testInstance.deleteDomainId( "" );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+
+        // testing deleting domain Id that should not exist
+        testInstance.deleteDomainId( "DOES-NOT-EXIST" );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+
+    }
+
+    @Test
+    public void testDeleteDomainId_ValidInput() {
+
+        // delete known domain Id
+        testInstance.deleteDomainId( "domain-7" );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+
+        // second delete on domain Id should not raise errors
+        testInstance.deleteDomainId( "domain-7" );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+
+        // delete known domain Id
+        // second delete should not raise errors
+        testInstance.deleteDomainId( "domain-34" );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+
+        // second delete on domain Id should not raise errors
+        // map holding this type should be empty, still should not raise an error
+        testInstance.deleteDomainId( "domain-34" );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+
+        // delete known domain Id
+        testInstance.deleteDomainId( "domain-V" );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-W" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-V" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-F" ) );
+
+        // second delete on domain Id should not raise errors
+        testInstance.deleteDomainId( "domain-V" );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-W" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-V" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-F" ) );
+
+        // final checks
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-W" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-V" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-F" ) );
+
+        assertEquals( 0, testInstance.getDatasourceType( TYPE_1 ).size() );
+        assertEquals( 2, testInstance.getDatasourceType( TYPE_2 ).size() );
+
+    }
+
+    @Test
+    public void testGetDatasourceType() {
+
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-34" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-W" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-V" ) );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-F" ) );
+
+        // sanity check
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "DOES-NOT-EXIST" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "domain-7777777" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( null ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "" ) );
+        assertFalse( testInstance.getDatasourceType( TYPE_1 ).contains( "      " ) );
+
+        assertNotNull( testInstance.getDatasourceType( null ) );
+        assertNotNull( testInstance.getDatasourceType( "" ) );
+        assertNotNull( testInstance.getDatasourceType( "    " ) );
+        assertNotNull( testInstance.getDatasourceType( "DOES-NOT-EXIST" ) );
+    }
+
+    /**
+     * For detailed test for class
+     */
+    @Test
+    public void testScenario1() {
+
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-W" ) );
+        assertEquals( 3, testInstance.getDatasourceType( TYPE_2 ).size() );
+
+        testInstance.deleteDomainId( "domain-W" );
+
+        assertFalse( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-W" ) );
+        assertEquals( 2, testInstance.getDatasourceType( TYPE_2 ).size() );
+
+        testInstance.reset();
+        testInstance.reset(); // trying second reset
+
+        assertEquals( 0, testInstance.getDatasourceType( TYPE_2 ).size() );
+
+        testInstance.addDatasourceType( TYPE_2, "domain-W" );
+        assertTrue( testInstance.getDatasourceType( TYPE_2 ).contains( "domain-W" ) );
+        assertEquals( 1, testInstance.getDatasourceType( TYPE_2 ).size() );
+
+    }
+
+
+    private PentahoDataSourceTypeMap createInstanceWithTestData() {
+
+        PentahoDataSourceTypeMap pdstm = new PentahoDataSourceTypeMap();
+
+        pdstm.addDatasourceType( TYPE_1, "domain-7" );
+        pdstm.addDatasourceType( TYPE_1, "domain-34" );
+        pdstm.addDatasourceType( TYPE_2, "domain-W" );
+        pdstm.addDatasourceType( TYPE_2, "domain-V" );
+        pdstm.addDatasourceType( TYPE_2, "domain-F" );
+        return pdstm;
+    }
+}

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
@@ -14,70 +14,100 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2022 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.plugin.services.metadata;
 
-import org.junit.After;
+import org.apache.commons.io.IOUtils;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.pentaho.metadata.repository.DomainAlreadyExistsException;
-import org.pentaho.metadata.repository.DomainIdNullException;
-import org.pentaho.metadata.repository.DomainStorageException;
+import org.pentaho.metadata.model.Domain;
+import org.pentaho.metadata.model.LogicalModel;
+import org.pentaho.metadata.util.XmiParser;
 import org.pentaho.platform.api.engine.IUserRoleListService;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.UnifiedRepositoryException;
+import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.objfac.references.SingletonPentahoObjectReference;
 import org.pentaho.platform.engine.security.SecurityHelper;
 import org.pentaho.test.platform.repository2.unified.MockUnifiedRepository;
 import org.pentaho.test.platform.utils.TestResourceLocation;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.pentaho.platform.api.repository2.unified.RepositoryFilePermission.READ;
 import static org.pentaho.platform.api.repository2.unified.RepositoryFilePermission.WRITE;
+import static org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepository.PROPERTY_NAME_DATASOURCE_TYPE;
+import static org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepository.PROPERTY_NAME_DOMAIN_ID;
+import static org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepository.PROPERTY_NAME_LOCALE;
+import static org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepository.PROPERTY_NAME_TYPE;
+import static org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepository.TYPE_DOMAIN;
+import static org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepository.TYPE_LOCALE;
 import static org.pentaho.test.platform.repository2.unified.MockUnifiedRepository.everyone;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith ( MockitoJUnitRunner.class )
 public class PentahoMetadataDomainRepositoryTest {
 
-  private IUnifiedRepository repos = new MockUnifiedRepository( new UserProvider() );
-  @Mock private IUserRoleListService roleListService;
+  private static IUnifiedRepository repos = new MockUnifiedRepository( new UserProvider() );
 
-  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+  @ClassRule
+  public static TemporaryFolder tempFolder = new TemporaryFolder();
 
-  private PentahoMetadataDomainRepository domainRepos;
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
-  private InputStream xmi1, xmi2, xmi3;
+  private static PentahoMetadataDomainRepository domainRepos;
 
-  @Before public void before()
-    throws IOException, DomainStorageException, DomainIdNullException, DomainAlreadyExistsException {
+  private static InputStream xmi1, xmi2, xmi3;
+
+  private static final HashSet<Serializable> originalFileIds = new HashSet();
+
+  @BeforeClass
+  public static void setup() throws Exception {
     repos.createFolder( repos.getFile( "/etc" ).getId(),
       new RepositoryFile.Builder( "metadata" ).folder( true ).build(),
       new RepositoryFileAcl.Builder( MockUnifiedRepository.root() ).ace( everyone(), READ, WRITE ).build(), null );
-    File jaFile = tempFolder.newFile( "messages_ja.properties" );
-    File frFile = tempFolder.newFile( "messages_fr_FR.properties" );
     PentahoSystem.registerReference(
       new SingletonPentahoObjectReference.Builder<>( String.class ).object( "__root__" )
         .attributes( Collections.singletonMap( "id", "singleTenantAdminUserName" ) ).build() );
@@ -85,50 +115,771 @@ public class PentahoMetadataDomainRepositoryTest {
       new SingletonPentahoObjectReference.Builder<>( IUnifiedRepository.class ).object( repos ).build() );
     SecurityHelper.setMockInstance( new MockedSecurityHelper() );
 
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( new Domain() );
+
+    //capture original files to reset to later
+
+    RepositoryFile root = repos.getFile( "/" );
+    Stack<RepositoryFile> unvisited = new Stack<>();
+    unvisited.add( root );
+
+    // Keep track of original Files, will delete them between tests
+    walkRepository( repositoryFile -> originalFileIds.add( repositoryFile.getId() ) );
+
+    domainRepos = new PentahoMetadataDomainRepository( repos, null, xmiParser, null );
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    close( xmi1 );
+    close( xmi2 );
+    close( xmi3 );
+  }
+
+  public static void close( InputStream is ) throws IOException {
+    if ( is != null ) {
+      is.close();
+    }
+  }
+
+  @Before
+  public void before() {
+    // DELETE any recently added files
+    walkRepository( repositoryFile -> {
+      if ( !originalFileIds.contains( repositoryFile.getId() ) ) {
+        repos.deleteFile( repositoryFile.getId(), true, null );
+      }
+    } );
+  }
+
+  /**
+   * Walk repository and apply logic to each file.
+   * @param fn
+   */
+  public static void walkRepository( Consumer<RepositoryFile> fn ) {
+    // Simple DFS logic for tree
+    RepositoryFile root = repos.getFile( "/" );
+    Stack<RepositoryFile> unvisited = new Stack<>();
+    unvisited.add( root );
+
+    while ( !unvisited.isEmpty() ) {
+      RepositoryFile repositoryFile = unvisited.pop();
+      unvisited.addAll( repos.getChildren( repositoryFile.getId() ) );
+      fn.accept( repositoryFile );
+    }
+  }
+
+  private static InputStream getXmiInputStream() throws Exception {
+    return getInputSteam( new File( TestResourceLocation.TEST_RESOURCES + "/ImportTest/steel-wheels.xmi" ) );
+  }
+
+  private static InputStream getInputSteam( File file ) throws Exception {
+    return new ByteArrayInputStream( IOUtils.toByteArray( file.toURI() ) );
+  }
+
+  @Test
+  public void testGetDomainFilesNoSuchDomain() {
+    assertTrue( domainRepos.getDomainFilesData( "NOSUCH_DOMAIN" ).isEmpty() );
+  }
+
+  @Test
+  public void testGetDomainFiles() throws Exception {
+    // SETUP
+    File jaFile = tempFolder.newFile( "messages_ja.properties" );
+    File frFile = tempFolder.newFile( "messages_fr_FR.properties" );
+
     xmi1 = getXmiInputStream();
     xmi2 = getXmiInputStream();
     xmi3 = getXmiInputStream();
 
-    domainRepos = new PentahoMetadataDomainRepository( repos );
-    domainRepos.addLocalizationFile( "testDomain1.xmi", "ja", new FileInputStream( jaFile ), false );
-    domainRepos.addLocalizationFile( "testDomain1.xmi", "fr_FR", new FileInputStream( frFile ), false );
+    domainRepos.addLocalizationFile( "testDomain1.xmi", "ja", getInputSteam( jaFile ), false );
+    domainRepos.addLocalizationFile( "testDomain1.xmi", "fr_FR", getInputSteam( frFile ), false );
     domainRepos.storeDomain( xmi1, "testDomain1.xmi", false );
     domainRepos.storeDomain( xmi2, "testDomain_noLocaleFiles.xmi", false );
     domainRepos.storeDomain( xmi3, "testDomain_doesntEndIn_dotXMI", false );
-  }
 
-  @After public void after() throws IOException {
-    xmi1.close();
-    xmi2.close();
-    xmi3.close();
-  }
-
-  private InputStream getXmiInputStream() throws FileNotFoundException {
-    return new FileInputStream( new File( TestResourceLocation.TEST_RESOURCES + "/ImportTest/steel-wheels.xmi" ) );
-  }
-
-  @Test public void testGetDomainFilesNoSuchDomain() {
-    assertTrue( domainRepos.getDomainFilesData( "NOSUCH_DOMAIN" ).isEmpty() );
-  }
-
-  @Test public void testGetDomainFiles() {
+    // TEST 1
     Map<String, InputStream> domainFiles = domainRepos.getDomainFilesData( "testDomain1.xmi" );
     assertThat( domainFiles.size(), equalTo( 3 ) );
     assertThat( domainFiles.keySet().stream().sorted().collect( Collectors.joining( "," ) ),
       equalTo( "messages_fr_FR.properties,messages_ja.properties,testDomain1.xmi" ) );
 
+    // TEST 2
     domainFiles = domainRepos.getDomainFilesData( "testDomain_noLocaleFiles.xmi" );
     assertThat( domainFiles.size(), equalTo( 1 ) );
     assertThat( domainFiles.keySet().stream().sorted().collect( Collectors.joining( "," ) ),
       equalTo( "testDomain_noLocaleFiles.xmi" ) );
 
+    // TEST 3
     domainFiles = domainRepos.getDomainFilesData( "testDomain_doesntEndIn_dotXMI" );
     assertThat( domainFiles.size(), equalTo( 1 ) );
     assertThat( domainFiles.keySet().stream().sorted().collect( Collectors.joining( "," ) ),
       equalTo( "testDomain_doesntEndIn_dotXMI.xmi" ) );
-
   }
 
+  @Test
+  public void testAddDataSourceType_DSW() throws Exception {
+    // SETUP
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    InputStream inputStream = Mockito.mock( InputStream.class );
+    when( srfd.getInputStream() ).thenReturn( inputStream );
+    when( domainRepos.getXmiParser().parseXmi( inputStream ) ).thenReturn( createDSWTestObject() );
+
+    Map<String, Serializable> fileMetadata = new HashMap<>();
+
+    // EXECUTE
+    domainRepos.addDataSourceType( fileMetadata, srfd );
+
+    // VERIFY
+    assertTrue( fileMetadata.entrySet().stream().anyMatch( e ->
+            e.getKey().equals( PROPERTY_NAME_DATASOURCE_TYPE )
+            && e.getValue().equals( PentahoDataSourceType.DATA_SOURCE_WIZARD.toString() ) ) );
+  }
+
+  @Test
+  public void testAddDataSourceType_Metadata() throws Exception {
+    // SETUP
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    InputStream inputStream = Mockito.mock( InputStream.class );
+    when( srfd.getInputStream() ).thenReturn( inputStream );
+    when( domainRepos.getXmiParser().parseXmi( inputStream ) ).thenReturn( createMetadataTestObject() );
+
+    Map<String, Serializable> fileMetadata = new HashMap<>();
+
+    // EXECUTE
+    domainRepos.addDataSourceType( fileMetadata, srfd );
+
+    // VERIFY
+    assertTrue( fileMetadata.entrySet().stream().anyMatch( e ->
+            e.getKey().equals( PROPERTY_NAME_DATASOURCE_TYPE )
+                    && e.getValue().equals( PentahoDataSourceType.METADATA.toString() ) ) );
+  }
+
+  @Test
+  public void testAddDataSourceType_NullDomain() throws Exception {
+    // SETUP
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    InputStream inputStream = Mockito.mock( InputStream.class );
+    when( srfd.getInputStream() ).thenReturn( inputStream );
+    when( domainRepos.getXmiParser().parseXmi( inputStream ) ).thenReturn( null );
+
+    Map<String, Serializable> fileMetadata = new HashMap<>();
+
+    // EXECUTE
+    domainRepos.addDataSourceType( fileMetadata, srfd );
+
+    // VERIFY
+    assertFalse( fileMetadata.entrySet().stream().anyMatch( e ->
+            e.getKey().equals( PROPERTY_NAME_DATASOURCE_TYPE )
+                    && e.getValue().equals( PentahoDataSourceType.METADATA.toString() ) ) );
+    assertFalse( fileMetadata.entrySet().stream().anyMatch( e ->
+            e.getKey().equals( PROPERTY_NAME_DATASOURCE_TYPE )
+                    && e.getValue().equals( PentahoDataSourceType.DATA_SOURCE_WIZARD.toString() ) ) );
+  }
+
+  @Test
+  public void testCreateUniqueFile_nonLocale() throws Exception {
+    // SETUP
+    String filename = "TEST_FILE_NAME";
+    String domainId = "TEST_DOMAIN_ID";
+    String locale = null;
+    Serializable serializableMetadataDir = "test-metadata-dir-id";
+    String createdFileId = "TEST_CREATED_FILE_ID";
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
+
+    RepositoryFile rfCreated = Mockito.mock( RepositoryFile.class );
+    when( rfCreated.getId() ).thenReturn( createdFileId );
+    when( rfCreated.getName() ).thenReturn( filename );
+
+    RepositoryFile rfMetaDataDir = Mockito.mock( RepositoryFile.class );
+    when( rfMetaDataDir.getId() ).thenReturn( serializableMetadataDir );
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+    when( repository.createFile( any(), any(), any(), any() ) ).thenReturn( rfCreated );
+
+    // assume only #getMetadataDir() calls this function
+    when( repository.getFile( any() ) ).thenReturn( rfMetaDataDir );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    when( srfd.getInputStream() ).thenReturn( new ByteArrayInputStream( new byte[0] ) );
+
+    Map<String, Serializable> expectedMetadataMap = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    // EXECUTE
+    RepositoryFile actual = pmdr.createUniqueFile( filename, domainId, locale, srfd );
+
+    // VERIFY
+    assertEquals( filename, actual.getName() );
+
+    verify( repository, times( 1 ) ).createFile(
+            eq( serializableMetadataDir ),
+            argThat( f -> filename.equals( f.getName() ) ),
+            eq( srfd ),
+            isNull() );
+
+    verify( repository, times( 0 ) ).updateFile( any(), any(), any() );
+
+    verify( repository, times( 1 ) ).setFileMetadata(
+            argThat( id -> createdFileId.equals( id ) ),
+            argThat( map -> equalMaps( expectedMetadataMap, map ) ) );
+  }
+
+  @Test
+  public void testCreateUniqueFile_locale() throws Exception {
+    // SETUP
+    String filename = "TEST_FILE_NAME";
+    String domainId = "TEST_DOMAIN_ID";
+    String locale = "jp";
+    Serializable serializableMetadataDir = "test-metadata-dir-id";
+    String createdFileId = "TEST_CREATED_FILE_ID";
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
+
+    RepositoryFile rfCreated = Mockito.mock( RepositoryFile.class );
+    when( rfCreated.getId() ).thenReturn( createdFileId );
+    when( rfCreated.getName() ).thenReturn( filename );
+
+    RepositoryFile rfMetaDataDir = Mockito.mock( RepositoryFile.class );
+    when( rfMetaDataDir.getId() ).thenReturn( serializableMetadataDir );
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+    when( repository.createFile( any(), any(), any(), any() ) ).thenReturn( rfCreated );
+
+    // assume only #getMetadataDir() calls this function
+    when( repository.getFile( any() ) ).thenReturn( rfMetaDataDir );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    when( srfd.getInputStream() ).thenReturn( new ByteArrayInputStream( new byte[0] ) );
+
+    Map<String, Serializable> expectedMetadataMap = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_LOCALE );
+      put( PROPERTY_NAME_LOCALE, locale );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    // EXECUTE
+    RepositoryFile actual = pmdr.createUniqueFile( filename, domainId, locale, srfd );
+
+    // VERIFY
+    assertEquals( filename, actual.getName() );
+
+    verify( repository, times( 1 ) ).createFile(
+            eq( serializableMetadataDir ),
+            argThat( f -> filename.equals( f.getName() ) ),
+            eq( srfd ),
+            isNull() );
+
+    verify( repository, times( 0 ) ).updateFile( any(), any(), any() );
+
+    verify( repository, times( 1 ) ).setFileMetadata(
+            argThat( id -> createdFileId.equals( id ) ),
+            argThat( map -> equalMaps( expectedMetadataMap, map ) ) );
+  }
+
+  @Test
+  public void testUpdateFile_nonLocale() throws Exception {
+    // SETUP
+    String domainId = "TEST_DOMAIN_ID";
+
+    Map<String, Serializable> fileMetadata = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    Map<String, Serializable> expectedMetadataMap = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
+
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    when( srfd.getInputStream() ).thenReturn( new ByteArrayInputStream( new byte[0] ) );
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+
+    RepositoryFile domainFile = Mockito.mock( RepositoryFile.class );
+    when( domainFile.getId() ).thenReturn( domainId );
+
+    when( repository.getFileMetadata( eq( domainId ) ) ).thenReturn( fileMetadata );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    // EXECUTE
+    pmdr.updateFile( domainFile, srfd );
+
+    // VERIFY
+    verify( repository, times( 1 ) ).setFileMetadata(
+            argThat( id -> domainId.equals( id ) ),
+            argThat( map -> equalMaps( expectedMetadataMap, map ) ) );
+
+    verify( repository, times( 0 ) ).createFile( any(), any(), any(), any() );
+
+    verify( repository, times( 1 ) ).updateFile(
+            eq( domainFile ),
+            eq( srfd ),
+            isNull() );
+  }
+
+  @Test
+  public void testUpdateFile_nonLocale_DatasourceTypeChange() throws Exception {
+    // SETUP
+    String domainId = "TEST_DOMAIN_ID";
+
+    Map<String, Serializable> fileMetadata = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.DATA_SOURCE_WIZARD.toString() );
+    } };
+
+    Map<String, Serializable> expectedMetadataMap = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
+
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    when( srfd.getInputStream() ).thenReturn( new ByteArrayInputStream( new byte[0] ) );
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+
+    RepositoryFile domainFile = Mockito.mock( RepositoryFile.class );
+    when( domainFile.getId() ).thenReturn( domainId );
+
+    when( repository.getFileMetadata( eq( domainId ) ) ).thenReturn( fileMetadata );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    // EXECUTE
+    pmdr.updateFile( domainFile, srfd );
+
+    // VERIFY
+    verify( repository, times( 1 ) ).setFileMetadata(
+            argThat( id -> domainId.equals( id ) ),
+            argThat( map -> equalMaps( expectedMetadataMap, map ) ) );
+
+    verify( repository, times( 0 ) ).createFile( any(), any(), any(), any() );
+
+    verify( repository, times( 1 ) ).updateFile(
+            eq( domainFile ),
+            eq( srfd ),
+            isNull() );
+  }
+
+  @Test
+  public void testUpdateFile_locale() throws Exception {
+    // SETUP
+    String domainId = "TEST_DOMAIN_ID";
+
+    Map<String, Serializable> fileMetadata = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_LOCALE );
+      put( PROPERTY_NAME_LOCALE, "jp" );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    Map<String, Serializable> expectedMetadataMap = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_LOCALE );
+      put( PROPERTY_NAME_LOCALE, "jp" );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
+
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    when( srfd.getInputStream() ).thenReturn( new ByteArrayInputStream( new byte[0] ) );
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+
+    RepositoryFile domainFile = Mockito.mock( RepositoryFile.class );
+    when( domainFile.getId() ).thenReturn( domainId );
+
+    when( repository.getFileMetadata( eq( domainId ) ) ).thenReturn( fileMetadata );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    // EXECUTE
+    pmdr.updateFile( domainFile, srfd );
+
+    // VERIFY
+    verify( repository, times( 1 ) ).setFileMetadata(
+            argThat( id -> domainId.equals( id ) ),
+            argThat( map -> equalMaps( expectedMetadataMap, map ) ) );
+
+    verify( repository, times( 0 ) ).createFile( any(), any(), any(), any() );
+
+    verify( repository, times( 1 ) ).updateFile(
+            eq( domainFile ),
+            eq( srfd ),
+            isNull() );
+  }
+
+  @Test
+  public void testUpdateFile_locale_DatasourceTypeChange() throws Exception {
+    // SETUP
+    String domainId = "TEST_DOMAIN_ID";
+
+    Map<String, Serializable> fileMetadata = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_LOCALE );
+      put( PROPERTY_NAME_LOCALE, "jp" );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.DATA_SOURCE_WIZARD.toString() );
+    } };
+
+    Map<String, Serializable> expectedMetadataMap = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+      put( PROPERTY_NAME_TYPE, TYPE_LOCALE );
+      put( PROPERTY_NAME_LOCALE, "jp" );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
+
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    when( srfd.getInputStream() ).thenReturn( new ByteArrayInputStream( new byte[0] ) );
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+
+    RepositoryFile domainFile = Mockito.mock( RepositoryFile.class );
+    when( domainFile.getId() ).thenReturn( domainId );
+
+    when( repository.getFileMetadata( eq( domainId ) ) ).thenReturn( fileMetadata );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    // EXECUTE
+    pmdr.updateFile( domainFile, srfd );
+
+    // VERIFY
+    verify( repository, times( 1 ) ).setFileMetadata(
+            argThat( id -> domainId.equals( id ) ),
+            argThat( map -> equalMaps( expectedMetadataMap, map ) ) );
+
+    verify( repository, times( 0 ) ).createFile( any(), any(), any(), any() );
+
+    verify( repository, times( 1 ) ).updateFile(
+            eq( domainFile ),
+            eq( srfd ),
+            isNull() );
+  }
+
+  @Test
+  public void testIsMetadataDataSource() {
+    Domain domainMD = createMetadataTestObject();
+    assertTrue( domainRepos.isMetadataDataSource( domainMD ) );
+
+    Domain domainMD2 = createDSWTestObject();
+    domainMD2.setLogicalModels( null );
+    assertTrue( domainRepos.isMetadataDataSource( domainMD2 ) );
+
+    Domain domainDSW = createDSWTestObject();
+    assertFalse( domainRepos.isMetadataDataSource( domainDSW ) );
+  }
+
+  @Test
+  public void testIsDSWDatasource() {
+    Domain domainMD = createMetadataTestObject();
+    assertFalse( domainRepos.isDSWDatasource( domainMD ) );
+
+    Domain domainMD2 = createDSWTestObject();
+    domainMD2.setLogicalModels( null );
+    assertFalse( domainRepos.isDSWDatasource( domainMD2 ) );
+
+    Domain domainDSW = createDSWTestObject();
+    assertTrue( domainRepos.isDSWDatasource( domainDSW ) );
+  }
+
+  @Test
+  public void testGetDomain_MapData() {
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    InputStream inputStream = Mockito.mock( InputStream.class );
+    when( srfd.getInputStream() ).thenReturn( inputStream );
+
+    Domain domain = domainRepos.getDomain( new HashMap<>(), srfd );
+    assertNotNull( domain );
+  }
+
+  @Test
+  public void testGetDomain_MapData_UnifiedRepositoryException_Unknown() throws Exception {
+    thrown.expect( UnifiedRepositoryException.class );
+    thrown.expectMessage( "__UNKNOWN_ID__" );
+
+    // SETUP
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    InputStream inputStream = Mockito.mock( InputStream.class );
+    when( srfd.getInputStream() ).thenReturn( inputStream );
+
+    when( domainRepos.getXmiParser().parseXmi( inputStream ) ).thenThrow( new IOException() );
+
+    // EXECUTE
+    domainRepos.getDomain( new HashMap<>(), srfd );
+  }
+
+  @Test
+  public void testGetDomain_MapData_UnifiedRepositoryException_Id() throws Exception {
+    String domainId = "TESTING-124";
+    thrown.expect( UnifiedRepositoryException.class );
+    thrown.expectMessage( domainId );
+
+    // SETUP
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    InputStream inputStream = Mockito.mock( InputStream.class );
+    when( srfd.getInputStream() ).thenReturn( inputStream );
+
+    when( domainRepos.getXmiParser().parseXmi( inputStream ) ).thenThrow( new IOException() );
+
+    // EXECUTE
+    domainRepos.getDomain( new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, domainId );
+    }}, srfd );
+  }
+
+  @Test
+  public void testIsDomain() {
+    Map<String, Serializable> fileMetadataDomain = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.DATA_SOURCE_WIZARD.toString() );
+    } };
+
+    assertTrue( domainRepos.isDomain( fileMetadataDomain ) );
+
+    Map<String, Serializable> fileMetadataLocale = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+      put( PROPERTY_NAME_TYPE, TYPE_LOCALE );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.DATA_SOURCE_WIZARD.toString() );
+    } };
+
+    assertFalse( domainRepos.isDomain( fileMetadataLocale ) );
+
+    Map<String, Serializable> fileMetadataNonDomain = new HashMap<String, Serializable>() {{
+      put( "randomKey", "randomValue" );
+    } };
+
+    assertFalse( domainRepos.isDomain( fileMetadataNonDomain ) );
+  }
+
+  @Test
+  public void testHasDatasourceType() {
+    Map<String, Serializable> fileMetadataDomain = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.DATA_SOURCE_WIZARD.toString() );
+    } };
+
+    assertTrue( domainRepos.hasDatasourceType( fileMetadataDomain ) );
+
+    Map<String, Serializable> fileMetadataNonDomain = new HashMap<String, Serializable>() {{
+      put( "randomKey", "randomValue" );
+    } };
+
+    assertFalse( domainRepos.hasDatasourceType( fileMetadataNonDomain ) );
+  }
+
+  @Test
+  public void testMigrateDomain() throws Exception {
+    // SETUP
+    Serializable serializableMetadataDir = "test-metadata-dir-id";
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    InputStream inputStream = Mockito.mock( InputStream.class );
+    when( srfd.getInputStream() ).thenReturn( inputStream );
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+    when( repository.getDataForRead( any(), any() ) ).thenReturn( srfd );
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    Map<String, Serializable> fileMetadataLegacy = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+    } };
+
+    Map<String, Serializable> fileMetadataMigrated = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    // EXECUTE
+    Map<String, Serializable> fileMetadataActual = pmdr.migrateDomain( serializableMetadataDir, fileMetadataLegacy );
+
+    // VERIFY
+    assertTrue( equalMaps( fileMetadataMigrated, fileMetadataActual ) );
+
+    verify( repository, times( 1 ) ).setFileMetadata(
+            argThat( id -> serializableMetadataDir.equals( id ) ),
+            argThat( map -> equalMaps( fileMetadataMigrated, map ) ) );
+  }
+
+  @Test
+  public void testGetFileMetadataHelper_NonDomain() throws Exception {
+    // testing migration doesn't happen because this isn't a domain
+    // SETUP
+    Serializable serializableMetadataDir = "test-metadata-dir-id";
+
+    Map<String, Serializable> fileMetadataLegacy = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+    } };
+
+    Map<String, Serializable> fileMetadataExpected = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+    } };
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+    when( repository.getFileMetadata( any() ) ).thenReturn( fileMetadataLegacy );
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    // EXECUTE
+    Map<String, Serializable> fileMetadataActual = pmdr.getFileMetadataHelper( serializableMetadataDir );
+
+    // VERIFY
+    assertTrue( equalMaps( fileMetadataExpected, fileMetadataActual ) );
+  }
+
+  @Test
+  public void testGetFileMetadataHelper_hasDatasourceType() throws Exception {
+    // testing migration does not happen because migration already happened
+    // SETUP
+    Serializable serializableMetadataDir = "test-metadata-dir-id";
+
+    Map<String, Serializable> fileMetadataLegacy = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    Map<String, Serializable> fileMetadataExpected = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+    when( repository.getFileMetadata( any() ) ).thenReturn( fileMetadataLegacy );
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    // EXECUTE
+    Map<String, Serializable> fileMetadataActual = pmdr.getFileMetadataHelper( serializableMetadataDir );
+
+    // VERIFY
+    assertTrue( equalMaps( fileMetadataExpected, fileMetadataActual ) );
+  }
+
+  @Test
+  public void testGetFileMetadataHelper_migrateDomain() throws Exception {
+    // testing migration happens
+    // SETUP
+    Serializable serializableMetadataDir = "test-metadata-dir-id";
+    SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
+    InputStream inputStream = Mockito.mock( InputStream.class );
+    when( srfd.getInputStream() ).thenReturn( inputStream );
+
+    Map<String, Serializable> fileMetadataLegacy = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+    } };
+
+    Map<String, Serializable> fileMetadataExpected = new HashMap<String, Serializable>() {{
+      put( PROPERTY_NAME_DOMAIN_ID, "someId" );
+      put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      // testing this property is added
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+    } };
+
+    IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
+    when( repository.getDataForRead( any(), any() ) ).thenReturn( srfd );
+    when( repository.getFileMetadata( any() ) ).thenReturn( fileMetadataLegacy );
+
+    XmiParser xmiParser = Mockito.mock( XmiParser.class );
+    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
+
+    PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
+
+    // EXECUTE
+    Map<String, Serializable> fileMetadataActual = pmdr.getFileMetadataHelper( serializableMetadataDir );
+
+    // VERIFY
+    assertTrue( equalMaps( fileMetadataExpected, fileMetadataActual ) );
+
+    verify( repository, times( 1 ) ).setFileMetadata(
+            argThat( id -> serializableMetadataDir.equals( id ) ),
+            argThat( map -> equalMaps( fileMetadataExpected, map ) ) );
+  }
+
+  Domain createDSWTestObject() {
+    Domain domain = new Domain();
+
+    List<LogicalModel> models = new ArrayList<>();
+
+    LogicalModel lm1 = new LogicalModel();
+    lm1.setProperty( "AGILE_BI_GENERATED_SCHEMA", "TRUE" );
+    models.add( lm1 );
+
+    LogicalModel lm2 = new LogicalModel();
+    lm2.setProperty( "WIZARD_GENERATED_SCHEMA", "TRUE" );
+    models.add( lm2 );
+
+    domain.setLogicalModels( models );
+
+    return domain;
+  }
+
+  Domain createMetadataTestObject() {
+    Domain domain = createDSWTestObject();
+    domain.getLogicalModels().clear();
+
+    return domain;
+  }
+
+  /**
+   * Tests if two maps are equal in size and values.
+   * @param m1
+   * @param m2
+   * @param <K>
+   * @param <V>
+   * @return true is equal in size and values, false otherwise.
+   */
+  public static <K, V> boolean equalMaps( Map<K, V> m1, Map<K, V> m2 ) {
+    if ( m1 == null && m2 == null ) return true;
+    if ( m1 == null || m2 == null ) return false;
+    if ( m1.size() != m2.size() ) return false;
+
+    for ( K key: m1.keySet() )
+      if ( !m1.get( key ).equals( m2.get( key ) ) )
+        return false;
+    return true;
+  }
 
   public static class UserProvider implements MockUnifiedRepository.ICurrentUserProvider {
     public String getUser() {
@@ -140,9 +891,9 @@ public class PentahoMetadataDomainRepositoryTest {
     }
   }
 
-  private class MockedSecurityHelper extends SecurityHelper {
+  private static class MockedSecurityHelper extends SecurityHelper {
     @Override public IUserRoleListService getUserRoleListService() {
-      return roleListService;
+      return Mockito.mock( IUserRoleListService.class );
     }
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/SessionCachingMetadataDomainRepositoryTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/SessionCachingMetadataDomainRepositoryTest.java
@@ -14,31 +14,55 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2022 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.plugin.services.metadata;
 
+import org.apache.commons.logging.Log;
+import org.junit.Assert;
 import org.junit.Test;
 
+import org.mockito.Mockito;
 import org.pentaho.metadata.model.Domain;
+import org.pentaho.metadata.repository.IMetadataDomainRepository;
 import org.pentaho.platform.api.engine.ICacheManager;
+import org.pentaho.platform.api.engine.IConfiguration;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.ISystemConfig;
+import org.pentaho.platform.config.SystemConfig;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.test.platform.plugin.services.metadata.MockSessionAwareMetadataDomainRepository;
+import org.powermock.api.mockito.PowerMockito;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.pentaho.platform.plugin.services.metadata.SessionCachingMetadataDomainRepository.DEFAULT_NUMBER_OF_THREADS;
 
 public class SessionCachingMetadataDomainRepositoryTest {
 
@@ -94,7 +118,8 @@ public class SessionCachingMetadataDomainRepositoryTest {
     assertTrue( domainIds.contains( "id" ) );
     verify( mock, times( 1 ) ).getDomainIds();
     verify( mock, times( 1 ) ).reloadDomains();
-    verify( manager, times( 0 ) ).getFromRegionCache( "metadata-domain-repository", "domain-id-cache-for-session:1" );
+    verify( manager, times( 0 ) ).getFromRegionCache( "metadata-domain-repository",
+            "domain-id-cache-for-session:1" );
     verify( manager, times( 0 ) ).addCacheRegion( "domain-id-cache-for-session:1" );
   }
 
@@ -109,7 +134,8 @@ public class SessionCachingMetadataDomainRepositoryTest {
 
     ICacheManager manager = mock( ICacheManager.class );
     Set<String> ids = new HashSet<>( Arrays.asList( "domainId1", "domainId2" ) );
-    when( manager.getFromRegionCache( "metadata-domain-repository", "domain-id-cache-for-session:1" ) ).thenReturn( ids );
+    when( manager.getFromRegionCache( "metadata-domain-repository", "domain-id-cache-for-session:1" ) )
+            .thenReturn( ids );
 
     repo.cacheManager = manager;
     repo.domainIdsCacheEnabled = true;
@@ -117,6 +143,347 @@ public class SessionCachingMetadataDomainRepositoryTest {
     Set<String> domainIds = repo.getDomainIds();
     assertEquals( ids, domainIds );
     verify( mock, times( 0 ) ).reloadDomains();
-    verify( manager, times( 1 ) ).getFromRegionCache( "metadata-domain-repository", "domain-id-cache-for-session:1" );
+    verify( manager, times( 1 ) ).getFromRegionCache( "metadata-domain-repository",
+            "domain-id-cache-for-session:1" );
+  }
+
+  @Test
+  public void testCreateCallablesGetDomain() throws Exception {
+    MockSessionAwareMetadataDomainRepository mock = Mockito.mock( MockSessionAwareMetadataDomainRepository.class );
+    SessionCachingMetadataDomainRepository repo = new SessionCachingMetadataDomainRepository( mock );
+    String sessionId = "test-sessionId-1";
+
+    Collection<String> domainIds = Arrays.asList(
+            "test-domainId-1", "test-domainId-2", "test-domainId-3",
+            "test-domainId-4", "test-domainId-5" );
+
+    Collection<SessionCachingMetadataDomainRepository.GetDomainCallable> callables =
+            repo.createCallablesGetDomain( repo, domainIds, sessionId );
+
+    assertEquals( domainIds.size(), callables.size() );
+
+    domainIds.stream().forEach( id -> assertTrue( "domain id '" + id + "' not found",
+            callables.stream().anyMatch( c -> c.getDomainId() == id ) ) );
+  }
+
+  @Test
+  public void testGetDomainCallable_Call_Success() throws Exception {
+    String domainId = "test-domain-1";
+    Domain domain = new Domain();
+    domain.setId( domainId );
+    String sessionId = "test-sessionId-1";
+    Log logger = Mockito.mock( Log.class );
+    SessionCachingMetadataDomainRepository repo = Mockito.mock( SessionCachingMetadataDomainRepository.class );
+    when( repo.getDomain( domainId ) ).thenReturn( domain );
+
+    SessionCachingMetadataDomainRepository.GetDomainCallable getDomainCallable =
+            new SessionCachingMetadataDomainRepository.GetDomainCallable( repo, domainId, sessionId, logger );
+
+    String actual = getDomainCallable.call();
+
+    assertEquals( domainId, actual );
+
+  }
+
+  @Test
+  public void testGetDomainCallable_Call_Null() throws Exception {
+    String domainId = "test-domain-1";
+    String sessionId = "test-sessionId-1";
+    Log logger = Mockito.mock( Log.class );
+    SessionCachingMetadataDomainRepository repo = Mockito.mock( SessionCachingMetadataDomainRepository.class );
+    when( repo.getDomain( domainId ) ).thenReturn( null );
+
+    SessionCachingMetadataDomainRepository.GetDomainCallable getDomainCallable =
+            new SessionCachingMetadataDomainRepository.GetDomainCallable( repo, domainId, sessionId, logger );
+
+    String actual = getDomainCallable.call();
+
+    assertNull( actual );
+
+  }
+
+  @Test
+  public void testGetDomainIds() throws Exception {
+    // SETUP 1
+    IDataSourceAwareMetadataDomainRepository mockDataSourceAwareMetadataDomainRepository = Mockito.mock(
+            IDataSourceAwareMetadataDomainRepository.class );
+    ICacheManager mockCacheManager = Mockito.mock( ICacheManager.class );
+    boolean domainIdsCacheEnabled = false;
+    int numberOfThreads = 1;
+    IPentahoSession pentahoSession = Mockito.mock( IPentahoSession.class );
+    Set<String> domainIds = new HashSet<>( Arrays.asList(
+            "testDomainId-1", "testDomainId-2", "testDomainId-3", "testDomainId-4", "testDomainId-5" ) );
+    when( mockDataSourceAwareMetadataDomainRepository.getDomainIds() ).thenReturn( domainIds );
+    SessionCachingMetadataDomainRepository scmdr1 = new SessionCachingMetadataDomainRepository(
+            mockDataSourceAwareMetadataDomainRepository,
+            mockCacheManager, domainIdsCacheEnabled, numberOfThreads );
+
+    // EXECUTE 1
+    Set<String> actualDomainIds = scmdr1.getDomainIds( pentahoSession );
+
+    // VERIFY 1
+    domainIds.stream().forEach( domainId -> assertTrue( "Expected id:" + domainId,
+            actualDomainIds.contains( domainId ) ) );
+  }
+
+  @Test
+  public void testGetMetadataDomainIds() throws Exception {
+    // SETUP 1
+    IDataSourceAwareMetadataDomainRepository mockDataSourceAwareMetadataDomainRepository = Mockito.mock(
+            IDataSourceAwareMetadataDomainRepository.class );
+    ICacheManager mockCacheManager = Mockito.mock( ICacheManager.class );
+    boolean domainIdsCacheEnabled = false;
+    int numberOfThreads = 1;
+    IPentahoSession pentahoSession = Mockito.mock( IPentahoSession.class );
+    Set<String> domainIds = new HashSet<>( Arrays.asList(
+            "testDomainId-1", "testDomainId-2", "testDomainId-3", "testDomainId-4" ) );
+    when( mockDataSourceAwareMetadataDomainRepository.getMetadataDomainIds() ).thenReturn( domainIds );
+    SessionCachingMetadataDomainRepository scmdr1 = new SessionCachingMetadataDomainRepository(
+            mockDataSourceAwareMetadataDomainRepository,
+            mockCacheManager, domainIdsCacheEnabled, numberOfThreads );
+
+    // EXECUTE 1
+    Set<String> actualDomainIds = scmdr1.getMetadataDomainIds( pentahoSession );
+
+    // VERIFY 1
+    domainIds.stream().forEach( domainId -> assertTrue( "Expected id:" + domainId,
+            actualDomainIds.contains( domainId ) ) );
+  }
+
+  @Test
+  public void testGetMetadataDomainIds_NotSupported() throws Exception {
+    // SETUP
+    ICacheManager mockCacheManager = Mockito.mock( ICacheManager.class );
+    boolean domainIdsCacheEnabled = false;
+    int numberOfThreads = 1;
+    IPentahoSession pentahoSession = Mockito.mock( IPentahoSession.class );
+
+    IMetadataDomainRepository mockMetadataDomainRepository = Mockito.mock(
+            IMetadataDomainRepository.class );
+    SessionCachingMetadataDomainRepository scmdr2 = new SessionCachingMetadataDomainRepository(
+            mockMetadataDomainRepository,
+            mockCacheManager, domainIdsCacheEnabled, numberOfThreads );
+
+    // EXECUTE & VERIFY
+    try {
+      scmdr2.getMetadataDomainIds( pentahoSession );
+      Assert.fail( "Expected an UnsupportedOperationException to be thrown" );
+    } catch ( UnsupportedOperationException uoe ) {
+      assertThat( uoe.getMessage(), containsString( "not supported" ) );
+    }
+  }
+
+  @Test
+  public void testGetDataSourceWizardDomainIds() throws Exception {
+    // SETUP 1
+    IDataSourceAwareMetadataDomainRepository mockDataSourceAwareMetadataDomainRepository = Mockito.mock(
+            IDataSourceAwareMetadataDomainRepository.class );
+    ICacheManager mockCacheManager = Mockito.mock( ICacheManager.class );
+    boolean domainIdsCacheEnabled = false;
+    int numberOfThreads = 1;
+    IPentahoSession pentahoSession = Mockito.mock( IPentahoSession.class );
+    Set<String> domainIds = new HashSet<>( Arrays.asList(
+            "testDomainId-1", "testDomainId-2", "testDomainId-3" ) );
+    when( mockDataSourceAwareMetadataDomainRepository.getDataSourceWizardDomainIds() ).thenReturn( domainIds );
+    SessionCachingMetadataDomainRepository scmdr1 = new SessionCachingMetadataDomainRepository(
+            mockDataSourceAwareMetadataDomainRepository,
+            mockCacheManager, domainIdsCacheEnabled, numberOfThreads );
+
+    // EXECUTE 1
+    Set<String> actualDomainIds = scmdr1.getDataSourceWizardDomainIds( pentahoSession );
+
+    // VERIFY 1
+    domainIds.stream().forEach( domainId -> assertTrue( "Expected id:" + domainId,
+            actualDomainIds.contains( domainId ) ) );
+  }
+
+  @Test
+  public void testGetDataSourceWizardDomainIds_NotSupported() throws Exception {
+    // SETUP
+    ICacheManager mockCacheManager = Mockito.mock( ICacheManager.class );
+    boolean domainIdsCacheEnabled = false;
+    int numberOfThreads = 1;
+    IPentahoSession pentahoSession = Mockito.mock( IPentahoSession.class );
+    IMetadataDomainRepository mockMetadataDomainRepository = Mockito.mock(
+            IMetadataDomainRepository.class );
+    SessionCachingMetadataDomainRepository scmdr2 = new SessionCachingMetadataDomainRepository(
+            mockMetadataDomainRepository,
+            mockCacheManager, domainIdsCacheEnabled, numberOfThreads );
+
+    // EXECUTE & VERIFY
+    try {
+      scmdr2.getDataSourceWizardDomainIds( pentahoSession );
+      Assert.fail( "Expected an UnsupportedOperationException to be thrown" );
+    } catch ( UnsupportedOperationException uoe ) {
+      assertThat( uoe.getMessage(), containsString( "not supported" ) );
+    }
+  }
+
+  @Test
+  public void testGenerateDomainIdCacheKeyForSession() throws Exception {
+    // SETUP 1
+    boolean domainIdsCacheEnabled = false;
+    int numberOfThreads = 1;
+    IPentahoSession pentahoSession = new StandaloneSession( "test-session", "123" );
+    SessionCachingMetadataDomainRepository scmdr1 = new SessionCachingMetadataDomainRepository(
+            null, null, domainIdsCacheEnabled, numberOfThreads );
+
+    // EXECUTE 1
+    String domainKey1 = scmdr1.generateDomainIdCacheKeyForSession( pentahoSession );
+
+    // VERIFY 1
+    assertEquals( "domain-id-cache-for-session:123", domainKey1 );
+
+    // EXECUTE 2
+    String domainKey2 = scmdr1.generateDomainIdCacheKeyForSession( pentahoSession, "testType" );
+
+    // VERIFY 2
+    assertEquals( "domain-id-cache-for-session:testType:123", domainKey2 );
+
+    // VERIFY 3
+    /**  generateDomainIdCacheKeyForSession(session, type) should be different or else issues with cache retrieval for
+     * SessionCachingMetadataDomainRepository#getDomainIds()
+     * and SessionCachingMetadataDomainRepository#getDataSourceWizardDomainIds()
+     */
+    assertNotSame( "domainKeys are the same", domainKey1, domainKey2 );
+  }
+
+  @Test
+  public void testGetNumberOfThreads() throws Exception {
+    //  test various versions cases and versions of number
+    // SETUP 1
+    int highNumberOfThreads = 101; // random high number, not default value
+    int lowNumberOfThreads = 1; // should be below default
+    Properties properties = new Properties();
+    properties.setProperty( "number-threads", "-2" );
+    ISystemConfig systemConfig = createSystemConfigTestObject( properties );
+    SessionCachingMetadataDomainRepository scmdr = new SessionCachingMetadataDomainRepository(
+            null, null, true, 1 );
+
+    // VERIFY 1
+    // test negative numbers resolve to default
+    assertEquals( DEFAULT_NUMBER_OF_THREADS, scmdr.getNumberOfThreads( systemConfig ) );
+
+    // SETUP 2
+    properties.setProperty( "number-threads", "0" );
+
+    // VERIFY 2
+    // test 0 resolves to default
+    assertEquals( DEFAULT_NUMBER_OF_THREADS, scmdr.getNumberOfThreads( systemConfig ) );
+
+    // SETUP 3
+    assertTrue( 0 < lowNumberOfThreads && lowNumberOfThreads < DEFAULT_NUMBER_OF_THREADS );
+    properties.setProperty( "number-threads", Integer.toString( lowNumberOfThreads ) );
+
+    // VERIFY 3
+    assertEquals( lowNumberOfThreads, scmdr.getNumberOfThreads( systemConfig ) );
+
+    // SETUP 4
+    properties.setProperty( "number-threads", Integer.toString( DEFAULT_NUMBER_OF_THREADS ) );
+
+    // VERIFY 4
+    // sanity check that no side effects on specifying default
+    assertEquals( DEFAULT_NUMBER_OF_THREADS, scmdr.getNumberOfThreads( systemConfig ) );
+
+    // SETUP 5
+    assertTrue(  lowNumberOfThreads < DEFAULT_NUMBER_OF_THREADS );
+    properties.setProperty( "number-threads", Integer.toString( highNumberOfThreads ) );
+
+    // VERIFY 5
+    assertEquals( highNumberOfThreads, scmdr.getNumberOfThreads( systemConfig ) );
+
+    // SETUP 6
+    // verifying boolean value doesn't resolve to 1
+    properties.setProperty( "number-threads",  "true" );
+
+    // VERIFY 6
+    assertEquals( DEFAULT_NUMBER_OF_THREADS, scmdr.getNumberOfThreads( systemConfig ) );
+
+    // SETUP 7
+    properties.setProperty( "number-threads",  "1H" );
+
+    // VERIFY 7
+    // verifying non number value resolves to default
+    assertEquals( DEFAULT_NUMBER_OF_THREADS, scmdr.getNumberOfThreads( systemConfig ) );
+
+    // SETUP 8
+    properties.setProperty( "number-threads",  "" );
+
+    // VERIFY 8
+    // verifying emptyString resolves to default
+    assertEquals( DEFAULT_NUMBER_OF_THREADS, scmdr.getNumberOfThreads( systemConfig ) );
+
+    // SETUP 9
+    properties.clear();
+
+    // VERIFY 9
+    // verifying if property is not specified (ie null) resolves to default
+    assertEquals( DEFAULT_NUMBER_OF_THREADS, scmdr.getNumberOfThreads( systemConfig ) );
+  }
+
+  @Test
+  public void testAsyncRun() throws Exception {
+    final ConcurrentLinkedQueue<Integer> queue = new ConcurrentLinkedQueue();
+    // SETUP
+    Collection<Integer> integers = Arrays.asList( 1, 2, 3, 4 );
+
+    Collection<Callable<Integer>> tasks = new ArrayList<>();
+    for ( Integer i : integers ) {
+      // update queue to verify later tasks actually run
+      tasks.add( () -> { queue.add( i ); return i; }  );
+    }
+
+    ExecutorService executorService = Executors.newFixedThreadPool( 1 );
+    SessionCachingMetadataDomainRepository.PentahoAsyncThreadRunner patr =
+            new SessionCachingMetadataDomainRepository.PentahoAsyncThreadRunner( 1, null );
+
+    // EXECUTE
+    Thread thread = patr.asyncRun( () -> executorService, tasks );
+
+    // VERIFY
+    assertNotNull( thread );
+    assertTrue( "Timeout happened before threads stopped",
+            executorService.awaitTermination( 5, TimeUnit.SECONDS ) ); // should complete way before this
+    integers.stream().forEach( i -> assertTrue( "thread/task " + i + " not found", queue.contains( i ) ) );
+  }
+
+  @Test
+  public void testExecuteTasks() throws Exception {
+    // SETUP
+    Callable<Integer> task1 = () -> { return 1; };
+    Callable<Integer> task2 = () -> { return null; }; // null values won't be returned
+    Callable<Integer> task3 = () -> { return 3; };
+    // exceptions won't be returned
+    Callable<Integer> task4 = () -> { throw new Exception( "error in callable, but ignore" ); };
+    Callable<Integer> task5 = () -> { return 5; };
+    Callable<Integer> task6 = () -> { return 6; };
+
+    Collection<Callable<Integer>> tasks = Arrays.asList( task1, task2, task3, task4, task5, task6 );
+
+    ExecutorService executorService = Executors.newFixedThreadPool( 1 );
+
+    SessionCachingMetadataDomainRepository.PentahoAsyncThreadRunner patr =
+            new SessionCachingMetadataDomainRepository.PentahoAsyncThreadRunner( 1, null );
+
+    // EXECUTE
+    // ignore errors in console thrown from task2 and task4
+    Collection<Integer> actualExecuteTasks = patr.executeTasks( executorService, tasks );
+
+    // VERIFY
+    assertEquals( 4, actualExecuteTasks.size() );
+    assertTrue( actualExecuteTasks.contains( 1 ) );
+    assertTrue( actualExecuteTasks.contains( 3 ) );
+    assertTrue( actualExecuteTasks.contains( 5 ) );
+    assertTrue( actualExecuteTasks.contains( 6 ) );
+  }
+
+  public ISystemConfig createSystemConfigTestObject( Properties properties ) throws Exception {
+    IConfiguration configuration = Mockito.mock( IConfiguration.class );
+    PowerMockito.when( configuration.getId() ).thenReturn( "system" );
+    Mockito.when( configuration.getProperties() ).thenReturn( properties );
+
+    List<IConfiguration> configs = new ArrayList<>();
+    configs.add( configuration );
+    return new SystemConfig( configs );
   }
 }

--- a/extensions/src/test/java/org/pentaho/test/platform/plugin/services/metadata/MockSessionAwareMetadataDomainRepository.java
+++ b/extensions/src/test/java/org/pentaho/test/platform/plugin/services/metadata/MockSessionAwareMetadataDomainRepository.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2022 Hitachi Vantara. All rights reserved.
  *
  */
 


### PR DESCRIPTION
…ping Track of Datasource Type Ids & Populating Cache

- created new interface IDataSourceAwareMetadataDomainRepository with methods #getMetadataDomainIds and #getDataSourceWizardDomainIds
- updated PentahoMetadataDomainRepository.java to use new interface
- added in logic to asynchronously populate domain cache after calls to #getXXXDomainIds and #getDomainIds