### PR TITLE
[CLEANUP] Fix version on tomcat-logs/pom.xml

### DIFF
--- a/tomcat-logs/pom.xml
+++ b/tomcat-logs/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <artifactId>pentaho-platform-ce-parent</artifactId>
         <groupId>pentaho</groupId>
-        <version>9.4.0.0-SNAPSHOT</version>
+        <version>9.3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pentaho-tomcat-logs</artifactId>
-    <version>9.4.0.0-SNAPSHOT</version>
+    <version>9.3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>


### PR DESCRIPTION
Wrong version was included on commit 'db160ca2f4c9bd32660490b5dde16e9beb01c608': [SP-6181][PDI-18988]:Fixed Username and Password exposed in cleartext on Server logs when adding or importing Hadoop Cluster

