### PR TITLE
[BACKLOG-37325] FIX scrollbars for Schedule and Administration perspectives

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
@@ -988,6 +988,7 @@ div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem:hover:not(.gwt-
 #pucContent {
   position: unset;
   flex: auto;
+  min-height: 0;
 }
 /* endregion #pucWrapper et al. */
 


### PR DESCRIPTION
@pentaho/wcag, please review and merge, asap.

Regression caused by https://github.com/pentaho/pentaho-commons-gwt-modules/pull/881 et al.

The regression caused the Schedule perspective to show no scrollbars.
Also, the Administration perspective to only show the vertical scrollbar, albeit remaining scrollable with the scroll wheel...