### PR TITLE
[SP-6319] - Backport of PPP-3713 - Beanshell version we're using is vulnerable to serialization exploit - CVE-2016-2510 (9.3 Suite)

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -236,9 +236,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.beanshell</groupId>
+      <groupId>org.apache-extras.beanshell</groupId>
       <artifactId>bsh</artifactId>
-      <version>${bsh.version}</version>
+      <version>${beanshell.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <commons-math3.version>3.6.1</commons-math3.version>
     <curvesapi.version>1.06</curvesapi.version>
     <commons-compress.version>1.20</commons-compress.version>
-    <bsh.version>1.3.0</bsh.version>
     <groovy-all.version>2.4.8</groovy-all.version>
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
     <license.current.year>2018</license.current.year>

--- a/user-console/pom.xml
+++ b/user-console/pom.xml
@@ -15,7 +15,6 @@
     <gwt.outputDirectory>${project.build.directory}/${project.artifactId}-gwt-${project.version}</gwt.outputDirectory>
     <json-simple.version>1.1</json-simple.version>
     <license.header.definition.file>${basedir}/../license/styles/javadoc_style_license_header.xml</license.header.definition.file>
-    <bsh.version>1.3.0</bsh.version>
     <mockito.version>1.8.5</mockito.version>
     <commons-xul.version>9.3.0.0-SNAPSHOT</commons-xul.version>
     <common-ui.version>9.3.0.0-SNAPSHOT</common-ui.version>
@@ -328,9 +327,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.beanshell</groupId>
+      <groupId>org.apache-extras.beanshell</groupId>
       <artifactId>bsh</artifactId>
-      <version>${bsh.version}</version>
+      <version>${beanshell.version}</version>
     </dependency>
     <dependency>
       <groupId>org.webjars.npm</groupId>


### PR DESCRIPTION
@andreramos89 
@bcostahitachivantara 
@smmribeiro 

Original PR: https://github.com/pentaho/pentaho-platform/pull/5242