### PR TITLE
[PPP-4956] - Tomcat's Server version is disclosed on error pages

### DIFF
--- a/assemblies/pentaho-war/src/main/webapp/WEB-INF/web.xml
+++ b/assemblies/pentaho-war/src/main/webapp/WEB-INF/web.xml
@@ -581,6 +581,4 @@
 		<error-code>500</error-code>
 		<location>/unavailable.html</location>
 	</error-page>
-
-
 </web-app>


### PR DESCRIPTION
Added a restriction for server info in the error messages in the server configuration files

@smmribeiro 
@bcostahitachivantara 
@renato-s 