### PR TITLE
[BACKLOG-37966] Toolbar improvements in PUC

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/Mantle.jsp
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/Mantle.jsp
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+* Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
 --%>
 
 <!DOCTYPE html>
@@ -203,11 +203,11 @@
 <body oncontextmenu="return false;" class="pentaho-page-background">
 
   <div id="pucWrapper" cellspacing="0" cellpadding="0" style="width: 100%; height: 100%;">
-    
+
     <div id="pucHeader" class="responsive" cellspacing="0" cellpadding="0">
       <div id="pucMenuBar"></div>
       <div id="pucBurgerToolbar"></div>
-      <div id="pucTabsMenuBar" class="flex-row"></div>
+      <div id="pucTabsMenuBar"></div>
       <div id="pucPerspectives"></div>
       <div id="pucToolBar"></div>
       <div id="pucUserDropDown"></div>

--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
@@ -1206,10 +1206,16 @@ div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem:hover:not(.gwt-
 #mainToolbarWrapper > tbody > tr,
 #mainToolbarWrapper > tbody > tr > td,
 #mainToolbarWrapper > tbody > tr > td > div,
-#mainToolbar,
-#burgerToolbar,
 :is(#mainToolbar, #burgerToolbar) > tbody > tr > td > table {
   display: contents;
+}
+
+#mainToolbar, #burgerToolbar, #tabsMenuBar {
+  display: flex;
+  flex: 0 1 auto;
+  width: auto !important;
+  flex-wrap: wrap;
+  gap: 0;
 }
 
 :where(#pucWrapper:not(.burger-mode)) #burgerToolbar {
@@ -1224,6 +1230,16 @@ div#customDropdownPopupMajor .gwt-MenuBar-vertical .gwt-MenuItem:hover:not(.gwt-
   /* Passed by GWT via inline-style */
   --flex-max-width: initial;
   max-width: var(--flex-max-width, 10px);
+}
+
+:where(#pucWrapper.burger-mode) #mainToolbar .spacer {
+  /* Nuke the spacer widths because these would only flex after the whole toolbar
+     would wrap to a new row. This ensures less rows from the start. */
+  width: auto !important;
+}
+
+:where(#pucWrapper.burger-mode) #mainToolbar {
+  margin-left: auto;
 }
 
 :is(#mainToolbar, #burgerToolbar) :is(.toolbar-button, .toolbar-toggle-button) {
@@ -1582,8 +1598,12 @@ hr {
 }
 
 /* region Burger Menu Mode */
-#burgerBarPerspectiveMenu, #pucTabsMenuBar {
+#pucTabsMenuBar {
   display: none;
+}
+
+#pucTabsMenuBar > * {
+  display: contents;
 }
 
 /* puc header */
@@ -1595,8 +1615,9 @@ hr {
   display: none;
 }
 
-:where(.burger-mode) :is(#burgerBarPerspectiveMenu, #pucTabsMenuBar) {
-  display: block;
+:where(.burger-mode) #pucTabsMenuBar {
+  /* Show children when burger mode */
+  display: contents;
 }
 
 :where(.burger-mode) #pucHeader {
@@ -1772,7 +1793,7 @@ hr {
   display: none;
 }
 
-.empty-tabs-menu {
+#tabsMenuBar.empty-tabs-menu {
   display: none;
 }
 


### PR DESCRIPTION
@pentaho/wcag , Please Review.
 toolbars using `display:contents` made it difficult to navigate toolbar using keyboard. This PR fixes that.
