### PR TITLE
[SP-6409] Backport of PDI-19803 - Loss of functionality present in th…

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -1491,30 +1491,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jsch</artifactId>
-      <version>${jsch.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jzlib</artifactId>
-      <version>${jzlib.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.enterprisedt</groupId>
       <artifactId>edtftpj</artifactId>
       <version>${edtftpj.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,6 @@
     <guava.version>17.0</guava.version>
     <dumbster.version>1.6.0</dumbster.version>
     <commons-pool.version>1.5.7</commons-pool.version>
-    <jsch.version>0.1.54</jsch.version>
     <jcommon-logging-log4jlog.version>1.0.2</jcommon-logging-log4jlog.version>
     <commons-cli.version>1.2</commons-cli.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>


### PR DESCRIPTION
…e PDI 'SFTP Put' step due to outdated jsch-0.1.54.jar (9.3 Suite)

Remove unused jsch
Already getting pulled as a transitive dependency from kettle

(cherry picked from commit 967c6cce2a44826cf16aee06799bc1e8f5e6a516)

Original PR: [#5341](https://github.com/pentaho/pentaho-platform/pull/5341)

@bcostahitachivantara @renato-s @andreramos89 