### PR TITLE
BACKLOG-38036 - Fixed assembly so that "scheduler-plugin" will be

### DIFF
--- a/assemblies/pentaho-solutions/pom.xml
+++ b/assemblies/pentaho-solutions/pom.xml
@@ -100,6 +100,13 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>pentaho</groupId>
+                  <artifactId>pentaho-scheduler-plugin</artifactId>
+                  <version>${project.version}</version>
+                  <type>zip</type>
+                  <outputDirectory>${prepared.plugins.directory}</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>pentaho</groupId>
                   <artifactId>pentaho-pdi-platform-plugin-package</artifactId>
                   <version>${project.version}</version>
                   <type>zip</type>


### PR DESCRIPTION
included in the "pentaho-solution/system" folder