### PR TITLE
[BACKLOG-37873][BACKLOG-38655] Added ability for a theme to indicate it is responsive

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/ui/Theme.java
+++ b/api/src/main/java/org/pentaho/platform/api/ui/Theme.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 /**
  * Theme encapsulates a collection of ThemeResources and a root directory to access them from.
- * 
+ *
  * User: nbaker Date: 5/15/11
  */
 public class Theme implements Serializable {
@@ -42,6 +42,7 @@ public class Theme implements Serializable {
   private String themeRootDir;
   private boolean hidden;
   private String id;
+  private boolean responsive;
 
   public Theme( String id, String name, String rootDir ) {
     this.id = id;
@@ -110,5 +111,27 @@ public class Theme implements Serializable {
 
   public void setId( String id ) {
     this.id = id;
+  }
+
+  /**
+   * Gets a value that indicates whether the theme is responsive.
+   * @return `true` if responsive; `false`, otherwise.
+   */
+  public boolean getResponsive() {
+    return responsive;
+  }
+
+  /**
+   * Sets whether the theme is responsive.
+   * <p>
+   * Responsive themes enable certain CSS classes, e.g. `responsive`, to behave in a responsive manner.
+   * <p>
+   * When the current theme is responsive, the CSS class `responsive-theme` is added to the HTML document's root
+   * element, `html`.
+   *
+   * @param responsive `true` if responsive; `false`, otherwise.
+   */
+  public void setResponsive( boolean responsive ) {
+    this.responsive = responsive;
   }
 }

--- a/assemblies/pentaho-war/src/main/webapp/js/themeResources.js
+++ b/assemblies/pentaho-war/src/main/webapp/js/themeResources.js
@@ -34,11 +34,11 @@ window.onload = function () {
 }
 
 if(window.core_theme_tree){
-  includeResources(core_theme_tree);
+  includeResources(core_theme_tree, true);
 }
 
 if(window.module_theme_tree){
-  includeResources(module_theme_tree);
+  includeResources(module_theme_tree, false);
 }
 
 function addStylesheet(url) {
@@ -56,10 +56,14 @@ function addScript(url) {
     document.getElementsByTagName('head')[0].appendChild(script);
 }
 
-function includeResources(resourceTree) {
+function includeResources(resourceTree, isCore) {
   var activeTheme = resourceTree && resourceTree[active_theme];
   if(!activeTheme) { return; }
-  
+
+  if(isCore && activeTheme.responsive) {
+    document.documentElement.classList.add("responsive-theme");
+  }
+
   var cssPat = /\.css$/;
   var resources = activeTheme.resources;
   for(var i = 0; i < resources.length; i++){
@@ -67,7 +71,7 @@ function includeResources(resourceTree) {
     var basePath = CONTEXT_PATH + activeTheme.rootDir;
     if(cssPat.test(baseName)){
       addStylesheet(basePath + baseName);
-      
+
       // Check to see if we're in a mobile device, if so add a "-mobile"
       if(navigator.userAgent.match(/(iPad|iPod|iPhone)/) != null){
         addStylesheet(basePath + baseName.replace('.css', '') + '-mobile.css');

--- a/extensions/src/main/java/org/pentaho/platform/web/html/themes/PluginThemeResolver.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/html/themes/PluginThemeResolver.java
@@ -48,7 +48,7 @@ import java.util.ResourceBundle;
  * Plugins that specify a "root_theme_folder" will have this folder's subfolders added as themes. If the themes are also
  * in the "system_themes' plugin setting they will be added as system-level themes. If there's already a system theme by
  * that name loaded it will be overridden.
- * 
+ *
  * User: nbaker Date: 5/15/11
  */
 public class PluginThemeResolver implements IThemeResolver {
@@ -138,6 +138,7 @@ public class PluginThemeResolver implements IThemeResolver {
         Theme theme =
             new Theme( themeId, themeName, "content/" + pluginId + "/" + rootThemeFolder + "/" + themeId + "/" );
         theme.setHidden( "true".equals( themeNode.attributeValue( "hidden" ) ) );
+        theme.setResponsive( "true".equals( themeNode.attributeValue( "responsive" ) ) );
 
         if ( "true".equals( themeNode.attributeValue( "system" ) ) ) {
           moduleThemeInfo.getSystemThemes().add( theme );

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/ThemeServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/ThemeServlet.java
@@ -41,7 +41,7 @@ import java.io.OutputStream;
 /**
  * Writes out the current Theme Tree out as Javascript. The current system and active module theme information is turned
  * into a JSON object for use by the web client
- * 
+ *
  * User: nbaker Date: 5/24/11
  */
 public class ThemeServlet extends ServletBase {
@@ -66,7 +66,7 @@ public class ThemeServlet extends ServletBase {
       // look for a passed in theme context (content generator, other named area)
       String moduleName = req.getParameter( "context" );
       OutputStream out = resp.getOutputStream();
-      resp.setContentType( "text/javascript" ); //$NON-NLS-1$ 
+      resp.setContentType( "text/javascript" ); //$NON-NLS-1$
       resp.setHeader( "Cache-Control", "no-cache" ); //$NON-NLS-1$
 
       IUserSettingService settingsService = PentahoSystem.get( IUserSettingService.class, getPentahoSession( req ) );
@@ -107,6 +107,8 @@ public class ThemeServlet extends ServletBase {
         themeObject = new JSONObject();
         root.put( theme.getId(), themeObject );
         themeObject.put( "rootDir", theme.getThemeRootDir() );
+        themeObject.put( "responsive", theme.getResponsive() );
+
         for ( ThemeResource res : theme.getResources() ) {
           themeObject.append( "resources", res.getLocation() );
         }


### PR DESCRIPTION
- Responsive themes will have CSS class `responsive-theme` be added to the html element
- Allows responsive primitives' CSS rules to be shared across themes and between the `responsive` and the new `responsive-content` CSS classes

Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/41

/cc @pentaho/hoth