### PR TITLE
[BACKLOG-39182] Ensure TabsMenu does not show up in themes other than Ruby

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/MantleStyle.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/MantleStyle.css
@@ -888,3 +888,7 @@ code {
   padding-bottom: 10px;
   padding-top: 10px;
 }
+
+#pucTabsMenuBar{
+  display: none;
+}

--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
@@ -1598,9 +1598,6 @@ hr {
 }
 
 /* region Burger Menu Mode */
-#pucTabsMenuBar {
-  display: none;
-}
 
 #pucTabsMenuBar > * {
   display: contents;


### PR DESCRIPTION
- Move display:none on #pucTabsMenuBar to MantleStyle.css, so that it is hidden for all themes by default instead of just ruby