### PR TITLE
[BACKLOG-37872] Fixed session scope for Pentaho plugin spring beans used from jax-rs api

### DIFF
--- a/core/src/main/java/org/pentaho/platform/engine/core/system/objfac/AbstractSpringPentahoObjectFactory.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/objfac/AbstractSpringPentahoObjectFactory.java
@@ -203,10 +203,12 @@ public abstract class AbstractSpringPentahoObjectFactory implements IPentahoObje
     // Set the Thread Context Classloader to that of the classloader who loaded this class.
     ClassLoader originalClassLoader = null;
     Object object;
-    
+    IPentahoSession previousSpringSession = null;
     try {
       originalClassLoader = Thread.currentThread().getContextClassLoader();
       Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+
+      previousSpringSession = SpringScopeSessionHolder.SESSION.get();
 
       if ( session instanceof StandaloneSession ) {
         // first ask Spring for the object, if it is session scoped it will fail
@@ -254,6 +256,8 @@ public abstract class AbstractSpringPentahoObjectFactory implements IPentahoObje
       }
 
     } finally {
+      SpringScopeSessionHolder.SESSION.set( previousSpringSession );
+
       if ( originalClassLoader != null ) {
         Thread.currentThread().setContextClassLoader( originalClassLoader );
       }

--- a/core/src/main/java/org/pentaho/platform/engine/core/system/objfac/spring/SpringPentahoObjectReference.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/objfac/spring/SpringPentahoObjectReference.java
@@ -69,13 +69,14 @@ public class SpringPentahoObjectReference<T> implements IPentahoObjectReference<
   @Override
   @SuppressWarnings( "unchecked" )
   public T getObject() {
+    IPentahoSession previousSession = SpringScopeSessionHolder.SESSION.get();
     IPentahoSession sessionToUse = session != null ? session : PentahoSessionHolder.getSession();
     SpringScopeSessionHolder.SESSION.set( sessionToUse );
     ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
       Object obj = context.getBeanFactory().getBean( name );
-      SpringScopeSessionHolder.SESSION.set( null );
+      SpringScopeSessionHolder.SESSION.set( previousSession );
 
       if ( obj instanceof IPentahoInitializer ) {
         ( (IPentahoInitializer) obj ).init( sessionToUse );


### PR DESCRIPTION
Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/68

For each Pentaho plugin the [`PentahoSystemPluginManager`](https://github.com/pentaho/pentaho-platform/blob/21bd70d66c1575c6a9746ee6cfe0ec06b5115e81/extensions/src/main/java/org/pentaho/platform/plugin/services/pluginmgr/PentahoSystemPluginManager.java#L291C24-L291C24) creates a Spring application context for it, and a corresponding`StandaloneSpringPentahoObjectFactory`, which kind of manages the Spring context. The plugin manager [initializes the object facory](https://github.com/pentaho/pentaho-platform/blob/21bd70d66c1575c6a9746ee6cfe0ec06b5115e81/core/src/main/java/org/pentaho/platform/engine/core/system/objfac/StandaloneSpringPentahoObjectFactory.java#L63). 

When initialized, the object factory installs some special Spring scopes for request and session scopes: https://github.com/pentaho/pentaho-platform/blob/21bd70d66c1575c6a9746ee6cfe0ec06b5115e81/core/src/main/java/org/pentaho/platform/engine/core/system/objfac/StandaloneSpringPentahoObjectFactory.java#L88-L95. 

These scope handlers control reading plugin beans having a request or session scope.

For reasons I don't totally understand, the `ThreadLocalScope` class reads all beans from the session stored in `SpringScopeSessionHolder`, and is counting on others to place the proper Pentaho session in it, before this being called:
https://github.com/pentaho/pentaho-platform/blob/21bd70d66c1575c6a9746ee6cfe0ec06b5115e81/core/src/main/java/org/pentaho/platform/engine/core/system/objfac/StandaloneSpringPentahoObjectFactory.java#L120-L133

What is happening currently, for plugin Spring beans with a scope of session or request, is that trying to get the bean results in an NPE, lacking a Pentaho session, and breaking Spring's assumption that the scope actually creates an object through the given factory, if there is none in yet...

The `SpringScopeSessionHolder.SESSION.set(...)` is currently only being called from:

https://github.com/pentaho/pentaho-platform/blob/21bd70d66c1575c6a9746ee6cfe0ec06b5115e81/core/src/main/java/org/pentaho/platform/engine/core/system/objfac/spring/SpringPentahoObjectReference.java#L71-L79

And:
https://github.com/pentaho/pentaho-platform/blob/21bd70d66c1575c6a9746ee6cfe0ec06b5115e81/core/src/main/java/org/pentaho/platform/engine/core/system/objfac/AbstractSpringPentahoObjectFactory.java#L211-L216

In the latter, the session is only being set for sessions of type `StandalonePentahoSession`, because, supposedly, for normal session types, Spring would be able to handle it, somehow:
> Spring can handle the object retrieval since we are not dealing with StandaloneSession

---

Currently, `SpringScopeSessionHolder.SESSION` is being used as a temporary location to exchange a session object between some comsumer classes and the registered Spring session and request scope handlers.

Not fully understanding the current workings, the communication path between these must not be broken.
At the same time, there are contexts via which no code is setting the current session in `SpringScopeSessionHolder.SESSION`, namely when the Spring context is being used directly, as happens when the JAX-RS framework tries to instantiate resource beans.

The proposed solution transforms `SpringScopeSessionHolder.SESSION` into an "ambience" storage for the session and sets it additionally in the`JAXRSPluginServlet` which is responsible by booting the JAX-RS fwk for plugin endpoints. Also changes previous places where `SpringScopeSessionHolder.SESSION` was beng set to match the ambience semantics and restoring any previous value there previously set.

@pentaho/hoth, @pentaho/r2d2, @pentaho/millenniumfalcon, please review at your will.