### PR TITLE
[BACKLOG-39324] Created PentahoPluginWSSpringServlet to handle jaxws

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
@@ -391,7 +391,7 @@
         <sec:intercept-url pattern="\A/webservices/userroleservice\?wsdl.*\Z" access="Anonymous,Authenticated" />
         <sec:intercept-url pattern="\A/webservices/authorizationpolicy\?wsdl.*\Z" access="Anonymous,Authenticated" />
         <sec:intercept-url pattern="\A/webservices/rolebindingdao\?wsdl.*\Z" access="Anonymous,Authenticated" />
-        <sec:intercept-url pattern="\A/webservices/scheduler\?wsdl.*\Z" access="Anonymous,Authenticated" />
+        <sec:intercept-url pattern="\A/webservices/plugins/scheduler-plugin/scheduler\?wsdl.*\Z" access="Anonymous,Authenticated" />
         <sec:intercept-url pattern="\A/webservices/repositorysync\?wsdl.*\Z" access="Anonymous,Authenticated" />
         <sec:intercept-url pattern="\A/webservices/datasourcemgmtservice\?wsdl.*\Z" access="Anonymous,Authenticated" />
         <sec:intercept-url pattern="\A/webservices/.*\Z" access="Authenticated" />

--- a/assemblies/pentaho-war/src/main/webapp/WEB-INF/web.xml
+++ b/assemblies/pentaho-war/src/main/webapp/WEB-INF/web.xml
@@ -342,6 +342,13 @@
   </servlet>
 
   <servlet>
+    <servlet-name>jaxwsPluginEndpoint-spring</servlet-name>
+    <display-name>jaxwsPluginEndpoint-spring</display-name>
+    <description>JAX-WS endpoint for plugins</description>
+    <servlet-class>org.pentaho.platform.web.servlet.PentahoPluginWSSpringServlet</servlet-class>
+  </servlet>
+
+  <servlet>
     <servlet-name>jaxrsEndpoint-spring</servlet-name>
     <description>JAX-RS endpoint</description>
     <servlet-class>org.pentaho.platform.web.servlet.JAXRSServlet</servlet-class>
@@ -378,6 +385,11 @@
   <servlet-mapping>
     <servlet-name>jaxwsEndpoint-spring</servlet-name>
     <url-pattern>/webservices/*</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>
+    <servlet-name>jaxwsPluginEndpoint-spring</servlet-name>
+    <url-pattern>/webservices/plugins/*</url-pattern>
   </servlet-mapping>
 
   <servlet-mapping>

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/PentahoPluginWSSpringServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/PentahoPluginWSSpringServlet.java
@@ -1,0 +1,167 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ */
+
+package org.pentaho.platform.web.servlet;
+
+import com.sun.xml.ws.transport.http.servlet.ServletAdapterList;
+import com.sun.xml.ws.transport.http.servlet.SpringBinding;
+import com.sun.xml.ws.transport.http.servlet.WSServletDelegate;
+import org.pentaho.platform.api.engine.IPlatformPlugin;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.plugin.services.pluginmgr.PentahoSystemPluginManager;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.web.context.support.XmlWebApplicationContext;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PentahoPluginWSSpringServlet extends HttpServlet {
+
+  private Pattern uriPattern = Pattern.compile( ".*/webservices/plugins/([-\\w]+)/.+" );
+  Map<String, WSServletDelegate> delegateMap = new HashMap<>();
+  ServletAdapterList adapters = new ServletAdapterList();
+  public void init( ServletConfig servletConfig ) throws ServletException {
+    super.init( servletConfig );
+  }
+
+  @SuppressWarnings( "unchecked" )
+  protected WSServletDelegate createPluginWSDelegate( String pluginPath, ClassLoader pluginClassLoader ) {
+    ClassLoader origClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      // this needs to be set because when the Spring service tries to create the webservice endpoint, something
+      // buried in the webservice implementation tries to use the thread's classloader to instantiate the object
+      Thread.currentThread().setContextClassLoader( pluginClassLoader );
+      ApplicationContext appContext = getAppContext( pluginPath, pluginClassLoader );
+
+      Set<SpringBinding> bindings = new LinkedHashSet<>();
+
+      bindings.addAll( appContext.getBeansOfType( SpringBinding.class ).values() );
+
+      adapters = new ServletAdapterList();
+      for ( SpringBinding binding : bindings ) {
+        binding.create( adapters );
+      }
+
+      return new WSServletDelegate( adapters, getServletContext() );
+    } finally {
+      Thread.currentThread().setContextClassLoader( origClassLoader );
+    }
+  }
+
+  public ServletAdapterList getAdapters() {
+    return adapters;
+  }
+
+  protected ApplicationContext getAppContext( String pluginPath, ClassLoader pluginClassLoader ) {
+    XmlWebApplicationContext wac = new XmlWebApplicationContext() {
+      @Override
+      protected Resource getResourceByPath( String path ) {
+        return new FileSystemResource( new File( path ) );
+      }
+
+      @Override
+      protected DefaultListableBeanFactory createBeanFactory() {
+        DefaultListableBeanFactory beanFactory = super.createBeanFactory();
+        beanFactory.setBeanClassLoader( pluginClassLoader );
+        return beanFactory;
+      }
+    };
+
+    wac.setServletContext( getServletContext() );
+    wac.setServletConfig( getServletConfig() );
+    wac.setNamespace( getServletName() );
+    wac.setClassLoader( pluginClassLoader );
+
+    String springFile = pluginPath + File.separator + "plugin.ws.spring.xml";  //$NON-NLS-1$ //$NON-NLS-2$
+    wac.setConfigLocations( springFile );
+    wac.refresh();
+
+    return wac;
+  }
+
+  protected void doPost( HttpServletRequest request, HttpServletResponse response ) throws ServletException {
+    WSServletDelegate delegate = delegateMap.get( request.getRequestURI() );
+    if ( null == delegate ) {
+      delegate = getWsServletDelegate( request );
+      delegateMap.put( request.getRequestURI(), delegate );
+    }
+    delegate.doPost( request, response, getServletContext() );
+}
+
+  protected void doGet( HttpServletRequest request, HttpServletResponse response ) throws ServletException {
+    WSServletDelegate delegate = delegateMap.get( request.getRequestURI() );
+    if ( null == delegate ) {
+      delegate = getWsServletDelegate( request );
+      delegateMap.put( request.getRequestURI(), delegate );
+    }
+    delegate.doGet( request, response, getServletContext() );
+  }
+
+  protected void doPut( HttpServletRequest request, HttpServletResponse response ) throws ServletException {
+    WSServletDelegate delegate = delegateMap.get( request.getRequestURI() );
+    if ( null == delegate ) {
+      delegate = getWsServletDelegate( request );
+      delegateMap.put( request.getRequestURI(), delegate );
+    }
+    delegate.doPut( request, response, getServletContext() );
+  }
+
+  protected void doDelete( HttpServletRequest request, HttpServletResponse response ) throws ServletException {
+    WSServletDelegate delegate = delegateMap.get( request.getRequestURI() );
+    if ( null == delegate ) {
+      delegate = getWsServletDelegate( request );
+      delegateMap.put( request.getRequestURI(), delegate );
+    }
+    delegate.doDelete( request, response, getServletContext() );
+  }
+
+  private WSServletDelegate getWsServletDelegate( HttpServletRequest request ) {
+    IPlatformPlugin plugin = PentahoSystem.get( IPlatformPlugin.class, null,
+      Collections.singletonMap( PentahoSystemPluginManager.PLUGIN_ID, getPluginNameFromUri( request.getRequestURI() ) ) );
+    GenericApplicationContext beanFactory = PentahoSystem
+      .get( GenericApplicationContext.class, null,
+        Collections.singletonMap( PentahoSystemPluginManager.PLUGIN_ID, plugin.getId() ) );
+    return createPluginWSDelegate(
+      PentahoSystem.getApplicationContext().getSolutionPath( "system/" + plugin.getSourceDescription() )
+      , beanFactory.getClassLoader() );
+  }
+
+  private String getPluginNameFromUri( String uri ) {
+    Matcher m = uriPattern.matcher( uri );
+    if ( m.matches() ) {
+      return m.group( 1 );
+    } else {
+      return "";
+    }
+  }
+}


### PR DESCRIPTION
endpoints in plugins. Endpoints must be defined in a plugin.ws.spring.xml file within the plugin, endpoint path must be of the form webservices/plugins/<plugin-id>/<endpoint>.  Updated filter to handle relocating scheduler web service endpoint.