### PR TITLE
[BACKLOG-39648] Dashboard interface is cropped on the right side

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
@@ -306,7 +306,8 @@ public class SolutionBrowserPanel extends HorizontalPanel {
     int adjustedWidth = solutionNavigatorPanel.getOffsetWidth() + splitterWidth;
     int width = this.getOffsetWidth() - adjustedWidth;
     if ( width > 0 ) {
-      contentTabPanel.setWidth( width + "px" );
+      String widthString = "calc( 100vw - " + adjustedWidth + "px )";
+      contentTabPanel.setTabBarWidth( widthString );
     }
   }
 

--- a/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
@@ -40,6 +40,7 @@ import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
 import org.pentaho.gwt.widgets.client.tabs.PentahoTab;
 import org.pentaho.gwt.widgets.client.utils.FrameUtils;
 import org.pentaho.gwt.widgets.client.utils.MenuBarUtils;
+import org.pentaho.gwt.widgets.client.utils.string.CssUtils;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
 import org.pentaho.mantle.client.dialogs.WaitPopup;
 import org.pentaho.mantle.client.events.EventBusUtil;
@@ -112,6 +113,11 @@ public class MantleTabPanel extends org.pentaho.gwt.widgets.client.tabs.PentahoT
     tabsMenuItem.setSubMenu( tabsSubMenuBar );
     tabsMenuBar.addStyleName( CLASS_FLEX_ROW );
     tabsMenuBar.addStyleName( CLASS_EMPTY_TABS_MENU );
+    setTabBarWidth( "100vw" );
+  }
+
+  public void setTabBarWidth( String widthString ){
+    CssUtils.setElementWidth( getTabBar(), widthString );
   }
 
   public void addTab( String text, String tooltip, boolean closeable, Widget content ) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/themes/ruby/mantleRuby.css
@@ -1780,7 +1780,6 @@ hr {
 
 .panelWithTitledToolbar .pentaho-tab-bar {
   display: flex;
-  width: 100vw;
   overflow-x: auto;
   scrollbar-width: thin;
   overflow-y: hidden;


### PR DESCRIPTION
To be merged with https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1019

- Fix tab-width when Solution Browser is present
- Ensure fix works when SolutionBrowser isn't present and hasn't loaded
- Add setElementWidth helper method in CssUtils to bypass restrictions on GWT style helper methods

The only way I could figure out how to get a horizontal scroll is by setting a width value in `.css` file or in-line `style` attribute.

GWT style helper methods do not like units that aren't px, so, I created a helper method in lieu of rewrapping GWT classes down to Style