### PR TITLE
[BACKLOG-39454]- Lots of errors coming up on logs when server 10.1 is configured to use Java 8. Updating JBoss-Logging jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <org.json.version>3.1.1</org.json.version>
     <!-- @Null @Nullable annotations -->
     <com.github.spotbugs.annotations.version>4.2.3</com.github.spotbugs.annotations.version>
-    <jboss-logging.version>3.5.3.Final</jboss-logging.version>
+    <jboss-logging.version>3.4.3.Final</jboss-logging.version>
     <classmate.version>1.6.0</classmate.version>
     <javax.persistence-api.version>2.2</javax.persistence-api.version>
     <byte-buddy.version>1.12.16</byte-buddy.version>


### PR DESCRIPTION
[BACKLOG-39454]- Lots of errors coming up on logs when server 10.1 is configured to use Java 8. Updating JBoss-Logging jar.

[BACKLOG-39454]: https://hv-eng.atlassian.net/browse/BACKLOG-39454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ