### PR TITLE
[BACKLOG-39797] Updating properties of

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-jdbc.properties
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-jdbc.properties
@@ -25,7 +25,7 @@ datasource.validation.query=SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS
 # for a connection to be returned before throwing an exception, or <= 0 to wait indefinitely. Default value is -1
 datasource.pool.max.wait=-1
 
-# The maximum number of active connections that can be allocated from this pool at the same time, or negative for no limit. Default value is 8
+# The maximum number of connections that can be allocated from this pool at the same time, or negative for no limit. Default value is 8
 datasource.pool.max.active=8
  
 # The maximum number of connections that can remain idle in the pool, without extra ones being destroyed, or negative for no limit. Default value is 8

--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-jdbc.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security-jdbc.xml
@@ -58,8 +58,8 @@
 		<property name="password" value="${datasource.password}" />
 		<!-- the following are optional -->
 		<property name="validationQuery" value="${datasource.validation.query}" />
-		<property name="maxWait" value="${datasource.pool.max.wait}" />
-		<property name="maxActive" value="${datasource.pool.max.active}" />
+		<property name="maxWaitMillis" value="${datasource.pool.max.wait}" />
+		<property name="maxTotal" value="${datasource.pool.max.active}" />
 		<property name="maxIdle" value="${datasource.max.idle}" />
 		<property name="minIdle" value="${datasource.min.idle}" />
 	</bean>


### PR DESCRIPTION
org.pentaho.di.core.database.util.DecryptingDataSource to match org.apache.commons.dbcp2.BasicDataSource after dbcp2 library update.