### PR TITLE
[BACKLOG-39812] PIR report doesnt render in New Window or Via Deeplink

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/ui/tabs/MantleTabPanel.java
@@ -130,6 +130,9 @@ public class MantleTabPanel extends org.pentaho.gwt.widgets.client.tabs.PentahoT
       selectTab( tab );
     }
     MantleTabMenuItem menuItem = createTabMenuItem( tab );
+    if( tabsSubMenuBar == null || tabsMenuBar == null ){
+      return; //TODO bypass implemented as a race condition workaround for BACKLOG-39781
+    }
     linkTabToMenuItem( tab, menuItem );
     tabsSubMenuBar.addItem( menuItem );
     contextMenuRefreshThreshold( true );
@@ -164,7 +167,7 @@ public class MantleTabPanel extends org.pentaho.gwt.widgets.client.tabs.PentahoT
       tabsMenuItem.setText( "" );
     } else {
       tabsMenuBar.removeStyleName( CLASS_EMPTY_TABS_MENU );
-      String tabMenuText;
+      String tabMenuText = "";
       int tabCount = getTabCount();
       if ( tabCount > 1 ) {
         int tabIndex = tabsSubMenuBar.getItemIndex( getLinkedTabMenuItem( selectedTab ) ) + 1;


### PR DESCRIPTION
- provide temporary workaround so that opened, deep-linked reports will render in new tabs
- this breaks burger tabs menu in that this first tab will not be accessible in burger mode