### PR TITLE
[BISERVER-15031] - Limit the PIR Export via REST API to the allowed types - null protection missing

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
@@ -764,8 +764,12 @@ public class RepositoryResource extends AbstractJaxRSResource {
   }
 
   private boolean validatePrptiOutputFormat() {
-    String outputFormat = this.httpServletRequest.getParameterMap().get( "output-target" )[0];
-    return AllowedPrptiTypes.getByType( outputFormat ) != null;
+    boolean valid = true;
+    if ( this.httpServletRequest.getParameterMap() != null && this.httpServletRequest.getParameterMap().containsKey( "output-target" ) ) {
+      String outputFormat = this.httpServletRequest.getParameterMap().get( "output-target" )[0];
+      valid = AllowedPrptiTypes.getByType( outputFormat ) != null;
+    }
+    return valid;
   }
 
   abstract class CGFactory implements ContentGeneratorDescriptor {


### PR DESCRIPTION
Null protection was missing from the validation

@smmribeiro 
@renato-s 
