### PR TITLE
[BACKLOG-39584] JDK17 changes:

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -11,7 +11,6 @@
   <version>10.2.0.0-SNAPSHOT</version>
   <properties>
     <maven-surefire-plugin.reuseForks>false</maven-surefire-plugin.reuseForks>
-    <mockito-all.version>1.8.5</mockito-all.version>
     <license.header.definition.file>${basedir}/../license/styles/javadoc_style_license_header.xml</license.header.definition.file>
     <commons-lang.version>2.6</commons-lang.version>
     <license.header.file>${basedir}/../license/templates/LGPL-2.1.txt</license.header.file>
@@ -20,6 +19,7 @@
     <commons-xul.version>10.2.0.0-SNAPSHOT</commons-xul.version>
     <commons-database.version>10.2.0.0-SNAPSHOT</commons-database.version>
     <pentaho-osgi-bundles.version>10.2.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
+    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
   </properties>
   <dependencies>
     <dependency>
@@ -141,15 +141,15 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito-all.version}</version>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito-core.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -157,6 +157,18 @@
           <groupId>*</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy-agent</artifactId>
+      <version>${byte-buddy.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>${byte-buddy.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.mail</groupId>

--- a/api/src/test/java/org/pentaho/platform/api/action/ActionPreProcessingExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/action/ActionPreProcessingExceptionTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -22,7 +22,7 @@ package org.pentaho.platform.api.action;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ActionPreProcessingExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/data/DBDatasourceServiceExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/data/DBDatasourceServiceExceptionTest.java
@@ -14,14 +14,14 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.data;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DBDatasourceServiceExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/ActionExecutionExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ActionExecutionExceptionTest.java
@@ -14,18 +14,18 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 
 import java.lang.reflect.Constructor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.pentaho.actionsequence.dom.IActionDefinition;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/ActionInitializationExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ActionInitializationExceptionTest.java
@@ -14,17 +14,17 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.pentaho.actionsequence.dom.IActionDefinition;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 
 import java.lang.reflect.Constructor;

--- a/api/src/test/java/org/pentaho/platform/api/engine/ActionSequenceExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ActionSequenceExceptionTest.java
@@ -14,16 +14,16 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.withSettings;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.pentaho.actionsequence.dom.IActionControlStatement;
 import org.pentaho.actionsequence.dom.IActionDefinition;

--- a/api/src/test/java/org/pentaho/platform/api/engine/ActionSequencePromptExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ActionSequencePromptExceptionTest.java
@@ -14,17 +14,17 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.pentaho.actionsequence.dom.IActionDefinition;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 
 import java.lang.reflect.Constructor;

--- a/api/src/test/java/org/pentaho/platform/api/engine/ActionValidationExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ActionValidationExceptionTest.java
@@ -14,17 +14,17 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.pentaho.actionsequence.dom.IActionDefinition;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/AuditExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/AuditExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/ComponentExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ComponentExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/IPentahoDefinableObjectFactoryTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/IPentahoDefinableObjectFactoryTest.java
@@ -14,15 +14,15 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IPentahoDefinableObjectFactoryTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/IPentahoObjectReferenceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/IPentahoObjectReferenceTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class IPentahoObjectReferenceTest {

--- a/api/src/test/java/org/pentaho/platform/api/engine/IPentahoRegistrableObjectFactoryTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/IPentahoRegistrableObjectFactoryTest.java
@@ -14,15 +14,15 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IPentahoRegistrableObjectFactoryTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/IPlatformPluginTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/IPlatformPluginTest.java
@@ -14,15 +14,15 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IPlatformPluginTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/InvalidParameterExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/InvalidParameterExceptionTest.java
@@ -14,18 +14,18 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.pentaho.platform.api.repository.ContentException;
 
 import java.lang.reflect.Constructor;
 
-import org.junit.Test;
-import org.pentaho.platform.api.repository.ContentException;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class InvalidParameterExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/ObjectFactoryExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ObjectFactoryExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/PentahoAccessControlExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/PentahoAccessControlExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/PentahoSystemExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/PentahoSystemExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/PlatformPluginRegistrationExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/PlatformPluginRegistrationExceptionTest.java
@@ -14,18 +14,18 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.pentaho.platform.api.repository.ContentException;
 
 import java.lang.reflect.Constructor;
 
-import org.junit.Test;
-import org.pentaho.platform.api.repository.ContentException;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class PlatformPluginRegistrationExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/PluginBeanDefinitionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/PluginBeanDefinitionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static junit.framework.TestCase.assertEquals;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/PluginBeanExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/PluginBeanExceptionTest.java
@@ -20,7 +20,7 @@
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/PluginLifecycleExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/PluginLifecycleExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/PluginServiceDefinitionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/PluginServiceDefinitionTest.java
@@ -14,19 +14,19 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Created by bgroves on 10/29/15.

--- a/api/src/test/java/org/pentaho/platform/api/engine/ServerStatusProviderTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ServerStatusProviderTest.java
@@ -14,17 +14,19 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
@@ -35,6 +37,7 @@ import static org.mockito.Mockito.times;
  * @author tkafalas
  *
  */
+@RunWith( MockitoJUnitRunner.class )
 public class ServerStatusProviderTest {
   private IServerStatusProvider serverStatusProvider;
   static final String MESSAGE1 = "This is a test";

--- a/api/src/test/java/org/pentaho/platform/api/engine/ServiceExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ServiceExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/ServiceInitializationExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/ServiceInitializationExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/UnresolvedParameterExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/UnresolvedParameterExceptionTest.java
@@ -14,19 +14,20 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.pentaho.actionsequence.dom.IActionDefinition;
 
 import java.lang.reflect.Constructor;
 
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.pentaho.actionsequence.dom.IActionDefinition;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class UnresolvedParameterExceptionTest {
   @Test

--- a/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/AccessDeniedExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/AccessDeniedExceptionTest.java
@@ -14,15 +14,16 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine.security.userroledao;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 import java.lang.reflect.Constructor;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AccessDeniedExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/AlreadyExistsExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/AlreadyExistsExceptionTest.java
@@ -14,17 +14,16 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine.security.userroledao;
 
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.Test;
 import java.lang.reflect.Constructor;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AlreadyExistsExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/NotFoundExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/NotFoundExceptionTest.java
@@ -14,15 +14,15 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine.security.userroledao;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.lang.reflect.Constructor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NotFoundExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/UncategorizedUserRoleDaoExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/UncategorizedUserRoleDaoExceptionTest.java
@@ -14,15 +14,16 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine.security.userroledao;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 import java.lang.reflect.Constructor;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class UncategorizedUserRoleDaoExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/UserRoleInfoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/security/userroledao/UserRoleInfoTest.java
@@ -14,19 +14,19 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.engine.security.userroledao;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by bgroves on 11/6/15.

--- a/api/src/test/java/org/pentaho/platform/api/monitoring/snmp/BasicSerializerTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/monitoring/snmp/BasicSerializerTest.java
@@ -14,16 +14,16 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.monitoring.snmp;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by bgroves on 10/20/15.
@@ -33,7 +33,7 @@ public class BasicSerializerTest {
 
   public IVariableSerializer.BasicSerializer serializer;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     serializer = new IVariableSerializer.BasicSerializer();
   }

--- a/api/src/test/java/org/pentaho/platform/api/monitoring/snmp/SnmpVariableTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/monitoring/snmp/SnmpVariableTest.java
@@ -14,15 +14,15 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.monitoring.snmp;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SnmpVariableTest {
   @Test

--- a/api/src/test/java/org/pentaho/platform/api/repository/ContentExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository/ContentExceptionTest.java
@@ -14,17 +14,17 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ContentExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/repository/RepositoryExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository/RepositoryExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository/SolutionRepositoryExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository/SolutionRepositoryExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository/SolutionRepositoryServiceExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository/SolutionRepositoryServiceExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository/datasource/DatasourceMgmtServiceExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository/datasource/DatasourceMgmtServiceExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository.datasource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository/datasource/DuplicateDatasourceExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository/datasource/DuplicateDatasourceExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository.datasource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository/datasource/NonExistingDatasourceExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository/datasource/NonExistingDatasourceExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository.datasource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileAceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileAceTest.java
@@ -14,22 +14,22 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileAclTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileAclTest.java
@@ -14,26 +14,26 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Created by bgroves on 10/23/15.
@@ -49,7 +49,7 @@ public class RepositoryFileAclTest {
 
   private RepositoryFileAcl acl;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     acl = new RepositoryFileAcl( ID, SID, INHERITING, ACES );
   }

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileSidTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileSidTest.java
@@ -14,21 +14,21 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
 
 /**
  * Created by bgroves on 10/23/15.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileTest.java
@@ -20,21 +20,21 @@
 
 package org.pentaho.platform.api.repository2.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RepositoryFileTest {
 
@@ -63,7 +63,7 @@ public class RepositoryFileTest {
 
   private RepositoryFile file;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     if ( !LOCALE_PROP.containsKey( RepositoryFile.DEFAULT_LOCALE ) ) {
       LOCALE_PROP.put( RepositoryFile.DEFAULT_LOCALE, null );

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileTreeTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryFileTreeTest.java
@@ -14,19 +14,19 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,8 +35,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by bgroves on 10/23/15.
@@ -53,7 +53,7 @@ public class RepositoryFileTreeTest {
 
   private RepositoryFileTree fileTree;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     fileTree = new RepositoryFileTree( REPO_FILE, CHILDREN );
     fileTree.setVersioningEnabled( VERSION_ENABLED );
@@ -88,7 +88,7 @@ public class RepositoryFileTreeTest {
   @Test
   public void testBuilder() {
     RepositoryFile nullFile =
-        new RepositoryFile( null, null, false, false, true,
+        new RepositoryFile( "null", null, false, false, true,
       false, null, null, null, null, false, null, null, null, null, null, null, null, null, new Long( 1 ), null, null );
     RepositoryFileTree.Builder nullBuilder = new RepositoryFileTree.Builder( nullFile );
     RepositoryFileTree anotherFileTree = nullBuilder.build();

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryLifecycleManagerExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryLifecycleManagerExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryRequestTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryRequestTest.java
@@ -14,20 +14,20 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by bgroves on 10/28/15.
@@ -50,7 +50,7 @@ public class RepositoryRequestTest {
 
   private RepositoryRequest request;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request = new RepositoryRequest( PATH, SHOW_HIDE, DEPTH, LEGACY_FILTER );
     request.setTypes( RepositoryRequest.FILES_TYPE_FILTER.FILES );

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryAccessDeniedExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryAccessDeniedExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryFileExistsExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryFileExistsExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryMalformedNameExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryMalformedNameExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryReferentialIntegrityExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/UnifiedRepositoryReferentialIntegrityExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/VersionSummaryTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/VersionSummaryTest.java
@@ -14,25 +14,25 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.repository2.unified;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Created by bgroves on 10/26/15.
@@ -51,7 +51,7 @@ public class VersionSummaryTest {
 
   private VersionSummary versionSummary;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     versionSummary = new VersionSummary( ID, FILE_ID, ACL_CHANGE, DATE, AUTHOR, MESSAGE, LABELS );
   }

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/SimpleRepositoryFileDataTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/SimpleRepositoryFileDataTest.java
@@ -20,8 +20,8 @@
 
 package org.pentaho.platform.api.repository2.unified.data;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
 
 import java.io.ByteArrayInputStream;
@@ -29,11 +29,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -54,7 +54,7 @@ public class SimpleRepositoryFileDataTest {
   private SimpleRepositoryFileData file;
   private InputStream inputStreamSpy;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     inputStreamSpy = spy( INPUT_STREAM );
     file = new SimpleRepositoryFileData( inputStreamSpy, ENCODING, MIME_TYPE );

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/node/DataNodeRefTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/node/DataNodeRefTest.java
@@ -20,11 +20,11 @@
 
 package org.pentaho.platform.api.repository2.unified.data.node;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DataNodeRefTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/node/DataNodeTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/node/DataNodeTest.java
@@ -20,19 +20,19 @@
 
 package org.pentaho.platform.api.repository2.unified.data.node;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DataNodeTest {
   public static final String NODE_NAME = "newNode";
@@ -61,7 +61,7 @@ public class DataNodeTest {
 
   public DataNode node;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     node = new DataNode( NODE_NAME );
     node.setId( NODE_ID );

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/node/DataPropertyTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/node/DataPropertyTest.java
@@ -20,16 +20,16 @@
 
 package org.pentaho.platform.api.repository2.unified.data.node;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DataPropertyTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/node/NodeRepositoryFileDataTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/node/NodeRepositoryFileDataTest.java
@@ -20,7 +20,7 @@
 
 package org.pentaho.platform.api.repository2.unified.data.node;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static junit.framework.TestCase.assertEquals;
 

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/sample/SampleRepositoryFileDataTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/data/sample/SampleRepositoryFileDataTest.java
@@ -20,10 +20,10 @@
 
 package org.pentaho.platform.api.repository2.unified.data.sample;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by bgroves on 11/6/15.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/DataNodeDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/DataNodeDtoTest.java
@@ -20,12 +20,12 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 27-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/DataPropertyDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/DataPropertyDtoTest.java
@@ -20,10 +20,10 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 27-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/ExecutableFileTypeDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/ExecutableFileTypeDtoTest.java
@@ -20,9 +20,9 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 27-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/LocaleMapDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/LocaleMapDtoTest.java
@@ -20,12 +20,12 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 27-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/NodeRepositoryFileDataDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/NodeRepositoryFileDataDtoTest.java
@@ -20,9 +20,9 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 30-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/RepositoryFileAclAceDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/RepositoryFileAclAceDtoTest.java
@@ -20,12 +20,12 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 30-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/RepositoryFileAclDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/RepositoryFileAclDtoTest.java
@@ -20,9 +20,9 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 30-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/RepositoryFileDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/RepositoryFileDtoTest.java
@@ -20,12 +20,12 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 30-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/RepositoryFileTreeDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/RepositoryFileTreeDtoTest.java
@@ -20,12 +20,12 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 30-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/StringValueStringDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/StringValueStringDtoTest.java
@@ -20,9 +20,9 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 30-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/VersionSummaryDtoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/webservices/VersionSummaryDtoTest.java
@@ -20,13 +20,13 @@
 
 package org.pentaho.platform.api.repository2.unified.webservices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by efreitas on 30-07-2018.

--- a/api/src/test/java/org/pentaho/platform/api/scheduler/BackgroundExecutionExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/scheduler/BackgroundExecutionExceptionTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -22,7 +22,7 @@ package org.pentaho.platform.api.scheduler;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BackgroundExecutionExceptionTest {
 

--- a/api/src/test/java/org/pentaho/platform/api/test/ExceptionTester.java
+++ b/api/src/test/java/org/pentaho/platform/api/test/ExceptionTester.java
@@ -14,18 +14,15 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.test;
 
-import org.junit.Test;
-import org.pentaho.platform.api.engine.ActionExecutionException;
-
 import java.lang.reflect.Constructor;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Created by bgroves on 11/6/15.

--- a/api/src/test/java/org/pentaho/platform/api/ui/ModuleThemeInfoTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/ui/ModuleThemeInfoTest.java
@@ -14,17 +14,17 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
 
 /**
  * Created by bgroves on 10/26/15.

--- a/api/src/test/java/org/pentaho/platform/api/ui/ThemeResourceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/ui/ThemeResourceTest.java
@@ -14,16 +14,16 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 
 /**
  * Created by bgroves on 10/26/15.

--- a/api/src/test/java/org/pentaho/platform/api/ui/ThemeTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/ui/ThemeTest.java
@@ -14,22 +14,22 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 
 /**
  * Created by bgroves on 10/26/15.

--- a/api/src/test/java/org/pentaho/platform/api/util/PasswordServiceExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/util/PasswordServiceExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/api/src/test/java/org/pentaho/platform/api/util/PentahoChainedExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/util/PentahoChainedExceptionTest.java
@@ -14,19 +14,20 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.util;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class PentahoChainedExceptionTest {
   private static final String CAUSE_MSG = "Root cause";

--- a/api/src/test/java/org/pentaho/platform/api/util/PentahoCheckedChainedExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/util/PentahoCheckedChainedExceptionTest.java
@@ -14,23 +14,23 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by bgroves on 11/6/15.

--- a/api/src/test/java/org/pentaho/platform/api/util/XmlParseExceptionTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/util/XmlParseExceptionTest.java
@@ -14,13 +14,13 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.api.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.pentaho.platform.api.test.ExceptionTester.hasValidExceptionConstructors;
 

--- a/assemblies/pentaho-server/src/main/resources-filtered/start-pentaho-debug.sh
+++ b/assemblies/pentaho-server/src/main/resources-filtered/start-pentaho-debug.sh
@@ -48,6 +48,22 @@ if [ "$?" = 0 ]; then
   cd "$DIR/tomcat/bin"
   CATALINA_OPTS="-Xms2048m -Xmx6144m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8044 -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -Dfile.encoding=utf8 -Djava.locale.providers=COMPAT,SPI -DDI_HOME=\"$DI_HOME\""
   export CATALINA_OPTS
+
+  #Sets options that only get read by Java 11 to remove illegal reflective access warnings
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.lang=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.net=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.security=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.file=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.ftp=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.http=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.reflect.misc=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.management/javax.management=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.management/javax.management.openmbean=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
+  export JDK_JAVA_OPTIONS
   JAVA_HOME=$_PENTAHO_JAVA_HOME
   sh startup.sh
 fi

--- a/assemblies/pentaho-server/src/main/resources-filtered/start-pentaho.sh
+++ b/assemblies/pentaho-server/src/main/resources-filtered/start-pentaho.sh
@@ -54,12 +54,17 @@ if [ "$errCode" = 0 ]; then
   #Sets options that only get read by Java 11 to remove illegal reflective access warnings
   JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"
   JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.lang=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
   JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.net=ALL-UNNAMED"
   JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens=java.base/java.security=ALL-UNNAMED"
   JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.file=ALL-UNNAMED"
   JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.ftp=ALL-UNNAMED"
   JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.http=ALL-UNNAMED"
-  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED"  
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/sun.reflect.misc=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.management/javax.management=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.management/javax.management.openmbean=ALL-UNNAMED"
+  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
   export JDK_JAVA_OPTIONS
 
   JAVA_HOME=$_PENTAHO_JAVA_HOME

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -582,9 +582,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -628,26 +628,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>${mockito-core.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito-core.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/src/main/java/org/pentaho/platform/engine/security/LoginAttemptService.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/LoginAttemptService.java
@@ -14,13 +14,12 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2020 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2020-2024 Hitachi Vantara. All rights reserved.
  *
  */
-
-
 package org.pentaho.platform.engine.security;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -31,8 +30,10 @@ import java.util.concurrent.TimeUnit;
 
 public class LoginAttemptService implements ILoginAttemptService {
 
-  private LoadingCache<String, Integer> attemptsCache;
-  private final int maxAttempt;
+  @VisibleForTesting
+  protected LoadingCache<String, Integer> attemptsCache;
+  @VisibleForTesting
+  protected final int maxAttempt;
 
   public LoginAttemptService( int maxAttempt, int cacheMinutes ) {
     this.maxAttempt = maxAttempt;

--- a/core/src/test/java/org/pentaho/platform/engine/security/LoginAttemptServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/LoginAttemptServiceTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2020 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2020-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -29,7 +29,6 @@ import org.pentaho.platform.api.security.ILoginAttemptService;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
-import static org.powermock.reflect.Whitebox.getInternalState;
 import static org.junit.Assert.assertEquals;
 
 public class LoginAttemptServiceTest {
@@ -50,7 +49,7 @@ public class LoginAttemptServiceTest {
     int maxAttempt = 3;
     int cacheMinutes = 60;
     ILoginAttemptService loginAttemptService = new LoginAttemptService( maxAttempt, cacheMinutes );
-    assertEquals( maxAttempt, (int) getInternalState( loginAttemptService, "maxAttempt" ) );
+    assertEquals( maxAttempt, ((LoginAttemptService)loginAttemptService).maxAttempt );
   }
 
   @Test
@@ -63,22 +62,15 @@ public class LoginAttemptServiceTest {
 
     for ( int i = 1; i <= attempts; i++ ) {
       loginAttemptService.loginFailed( key );
-      assertEquals(
-        Integer.valueOf( i ),
-        ( (LoadingCache<String, Integer>) getInternalState( loginAttemptService, "attemptsCache" ) ).get( key )
-      );
+      assertEquals( Integer.valueOf( i ), ( ( (LoginAttemptService) loginAttemptService ).attemptsCache ).get( key ) );
     }
   }
-
-
 
   @Test
   public void testLoginSucceeded() throws ExecutionException {
     testLoginFailed();
     loginAttemptService.loginSucceeded( key );
-    assertEquals(
-      Integer.valueOf( 0 ),
-      ( (LoadingCache<String, Integer>) getInternalState( loginAttemptService, "attemptsCache" ) ).get( key ) );
+    assertEquals( Integer.valueOf( 0 ), ( ( (LoginAttemptService) loginAttemptService ).attemptsCache ).get( key ) );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/services/connection/datasource/dbcp/PooledDatasourceHelperTest.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -37,13 +37,13 @@ import java.util.HashMap;
 import java.util.Properties;
 
 import org.apache.commons.dbcp2.ConnectionFactory;
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.database.DatabaseDialectException;
 import org.pentaho.database.IDatabaseDialect;
@@ -315,7 +315,7 @@ public class PooledDatasourceHelperTest {
 
     ConnectionFactory factory = PooledDatasourceHelper.getConnectionFactory( connection, "jdbc:mysql://localhost" );
 
-    Properties props = (Properties) Whitebox.getInternalState( factory, "properties" );
+    Properties props = ((DriverManagerConnectionFactory) factory).getProperties();
     assertEquals( user, props.getProperty( "user" ) );
     assertEquals( password, props.getProperty( "password" ) );
   }
@@ -328,7 +328,7 @@ public class PooledDatasourceHelperTest {
 
     ConnectionFactory factory = PooledDatasourceHelper.getConnectionFactory( connection, "jdbc:mariadb://localhost" );
 
-    Properties props = (Properties) Whitebox.getInternalState( factory, "properties" );
+    Properties props = ((DriverManagerConnectionFactory) factory).getProperties();
     assertEquals( user, props.getProperty( "user" ) );
     assertEquals( password, props.getProperty( "password" ) );
   }
@@ -341,7 +341,7 @@ public class PooledDatasourceHelperTest {
 
     ConnectionFactory factory = PooledDatasourceHelper.getConnectionFactory( connection, "jdbc:microsoft:sqlserver://localhost" );
 
-    Properties props = (Properties) Whitebox.getInternalState( factory, "properties" );
+    Properties props = ((DriverManagerConnectionFactory) factory).getProperties();
     assertEquals( user, props.getProperty( "user" ) );
     assertEquals( password, props.getProperty( "password" ) );
 

--- a/core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -34,7 +34,6 @@ import org.pentaho.platform.api.engine.PluginBeanException;
 import org.pentaho.platform.api.workitem.IWorkItemLifecycleEventPublisher;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.workitem.DummyPublisher;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -51,7 +50,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
 @RunWith( MockitoJUnitRunner.class )
-@PrepareForTest( { PentahoSystem.class, ActionUtil.class } )
 public class ActionUtilTest {
 
   @Test( expected = ActionInvocationException.class )

--- a/core/src/test/java/org/pentaho/platform/workitem/WorkItemLifecycleEventUtilTest.java
+++ b/core/src/test/java/org/pentaho/platform/workitem/WorkItemLifecycleEventUtilTest.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -27,13 +27,11 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.platform.api.workitem.IWorkItemLifecycleEventPublisher;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 
 @RunWith( MockitoJUnitRunner.class )
-@PrepareForTest( { PentahoSystem.class } )
 public class WorkItemLifecycleEventUtilTest {
 
   private final WorkItemLifecyclePhase lifecyclePhase = WorkItemLifecyclePhase.DISPATCHED;

--- a/core/src/test/java/org/pentaho/test/BeanTester.java
+++ b/core/src/test/java/org/pentaho/test/BeanTester.java
@@ -22,6 +22,7 @@ package org.pentaho.test;
 
 import org.junit.Assume;
 import org.junit.Test;
+import org.springframework.context.annotation.Bean;
 
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
@@ -30,13 +31,17 @@ import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
 import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class BeanTester {
+public abstract class BeanTester {
   private Class<?> clazz;
   private boolean testHasValidBeanConstructor;
   private boolean testHasValidGettersAndSetters;
   private boolean testHasValidBeanHashCode;
   private boolean testHasValidBeanEquals;
   private boolean testHasValidBeanToString;
+
+  public BeanTester () {
+    this( org.pentaho.test.BeanTester.class, true, true, true, true, true );
+  }
 
   public BeanTester( Class<?> clazz ) {
     this( clazz, true, true, true, true, true );

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -27,6 +27,8 @@
     <pentaho-actionsequence-dom.version>10.2.0.0-SNAPSHOT</pentaho-actionsequence-dom.version>
     <pentaho-metadata.version>10.2.0.0-SNAPSHOT</pentaho-metadata.version>
     <pentaho-chartbeans.version>10.2.0.0-SNAPSHOT</pentaho-chartbeans.version>
+    <maven-surefire-plugin.argLine> --add-opens=java.base/java.lang=ALL-UNNAMED </maven-surefire-plugin.argLine>
+    <nashorn.version>15.4</nashorn.version>
   </properties>
   <dependencies>
     <!-- @Null, @Nullable annotations -->
@@ -2150,15 +2152,15 @@
       <artifactId>org.osgi.compendium</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.openjdk.nashorn</groupId>
+      <artifactId>nashorn-core</artifactId>
+      <version>${nashorn.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>${mockito-core.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -2195,18 +2197,6 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>${hamcrest-library.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.bean-matchers</groupId>

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/ImportSessionTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/ImportSessionTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -37,7 +37,6 @@ import org.pentaho.platform.api.repository2.unified.RepositoryFileExtraMetaData;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifestEntity;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifestFormatException;
-import org.powermock.reflect.Whitebox;
 
 public class ImportSessionTest {
   private static final String PATH = "path";
@@ -124,8 +123,8 @@ public class ImportSessionTest {
     when( manifest.getExportManifestEntity( nullable( String.class ) )).thenReturn( entity );
     when( entity.getRepositoryFileExtraMetaData() ).thenReturn( repositoryFileExtraMetaData );
 
-    Whitebox.setInternalState( importSession, "manifest", manifest );
-    Assert.assertEquals( repositoryFileExtraMetaData, importSession.processExtraMetaDataForFile( "filePath" ));
+    importSession.setManifest( manifest );
+    Assert.assertEquals( repositoryFileExtraMetaData, importSession.processExtraMetaDataForFile( "filePath" ) );
 
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2022 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -84,7 +84,7 @@ import static org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomai
 import static org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepository.TYPE_DOMAIN;
 import static org.pentaho.platform.plugin.services.metadata.PentahoMetadataDomainRepository.TYPE_LOCALE;
 import static org.pentaho.test.platform.repository2.unified.MockUnifiedRepository.everyone;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @RunWith ( MockitoJUnitRunner.class )
 public class PentahoMetadataDomainRepositoryTest {

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/SessionCachingMetadataDomainRepositoryTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/SessionCachingMetadataDomainRepositoryTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2022 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -35,7 +35,6 @@ import org.pentaho.platform.config.SystemConfig;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.test.platform.plugin.services.metadata.MockSessionAwareMetadataDomainRepository;
-import org.powermock.api.mockito.PowerMockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -479,7 +478,7 @@ public class SessionCachingMetadataDomainRepositoryTest {
 
   public ISystemConfig createSystemConfigTestObject( Properties properties ) throws Exception {
     IConfiguration configuration = Mockito.mock( IConfiguration.class );
-    PowerMockito.when( configuration.getId() ).thenReturn( "system" );
+    Mockito.when( configuration.getId() ).thenReturn( "system" );
     Mockito.when( configuration.getProperties() ).thenReturn( properties );
 
     List<IConfiguration> configs = new ArrayList<>();

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/security/userrole/PentahoEhCacheBasedUserCacheTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/security/userrole/PentahoEhCacheBasedUserCacheTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2020 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2020-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -27,42 +27,15 @@ import org.junit.Test;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.internal.util.reflection.Whitebox.getInternalState;
-import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
 
 public class PentahoEhCacheBasedUserCacheTest {
 
   @Before
   public void setUp() {
-
-  }
-
-  @Test
-  public void testIsCaseSensitive() {
-    PentahoEhCacheBasedUserCache userCache = new PentahoEhCacheBasedUserCache();
-
-    setInternalState( userCache, "caseSensitive", true );
-    assertTrue( userCache.isCaseSensitive() );
-
-    setInternalState( userCache, "caseSensitive", false );
-    assertFalse( userCache.isCaseSensitive() );
-  }
-
-  @Test
-  public void testSetCaseSensitive() {
-    PentahoEhCacheBasedUserCache userCache = new PentahoEhCacheBasedUserCache();
-
-    userCache.setCaseSensitive( true );
-    assertTrue( (boolean) getInternalState( userCache, "caseSensitive" ) );
-
-    userCache.setCaseSensitive( false );
-    assertFalse( (boolean) getInternalState( userCache, "caseSensitive" ) );
 
   }
 

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/UserRoleDaoResourceTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2021 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -23,7 +23,6 @@ package org.pentaho.platform.web.http.api.resources;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.security.userroledao.AlreadyExistsException;
 import org.pentaho.platform.api.engine.security.userroledao.IPentahoRole;
@@ -408,13 +407,11 @@ public class UserRoleDaoResourceTest {
   public void testCreateUserAndCheckDataSent() throws Exception {
     ArgumentCaptor<User> argument = ArgumentCaptor.forClass( User.class );
 
-    UserRoleDaoService userRoleDaoService = mock( UserRoleDaoService.class );
-    Whitebox.setInternalState( userRoleResource, "userRoleDaoService", userRoleDaoService );
     String username = "name";
     String password = "password";
     String b64Password = "ENC:" + Base64.getEncoder().encodeToString( password.getBytes() );
     Response response = userRoleResource.createUser( new User( username, b64Password ) );
-    verify( userRoleDaoService, times( 1 ) ).createUser( argument.capture() );
+    verify( userRoleService, times( 1 ) ).createUser( argument.capture() );
 
     assertEquals( username, argument.getValue().getUserName() );
     assertEquals( password, argument.getValue().getPassword() );

--- a/extensions/src/test/java/org/pentaho/platform/web/http/security/PreventBruteForceUsernamePasswordAuthenticationFilterTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/security/PreventBruteForceUsernamePasswordAuthenticationFilterTest.java
@@ -14,7 +14,7 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2020-2021 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2020-2024 Hitachi Vantara. All rights reserved.
  *
  */
 package org.pentaho.platform.web.http.security;
@@ -25,6 +25,7 @@ import org.pentaho.platform.api.security.ILoginAttemptService;
 import org.pentaho.platform.engine.security.LoginAttemptService;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -35,7 +36,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.reflect.Whitebox.setInternalState;
 
 
 public class PreventBruteForceUsernamePasswordAuthenticationFilterTest {
@@ -64,12 +64,12 @@ public class PreventBruteForceUsernamePasswordAuthenticationFilterTest {
   @Test
   public void testAttemptAuthenticationWithoutBlock() {
     PreventBruteForceUsernamePasswordAuthenticationFilter authenticationFilter =
-    spy( new PreventBruteForceUsernamePasswordAuthenticationFilter( mockLoginAttemptService ) );
+      spy( new PreventBruteForceUsernamePasswordAuthenticationFilter( mockLoginAttemptService ) );
 
     when( mockLoginAttemptService.isBlocked( ip ) ).thenReturn( false );
     when( mockAuthenticationManager.authenticate( any() ) ).thenReturn( mockAuthentication );
 
-    setInternalState( authenticationFilter, "authenticationManager", mockAuthenticationManager );
+    authenticationFilter.setAuthenticationManager( mockAuthenticationManager );
 
     authenticationFilter.attemptAuthentication( mockRequest, mockResponse );
     verify( mockLoginAttemptService, times( 1 ) ).isBlocked( ip );

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,8 @@
     <edtftpj.version>2.1.0</edtftpj.version>
     <jzlib.version>1.0.7</jzlib.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13.2</junit.version>
+    <junit-jupiter.version>5.10.2</junit-jupiter.version>
     <mockrunner.version>0.3.1</mockrunner.version>
     <jempbox.version>0.2.0</jempbox.version>
     <json-unit.version>1.5.5</json-unit.version>
@@ -148,7 +149,7 @@
     <gdata-client-meta.version>1.0</gdata-client-meta.version>
     <owasp.encoder.version>1.2</owasp.encoder.version>
     <powermock.version>1.6.3</powermock.version>
-    <mockito-core.version>4.0.0</mockito-core.version>
+    <mockito-core.version>5.10.0</mockito-core.version>
     <apacheds.version>1.5.5</apacheds.version>
     <jcommon.version>1.0.16</jcommon.version>
     <drools.version>6.4.0.Final</drools.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -21,6 +21,8 @@
     <jettison.version>1.1</jettison.version>
     <hamcrest-core.version>2.2</hamcrest-core.version>
     <xmlunit.version>1.3</xmlunit.version>
+    <maven-surefire-plugin.argLine> --add-opens=java.base/java.lang=ALL-UNNAMED </maven-surefire-plugin.argLine>
+    <maven-failsafe-plugin.argLine> --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.management/javax.management.openmbean=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED </maven-failsafe-plugin.argLine>
   </properties>
   <dependencies>
     <dependency>
@@ -823,12 +825,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito-core.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
       <version>${mockito-core.version}</version>
       <scope>test</scope>
     </dependency>

--- a/repository/src/main/java/org/apache/jackrabbit/core/security/authorization/acl/MagicGroup.java
+++ b/repository/src/main/java/org/apache/jackrabbit/core/security/authorization/acl/MagicGroup.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -24,7 +24,6 @@ import org.apache.jackrabbit.core.security.principal.UnknownPrincipal;
 import org.pentaho.platform.repository2.unified.jcr.IPentahoInternalPrincipal;
 
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.Enumeration;
 
 /**
@@ -36,7 +35,7 @@ import java.util.Enumeration;
  * 
  * @author mlowery
  */
-public class MagicGroup extends UnknownPrincipal implements Group, IPentahoInternalPrincipal {
+public class MagicGroup extends UnknownPrincipal implements IPentahoInternalPrincipal {
 
   private static final long serialVersionUID = 2395449661136335711L;
 
@@ -44,22 +43,17 @@ public class MagicGroup extends UnknownPrincipal implements Group, IPentahoInter
     super( name );
   }
 
-  @Override
   public boolean addMember( Principal arg0 ) {
     throw new UnsupportedOperationException();
   }
-
-  @Override
   public boolean isMember( Principal arg0 ) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public Enumeration<? extends Principal> members() {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public boolean removeMember( Principal arg0 ) {
     throw new UnsupportedOperationException();
   }

--- a/repository/src/main/java/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntry.java
+++ b/repository/src/main/java/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntry.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -31,6 +31,7 @@ import org.apache.jackrabbit.core.security.authorization.PrivilegeBits;
 import org.apache.jackrabbit.core.security.authorization.PrivilegeManagerImpl;
 import org.apache.jackrabbit.core.value.InternalValue;
 import org.apache.jackrabbit.spi.Name;
+import org.pentaho.platform.repository2.unified.jcr.jackrabbit.security.SpringSecurityRolePrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,6 @@ import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -158,7 +158,7 @@ public class PentahoEntry implements AccessControlConstants {
         boolean isGroupEntry = false;
         Principal princ = principalMgr.getPrincipal(principalName);
         if (princ != null) {
-          isGroupEntry = (princ instanceof Group );
+          isGroupEntry = ( princ instanceof SpringSecurityRolePrincipal );
         }
 
         InternalValue[] privValues = aceNode.getProperty(P_PRIVILEGES).internalGetValues();

--- a/repository/src/main/java/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntryCollector.java
+++ b/repository/src/main/java/org/apache/jackrabbit/core/security/authorization/acl/PentahoEntryCollector.java
@@ -22,7 +22,6 @@ package org.apache.jackrabbit.core.security.authorization.acl;
 
 import java.io.InputStream;
 import java.security.Principal;
-import java.security.acl.Group;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,6 +54,7 @@ import org.pentaho.platform.engine.security.SecurityHelper;
 import org.pentaho.platform.repository2.unified.jcr.IAclMetadataStrategy.AclMetadata;
 import org.pentaho.platform.repository2.unified.jcr.JcrRepositoryFileAclUtils;
 import org.pentaho.platform.repository2.unified.jcr.JcrTenantUtils;
+import org.pentaho.platform.repository2.unified.jcr.jackrabbit.security.SpringSecurityRolePrincipal;
 import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -399,7 +399,7 @@ public class PentahoEntryCollector extends EntryCollector {
     Principal ownerPrincipal = systemSession.getPrincipalManager().getPrincipal( owner );
     if ( ownerPrincipal != null ) {
       Principal magicPrincipal = null;
-      if ( ownerPrincipal instanceof Group ) {
+      if ( ownerPrincipal instanceof SpringSecurityRolePrincipal ) {
         magicPrincipal = new MagicGroup( JcrTenantUtils.getTenantedUser( ownerPrincipal.getName() ) );
       } else {
         magicPrincipal = new MagicPrincipal( JcrTenantUtils.getTenantedUser( ownerPrincipal.getName() ) );
@@ -514,7 +514,7 @@ public class PentahoEntryCollector extends EntryCollector {
     if ( ace != null ) {
 
       Principal principal = ace.getPrincipal();
-      boolean isGroupEntry = principal instanceof Group;
+      boolean isGroupEntry = principal instanceof SpringSecurityRolePrincipal;
       PrivilegeBits bits = ( (ACLTemplate.Entry) ace ).getPrivilegeBits();
       boolean isAllow = ( (ACLTemplate.Entry) ace ).isAllow();
 

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/IPentahoInternalPrincipal.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/IPentahoInternalPrincipal.java
@@ -21,6 +21,7 @@
 package org.pentaho.platform.repository2.unified.jcr;
 
 import java.security.Principal;
+import java.util.Enumeration;
 
 /**
  * Marker interface that denotes principals that are part of internal ACEs that are never exposed to clients.

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileAclDao.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileAclDao.java
@@ -51,7 +51,6 @@ import javax.jcr.security.Privilege;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -243,7 +242,7 @@ public class JcrRepositoryFileAclDao implements IRepositoryFileAclDao {
     String name = principal.getName();
     DefaultPermissionConversionHelper permissionConversionHelper = new DefaultPermissionConversionHelper( session );
 
-    if ( principal instanceof Group ) {
+    if ( principal instanceof SpringSecurityRolePrincipal ) {
       sid =
           new RepositoryFileSid( JcrTenantUtils.getRoleNameUtils().getPrincipleName( name ),
               RepositoryFileSid.Type.ROLE );

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityLoginModule.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityLoginModule.java
@@ -39,7 +39,6 @@ import javax.jcr.SimpleCredentials;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.login.LoginException;
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -201,7 +200,7 @@ public class SpringSecurityLoginModule extends AbstractLoginModule {
   protected Principal getPrincipal( final Credentials credentials ) {
     String userId = getUserID( credentials );
     Principal principal = principalProvider.getPrincipal( userId );
-    if ( principal == null || principal instanceof Group ) {
+    if ( principal == null || principal instanceof SpringSecurityRolePrincipal ) {
       // no matching user principal
       return null;
     } else {

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityPrincipalProvider.java
@@ -14,14 +14,13 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
 package org.pentaho.platform.repository2.unified.jcr.jackrabbit.security;
 
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -330,7 +329,7 @@ public class SpringSecurityPrincipalProvider implements PrincipalProvider {
     // make sure it's a user; also, repo admins are never in back-end--no
     // need to attempt to look them up; also acl
     // metadata principals never have group membership
-    if ( !( principal instanceof Group ) && !( principal instanceof AdminPrincipal )
+    if ( !( principal instanceof SpringSecurityRolePrincipal ) && !( principal instanceof AdminPrincipal )
       && !( principal instanceof AclMetadataPrincipal ) ) {
       UserDetails user = internalGetUserDetails( principal.getName() );
       if ( user == null ) {

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityRolePrincipal.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/jackrabbit/security/SpringSecurityRolePrincipal.java
@@ -14,7 +14,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2002-2024 Hitachi Vantara. All rights reserved.
  *
  */
 
@@ -23,13 +23,12 @@ package org.pentaho.platform.repository2.unified.jcr.jackrabbit.security;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.Enumeration;
 
 /**
  * In Spring Security, there are users and roles. This class represents a Spring Security role. This class is the
  * Jackrabbit representation of a {@code org.springframework.security.acls.sid.GrantedAuthoritySid}. This class was
- * required as no {@link Group} implementations were found that could re-used.
+ * required as no Group implementations were found that could re-used.
  * 
  * <p>
  * Why Group and not Principal? Group is more like a Spring Security role in that there can be "members" that have
@@ -39,7 +38,7 @@ import java.util.Enumeration;
  * 
  * @author mlowery
  */
-public class SpringSecurityRolePrincipal implements Group {
+public class SpringSecurityRolePrincipal implements Principal {
 
   // ~ Static fields/initializers
   // ======================================================================================

--- a/user-console/pom.xml
+++ b/user-console/pom.xml
@@ -15,7 +15,7 @@
     <gwt.outputDirectory>${project.build.directory}/${project.artifactId}-gwt-${project.version}</gwt.outputDirectory>
     <json-simple.version>1.1</json-simple.version>
     <license.header.definition.file>${basedir}/../license/styles/javadoc_style_license_header.xml</license.header.definition.file>
-    <mockito.version>1.8.5</mockito.version>
+    <mockito.version>5.10.0</mockito.version>
     <commons-xul.version>10.2.0.0-SNAPSHOT</commons-xul.version>
     <common-ui.version>10.2.0.0-SNAPSHOT</common-ui.version>
     <commons-gwt.version>10.2.0.0-SNAPSHOT</commons-gwt.version>
@@ -324,7 +324,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
java.security.acl package was removed, needed to replace the old Group interface with our implementation
Unit test updates to remove old test frameworks and replace with latest mockito.
Additional add-opens arguments when launching the server to work around stronger package encapsulation.