### PR TITLE
[BISERVER-14864] - Empty file when downloading PIR to Excel 97-2003 format once data is past Excel limitations

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
@@ -1043,7 +1043,6 @@ public class RepositoryResource extends AbstractJaxRSResource {
     MIME_TYPE_EMAIL( "mime-message/text/html" ),
     MIME_TYPE_PDF( "pageable/pdf" ),
     MIME_TYPE_CSV( "table/csv;page-mode=stream" ),
-    MIME_TYPE_XLS( "table/excel;page-mode=flow" ),
     MIME_TYPE_XLSX( "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;page-mode=flow" ),
     MIME_TYPE_TXT( "pageable/text" ),
     MIME_TYPE_RTF( "table/rtf;page-mode=flow" );


### PR DESCRIPTION
Removed options to download .xls files