### PR TITLE
[BACKLOG-40086] Schedule Output Perspective : Allow user to browse Scheduled contents from a VFS location folder

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.fileButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.fileButtons.js
@@ -21,8 +21,6 @@ define([
   "common-ui/jquery"
 ], function (BrowserUtils) {
 
-  const buttonIds = ["#openButton", "#openNewButton", "#runButton", "#editButton", "#cutbutton", "#copyButton", "#deleteButton", "#renameButton", "#downloadButton", "#shareButton", "#scheduleButton", "#favoritesButton", "#propertiesButton"];
-
   var local = {
     renameDialog: null,
 
@@ -196,7 +194,11 @@ define([
     },
 
     isVfsConnection: function( isVfsConnection ){
-      buttonIds.forEach((buttonId) => $(buttonId).prop("disabled", isVfsConnection));
+      this.buttons.forEach((buttonDef) => {
+        if(buttonDef.id !== "separator") {
+          $("#" + buttonDef.id).prop("disabled", isVfsConnection);
+        }
+      });
     },
 
     eventLogger: function (event) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.fileButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.fileButtons.js
@@ -193,10 +193,10 @@ define([
       }
     },
 
-    isVfsConnection: function( isVfsConnection ){
+    enableButtons: function (enableButtons) {
       this.buttons.forEach((buttonDef) => {
-        if(buttonDef.id !== "separator") {
-          $("#" + buttonDef.id).prop("disabled", isVfsConnection);
+        if (buttonDef.id !== "separator") {
+          $("#" + buttonDef.id).prop("disabled", !enableButtons);
         }
       });
     },

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.fileButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.fileButtons.js
@@ -21,6 +21,8 @@ define([
   "common-ui/jquery"
 ], function (BrowserUtils) {
 
+  const buttonIds = ["#openButton", "#openNewButton", "#runButton", "#editButton", "#cutbutton", "#copyButton", "#deleteButton", "#renameButton", "#downloadButton", "#shareButton", "#scheduleButton", "#favoritesButton", "#propertiesButton"];
+
   var local = {
     renameDialog: null,
 
@@ -191,6 +193,10 @@ define([
           }
         }
       }
+    },
+
+    isVfsConnection: function( isVfsConnection ){
+      buttonIds.forEach((buttonId) => $(buttonId).prop("disabled", isVfsConnection));
     },
 
     eventLogger: function (event) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
@@ -20,8 +20,6 @@ define([
   "common-ui/jquery"
 ], function () {
 
-  const buttonIds = ["#newFolderButton", "#deleteFolderButton", "#renameButton", "#pasteButton", "#uploadButton", "#downloadButton", "#propertiesButton"];
-
   var local = {
     renameDialog: null,
 
@@ -156,7 +154,11 @@ define([
     },
 
     isVfsConnection: function( isVfsConnection ){
-      buttonIds.forEach((buttonId) => $(buttonId).prop("disabled", isVfsConnection));
+      this.buttons.forEach((buttonDef) => {
+        if(buttonDef.id !== "separator") {
+          $("#" + buttonDef.id).prop("disabled", isVfsConnection);
+        }
+      });
     },
 
     eventLogger: function (event) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
@@ -153,10 +153,10 @@ define([
       }
     },
 
-    isVfsConnection: function( isVfsConnection ){
+    enableButtons: function (enableButtons) {
       this.buttons.forEach((buttonDef) => {
-        if(buttonDef.id !== "separator") {
-          $("#" + buttonDef.id).prop("disabled", isVfsConnection);
+        if (buttonDef.id !== "separator") {
+          $("#" + buttonDef.id).prop("disabled", !enableButtons);
         }
       });
     },

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
@@ -20,6 +20,8 @@ define([
   "common-ui/jquery"
 ], function () {
 
+  const buttonIds = ["#newFolderButton", "#deleteFolderButton", "#renameButton", "#pasteButton", "#uploadButton", "#downloadButton", "#propertiesButton"];
+
   var local = {
     renameDialog: null,
 
@@ -151,6 +153,10 @@ define([
           $("#renameButton").prop("disabled", true);
         }
       }
+    },
+
+    isVfsConnection: function( isVfsConnection ){
+      buttonIds.forEach((buttonId) => $(buttonId).prop("disabled", isVfsConnection));
     },
 
     eventLogger: function (event) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -1246,19 +1246,7 @@ define([
           url: url,
           success: function (response) {
             if (response.children) {
-              var toAppend = "";
-              for(var i = 0; i < response.children.length; i++) {
-                var child = response.children[i].file;
-                toAppend += "<div id=\"" + child.id + "\" class=\"folder\" path=\"" + child.path +
-                    "\" ext=\"" + child.name + "\" desc=\"" + child.name + "\">" +
-                    "<div class=\"element\" role='treeitem' aria-selected='false' aria-expanded='false' tabindex='-1'>" +
-                    "<div class=\"expandCollapse\"></div>" +
-                    "<div class=\"icon\"></div>" +
-                    "<div class=\"title\">" + ( child.title ? child.title : child.name ) + "</div>" +
-                    "</div>" +
-                    "<div class=\"folders\" style=\"\"></div>" +
-                    "</div>"
-              }
+              var toAppend = templates.folders(FileBrowser.fileBrowserModel.get("fileListModel").reformatResponse(response));
               $target.find("> .folders").append(toAppend ? toAppend : "");
               depth = $target.attr("path").split("/").length;
             }

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -601,7 +601,11 @@ define([
         expandedPathParam = "&expandedPath=" + FileBrowser.fileBrowserModel.get("startFolder");
       }
 
-      return CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/tree?depth=1&filter=FOLDERS&showHidden=" + this.get("showHiddenFiles") + expandedPathParam;
+      /**
+       * TODO BACKLOG-40086: In order to prevent regressions in current behavior we include the depth parameter here like it was for repository api.
+       * This is expensive, however, fetching the entire folder tree to whatever depth, just to view a specific folder.
+       */
+      return CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/tree?depth="+ depth +"&filter=FOLDERS&showHidden=" + this.get("showHiddenFiles") + expandedPathParam;
     },
 
     getRepositoryFolderChildren: function (response) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -522,6 +522,7 @@ define([
     updateData: function () {
       var myself = this;
       myself.set("runSpinner", true);
+      myself.clearTreeCache();
       myself.fetchTreeRootData(function (response) {
         var trash = {
           "file": {
@@ -543,6 +544,25 @@ define([
         //Add trash to data model
         response.children.push(trash);
         myself.set("data", response);
+      });
+    },
+
+    clearTreeCache: function () {
+      let url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/files/tree/cache";
+
+      $.ajax({
+        async: true,
+        cache: false, // prevent IE from caching the request
+        type: 'DELETE',
+        dataType: "json",
+        url: url,
+        success: function (response) {
+        },
+        error: function () {
+          //TODO SOMETHING ON ERROR look at browser.dialogs
+        },
+        beforeSend: function (xhr) {
+        }
       });
     },
 
@@ -577,7 +597,7 @@ define([
         expandedPathParam = "&expandedPath=" + FileBrowser.fileBrowserModel.get("startFolder");
       }
 
-      return "/pentaho/plugin/scheduler-plugin/api/generic-files/files/tree?depth=1&showHidden=false&filter=FOLDERS" + expandedPathParam;
+      return CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/files/tree?depth=1&showHidden=false&filter=FOLDERS" + expandedPathParam;
     }
   });
 
@@ -1150,8 +1170,11 @@ define([
         FileBrowser.fileBrowserModel.updateFolderButtons($folder.attr("path"));
         myself.updateDescriptions();
 
-        //scroll the selected folder div into view
-        $("div.folders .selected").get()[0].scrollIntoView();
+        //scroll the first selected folder div into view
+        let selectedFolders = $("div.folders .selected").get();
+        if (selectedFolders.length > 0) {
+          selectedFolders[0].scrollIntoView();
+        }
       }
     },
 
@@ -1454,6 +1477,12 @@ define([
       setTimeout(function () {
         myself.model.set("runSpinner", false);
       }, 100);
+
+      //scroll the first selected file div into view
+      let selectedFiles = $("div.file.selected").get();
+      if (selectedFiles.length > 0) {
+        selectedFiles[0].scrollIntoView();
+      }
     },
 
     /*!

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -33,6 +33,8 @@ define([
   "common-ui/jquery"
 ], function (FileButtons, FolderButtons, TrashButtons, TrashItemButtons, BrowserUtils, MultiSelectButtons, RenameDialog, Spinner, spin, templates, Encoder, a11yUtil) {
 
+  const REPOSITORY_ROOT_PATH = "/";
+
   if (window.parent.mantle_isBrowseRepoDirty == undefined) {
     window.parent.mantle_isBrowseRepoDirty = false;
   }
@@ -358,12 +360,7 @@ define([
     },
 
     updateFolderButtons: function( _folderPath) {
-      let isRepoPath;
-      if (_folderPath){
-        isRepoPath = isRepositoryPath(_folderPath);
-      } else {
-        isRepoPath = false;
-      }
+      const isRepoPath = !!_folderPath && isRepositoryPath(_folderPath);
 
       var userHomePath = Encoder.encodeRepositoryPath(window.parent.HOME_FOLDER);
       var model = FileBrowser.fileBrowserModel; // trap model
@@ -575,7 +572,10 @@ define([
           localSequenceNumber = myself.get("sequenceNumber"),
           url = this.getFolderTreeRootRequest();
 
-      FileBrowser.clearTreeCache();
+      //Clear the cache if flag is set. Flag is cleared later in the File List Model.
+      if (window.parent.mantle_isBrowseRepoDirty) {
+        FileBrowser.clearTreeCache();
+      }
 
       $.ajax({
         async: true,
@@ -610,7 +610,7 @@ define([
     getRepositoryFolderChildren: function (response) {
       for (let i = 0; i < response.children.length; i++) {
         const childFolder = response.children[i];
-        if (childFolder.file.path == "/") {
+        if (isRepositoryRootPath(childFolder.file.path)) {
           return childFolder.children;
         }
       }
@@ -1959,7 +1959,11 @@ define([
   }
 
   function isRepositoryPath(path) {
-    return path.charAt(0) === "/";
+    return path.charAt(0) === REPOSITORY_ROOT_PATH;
+  }
+
+  function isRepositoryRootPath(path) {
+    return path === REPOSITORY_ROOT_PATH;
   }
 
   function encodeGenericPath(path) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -572,10 +572,7 @@ define([
           localSequenceNumber = myself.get("sequenceNumber"),
           url = this.getFolderTreeRootRequest();
 
-      //Clear the cache if flag is set. Flag is cleared later in the File List Model.
-      if (window.parent.mantle_isBrowseRepoDirty) {
-        FileBrowser.clearTreeCache();
-      }
+      FileBrowser.clearTreeCache();
 
       $.ajax({
         async: true,
@@ -727,11 +724,6 @@ define([
           url = this.getFileListRequest(encodeGenericPath(path == null ? ":" : path)),
           localSequenceNumber = myself.get("sequenceNumber");
 
-      // BACKLOG-40086: Clear the tree cache if flag is set. Flag is cleared below in ajax success block.
-      if (window.parent.mantle_isBrowseRepoDirty == true) {
-        FileBrowser.clearTreeCache();
-      }
-
       $.ajax({
         async: true,
         cache: false, // prevent IE from caching the request
@@ -782,8 +774,10 @@ define([
                 myself.set("runSpinner", false);
               }
             }
+          } else {
+            // BACKLOG-40086: Clear the server-side tree cache if isBrowseRepoDirty flag is set.
+            FileBrowser.clearTreeCache();
           }
-
         }
       });
     },

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -561,7 +561,6 @@ define([
       };
 
       myself.set("runSpinner", true);
-      FileBrowser.clearTreeCache();
       myself.fetchTreeRootData(function (response) {
         let foundRepositoryFolder = false;
 
@@ -587,6 +586,8 @@ define([
       var myself = this,
           localSequenceNumber = myself.get("sequenceNumber"),
           url = this.getFolderTreeRootRequest();
+
+      FileBrowser.clearTreeCache();
 
       $.ajax({
         async: true,
@@ -725,7 +726,7 @@ define([
 
     fetchData: function (path, callback) {
       var myself = this,
-          url = this.getFileListRequest(path == null ? ":" : encodeGenericPath(path)),
+          url = this.getFileListRequest(encodeGenericPath(path == null ? ":" : path)),
           localSequenceNumber = myself.get("sequenceNumber");
 
       // BACKLOG-40086: Clear the tree cache if flag is set. Flag is cleared below in ajax success block.
@@ -1262,8 +1263,8 @@ define([
         var path = $target.attr("path");
         var myself = this;
 
-        var url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/" +
-            FileBrowser.encodePathComponents(path == null ? ":" : encodeGenericPath(path))
+        var url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/"
+            + FileBrowser.encodePathComponents(encodeGenericPath(path))
             + "/tree?depth=1&showHidden=" + myself.model.get("showHiddenFiles") + "&filter=FOLDERS";
         $.ajax({
           async: true,

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -1175,7 +1175,7 @@ define([
         myself.updateDescriptions();
 
         //scroll the first selected folder div into view
-        let selectedFolders = $("div.folders .selected").get();
+        const selectedFolders = $("div.folders .selected").get();
         if (selectedFolders.length > 0) {
           selectedFolders[0].scrollIntoView();
         }
@@ -1481,7 +1481,7 @@ define([
       }, 100);
 
       //scroll the first selected file div into view
-      let selectedFiles = $("div.file.selected").get();
+      const selectedFiles = $("div.file.selected").get();
       if (selectedFiles.length > 0) {
         selectedFiles[0].scrollIntoView();
       }

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -235,7 +235,7 @@ define([
     let url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/tree/cache";
 
     $.ajax({
-      async: true,
+      async: false,
       cache: false, // prevent IE from caching the request
       type: 'DELETE',
       dataType: "json",
@@ -358,7 +358,12 @@ define([
     },
 
     updateFolderButtons: function( _folderPath) {
-      const isRepoPath = isRepositoryPath(_folderPath);
+      let isRepoPath;
+      if (_folderPath){
+        isRepoPath = isRepositoryPath(_folderPath);
+      } else {
+        isRepoPath = false;
+      }
 
       var userHomePath = Encoder.encodeRepositoryPath(window.parent.HOME_FOLDER);
       var model = FileBrowser.fileBrowserModel; // trap model
@@ -412,10 +417,10 @@ define([
             folderButtons.updateFolderPermissionButtons(false, model.get('browserUtils').multiSelectItems, false);
           }
         });
-      } else {
+      } //else {
         // This is a VFS Connection path
         //TODO BACKLOG-40086: refactor when we've implemented permissions for vfs connections folders/files
-      }
+        //}
     },
 
     updateFileClicked: function () {
@@ -446,7 +451,7 @@ define([
       fileButtons.enableButtons(isRepoPath);
 
       //Ajax request to check write permissions for file
-      if( filePath.charAt(0) == "/" ) {
+      if( isRepoPath ) {
         filePath = Encoder.encodeRepositoryPath(filePath);
 
         $.ajax({
@@ -465,10 +470,10 @@ define([
             fileButtons.updateFilePermissionButtons(false);
           }
         });
-      } else {
+      } //else {
         // this is a VFS connection path
         //TODO BACKLOG-40086: refactor when we've implemented permissions for vfs connections folders/files
-      }
+        //}
     },
 
     updateFolderLastClick: function () {
@@ -562,7 +567,7 @@ define([
 
         //Add the trash folder once to the first Repository folder
         for (let i = 0; i < response.children.length; i++) {
-          let childFolder = response.children[i];
+          const childFolder = response.children[i];
           if (childFolder.file.path == "/") {
             childFolder.children.push(trashFolder);
             foundRepositoryFolder = true;
@@ -723,7 +728,7 @@ define([
           url = this.getFileListRequest(path == null ? ":" : encodeGenericPath(path)),
           localSequenceNumber = myself.get("sequenceNumber");
 
-      // BACKLOG-40086: Clear the tree cache if flag is set. Cleared below in ajax success block.
+      // BACKLOG-40086: Clear the tree cache if flag is set. Flag is cleared below in ajax success block.
       if (window.parent.mantle_isBrowseRepoDirty == true) {
         FileBrowser.clearTreeCache();
       }
@@ -1959,7 +1964,7 @@ define([
   }
 
   function encodeGenericPath(path) {
-    return path.replaceAll(':','~').replaceAll('/',':');
+    return path.replaceAll(":", "~").replaceAll("/", ":");
   }
 
   return {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -358,18 +358,18 @@ define([
     },
 
     updateFolderButtons: function( _folderPath) {
-      const isRepositoryPath = _isRepositoryPath(_folderPath);
+      const isRepoPath = isRepositoryPath(_folderPath);
 
       var userHomePath = Encoder.encodeRepositoryPath(window.parent.HOME_FOLDER);
       var model = FileBrowser.fileBrowserModel; // trap model
       var folderPath = Encoder.encodeRepositoryPath( _folderPath);
 
-      folderButtons.enableButtons(isRepositoryPath);
+      folderButtons.enableButtons(isRepoPath);
 
       // BACKLOG-23730: server+client side code uses centralized logic to check if user can download/upload
 
       //Ajax request to check if user can download
-      if( isRepositoryPath ) {
+      if( isRepoPath ) {
         $.ajax({
           url: CONTEXT_PATH + "api/repo/files/canDownload?dirPath=" + encodeURIComponent(_folderPath),
           type: "GET",
@@ -442,8 +442,8 @@ define([
       fileButtons.canDownload(this.get("canDownload"));
 
       var filePath = clickedFile.obj.attr("path");
-      const isRepositoryPath = _isRepositoryPath(filePath);
-      fileButtons.enableButtons(isRepositoryPath);
+      const isRepoPath = isRepositoryPath(filePath);
+      fileButtons.enableButtons(isRepoPath);
 
       //Ajax request to check write permissions for file
       if( filePath.charAt(0) == "/" ) {
@@ -720,7 +720,7 @@ define([
 
     fetchData: function (path, callback) {
       var myself = this,
-          url = this.getFileListRequest(path == null ? ":" : _encodeGenericPath(path)),
+          url = this.getFileListRequest(path == null ? ":" : encodeGenericPath(path)),
           localSequenceNumber = myself.get("sequenceNumber");
 
       // BACKLOG-40086: Clear the tree cache if flag is set. Cleared below in ajax success block.
@@ -1258,7 +1258,7 @@ define([
         var myself = this;
 
         var url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/" +
-            FileBrowser.encodePathComponents(path == null ? ":" : _encodeGenericPath(path))
+            FileBrowser.encodePathComponents(path == null ? ":" : encodeGenericPath(path))
             + "/tree?depth=1&showHidden=" + myself.model.get("showHiddenFiles") + "&filter=FOLDERS";
         $.ajax({
           async: true,
@@ -1954,11 +1954,11 @@ define([
     return response;
   }
 
-  function _isRepositoryPath(path) {
+  function isRepositoryPath(path) {
     return path.charAt(0) === "/";
   }
 
-  function _encodeGenericPath(path) {
+  function encodeGenericPath(path) {
     return path.replaceAll(':','~').replaceAll('/',':');
   }
 

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -243,7 +243,7 @@ define([
       success: function (response) {
       },
       error: function () {
-        //TODO SOMETHING ON ERROR look at browser.dialogs
+        //TODO indicate error via dialog?
       },
       beforeSend: function (xhr) {
       }
@@ -562,21 +562,9 @@ define([
 
       myself.set("runSpinner", true);
       myself.fetchTreeRootData(function (response) {
-        let foundRepositoryFolder = false;
 
         //Add the trash folder once to the first Repository folder
-        for (let i = 0; i < response.children.length; i++) {
-          const childFolder = response.children[i];
-          if (childFolder.file.path == "/") {
-            childFolder.children.push(trashFolder);
-            foundRepositoryFolder = true;
-            break;
-          }
-        }
-        if (!foundRepositoryFolder) {
-          //This is a CE instance, place the trash folder at the end of the first generation list
-          response.children.push(trashFolder);
-        }
+        myself.getRepositoryFolderChildren(response).push(trashFolder);
 
         myself.set("data", response);
       });
@@ -617,6 +605,16 @@ define([
       }
 
       return CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/tree?depth=1&filter=FOLDERS&showHidden=" + this.get("showHiddenFiles") + expandedPathParam;
+    },
+
+    getRepositoryFolderChildren: function (response) {
+      for (let i = 0; i < response.children.length; i++) {
+        const childFolder = response.children[i];
+        if (childFolder.file.path == "/") {
+          return childFolder.children;
+        }
+      }
+      return response.children;
     }
   });
 

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -552,7 +552,7 @@ define([
     },
 
     clearTreeCache: function () {
-      let url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/files/tree/cache";
+      let url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/tree/cache";
 
       $.ajax({
         async: true,
@@ -601,7 +601,7 @@ define([
         expandedPathParam = "&expandedPath=" + FileBrowser.fileBrowserModel.get("startFolder");
       }
 
-      return CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/files/tree?depth=1&showHidden=false&filter=FOLDERS" + expandedPathParam;
+      return CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/tree?depth=1&showHidden=false&filter=FOLDERS" + expandedPathParam;
     }
   });
 
@@ -771,7 +771,7 @@ define([
       }
       else {
         //request = CONTEXT_PATH + "api/repo/files/" + path + "/tree?depth=-1&showHidden=" + this.get("showHiddenFiles") + "&filter=*|FILES";
-        request = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/files/" + path + "/tree?depth=1&showHidden=" + this.get("showHiddenFiles") + "&filter=FILES";
+        request = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/" + path + "/tree?depth=1&showHidden=" + this.get("showHiddenFiles") + "&filter=FILES";
       }
       return request;
     }
@@ -1236,7 +1236,7 @@ define([
         var path = $target.attr("path");
         var myself = this;
 
-        var url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/files/" +
+        var url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/" +
             FileBrowser.encodePathComponents(path == null ? ":" : path.replaceAll(':','~').replaceAll('/',':'))
             + "/tree?depth=1&showHidden=" + myself.model.get("showHiddenFiles") + "&filter=FOLDERS";
         $.ajax({

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
@@ -182,7 +182,7 @@ define([
       trashPath: (this.file.name.charAt(0) == "/") ? this.file.pathText + this.file.originalParentFolderPath + this.file.name : this.file.pathText + this.file.originalParentFolderPath + "/" + this.file.name,
       name: nameNoExtension,
       title: title,
-      id: this.file.id,
+      objectId: this.file.objectId,
       classes: extension,
       description: this.file.description,
       folder: this.file.folder,

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
@@ -87,11 +87,11 @@ define([
 
   //folder template with recursive behavior
   templates.folderText =
-      "{{#ifCond file.folder 'true'}}" +
+      "{{#ifCond file.folder true}}" +
           "{{#ifCond file.path '.trash'}}" +
-          "<div id='{{file.id}}' class='trash folder' path='{{file.path}}' ext='{{file.name}}' desc='{{file.name}}'>" +
+          "<div id='{{file.objectId}}' class='trash folder' path='{{file.path}}' ext='{{file.name}}' desc='{{file.name}}'>" +
           "{{else}}" +
-          "<div id='{{file.id}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}'>" +
+          "<div id='{{file.objectId}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}'>" +
           "{{/ifCond}}" +
           "<div class='element' role='treeitem' aria-selected='false' aria-expanded='false' tabindex='-1'>" +
           "<div class='expandCollapse'> </div>" +
@@ -113,19 +113,19 @@ define([
 
   //file template
   templates.file = Handlebars.compile(
-      "{{#ifCond folder 'false' }}" +
+      "{{#ifCond folder false}}" +
           "{{#if trash}}" +
-          "<div id='{{id}}' class='file' origPath='{{origPath}}' path='{{path}}' type='file' ext='{{trashPath}}' title='{{trashPath}}' role='option'>" +
+          "<div id='{{objectId}}' class='file' origPath='{{origPath}}' path='{{path}}' type='file' ext='{{trashPath}}' title='{{trashPath}}' role='option'>" +
           "{{else}}" +
-          "<div id='{{id}}' class='file' path='{{path}}' type='file' desc='{{description}}' ext='{{fileWithExtension}}' role='option'>" +
+          "<div id='{{objectId}}' class='file' path='{{path}}' type='file' desc='{{description}}' ext='{{fileWithExtension}}' role='option'>" +
           "{{/if}}" +
           "<div class='icon {{classes}}'> </div>" +
           "<div class='title'>{{title}}</div>" +
           "</div>" +
           "{{/ifCond}}" +
-          "{{#ifCond trash 'true'}}" +
-          "{{#ifCond folder 'true'}}" +
-          "<div id='{{id}}' class='file' origPath='{{trashPath}}' path='{{path}}' type='folder' ext='{{trashPath}}' title='{{trashPath}}' role='option'>" +
+          "{{#ifCond trash true}}" +
+          "{{#ifCond folder true}}" +
+          "<div id='{{objectId}}' class='file' origPath='{{trashPath}}' path='{{path}}' type='folder' ext='{{trashPath}}' title='{{trashPath}}' role='option'>" +
           "<div class='icon trashFolder'> </div>" +
           "<div class='title'>{{title}}</div>" +
           "</div>" +

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
@@ -91,7 +91,11 @@ define([
           "{{#ifCond file.path '.trash'}}" +
           "<div id='{{file.objectId}}' class='trash folder' path='{{file.path}}' ext='{{file.name}}' desc='{{file.name}}'>" +
           "{{else}}" +
-          "<div id='{{file.objectId}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}'>" +
+              "{{#if file.title}}" +
+                  "<div id='{{file.objectId}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}' title='{{file.title}}'>" +
+              "{{else}}" +
+                  "<div id='{{file.objectId}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}' title='{{file.name}}'>" +
+              "{{/if}}" +
           "{{/ifCond}}" +
           "<div class='element' role='treeitem' aria-selected='false' aria-expanded='false' tabindex='-1'>" +
           "<div class='expandCollapse'> </div>" +


### PR DESCRIPTION
Issue: https://hv-eng.atlassian.net/browse/BACKLOG-40086
Depends on:
- https://github.com/pentaho/pentaho-scheduler-plugin/pull/145

To also be merged with:
- https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/191
- https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1028


--
- Maintain repository folder/file actions and disable all for VFS Connections for now
- Utilize scheduler-plugin api for REST calls
- Refactor FileBrowserFolderTreeModel.fetchData to fetchTreeRootData as it is only ever used for fetching the root tree and associated scheduler-plugin/api endpoint
- Refactor FileBrowserFileListModel.reformatResponse, customSort, the trash folder, and browser.templates to match the response objects returned by scheduler-plugin/api endpoints
- Ensure hyperlinked folder from Schedules -> Browse Perspective is scrolled into view