### PR TITLE
[BACKLOG-40086] Schedule Output Perspective : Allow user to browse Scheduled contents from a VFS location folder

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -445,7 +445,6 @@ define([
 
       var filePath = clickedFile.obj.attr("path");
       const isRepoPath = isRepositoryPath(filePath);
-      fileButtons.enableButtons(isRepoPath);
 
       //Ajax request to check write permissions for file
       if( isRepoPath ) {
@@ -1005,6 +1004,14 @@ define([
           }
         });
       });
+
+      // TODO BACKLOG-40086: for now, disable all file actions for VFS Connections, i.e. isRepoPath = false
+      let selectedFilePath = fileClicked ? fileClicked.attr("path") : false;
+      if (selectedFilePath && buttonsType.enableButtons) {
+        const isRepoPath = isRepositoryPath(selectedFilePath);
+        buttonsType.enableButtons(isRepoPath);
+      }
+
       model.updateFolderButtons( folderClicked == undefined ? window.parent.HOME_FOLDER : folderClicked.attr("path") );
     },
 
@@ -1062,6 +1069,13 @@ define([
           }
         });
       });
+
+      // TODO BACKLOG-40086: for now, disable all file actions for VFS Connections, i.e. isRepoPath = false
+      let selectedFilePath = fileClicked ? fileClicked.attr("path") : false;
+      if (selectedFilePath && buttonsType.enableButtons) {
+        const isRepoPath = isRepositoryPath(selectedFilePath);
+        buttonsType.enableButtons(isRepoPath);
+      }
     },
 
     checkButtonsEnabled: function () {
@@ -1859,7 +1873,9 @@ define([
     doubleClickFile: function (event) {
       var path = $(event.currentTarget).attr("path");
       //if not trash item, try to open the file.
-      if (FileBrowser.fileBrowserModel.getLastClick() != "trashItem") {
+
+      //TODO BACKLOG-40086: disable double click actions on VFS Connection files for now. To be addressed in BACKLOG-40475
+      if (isRepositoryRootPath(path) && FileBrowser.fileBrowserModel.getLastClick() != "trashItem") {
         this.model.get("openFileHandler")(path, "run");
       }
     },

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.multiSelectButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.multiSelectButtons.js
@@ -114,6 +114,14 @@ define([
 
     eventLogger: function (event) {
       console.log(event.action + " : " + event.message);
+    },
+
+    enableButtons: function (enableButtons) {
+      this.buttons.forEach((buttonDef) => {
+        if (buttonDef.id !== "separator") {
+          $("#" + buttonDef.id).prop("disabled", !enableButtons);
+        }
+      });
     }
 
   };


### PR DESCRIPTION
Follow up to QA testing results round 1:
Disable file action buttons for multi-select, and disable double-click to "open" for VFS Connections
- These blocks/code will be modified in BACKLOG-40475 wherein we investigate enabling "open" for VFS Connection files