### PR TITLE
[BACKLOG-40086] Testing feedback subtasks [BACKLOG-40485][BACKLOG-40486]

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -445,7 +445,6 @@ define([
 
       var filePath = clickedFile.obj.attr("path");
       const isRepoPath = isRepositoryPath(filePath);
-      fileButtons.enableButtons(isRepoPath);
 
       //Ajax request to check write permissions for file
       if( isRepoPath ) {
@@ -698,6 +697,11 @@ define([
 
           obj.file = response.children[i].file;
           obj.file.pathText = jQuery.i18n.prop('originText') + " " //i18n
+
+          if(!obj.file.objectId){
+            obj.file.objectId = obj.file.path;
+          }
+
           newResp.children.push(obj);
         }
       }
@@ -725,7 +729,7 @@ define([
 
     fetchData: function (path, callback) {
       var myself = this,
-          url = this.getFileListRequest(encodeGenericPath(path == null ? ":" : path)),
+          url = this.getFileListRequest(FileBrowser.encodePathComponents(encodeGenericPath(path == null ? ":" : path))),
           localSequenceNumber = myself.get("sequenceNumber");
 
       $.ajax({
@@ -1005,6 +1009,14 @@ define([
           }
         });
       });
+
+      // TODO BACKLOG-40086: for now, disable all file actions for VFS Connections, i.e. isRepoPath = false
+      const selectedFilePath = fileClicked ? fileClicked.attr("path") : null;
+      if (selectedFilePath != null && buttonsType.enableButtons) {
+        const isRepoPath = isRepositoryPath(selectedFilePath);
+        buttonsType.enableButtons(isRepoPath);
+      }
+
       model.updateFolderButtons( folderClicked == undefined ? window.parent.HOME_FOLDER : folderClicked.attr("path") );
     },
 
@@ -1062,6 +1074,13 @@ define([
           }
         });
       });
+
+      // TODO BACKLOG-40086: for now, disable all file actions for VFS Connections, i.e. isRepoPath = false
+      const selectedFilePath = fileClicked ? fileClicked.attr("path") : null;
+      if (selectedFilePath != null && buttonsType.enableButtons) {
+        const isRepoPath = isRepositoryPath(selectedFilePath);
+        buttonsType.enableButtons(isRepoPath);
+      }
     },
 
     checkButtonsEnabled: function () {
@@ -1859,7 +1878,9 @@ define([
     doubleClickFile: function (event) {
       var path = $(event.currentTarget).attr("path");
       //if not trash item, try to open the file.
-      if (FileBrowser.fileBrowserModel.getLastClick() != "trashItem") {
+
+      //TODO BACKLOG-40086: disable double click actions on VFS Connection files for now. To be addressed in BACKLOG-40475
+      if (isRepositoryRootPath(path) && FileBrowser.fileBrowserModel.getLastClick() != "trashItem") {
         this.model.get("openFileHandler")(path, "run");
       }
     },

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.multiSelectButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.multiSelectButtons.js
@@ -114,6 +114,14 @@ define([
 
     eventLogger: function (event) {
       console.log(event.action + " : " + event.message);
+    },
+
+    enableButtons: function (enableButtons) {
+      this.buttons.forEach((buttonDef) => {
+        if (buttonDef.id !== "separator") {
+          $("#" + buttonDef.id).prop("disabled", !enableButtons);
+        }
+      });
     }
 
   };


### PR DESCRIPTION
[BACKLOG-40086] Schedule Output Perspective : Allow user to browse Scheduled contents from a VFS location folder
Follow up sub-task:
[BACKLOG-40485] Disable file action buttons for multi-select, and disable double-click to "open" for VFS Connections
- These blocks/code will be modified in BACKLOG-40475 wherein we investigate enabling "open" for VFS Connection files
[BACKLOG-40486] Investigate ctrl+click in VFS Connection Files (cannot ctrl+click to add >1 to selection, only remove)
- Add `id` to file elements in cases wher `objectId` is missing in response object, use `path` instead


[BACKLOG-40086]: https://hv-eng.atlassian.net/browse/BACKLOG-40086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BACKLOG-40485]: https://hv-eng.atlassian.net/browse/BACKLOG-40485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BACKLOG-40486]: https://hv-eng.atlassian.net/browse/BACKLOG-40486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ