### PR TITLE
[BACKLOG-40489] Error when accessing browse files with a user with sp…

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -97,6 +97,11 @@ define([
     return Encoder.encode("{0}", path);
   };
 
+  FileBrowser.encodeGenericFilePathComponents = function (path) {
+    const encodedFilePath = Encoder.encodeGenericFilePath(path);
+    return Encoder.encode("{0}", encodedFilePath);
+  }
+
   FileBrowser.setShowHiddenFiles = function (value) {
     this.showHiddenFiles = value;
   };
@@ -729,7 +734,7 @@ define([
 
     fetchData: function (path, callback) {
       var myself = this,
-          url = this.getFileListRequest(FileBrowser.encodePathComponents(encodeGenericPath(path == null ? ":" : path))),
+          url = this.getFileListRequest(FileBrowser.encodeGenericFilePathComponents(path == null ? "/" : path)),
           localSequenceNumber = myself.get("sequenceNumber");
 
       $.ajax({
@@ -1279,7 +1284,7 @@ define([
         var myself = this;
 
         var url = CONTEXT_PATH + "plugin/scheduler-plugin/api/generic-files/"
-            + FileBrowser.encodePathComponents(encodeGenericPath(path))
+            + FileBrowser.encodeGenericFilePathComponents(path)
             + "/tree?depth=1&showHidden=" + myself.model.get("showHiddenFiles") + "&filter=FOLDERS";
         $.ajax({
           async: true,
@@ -1985,12 +1990,9 @@ define([
     return path === REPOSITORY_ROOT_PATH;
   }
 
-  function encodeGenericPath(path) {
-    return path.replaceAll(":", "~").replaceAll("/", ":");
-  }
-
   return {
     encodePathComponents: FileBrowser.encodePathComponents,
+    encodeGenericFilePathComponents: FileBrowser.encodeGenericFilePathComponents,
     setContainer: FileBrowser.setContainer,
     setOpenFileHandler: FileBrowser.setOpenFileHandler,
     setShowHiddenFiles: FileBrowser.setShowHiddenFiles,


### PR DESCRIPTION
…ecial characteres (that used to work before)

- Use new Encoder encode function for generic file paths to address handling of "~" in file paths

Related PRs (including this one), to be merged together:
1. https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1762
2. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1032
3. https://github.com/pentaho/pentaho-scheduler-plugin/pull/164
4. https://github.com/pentaho/pentaho-platform/pull/5583