### PR TITLE
[BISERVER-14948] - Using LDAP authentication, Admin user is not able to view, identify and hence empty the non-admin user’s trash.

### DIFF
--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelper.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelper.java
@@ -371,28 +371,18 @@ public class DefaultDeleteHelper implements IDeleteHelper {
     if ( isAdmin() ) {
       List<RepositoryFile> deletedFiles = new ArrayList<>();
       ITenant tenant = JcrTenantUtils.getTenant();
-      // BISERVER-14482: this user list refers to Jcr, as so, if authentication/authorization is otherwise managed
-      // (LDAP, for instance), one has to guarantee that the current user is on this list!
-      // The correct way would be to fix the list by obtaining the LDAP users, but this has the potential of getting
-      // thousands of users and, consequently, thousands of deleted files!
-      List<String> userList = getUserList();
-      String currentUser = getCurrentUser();
-      if ( !userList.contains( currentUser ) ) {
-        userList.add( currentUser );
-      }
-      for ( String user : userList ) {
-        String homePath = getHomePath( tenant, user );
-        try {
-          Node userHomeFolderNode = (Node) session.getItem( homePath );
-          if ( userHomeFolderNode.hasNode( FOLDER_NAME_TRASH ) ) {
-            Node trashNode = userHomeFolderNode.getNode( FOLDER_NAME_TRASH );
-            List<RepositoryFile> deletedForUser = getDeletedFiles( session, pentahoJcrConstants, trashNode, user );
-            deletedFiles.addAll( deletedForUser );
+      // Because of LDAP and others, for the admin to be able to access all the trash files, we iterate through all users' trash folders
+      Node userHomeFolderNode = (Node) session.getItem( ServerRepositoryPaths.getTenantHomeFolderPath( tenant ) );
+      if ( userHomeFolderNode != null ) {
+        NodeIterator it = userHomeFolderNode.getNodes();
+        while ( it.hasNext() ) { //iterate by user folder
+          //if in the future, we need to limit the number of files, a limit in this while could be a solution
+          Node node = (Node) it.next();
+          if ( node.hasNodes() && node.hasNode( FOLDER_NAME_TRASH ) ) {
+            Node trashNode = node.getNode( FOLDER_NAME_TRASH );
+            deletedFiles.addAll(
+              getDeletedFiles( session, pentahoJcrConstants, trashNode, node.getName() ) );
           }
-        } catch ( PathNotFoundException e ) {
-          logger.warn( MessageFormat.format(
-            Messages.getInstance()
-              .getString( "DefaultDeleteHelper.PATH_NOT_FOUND_EXCEPTION" ), homePath, user ), e );
         }
       }
       Collections.sort( deletedFiles );

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelperTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelperTest.java
@@ -314,6 +314,7 @@ public class DefaultDeleteHelperTest {
     final Calendar date1 = Calendar.getInstance();
     final Node deletedNode1 = createDeletedNode( path1, date1 );
 
+
     final String path2 = "path2";
     final Calendar date2 = Calendar.getInstance();
     final Node deletedNode2 = createDeletedNode( path2, date2 );
@@ -328,6 +329,7 @@ public class DefaultDeleteHelperTest {
 
     final Node nodeOtherFolder = mock( Node.class );
     when( nodeOtherFolder.hasNode( anyString() ) ).thenReturn( true );
+    when( nodeOtherFolder.hasNodes(  ) ).thenReturn( true );
     when( nodeOtherFolder.getNode( anyString() ) ).thenReturn( nodeTrash );
 
     final String pathUsr = "pathUser";
@@ -344,6 +346,7 @@ public class DefaultDeleteHelperTest {
 
     final Node nodeUserFolder = mock( Node.class );
     when( nodeUserFolder.hasNode( anyString() ) ).thenReturn( true );
+    when( nodeUserFolder.hasNodes(  ) ).thenReturn( true );
     when( nodeUserFolder.getNode( anyString() ) ).thenReturn( nodeTrashUsr );
 
     final boolean[] admin = { false };
@@ -359,6 +362,17 @@ public class DefaultDeleteHelperTest {
     };
     when( session.getItem( endsWith( "/other" ) ) ).thenReturn( nodeOtherFolder );
     when( session.getItem( endsWith( "/test" ) ) ).thenReturn( nodeUserFolder );
+
+    final Node nodeHomeFolder = mock( Node.class );
+    when( nodeHomeFolder.hasNode( anyString() ) ).thenReturn( true );
+    when( nodeHomeFolder.getNodes() ).thenAnswer( invoc -> {
+      NodeIterator nodeIteratorHome = mock( NodeIterator.class );
+      when( nodeIteratorHome.hasNext() ).thenReturn( true, true, false );
+      when( nodeIteratorHome.next() ).thenReturn( nodeOtherFolder, nodeUserFolder );
+      return nodeIteratorHome;
+    } );
+
+    when ( session.getItem( "/pentaho/tenant0/home" ) ).thenReturn( nodeHomeFolder );
 
     // regular user
     final List<RepositoryFile> deletedFiles = defaultDeleteHelper.getAllDeletedFiles( session, pentahoJcrConstants );
@@ -390,6 +404,7 @@ public class DefaultDeleteHelperTest {
 
     final Node nodeUser1 = mock( Node.class );
     when( nodeUser1.hasNode( anyString() ) ).thenReturn( true );
+    when( nodeUser1.hasNodes(  ) ).thenReturn( true );
     when( nodeUser1.getNode( anyString() ) ).thenReturn( nodeTrashUser1 );
 
     final String pathUser2 = "pathUser2";
@@ -406,6 +421,7 @@ public class DefaultDeleteHelperTest {
 
     final Node nodeUser2 = mock( Node.class );
     when( nodeUser2.hasNode( anyString() ) ).thenReturn( true );
+    when( nodeUser2.hasNodes(  ) ).thenReturn( true );
     when( nodeUser2.getNode( anyString() ) ).thenReturn( nodeTrashUser2 );
 
 
@@ -424,6 +440,7 @@ public class DefaultDeleteHelperTest {
     final Node nodeUserTest = mock( Node.class );
     when( nodeUserTest.hasNode( anyString() ) ).thenReturn( true );
     when( nodeUserTest.getNode( anyString() ) ).thenReturn( nodeTrashUserTest );
+    when( nodeUserTest.hasNodes( ) ).thenReturn( true );
 
     defaultDeleteHelper = new DefaultDeleteHelper( lockHelper, pathConversionHelper ) {
       @Override
@@ -443,6 +460,19 @@ public class DefaultDeleteHelperTest {
     when( session.getItem( endsWith( "/test" ) ) ).thenReturn( nodeUserTest );
     when( session.getItem( endsWith( "/user2" ) ) ).thenReturn( nodeUser2 );
     when( session.getItem( endsWith( "/user1" ) ) ).thenReturn( nodeUser1 );
+
+    final Node nodeHomeFolder = mock( Node.class );
+    when( nodeHomeFolder.hasNode( anyString() ) ).thenReturn( true );
+    when( nodeHomeFolder.getNodes() ).thenAnswer( invoc -> {
+      NodeIterator nodeIteratorHome = mock( NodeIterator.class );
+      when( nodeIteratorHome.hasNext() ).thenReturn( true, true, true, false );
+      when( nodeIteratorHome.next() ).thenReturn( nodeUserTest, nodeUser2, nodeUser1 );
+      return nodeIteratorHome;
+    } );
+
+    when ( session.getItem( "/pentaho/tenant0/home" ) ).thenReturn( nodeHomeFolder );
+
+
 
     final List<RepositoryFile> deletedFilesAdmin = defaultDeleteHelper.getAllDeletedFiles( session, pentahoJcrConstants );
     assertNotNull( deletedFilesAdmin );


### PR DESCRIPTION
Change in the way the thrashed files are being returned to the PUC UI. Now all files should be visible for admin users.

@smmribeiro 
@befc 
@renato-s 
@joana-fb 
@miguelappleton 