### PR TITLE
[BACKLOG-40489] Error when accessing browse files with a user with special characters

### DIFF
--- a/user-console/src/main/resources-filtered/org/pentaho/mantle/public/browser/index.jsp
+++ b/user-console/src/main/resources-filtered/org/pentaho/mantle/public/browser/index.jsp
@@ -109,7 +109,7 @@
 				success: function (response) {
 					if(response != null && response.length > 0) {
 
-						open_dir = decodeURIComponent(response);
+						open_dir = response;
 
 						var headers = {};
                         var csrfToken = csrfService.getToken(initialFolderResourceUrl);


### PR DESCRIPTION
- Fix unnecessary "scheduler_folder" session-variable URI decoding that was causing a problem with folders with special characters. -- The value is not URI encoded in the response in the first place, so it was not decoding anything, just breaking on special characters.