### PR TITLE
[BISERVER-15027] MySQL8 database repository for pentaho server does not work properly with mysql8 jar

### DIFF
--- a/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -126,6 +126,7 @@
         <Logger name="org.pentaho.di.monitor" level="ERROR"/>
         <Logger name="org.pentaho.platform.engine.core.system.status" level="INFO"/>
         <Logger name="org.pentaho.hadoop.shim.DriverManager" level="INFO"/>
+        <Logger name="org.pentaho.database.dialect.MySQLDatabaseDialect" level="INFO"/>
         
         <!-- =========================== -->
         <!-- Repository Import Log Level -->


### PR DESCRIPTION
[BISERVER-15027] MySQL8 database repository for pentaho server does not work properly with mysql8 jar

[BISERVER-15027]: https://hv-eng.atlassian.net/browse/BISERVER-15027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ