### PR TITLE
[BACKLOG-40475] Browse Perspective: "Open" PVFS file actions

### DIFF
--- a/user-console/pom.xml
+++ b/user-console/pom.xml
@@ -159,6 +159,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>commons-xul-core</artifactId>
       <version>${commons-xul.version}</version>

--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/SolutionBrowserPanel.java
@@ -29,6 +29,7 @@ import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.http.client.RequestException;
 import com.google.gwt.http.client.Response;
+import com.google.gwt.http.client.URL;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
@@ -50,6 +51,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
 import org.pentaho.gwt.widgets.client.dialogs.PromptDialogBox;
 import org.pentaho.gwt.widgets.client.filechooser.RepositoryFile;
+import org.pentaho.gwt.widgets.client.genericfile.GenericFileNameUtils;
 import org.pentaho.gwt.widgets.client.utils.NameUtils;
 import org.pentaho.mantle.client.EmptyRequestCallback;
 import org.pentaho.mantle.client.commands.AbstractCommand;
@@ -89,6 +91,8 @@ public class SolutionBrowserPanel extends HorizontalPanel {
 
   private static final String FILE_EXTENSION_DELIMETER = ".";
 
+  private static final char FILE_PATH_SEPARATOR = '/';
+
   private final int defaultSplitPosition = 220; //$NON-NLS-1$
 
   private SplitLayoutPanel navigatorAndContentSplit = new SplitLayoutPanel() {
@@ -110,11 +114,17 @@ public class SolutionBrowserPanel extends HorizontalPanel {
   private PickupDragController dragController;
   private List<String> executableFileExtensions = new ArrayList<String>();
   private static List<String> supportedFileExtensions;
+
+  private static List<String> supportedGenericFileExtensions;
   private JsArrayString filters;
 
   {
     supportedFileExtensions = Arrays.asList( "cda", "xaction", "kjb", "xcdf", "wcdf",
       "xjpivot", "ktr", "prpt", "url", "xanalyzer", "prpti", "xdash" );
+  }
+
+  {
+    supportedGenericFileExtensions = Arrays.asList( "html", "pdf", "txt", "rtf", "xlsx" );
   }
 
   private Command ToggleLocalizedNamesCommand = new Command() {
@@ -358,21 +368,53 @@ public class SolutionBrowserPanel extends HorizontalPanel {
       //CHECKSTYLE IGNORE LineLength FOR NEXT 1 LINES
       solutionNavigator.@org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel::showPluginError(Ljava/lang/String;)(filename);
     }
+    $wnd.mantle_showUnsupportedFiletypeError = function (filename, extension) {
+      //CHECKSTYLE IGNORE LineLength FOR NEXT 1 LINES
+      solutionNavigator.@org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel::showUnsupportedFiletypeError(Ljava/lang/String;Ljava/lang/String;)(filename, extension);
+    }
+    $wnd.mantle_showGenericError = function (errorMessage) {
+      //CHECKSTYLE IGNORE LineLength FOR NEXT 1 LINES
+      solutionNavigator.@org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel::showGenericError(Ljava/lang/String;)(errorMessage);
+    }
     $wnd.mantle_isSupportedExtension = function (extension) {
       //CHECKSTYLE IGNORE LineLength FOR NEXT 1 LINES
       return solutionNavigator.@org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel::isSupportedExtension(Ljava/lang/String;)(extension);
     }
+    $wnd.mantle_isRepositoryPath = function (path) {
+      //CHECKSTYLE IGNORE LineLength FOR NEXT 1 LINES
+      return solutionNavigator.@org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel::isRepositoryPath(Ljava/lang/String;)(path);
+    }
+    $wnd.mantle_isSupportedGenericFileExtension = function (extension) {
+      //CHECKSTYLE IGNORE LineLength FOR NEXT 1 LINES
+      return solutionNavigator.@org.pentaho.mantle.client.solutionbrowser.SolutionBrowserPanel::isSupportedGenericFileExtension(Ljava/lang/String;)(extension);
+    }
   }-*/;
 
   public void showPluginError( String filename ) {
+    showError( Messages.getString( "error.NoPlugin" ), Messages.getString( "error.NoPluginText", filename ) );
+  }
+
+  public void showUnsupportedFiletypeError( String fileName, String extension ){
+    showError( "Unsupported File Type", "Cannot open file \"" + fileName + "\" with unsupported extension \"" + extension +"\".");
+  }
+
+  public void showGenericError( String errorMessage ) {
+    showError( Messages.getString( "error" ), errorMessage );
+  }
+
+  private void showError( String dialogTitle, String errorMessage ) {
     InfoDialog dialogBox =
-      new InfoDialog( Messages.getString( "error.NoPlugin" ), Messages.getString( "error.NoPluginText", filename ), true, false, true ); //$NON-NLS-1$ $NON-NLS-2$
+      new InfoDialog( dialogTitle, errorMessage, true, false, true ); //$NON-NLS-1$ $NON-NLS-2$
     dialogBox.setWidth( "350px" );
     dialogBox.center();
   }
 
   public boolean isSupportedExtension( String extension ) {
     return supportedFileExtensions.contains( extension );
+  }
+
+  public boolean isSupportedGenericFileExtension( String extension ){
+    return supportedGenericFileExtensions.contains( extension );
   }
 
   public void setDashboardsFilter( JsArrayString filters ) {
@@ -392,6 +434,10 @@ public class SolutionBrowserPanel extends HorizontalPanel {
     return NameUtils.URLEncode( id );
   }
 
+  private String encodeGenericFilePath( String path ){
+    return NameUtils.URLEncode( GenericFileNameUtils.encodePath( path ) );
+  }
+
   public List<String> getExecutableFileExtensions() {
     return executableFileExtensions;
   }
@@ -403,7 +449,16 @@ public class SolutionBrowserPanel extends HorizontalPanel {
     } catch ( IllegalArgumentException e ) {
       // bad mode passed in, using default
     }
-    openFile( fileNameWithPath, realMode );
+
+    /*
+    TODO BACKLOG-40475: For now, we only support RUN ("Open") and NEWWINDOW ("Open in new window") modes for PVFS files.
+     This logic can be better integrated into the existing flow in a future release.
+     */
+    if( isRepositoryPath( fileNameWithPath ) ) {
+      openFile( fileNameWithPath, realMode );
+    } else {
+      openGenericFile( fileNameWithPath, realMode);
+    }
   }
 
   public void getFile( final String solutionPath, final SolutionFileHandler handler ) {
@@ -435,6 +490,40 @@ public class SolutionBrowserPanel extends HorizontalPanel {
       } );
     } catch ( RequestException e ) {
       // showError(e);
+    }
+  }
+
+  //TODO BACKLOG-40475: See if we can integrate the PVFS flow into the repository flow. For now we have a seperate, similar function.
+  private void openGenericFile( String filePath, COMMAND mode ) {
+    String url = null;
+    String extension = ""; //$NON-NLS-1$
+
+    String fileName = filePath.substring( filePath.lastIndexOf( FILE_PATH_SEPARATOR ) +1 );
+
+    fileName = URL.decode( fileName ).replace( "%23", "#" );
+
+    if ( fileName.lastIndexOf( FILE_EXTENSION_DELIMETER ) > 0 ) { //$NON-NLS-1$
+      extension = fileName.substring( fileName.lastIndexOf( FILE_EXTENSION_DELIMETER ) + 1 ); //$NON-NLS-1$
+    }
+
+    // For now, we only support a limited set of extensions for PVFS files
+    if ( isSupportedGenericFileExtension( extension ) ) {
+      url = getPath() + "plugin/scheduler-plugin/api/generic-files/" + encodeGenericFilePath( filePath )
+        + "/content"; //$NON-NLS-1$ //$NON-NLS-2$
+    } else {
+      showUnsupportedFiletypeError( fileName, extension );
+      return;
+    }
+
+    // force to open pdf files in another window due to issues with pdf readers in IE browsers
+    // via class added on themeResources for IE browsers
+    boolean pdfReaderEmbeded = RootPanel.getBodyElement().getClassName().contains( "pdfReaderEmbeded" );
+    if ( mode == FileCommand.COMMAND.NEWWINDOW || ( extension.equals( "pdf" ) && pdfReaderEmbeded ) ) {
+      Window.open( url, "_blank", "menubar=yes,location=no,resizable=yes,scrollbars=yes,status=no" ); //$NON-NLS-1$ //$NON-NLS-2$
+    } else {
+      PerspectiveManager.getInstance().setPerspective( PerspectiveManager.OPENED_PERSPECTIVE );
+      contentTabPanel.showNewURLTab( fileName, fileName, url, true );
+      addRecent( encodeUri( filePath ), fileName );
     }
   }
 
@@ -470,6 +559,7 @@ public class SolutionBrowserPanel extends HorizontalPanel {
     }
   }
 
+  //TODO if we can use IGenericFile here, we could better integrate the PVFS flow into existing code
   public void openFile( final RepositoryFile repositoryFile, final FileCommand.COMMAND mode ) {
 
     String fileNameWithPath = repositoryFile.getPath();
@@ -494,7 +584,7 @@ public class SolutionBrowserPanel extends HorizontalPanel {
           showPluginError( repositoryFile.getName() );
           return;
         }
-        url = getPath() + "api/repos/" + pathToId( fileNameWithPath ) + "/content"; //$NON-NLS-1$ //$NON-NLS-2$
+        url = getPath() + "plugin/scheduler-plugin/api/generic-files/" + encodeGenericFilePath( fileNameWithPath ) + "/content"; //$NON-NLS-1$ //$NON-NLS-2$
       } else {
         ContentTypePlugin plugin = PluginOptionsHelper.getContentTypePlugin( fileNameWithPath );
         url =
@@ -837,4 +927,8 @@ public class SolutionBrowserPanel extends HorizontalPanel {
   private native void createSchedule( final String repositoryFileId, final String repositoryFilePath )/*-{
     $wnd.pho.createSchedule( repositoryFileId, repositoryFilePath );
   }-*/;
+
+  private boolean isRepositoryPath( String path ){
+    return GenericFileNameUtils.isRepositoryPath( path );
+  }
 }

--- a/user-console/src/main/resources-filtered/org/pentaho/mantle/public/browser/index.jsp
+++ b/user-console/src/main/resources-filtered/org/pentaho/mantle/public/browser/index.jsp
@@ -68,14 +68,20 @@
       mode = "edit";
     }
 
-    // show the opened perspective
+    // show the opened perspective if this is a supported file type (except for pdf)
     var extension = path.split(".").pop();
     var hasPlugin = window.parent.PluginOptionHelper_hasPlugin(path);
+    var filename = path.split('\\').pop().split('/').pop();
     if (window.parent.mantle_isSupportedExtension(extension) && !hasPlugin) {
-        var filename = path.split('\\').pop().split('/').pop();
         window.parent.mantle_showPluginError(filename);
         return;
     }
+
+    if (!window.parent.mantle_isRepositoryPath(path) && !window.parent.mantle_isSupportedGenericFileExtension(extension)) {
+      window.parent.mantle_showUnsupportedFiletypeError(filename, extension);
+      return;
+    }
+
     // force to open pdf files in another window due to issues with pdf readers in IE browsers
     // via class added on themeResources for IE browsers
     if (!($("body").hasClass("pdfReaderEmbeded") && extension == "pdf")) {

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.fileButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.fileButtons.js
@@ -193,10 +193,25 @@ define([
       }
     },
 
+    //TODO Only enable the open buttons for supported file types...
     enableButtons: function (enableButtons) {
       this.buttons.forEach((buttonDef) => {
-        if (buttonDef.id !== "separator") {
-          $("#" + buttonDef.id).prop("disabled", !enableButtons);
+        //TODO for now, "Open" and "Open in new window" buttons are always enabled. Extension support/error dialog is handled in SolutionBrowserPanel.
+        if (buttonDef.id !== "openButton" && buttonDef.id !== "openNewButton") {
+          let target;
+          if ( buttonDef.id == "separator" ){
+            target = $(".separator");
+          } else {
+            target = $("#" + buttonDef.id);
+          }
+
+          target.prop("disabled", !enableButtons);
+
+          if( !enableButtons ){
+            target.hide();
+          } else {
+            target.show();
+          }
         }
       });
     },

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.folderButtons.js
@@ -155,8 +155,19 @@ define([
 
     enableButtons: function (enableButtons) {
       this.buttons.forEach((buttonDef) => {
-        if (buttonDef.id !== "separator") {
-          $("#" + buttonDef.id).prop("disabled", !enableButtons);
+        let target;
+        if (buttonDef.id == "separator") {
+          target = $(".separator");
+        } else {
+          target = $("#" + buttonDef.id);
+        }
+
+        target.prop("disabled", !enableButtons);
+
+        if (!enableButtons) {
+          target.hide();
+        } else {
+          target.show();
         }
       });
     },

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.multiSelectButtons.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.multiSelectButtons.js
@@ -118,8 +118,21 @@ define([
 
     enableButtons: function (enableButtons) {
       this.buttons.forEach((buttonDef) => {
-        if (buttonDef.id !== "separator") {
-          $("#" + buttonDef.id).prop("disabled", !enableButtons);
+        if (buttonDef.id !== "openButton") {
+          let target;
+          if (buttonDef.id == "separator") {
+            target = $(".separator");
+          } else {
+            target = $("#" + buttonDef.id);
+          }
+
+          target.prop("disabled", !enableButtons);
+
+          if (!enableButtons) {
+            target.hide();
+          } else {
+            target.show();
+          }
         }
       });
     }


### PR DESCRIPTION
PR Set:
1. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1039
2. https://github.com/pentaho/pentaho-platform/pull/5616
3. https://github.com/pentaho/pentaho-scheduler-plugin/pull/178
4. https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/243

`SolutionBrowserPanel`:
- added spotbugs dependency so that we can use GenericFileNameUtils
- in this effort we will be supporting the following extensions for PVFS file "Open" actions
-- `supportedGenericFileExtensions = Arrays.asList( "html", "pdf", "txt", "rtf", "xlsx" );`
-- helper function to check if a fileName has an acceptable extension
- created general error dialog function to support existing plugin missing error along with new unsupported file type/extension error
-- made these functions accessible to other js files, along with isRepositoryPath
- introduced logical fork to separate Repository vs PVFS file opening for now
- introduced new `generic-files/<path>/content` endpoint for both Repository and PVFS files
- fixed recents encoding to match the current front/backend encoding/decoding

`browser.js` and related files:
- enabled "Open" and "Open in a new window" buttons for PVFS files, both single and multi-selected
-- re-enabled double-click to open functionality, which also fixes [BACKLOG-41004]
-- disable and hide all other buttons for folder and file actions
-- moved some repository-only logic under conditional to prevent re-showing of download and related buttons
- included new logic to decode folder/file names and paths as some special characters are now coming through encoded from the back-end [BACKLOG-41089]
- added conditional logic in index.jsp to check if the file extension for PVFS files is valid before opening the "Opened" perspective in case of double-click

[BACKLOG-41004]: https://hv-eng.atlassian.net/browse/BACKLOG-41004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ