### PR TITLE
[PPP-5105] Denial Of Service when changing file ACLs

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -129,7 +129,7 @@ import static org.apache.commons.lang.StringUtils.isBlank;
 @Path ( "/repo/files/" )
 public class FileResource extends AbstractJaxRSResource {
 
-  private static final String INVALID_SECURITY_PRINCIPAL_CHARACTERS = ".*[#,+\"\\\\<>]+.*";
+  private static final String INVALID_SECURITY_PRINCIPAL_CHARACTERS = "[#,+\"\\\\<>]";
   private static final Pattern INVALID_SECURITY_PRINCIPAL_PATTERN = Pattern.compile( INVALID_SECURITY_PRINCIPAL_CHARACTERS );
 
   public static final String APPLICATION_ZIP = "application/zip";
@@ -2521,6 +2521,6 @@ public class FileResource extends AbstractJaxRSResource {
    */
   @VisibleForTesting
   boolean validateSecurityPrincipal( String principal ) {
-    return !INVALID_SECURITY_PRINCIPAL_PATTERN.matcher( principal ).matches();
+    return !INVALID_SECURITY_PRINCIPAL_PATTERN.matcher( principal ).find();
   }
 }


### PR DESCRIPTION
Refactored the code according to the suggestion made in the [ticket's description](https://hv-eng.atlassian.net/browse/PPP-5105) by @dcleao. This will effectively correct the performance issue with the previous implementation by using the regex without wildcards and make usage of the `find()` method, that performs a lot better than `matches()`.

The target code is being covered by `FileResourceTest.validateSecurityPrincipal()`, from my evaluation, no further UTs seem to be necessary with this change.

Conducted some benchmark tests with JMH to better understand the impact and improvements with this change for both valid and invalid strings, before and after refactor:
Short strings (~10 char.):
```
Benchmark                                                       Mode  Cnt    Score    Error  Units
SecurityPrincipalValidatorBenchmark.benchmarkOriginalInvalid    avgt   25  199.008 ± 15.979  ns/op
SecurityPrincipalValidatorBenchmark.benchmarkOriginalValid      avgt   25  115.592 ±  5.005  ns/op
SecurityPrincipalValidatorBenchmark.benchmarkRefactoredInvalid  avgt   25   51.211 ±  1.235  ns/op
SecurityPrincipalValidatorBenchmark.benchmarkRefactoredValid    avgt   25   58.705 ±  0.698  ns/op
```
Long string (1000 char.):
```
Benchmark                                                       Mode  Cnt     Score     Error  Units
SecurityPrincipalValidatorBenchmark.benchmarkOriginalInvalid    avgt   25  1333.379 ±  47.356  ns/op
SecurityPrincipalValidatorBenchmark.benchmarkOriginalValid      avgt   25  3557.988 ± 114.289  ns/op
SecurityPrincipalValidatorBenchmark.benchmarkRefactoredInvalid  avgt   25   713.302 ±  21.342  ns/op
SecurityPrincipalValidatorBenchmark.benchmarkRefactoredValid    avgt   25   791.151 ±  12.725  ns/op
```