### PR TITLE
[BACKLOG-40443] - Closing a folder's "Properties..." dialog via "OK" in Browse Perspective returns focus to the folder's parent

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/FilePropertiesDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/solutionbrowser/fileproperties/FilePropertiesDialog.java
@@ -95,7 +95,11 @@ public class FilePropertiesDialog extends PromptDialogBox {
     okButton.getElement().setId( "filePropertiesOKButton" );
     cancelButton.getElement().setId( "filePropertiesCancelButton" );
 
-    parentPath = fileSummary.getPath().substring( 0, fileSummary.getPath().lastIndexOf( "/" ) );
+    if ( fileSummary.isFolder() ) {
+      parentPath = fileSummary.getPath();
+    } else {
+      parentPath = fileSummary.getPath().substring(0, fileSummary.getPath().lastIndexOf("/"));
+    }
 
     super.setCallback( new IDialogCallback() {
 


### PR DESCRIPTION
@pentaho/hoth Please review