### PR TITLE
[BISERVER-15067] Add toggle property to enable/disable admin access to other users trash

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
+++ b/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
@@ -178,4 +178,10 @@
      content
     <edit-permission>org.pentaho.repository.create</edit-permission>
     -->
+
+    <!--
+      This property controls whether admin users have access to all users' trash.
+      This is enabled by default, set the value to "false" to disable this access.
+    -->
+  <adminAccessAllUsersTrash>true</adminAccessAllUsersTrash>
 </pentaho-system>

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelper.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelper.java
@@ -41,7 +41,6 @@ import org.springframework.util.StringUtils;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
-import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
@@ -58,7 +57,6 @@ import javax.jcr.version.VersionHistory;
 import javax.jcr.version.VersionIterator;
 import javax.jcr.version.VersionManager;
 import java.io.Serializable;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -368,7 +366,7 @@ public class DefaultDeleteHelper implements IDeleteHelper {
       final PentahoJcrConstants pentahoJcrConstants )
     throws RepositoryException {
 
-    if ( isAdmin() ) {
+    if ( isAdmin() && canAdminAccessAllUsersTrash() ) {
       List<RepositoryFile> deletedFiles = new ArrayList<>();
       ITenant tenant = JcrTenantUtils.getTenant();
       // Because of LDAP and others, for the admin to be able to access all the trash files, we iterate through all users' trash folders
@@ -389,6 +387,10 @@ public class DefaultDeleteHelper implements IDeleteHelper {
       return deletedFiles;
     }
     return getDeletedFiles( session, pentahoJcrConstants );
+  }
+
+  private boolean canAdminAccessAllUsersTrash() {
+    return Boolean.parseBoolean( PentahoSystem.getSystemSetting( "adminAccessAllUsersTrash", "true" ) );
   }
 
   protected String getHomePath( ITenant tenant, String user ) {

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelperTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/DefaultDeleteHelperTest.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.pentaho.platform.api.engine.IPentahoSession;
@@ -32,6 +33,7 @@ import org.pentaho.platform.api.locale.IPentahoLocale;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.core.mt.Tenant;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.repository2.unified.ServerRepositoryPaths;
 import org.pentaho.platform.repository2.unified.exception.RepositoryFileDaoFileExistsException;
 import org.pentaho.platform.repository2.unified.exception.RepositoryFileDaoReferentialIntegrityException;
@@ -80,6 +82,7 @@ import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.ArgumentMatchers.endsWith;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -372,7 +375,7 @@ public class DefaultDeleteHelperTest {
       return nodeIteratorHome;
     } );
 
-    when ( session.getItem( "/pentaho/tenant0/home" ) ).thenReturn( nodeHomeFolder );
+    when( session.getItem( "/pentaho/tenant0/home" ) ).thenReturn( nodeHomeFolder );
 
     // regular user
     final List<RepositoryFile> deletedFiles = defaultDeleteHelper.getAllDeletedFiles( session, pentahoJcrConstants );
@@ -385,6 +388,17 @@ public class DefaultDeleteHelperTest {
     final List<RepositoryFile> deletedFilesAdmin = defaultDeleteHelper.getAllDeletedFiles( session, pentahoJcrConstants );
     assertNotNull( deletedFilesAdmin );
     assertEquals( 3, deletedFilesAdmin.size() );
+
+    // as admin all user trash access disabled
+    try ( MockedStatic<PentahoSystem> mockedPentahoSystem = mockStatic( PentahoSystem.class ) ) {
+      mockedPentahoSystem.when(
+        () -> PentahoSystem.getSystemSetting( "adminAccessAllUsersTrash", "false" ) )
+        .thenReturn( "false" );
+      admin[0] = true;
+      final List<RepositoryFile> deletedFilesAdminNoAccess = defaultDeleteHelper.getAllDeletedFiles( session, pentahoJcrConstants );
+      assertNotNull( deletedFilesAdminNoAccess );
+      assertEquals( 1, deletedFilesAdminNoAccess.size() );
+    }
   }
 
   @Test
@@ -470,7 +484,7 @@ public class DefaultDeleteHelperTest {
       return nodeIteratorHome;
     } );
 
-    when ( session.getItem( "/pentaho/tenant0/home" ) ).thenReturn( nodeHomeFolder );
+    when( session.getItem( "/pentaho/tenant0/home" ) ).thenReturn( nodeHomeFolder );
 
 
 


### PR DESCRIPTION
Added the property `adminAccessAllUsersTrash` to the `pentaho.xml` configuration file, by default it will keep the current behaviour of showing all user thrash to admin users, if disabled trash items of other users will not be shown to admins.

Should be merged together with: https://github.com/pentaho/pentaho-platform-ee/pull/1764