### PR TITLE
[BACKLOG-41134] [BACKLOG-40475] Disable Folder Actions under Repository

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/css/browser.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/css/browser.css
@@ -135,6 +135,12 @@
   background: url("../resources/images/folder.png") no-repeat -16px 3px;
 }
 
+/* Hide folder icons for all rootFolders: e.g. "Repository" and "VFS Connections" */
+#fileBrowserFolders.fileBrowserColumn .body div.first.folder.providerRootFolder > div.element > div.icon {
+  background: none;
+  width: 0px;
+}
+
 .fileBrowserColumn .body .file .icon {
   width: 20px;
   margin-right: 4px;

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
@@ -91,10 +91,10 @@ define([
           "{{#ifCond file.path '.trash'}}" +
           "<div id='{{file.objectId}}' class='trash folder' path='{{file.path}}' ext='{{file.name}}' desc='{{file.name}}'>" +
           "{{else}}" +
-              "{{#if file.title}}" +
-                  "<div id='{{file.objectId}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}' title='{{file.title}}'>" +
+              "{{#if file.isProviderRootPath}}" +
+                  "<div id='{{file.objectId}}' class='folder providerRootFolder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}' title='{{file.title}}'>" +
               "{{else}}" +
-                  "<div id='{{file.objectId}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}' title='{{file.name}}'>" +
+                  "<div id='{{file.objectId}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}' title='{{file.title}}'>" +
               "{{/if}}" +
           "{{/ifCond}}" +
           "<div class='element' role='treeitem' aria-selected='false' aria-expanded='false' tabindex='-1'>" +


### PR DESCRIPTION
- Disable all Folder Actions for root folders "Repository" and "VFS Connections"
- Hide icons for root folders, to communicate to users that they shouldn't be considered standard folders
- Fix title == null conditional. This should have originally been handled in browser.js reformatResponse and not done in the template.