### PR TITLE
[BACKLOG-41091] Use Decoded File Name and Title Values in Scheduler Perspective + Browse Perspective missed case

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -574,7 +574,7 @@ define([
 
         //Add the trash folder once to the first Repository folder
         myself.getRepositoryFolderChildren(response).push(trashFolder);
-        
+
         response.children = reformatResponse(response).children;
         myself.set("data", response);
       });
@@ -2013,7 +2013,12 @@ define([
         obj.file = response.children[i].file;
 
         if (obj.file.hasChildren){
-          obj.children = response.children[i].children;
+          const childFolderTree = {
+            file: obj.file,
+            children: response.children[i].children
+          }
+
+          obj.children = reformatResponse(childFolderTree).children;
         }
 
         obj.file.pathText = jQuery.i18n.prop('originText') + " " //i18n
@@ -2022,11 +2027,9 @@ define([
           obj.file.isProviderRootPath = true;
         }
 
-        //decode potentially encoded name and title attributes of PVFS paths
-        if( !isRepositoryPath(obj.file.path) && !obj.file.decoded ){
-          obj.file.name = decodePvfsFileAttribute(obj.file.name);
-          obj.file.title = obj.file.title === null ? obj.file.name : decodePvfsFileAttribute(obj.file.title);
-          obj.file.decoded = true;
+        // Default title to non-encoded name.
+        if (!obj.file.title) {
+          obj.file.title = obj.file.nameDecoded;
         }
 
         if(!obj.file.objectId){

--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.templates.js
@@ -89,22 +89,18 @@ define([
   templates.folderText =
       "{{#ifCond file.folder true}}" +
           "{{#ifCond file.path '.trash'}}" +
-          "<div id='{{file.objectId}}' class='trash folder' path='{{file.path}}' ext='{{file.name}}' desc='{{file.name}}'>" +
+          "<div id='{{file.objectId}}' class='trash folder' path='{{file.path}}' ext='{{file.nameDecoded}}' desc='{{file.nameDecoded}}'>" +
           "{{else}}" +
               "{{#if file.isProviderRootPath}}" +
-                  "<div id='{{file.objectId}}' class='folder providerRootFolder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}' title='{{file.title}}'>" +
+                  "<div id='{{file.objectId}}' class='folder providerRootFolder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.nameDecoded}}' title='{{file.title}}'>" +
               "{{else}}" +
-                  "<div id='{{file.objectId}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.name}}' title='{{file.title}}'>" +
+                  "<div id='{{file.objectId}}' class='folder' path='{{file.path}}' desc='{{file.description}}' ext='{{file.nameDecoded}}' title='{{file.title}}'>" +
               "{{/if}}" +
           "{{/ifCond}}" +
           "<div class='element' role='treeitem' aria-selected='false' aria-expanded='false' tabindex='-1'>" +
           "<div class='expandCollapse'> </div>" +
           "<div class='icon'> </div>" +
-          "{{#if file.title}}" +
           "<div class='title'>{{file.title}}</div>" +
-          "{{else}}" +
-          "<div class='title'>{{file.name}}</div>" +
-          "{{/if}}" +
           "</div>" +
           "<div class='folders' role='group'>" +
           "{{#each children}} {{> folder}} {{/each}}" +
@@ -165,7 +161,7 @@ define([
   //helper registration for file template
   Handlebars.registerHelper('file', function () {
     //handle file name
-    var name = this.file.name,
+    var name = this.file.nameDecoded,
         title = this.file.title,
         path = this.file.path;
 
@@ -186,7 +182,7 @@ define([
       classes: extension,
       description: this.file.description,
       folder: this.file.folder,
-      fileWithExtension: this.file.name
+      fileWithExtension: this.file.nameDecoded
     }));
   });
 


### PR DESCRIPTION
Start using IGenericFile#getNameDecoded() for purposes of UI display


PR Set:
https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1042
https://github.com/pentaho/pentaho-platform/pull/5652
https://github.com/pentaho/pentaho-scheduler-plugin/pull/187
https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/256