### PR TITLE
[BACKLOG-41394][BACKLOG-41395] Trash folder is always empty

### DIFF
--- a/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/browser/js/browser.js
@@ -550,7 +550,7 @@ define([
 
     updateData: function () {
       var myself = this;
-
+      const trashName = jQuery.i18n.prop('trash');
       const trashFolder = {
         "file": {
           "trash": "trash",
@@ -561,10 +561,11 @@ define([
           "objectId:": jQuery.i18n.prop('trash'),
           "locale": "en",
           "locked": "false",
-          "name": jQuery.i18n.prop('trash'),
+          "name": trashName,
+          "nameDecoded": trashName,
           "ownerType": "-1",
           "path": ".trash",
-          "title": jQuery.i18n.prop('trash'),
+          "title": trashName,
           "versioned": "false"
         }
       };
@@ -680,9 +681,10 @@ define([
         myself.set("deletedFiles", "");
         for (var i = 0; i < response.repositoryFileDto.length; i++) {
           var obj = {
-            file: Object
-          }
-          obj.file = response.repositoryFileDto[i];
+            file: response.repositoryFileDto[i]
+          };
+
+          obj.file.nameDecoded = obj.file.name;
           obj.file.trash = true;
           obj.file.pathText = jQuery.i18n.prop('originText') + " " //i18n
 
@@ -691,7 +693,7 @@ define([
              - Convert "folder" from string to boolean
              - Convert "id" to "objectId"
            */
-          obj.file.folder = (obj.file.folder == "true");
+          obj.file.folder = (obj.file.folder === "true");
           obj.file.objectId = obj.file.id;
 
           if (obj.file.id) {


### PR DESCRIPTION
Issues: [BACKLOG-41394](https://hv-eng.atlassian.net/issues/BACKLOG-41394) and [BACKLOG-41395](https://hv-eng.atlassian.net/issues/BACKLOG-41395)

Regression caused by [BACKLOG-41091](https://hv-eng.atlassian.net/issues/BACKLOG-41091), https://github.com/pentaho/pentaho-platform/pull/5652

The lack of the `nameDecoded` property in the Trash folder and contained files/folders data structures was causing an error evaluating the folder/file templates.

/cc @pentaho/hoth 

[BACKLOG-41394]: https://hv-eng.atlassian.net/browse/BACKLOG-41394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BACKLOG-41395]: https://hv-eng.atlassian.net/browse/BACKLOG-41395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BACKLOG-41091]: https://hv-eng.atlassian.net/browse/BACKLOG-41091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ