### PR TITLE
[BACKLOG-41349] Improve logging for schedule output location fallback

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
+++ b/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
@@ -184,4 +184,23 @@
       This is enabled by default, set the value to "false" to disable this access.
     -->
   <adminAccessAllUsersTrash>true</adminAccessAllUsersTrash>
+
+  <!--
+    System fallback scheduler output location.
+
+    When a schedule's output location is unavailable, the first available fallback location is used, in the order:
+    1. schedule owner user setting `default-scheduler-output-path`
+    2. system setting `default-scheduler-output-path` (this property)
+    3. schedule owner user home folder
+
+    A location is unavailable if:
+    1. Value is unspecified or empty.
+    2. Specified path has an invalid syntax.
+    3. Specified path does not exist.
+    4. Specified path is not a folder.
+    5. The schedule owner user does not have read/write access to the specified folder.
+
+    Example:
+    <default-scheduler-output-path>/public/output</default-scheduler-output-path>
+  -->
 </pentaho-system>

--- a/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/assemblies/pentaho-war/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -15,7 +15,7 @@
         <!-- ================================= -->
         <!-- Preserve messages in a local file -->
         <!-- ================================= -->
-        
+
         <!-- A time/date based rolling appender -->
         <RollingFile name="PENTAHOFILE" fileName="../logs/pentaho.log" filePattern="../logs/pentaho.log.%d{yyyy-MM-dd}">
             <PatternLayout>
@@ -83,7 +83,7 @@
             <DefaultRolloverStrategy max="1" />
         </RollingFile>
          -->
-         
+
         <!-- ========================================================== -->
         <!-- Special log file specifically for sensitive data access    -->
         <!-- on a per user/session/IP level                             -->
@@ -126,7 +126,7 @@
         <Logger name="org.pentaho.di.monitor" level="ERROR"/>
         <Logger name="org.pentaho.platform.engine.core.system.status" level="INFO"/>
         <Logger name="org.pentaho.hadoop.shim.DriverManager" level="INFO"/>
-        
+
         <!-- =========================== -->
         <!-- Repository Import Log Level -->
         <!-- =========================== -->
@@ -137,6 +137,13 @@
         <Logger name="org.pentaho.di.job.Job" level="INFO" additivity="false">
             <appender-ref ref="pdi-execution-appender"/>
         </Logger>
+
+        <!-- =========================== -->
+        <!-- Scheduler Log Levels        -->
+        <!-- =========================== -->
+        <!-- Set these to WARN to enable logging of scheduler output location validation and fallback process. -->
+        <Logger name="org.pentaho.platform.scheduler2.action.SchedulerOutputPathResolver" level="WARN"/>
+        <Logger name="org.pentaho.platform.web.http.api.resources.SchedulerOutputPathResolver" level="WARN"/>
 
         <!-- =========================== -->
         <!-- Mondrian Log Levels         -->


### PR DESCRIPTION
- Added documentation about the existing system setting `default-scheduler-output-path` to `pentaho.xml`
- Changed default log4j configuration to log WARN entries generated by `resources/SchedulerOutputPathResolver` and `action/SchedulerOutputPathResolver` classes

Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin/pull/189.

Issue: https://hv-eng.atlassian.net/browse/BACKLOG-41349

/cc @pentaho/hoth 