### PR TITLE
[CLEANUP] fixing failing test KarafBootTest#verifyStaleLockBehavior

### DIFF
--- a/extensions/src/test/java/org/pentaho/platform/osgi/KarafBootTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/osgi/KarafBootTest.java
@@ -420,7 +420,8 @@ public class KarafBootTest {
   public void verifyStaleLockBehavior() throws Exception {
     assertTrue( lockFile.createNewFile() );
     FileChannel fileChannel = FileChannel.open( lockFile.toPath(), Set.of( StandardOpenOption.WRITE ) );
-    fileChannel.write( ByteBuffer.wrap( "0".getBytes() ) );
+    // invalid pid -1 for windows/unix for KarafBoot#lockOwnerExists, pid 0 is still valid *nix pid in some environments
+    fileChannel.write( ByteBuffer.wrap( "-1".getBytes() ) );
     assertTrue( boot.waitForBootLock() );
   }
 


### PR DESCRIPTION
- changing the pid for a stale process to -1, instead of 0 to work with all systems


**suggested fix**, set stale/unused pid to `-1`, since it is a valid PID for an invalid process for windows and *nix:

- https://devblogs.microsoft.com/oldnewthing/20040223-00/?p=40503
- https://www.linfo.org/pid.html#:~:text=A%20PID%20(i.e.%2C%20process%20identification,always%20a%20non%2Dnegative%20integer.

**Backstory:**

On my local M2 Chip Mac, I was having the unit test `KarafBootTest#verifyStaleLockBehavior` fail, the process id (pid) `0` was actually being used
![mac_pid_0_fails](https://github.com/user-attachments/assets/5f188fad-d736-4fbc-88aa-12b7995e6a31)


![mac_debugger_evaluate_pid_0_in_use](https://github.com/user-attachments/assets/a3e33d79-6dbc-4974-9274-b16a5717b9cb)

When I set it to really high number pid `999999..`. that isn't used, the test pass:

![mac_pid_9999999_pass](https://github.com/user-attachments/assets/16e66781-95e4-4f93-87cc-f7cedc887f00)

When I set the pid to `-1`, the test pass:


![mac_pid_-1_pass](https://github.com/user-attachments/assets/d5551db0-e664-49c0-bcc5-989e6836cd36)
