### PR TITLE
[SP-6561] Backport of BISERVER-15087 - Issue using the “Execute Now” Option for scheduling with Ignore daylight saving adjustment (Use 24-hour interval) checked. (9.3 Suite)

### DIFF
--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -102,6 +102,12 @@
       <artifactId>jmock-junit4</artifactId>
       <version>${jmock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>
@@ -180,8 +186,8 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${hamcrest-core.version}</version>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest-library.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- endregion -->


### PR DESCRIPTION

Original commit: https://github.com/pentaho/pentaho-scheduler-plugin/commit/b3878768f7bbf9f7e3487c8686cb995053bb29f5

@pentaho/tatooine_dev 