### PR TITLE
[PDI-20206] Add base64/url decoding for passwords in LDAP authenticator

### DIFF
--- a/core/src/main/java/org/pentaho/commons/util/encoding/Decoder.java
+++ b/core/src/main/java/org/pentaho/commons/util/encoding/Decoder.java
@@ -1,0 +1,20 @@
+package org.pentaho.commons.util.encoding;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.util.Base64Utils;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+public class Decoder {
+  private Decoder() { }
+
+  public static String decodeIfEncoded( String encodedString ) {
+    if ( !StringUtils.isEmpty( encodedString ) && encodedString.startsWith( "ENC:" ) ) {
+      String password = new String( Base64Utils.decode( encodedString.substring( 4 ).getBytes() ) );
+      return URLDecoder.decode( password.replace( "+", "%2B" ), StandardCharsets.UTF_8 );
+    } else {
+      return encodedString;
+    }
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapAuthenticationProvider.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapAuthenticationProvider.java
@@ -20,9 +20,9 @@
 
 package org.pentaho.platform.plugin.services.security.userrole.ldap;
 
+import org.pentaho.commons.util.encoding.Decoder;
 import org.pentaho.platform.api.engine.security.IAuthenticationRoleMapper;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
-import org.pentaho.platform.repository2.userroledao.jackrabbit.security.DefaultPentahoPasswordEncoder;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -34,6 +34,7 @@ import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
 import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.security.ldap.authentication.LdapAuthenticator;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -81,9 +82,12 @@ public class DefaultLdapAuthenticationProvider extends LdapAuthenticationProvide
   @Override
   public Authentication authenticate( Authentication authentication ) throws AuthenticationException {
     Authentication decodedAuth = new UsernamePasswordAuthenticationToken(
-       authentication.getPrincipal(),
-       DefaultPentahoPasswordEncoder.decodePassword( (String) authentication.getCredentials() ),
-       authentication.getAuthorities() );
+      authentication.getName() != null ? authentication.getName() : "",
+      authentication.getCredentials() instanceof String
+        ? Decoder.decodeIfEncoded( authentication.getCredentials().toString() )
+        : authentication.getCredentials(),
+      authentication.getAuthorities() != null ? authentication.getAuthorities() : new ArrayList<>()
+    );
     final Authentication authenticate = super.authenticate( decodedAuth );
     for ( GrantedAuthority authority : authenticate.getAuthorities() ) {
       if ( authority.getAuthority().equals( authenticatedRole ) ) {

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapAuthenticationProvider.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapAuthenticationProvider.java
@@ -22,7 +22,9 @@ package org.pentaho.platform.plugin.services.security.userrole.ldap;
 
 import org.pentaho.platform.api.engine.security.IAuthenticationRoleMapper;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.repository2.userroledao.jackrabbit.security.DefaultPentahoPasswordEncoder;
 import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -78,7 +80,11 @@ public class DefaultLdapAuthenticationProvider extends LdapAuthenticationProvide
 
   @Override
   public Authentication authenticate( Authentication authentication ) throws AuthenticationException {
-    final Authentication authenticate = super.authenticate( authentication );
+    Authentication decodedAuth = new UsernamePasswordAuthenticationToken(
+       authentication.getPrincipal(),
+       DefaultPentahoPasswordEncoder.decodePassword( (String) authentication.getCredentials() ),
+       authentication.getAuthorities() );
+    final Authentication authenticate = super.authenticate( decodedAuth );
     for ( GrantedAuthority authority : authenticate.getAuthorities() ) {
       if ( authority.getAuthority().equals( authenticatedRole ) ) {
         return authenticate;

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapAuthenticationProviderTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/security/userrole/ldap/DefaultLdapAuthenticationProviderTest.java
@@ -27,8 +27,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.platform.api.engine.security.IAuthenticationRoleMapper;
 import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -68,11 +68,14 @@ public class DefaultLdapAuthenticationProviderTest {
   @Test
   public void testConstructors() {
     ldapAuthProvider = new DefaultLdapAuthenticationProvider( authenticator, roleMapper );
+    assertNotNull( ldapAuthProvider );
     ldapAuthProvider = new DefaultLdapAuthenticationProvider( authenticator, authoritiesPopulator, roleMapper );
+    assertNotNull( ldapAuthProvider );
     ldapAuthProvider = new DefaultLdapAuthenticationProvider( authenticator, authoritiesPopulator, roleMapper, "admin" );
+    assertNotNull( ldapAuthProvider );
   }
 
-  @Test( expected = IllegalArgumentException.class )
+  @Test( expected = BadCredentialsException.class )
   public void testAuthenticate_badArgs() {
     ldapAuthProvider = new DefaultLdapAuthenticationProvider( authenticator, roleMapper );
     ldapAuthProvider.authenticate( auth );
@@ -85,8 +88,33 @@ public class DefaultLdapAuthenticationProviderTest {
     when( usernamePasswordAuthenticationToken.getCredentials() ).thenReturn( "p@$$w0rd" );
 
     DirContextOperations dirContextOps = mock( DirContextOperations.class );
-    when( authenticator.authenticate( usernamePasswordAuthenticationToken ) ).thenReturn( dirContextOps );
-    Collection grantedAuthorities = Arrays.asList( new GrantedAuthority[]{ new SimpleGrantedAuthority( "admin" ) } );
+    when( authenticator.authenticate( any( Authentication.class ) ) ).thenReturn( dirContextOps );
+    Collection grantedAuthorities = Arrays.asList( new SimpleGrantedAuthority( "admin" ) );
+
+    when( authoritiesPopulator.getGrantedAuthorities( dirContextOps, "admin" ) ).thenReturn( grantedAuthorities );
+
+    UserDetailsContextMapper contextMapper = mock( UserDetailsContextMapper.class );
+    ldapAuthProvider.setUserDetailsContextMapper( contextMapper );
+    UserDetails userDetails = mock( UserDetails.class );
+    when( userDetails.getAuthorities() ).thenReturn( grantedAuthorities );
+    when( contextMapper.mapUserFromContext( any( DirContextOperations.class ), nullable( String.class ), any( grantedAuthorities.getClass() ) ) ).thenReturn( userDetails );
+    when( roleMapper.toPentahoRole( nullable( String.class ) ) ).thenReturn( "admin" );
+
+    Authentication result = ldapAuthProvider.authenticate( usernamePasswordAuthenticationToken );
+
+    assertNotNull( result );
+    assertEquals( "p@$$w0rd", result.getCredentials().toString() );
+  }
+
+  @Test
+  public void testEncodedAuthenticate() {
+    ldapAuthProvider = new DefaultLdapAuthenticationProvider( authenticator, authoritiesPopulator, roleMapper, "admin" );
+    when( usernamePasswordAuthenticationToken.getName() ).thenReturn( "admin" );
+    when( usernamePasswordAuthenticationToken.getCredentials() ).thenReturn( "ENC:cCU0MCUyNCUyNHcwcmQ=" );
+
+    DirContextOperations dirContextOps = mock( DirContextOperations.class );
+    when( authenticator.authenticate( any( Authentication.class ) ) ).thenReturn( dirContextOps );
+    Collection grantedAuthorities = Arrays.asList( new SimpleGrantedAuthority( "admin" ) );
 
     when( authoritiesPopulator.getGrantedAuthorities( dirContextOps, "admin" ) ).thenReturn( grantedAuthorities );
 

--- a/repository/src/main/java/org/pentaho/platform/repository2/userroledao/jackrabbit/security/DefaultPentahoPasswordEncoder.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/userroledao/jackrabbit/security/DefaultPentahoPasswordEncoder.java
@@ -20,19 +20,15 @@
 
 package org.pentaho.platform.repository2.userroledao.jackrabbit.security;
 
-import com.google.gwt.user.server.Base64Utils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.jackrabbit.core.security.authentication.CryptedSimpleCredentials;
+import org.pentaho.commons.util.encoding.Decoder;
 import org.pentaho.platform.engine.security.messages.Messages;
 import org.pentaho.platform.util.StringUtil;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.jcr.SimpleCredentials;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Default password encoder for the BI Server.
@@ -82,20 +78,11 @@ public class DefaultPentahoPasswordEncoder implements PasswordEncoder {
       return false;
     }
     try {
-      char[] decodedPassword = decodePassword( rawPass ).toCharArray();
+      char[] decodedPassword = Decoder.decodeIfEncoded( rawPass ).toCharArray();
       CryptedSimpleCredentials credentials = new CryptedSimpleCredentials( "dummyUser", encPass );
       return credentials.matches( new SimpleCredentials( "dummyUser", decodedPassword ) );
     } catch ( Exception e ) {
       throw new RuntimeException( e );
-    }
-  }
-
-  public static String decodePassword( String rawPass ) {
-    if ( !StringUtils.isEmpty( rawPass ) && rawPass.startsWith( "ENC:" ) ) {
-      String password = new String( Base64Utils.fromBase64( rawPass.substring( 4 ) ), StandardCharsets.UTF_8 );
-      return URLDecoder.decode( password.replace( "+", "%2B" ), StandardCharsets.UTF_8 );
-    } else {
-      return rawPass;
     }
   }
 

--- a/repository/src/main/java/org/pentaho/platform/repository2/userroledao/jackrabbit/security/DefaultPentahoPasswordEncoder.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/userroledao/jackrabbit/security/DefaultPentahoPasswordEncoder.java
@@ -82,7 +82,7 @@ public class DefaultPentahoPasswordEncoder implements PasswordEncoder {
       return false;
     }
     try {
-      char[] decodedPassword = decodePassword( rawPass );
+      char[] decodedPassword = decodePassword( rawPass ).toCharArray();
       CryptedSimpleCredentials credentials = new CryptedSimpleCredentials( "dummyUser", encPass );
       return credentials.matches( new SimpleCredentials( "dummyUser", decodedPassword ) );
     } catch ( Exception e ) {
@@ -90,16 +90,12 @@ public class DefaultPentahoPasswordEncoder implements PasswordEncoder {
     }
   }
 
-  private static char[] decodePassword( String rawPass ) {
-    try {
-      if ( !StringUtils.isEmpty( rawPass ) && rawPass.startsWith( "ENC:" ) ) {
-        String password = new String( Base64Utils.fromBase64( rawPass.substring( 4 ) ), StandardCharsets.UTF_8 );
-        return URLDecoder.decode( password.replace( "+", "%2B" ), StandardCharsets.UTF_8.name() ).toCharArray();
-      } else {
-        return rawPass.toCharArray();
-      }
-    } catch ( UnsupportedEncodingException e ) {
-      return rawPass.toCharArray();
+  public static String decodePassword( String rawPass ) {
+    if ( !StringUtils.isEmpty( rawPass ) && rawPass.startsWith( "ENC:" ) ) {
+      String password = new String( Base64Utils.fromBase64( rawPass.substring( 4 ) ), StandardCharsets.UTF_8 );
+      return URLDecoder.decode( password.replace( "+", "%2B" ), StandardCharsets.UTF_8 );
+    } else {
+      return rawPass;
     }
   }
 


### PR DESCRIPTION
As part of BISERVER-14644, it was missing to decode the passwords for LDAP authentication in the server. This PR reuses the method done in the previous issue (with some slight improvements) to also apply the same decodification on LDAP authentication.

@pentaho/tatooine_dev please review