### PR TITLE
Backport of PPP-4582 - Use of Vulnerable Component: Components/oauth_client_library_for_java (10.2 Suite)

### DIFF
--- a/assemblies/pentaho-solutions/pom.xml
+++ b/assemblies/pentaho-solutions/pom.xml
@@ -177,13 +177,6 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.pentaho.di.plugins</groupId>
-                  <artifactId>pdi-google-analytics-plugin</artifactId>
-                  <version>${project.version}</version>
-                  <type>zip</type>
-                  <outputDirectory>${prepared.kettle.plugins.directory}</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.pentaho.di.plugins</groupId>
                   <artifactId>pdi-salesforce-plugin</artifactId>
                   <version>${project.version}</version>
                   <type>zip</type>
@@ -206,13 +199,6 @@
                 <artifactItem>
                   <groupId>org.pentaho.di.plugins</groupId>
                   <artifactId>kettle-hl7-plugin</artifactId>
-                  <version>${project.version}</version>
-                  <type>zip</type>
-                  <outputDirectory>${prepared.kettle.plugins.directory}</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.pentaho.di.plugins</groupId>
-                  <artifactId>pentaho-googledrive-vfs-plugin</artifactId>
                   <version>${project.version}</version>
                   <type>zip</type>
                   <outputDirectory>${prepared.kettle.plugins.directory}</outputDirectory>


### PR DESCRIPTION
BACKPORT of:
[PPP-4582] Use of Vulnerable Component: Components/oauth_client_library_for_java

Remove unused plugins with vulnerabilities from assembly:
    - pentaho-googledrive-vfs
    - pdi-google-analytics-plugin

[PPP-4582]: https://hv-eng.atlassian.net/browse/PPP-4582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ