### PR TITLE
[BACKLOG-42817]-Upgrading fasterxml jaxrs to fasterxml jakarta rs to support with jersey 3.x and jakarta 3.x

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -29,12 +29,12 @@
     <!-- region - Fasterxml jackson providers are required to be in the main classloader for serialization of POJOs
          in the Publish Model step. -->
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+      <artifactId>jackson-jakarta-rs-json-provider</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-base</artifactId>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+      <artifactId>jackson-jakarta-rs-base</artifactId>
     </dependency>
     <!-- endregion -->
 


### PR DESCRIPTION
[BACKLOG-42817]-Upgrading fasterxml jaxrs to fasterxml jakarta rs to support with jersey 3.x and jakarta 3.x

[BACKLOG-42817]: https://hv-eng.atlassian.net/browse/BACKLOG-42817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ