### PR TITLE
[BACKLOG-41287]-Upgrading pentaho-platform from Java-EE to Jakarta-EE to support with Tomcat-10.X

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -11,6 +11,7 @@
   <artifactId>pentaho-platform-extensions</artifactId>
   <version>10.3.0.0-SNAPSHOT</version>
   <properties>
+    <cache.version>1.1.1</cache.version>
     <asm-attrs.version>2.2.3</asm-attrs.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -43,6 +44,11 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+      <version>${cache.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>


### PR DESCRIPTION
[BACKLOG-41287]-Upgrading pentaho-platform from Java-EE to Jakarta-EE to support with Tomcat-10.X

[BACKLOG-41287]: https://hv-eng.atlassian.net/browse/BACKLOG-41287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ