### PR TITLE
[BACKLOG-42885]-Upgrading Jetty version from 11.0.14 to 12.0.15 to support Jakarta EE 10

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2160,8 +2160,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-webapp</artifactId>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/extensions/src/test/java/org/pentaho/platform/web/servlet/DefaultSpringWadlResourceDocumentTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/servlet/DefaultSpringWadlResourceDocumentTest.java
@@ -15,7 +15,7 @@ package org.pentaho.platform.web.servlet;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.eclipse.jetty.webapp.WebAppClassLoader;
+import org.eclipse.jetty.ee10.webapp.WebAppClassLoader;
 import org.pentaho.platform.plugin.services.pluginmgr.PluginClassLoader;
 import org.springframework.core.io.ClassPathResource;
 

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -258,9 +258,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>${jaxb-api.version}</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${jakarta.xml.bind-api.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/user-console/pom.xml
+++ b/user-console/pom.xml
@@ -225,6 +225,16 @@
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-dev</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlets</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.gwt</groupId>


### PR DESCRIPTION
[BACKLOG-42885]-Upgrading Jetty version from 11.0.14 to 12.0.15 to support Jakarta EE 10

[BACKLOG-42885]: https://hv-eng.atlassian.net/browse/BACKLOG-42885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ