### PR TITLE
remove neethi jar runtime dependency

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2023,18 +2023,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.ws.commons.neethi</groupId>
-      <artifactId>neethi</artifactId>
-      <version>${neethi.version}</version>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>woodstox</groupId>
       <artifactId>wstx-asl</artifactId>
       <version>${wstx-asl.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,6 @@
     <hamcrest-library.version>1.3</hamcrest-library.version>
     <xmlenc.version>0.52</xmlenc.version>
     <jsendnsca.version>2.0.1</jsendnsca.version>
-    <neethi.version>2.0.1</neethi.version>
     <barbecue.version>1.5-beta1</barbecue.version>
     <jaxws-spring.version>1.8</jaxws-spring.version>
     <antlr-complete.version>3.5.2</antlr-complete.version>


### PR DESCRIPTION
- group changed from 'org.apache.ws.commons.neethi:neethi' to 'org.apache:neethi' back in 2007
- v2.0.1 does not have published pom.xml, caused IDE build issues, v2.0.2 and above does have pom.xml
- only artifact that uses neethi is axis2-kernel-1.5.jar
- PPP-4174 removed all axis2 jars from report-designer including axis2-kernel-1.5.jar