### PR TITLE
[SP-6635] Backport of PPP-4895 - Vulnerable Component: Jettison

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -16,7 +16,6 @@
     <prepared.war.directory>${pentaho-server.directory}/tomcat/webapps/pentaho</prepared.war.directory>
     <pentaho-hadoop-shims.version>10.2.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
     <prepared.war.lib.directory>${prepared.war.directory}/WEB-INF/lib</prepared.war.lib.directory>
-    <jettison.version>1.3.3</jettison.version>
     <datasource.resources.directory>${basedir}/src/main/resources/datasources</datasource.resources.directory>
     <hibernate-ehcache.version>5.4.24.Final</hibernate-ehcache.version>
     <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
     <mstor.version>0.9.13</mstor.version>
     <hibernate-commons-annotations.version>5.1.2.Final</hibernate-commons-annotations.version>
     <mina-core.version>2.0.0-M6</mina-core.version>
-    <jettison.version>1.2</jettison.version>
     <hamcrest-all.version>1.3</hamcrest-all.version>
     <javax.inject.version>1</javax.inject.version>
     <pentaho-vfs.version>1.0</pentaho-vfs.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -18,7 +18,6 @@
     <license.header.definition.file>${basedir}/../license/styles/javadoc_style_license_header.xml</license.header.definition.file>
     <hsqldb.version>1.8.0.7</hsqldb.version>
     <hamcrest-library.version>2.2</hamcrest-library.version>
-    <jettison.version>1.1</jettison.version>
     <hamcrest-core.version>2.2</hamcrest-core.version>
     <xmlunit.version>1.3</xmlunit.version>
     <maven-surefire-plugin.argLine> --add-opens=java.base/java.lang=ALL-UNNAMED </maven-surefire-plugin.argLine>


### PR DESCRIPTION
- [PPP-4895] Update jettison version to 1.5.4

[PPP-4895]: https://hv-eng.atlassian.net/browse/PPP-4895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ