### PR TITLE
[BISERVER-15135] - Username with prefix or suffix blank spaces on Login page triggers UsernameNotFound Exception, but session is created

### DIFF
--- a/assemblies/pentaho-war/src/main/webapp/jsp/PUCLogin.jsp
+++ b/assemblies/pentaho-war/src/main/webapp/jsp/PUCLogin.jsp
@@ -350,6 +350,9 @@
     var userState = '';
     <% } %>
 
+    let trimmedValue = $("#login #j_username").val().trim();
+    $("#login #j_username").val(trimmedValue);
+
     jQuery.ajax({
       type: "POST",
       url: "j_spring_security_check",


### PR DESCRIPTION
@pentaho/tatooine_dev 