### PR TITLE
[PPP-5594] handle potentially unsafe XPath queries

### DIFF
--- a/core/src/main/java/org/pentaho/platform/engine/core/system/SystemSettings.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/SystemSettings.java
@@ -239,7 +239,7 @@ public class SystemSettings extends PentahoBase implements ISystemSettings {
       return false;
     }
 
-    // We definitely need to allow "/" and "-", "." is also reasonable
+    // We need to allow "/", "-", "*", and "."
     return settingName.contains( "'" ) ||
       settingName.contains( "\"" ) ||
       settingName.contains( "<" ) ||
@@ -262,7 +262,6 @@ public class SystemSettings extends PentahoBase implements ISystemSettings {
       settingName.contains( "@" ) ||
       settingName.contains( "$" ) ||
       settingName.contains( "&" ) ||
-      settingName.contains( "*" ) ||
       settingName.contains( "+" ) ||
       settingName.contains( "=" ) ||
       settingName.contains( "~" );

--- a/core/src/main/java/org/pentaho/platform/engine/core/system/SystemSettings.java
+++ b/core/src/main/java/org/pentaho/platform/engine/core/system/SystemSettings.java
@@ -77,6 +77,12 @@ public class SystemSettings extends PentahoBase implements ISystemSettings {
     if ( doc == null ) {
       return defaultValue;
     }
+
+    if ( isXPathUnSafe( settingName ) ) {
+      error( Messages.getInstance().getString( "SYSTEMSETTINGS.XPATH_VIOLATION_DEFAULT", settingName ) );
+      return defaultValue;
+    }
+
     Node node = doc.selectSingleNode( "//" + settingName ); //$NON-NLS-1$
     if ( node == null ) {
       return defaultValue;
@@ -95,6 +101,10 @@ public class SystemSettings extends PentahoBase implements ISystemSettings {
     }
     Document doc = getSystemSettingsDocument( path );
     if ( doc == null ) {
+      return null;
+    }
+    if ( isXPathUnSafe( settingName ) ) {
+      error( Messages.getInstance().getString( "SYSTEMSETTINGS.XPATH_VIOLATION", settingName ) );
       return null;
     }
     settings = doc.selectNodes( "//" + settingName ); //$NON-NLS-1$
@@ -219,5 +229,42 @@ public class SystemSettings extends PentahoBase implements ISystemSettings {
 
   public String getSystemCfgSourceName() {
     return getAbsolutePath( SystemSettings.PENTAHOSETTINGSFILENAME );
+  }
+
+  // We rely on passing in values with characters that prevent us from using variables in the query, which
+  // would be the standard way of preventing dangerous user input. Instead, as a stop-gap, we can check that
+  // the strings we concatenate don't contain any of the other characters that would allow problematic queries.
+  private boolean isXPathUnSafe( String settingName ) {
+    if ( settingName == null ) {
+      return false;
+    }
+
+    // We definitely need to allow "/" and "-", "." is also reasonable
+    return settingName.contains( "'" ) ||
+      settingName.contains( "\"" ) ||
+      settingName.contains( "<" ) ||
+      settingName.contains( ">" ) ||
+      settingName.contains( "[" ) ||
+      settingName.contains( "]" ) ||
+      settingName.contains( "{" ) ||
+      settingName.contains( "}" ) ||
+      settingName.contains( "(" ) ||
+      settingName.contains( ")" ) ||
+      settingName.contains( "#" ) ||
+      settingName.contains( "%" ) ||
+      settingName.contains( ";" ) ||
+      settingName.contains( ":" ) ||
+      settingName.contains( "," ) ||
+      settingName.contains( "?" ) ||
+      settingName.contains( "\\" ) ||
+      settingName.contains( "|" ) ||
+      settingName.contains( "!" ) ||
+      settingName.contains( "@" ) ||
+      settingName.contains( "$" ) ||
+      settingName.contains( "&" ) ||
+      settingName.contains( "*" ) ||
+      settingName.contains( "+" ) ||
+      settingName.contains( "=" ) ||
+      settingName.contains( "~" );
   }
 }

--- a/core/src/main/resources/org/pentaho/platform/engine/core/messages/messages.properties
+++ b/core/src/main/resources/org/pentaho/platform/engine/core/messages/messages.properties
@@ -78,6 +78,8 @@ SYSTEMSETTINGS.CODE_LOG_NAME=SYSTEM-SETTINGS
 SYSTEMSETTINGS.DEBUG_GET_SYSTEM_SETTING_PATH=getSystemSetting system path=system/{0}
 SYSTEMSETTINGS.DEBUG_SYSTEM_SETTINGS_GET_FILE=SystemSettings.getFile path={0}
 SYSTEMSETTINGS.ERROR_0002_FILE_NOT_IN_SOLUTION=File {0} does not exist
+SYSTEMSETTINGS.XPATH_VIOLATION=XPath query \"{0}\" has a disallowed character! Using default value instead
+SYSTEMSETTINGS.XPATH_VIOLATION_DEFAULT=XPath query \"{0}\" has a disallowed character! Using default value instead
 
 SettingsPublisher.ERROR_0001_PUBLISH_FAILED=Could not publish System Settings
 SettingsPublisher.USER_DESCRIPTION=Refresh all of the system settings from the documents in {0}

--- a/core/src/test/resources/org/pentaho/platform/engine/core/messages/messages.properties
+++ b/core/src/test/resources/org/pentaho/platform/engine/core/messages/messages.properties
@@ -78,6 +78,8 @@ SYSTEMSETTINGS.CODE_LOG_NAME=SYSTEM-SETTINGS
 SYSTEMSETTINGS.DEBUG_GET_SYSTEM_SETTING_PATH=getSystemSetting system path=system/{0}
 SYSTEMSETTINGS.DEBUG_SYSTEM_SETTINGS_GET_FILE=SystemSettings.getFile path={0}
 SYSTEMSETTINGS.ERROR_0002_FILE_NOT_IN_SOLUTION=File {0} does not exist
+SYSTEMSETTINGS.XPATH_VIOLATION=XPath query \"{0}\" has a disallowed character! Using default value instead
+SYSTEMSETTINGS.XPATH_VIOLATION_DEFAULT=XPath query \"{0}\" has a disallowed character! Using default value instead
 
 SettingsPublisher.ERROR_0001_PUBLISH_FAILED=Could not publish System Settings
 SettingsPublisher.USER_DESCRIPTION=Refresh all of the system settings from the documents in {0}


### PR DESCRIPTION
This works around an issue where it may be possible to inject things into an XPath query used for retrieving system settings. We don't actually take user input in this scenarios, but its possible we accidentally could introduce something like that in the future. It is also possible for third party code to use this in an unsafe way.

We can't use variables, which would be the more typical approach here, because we need to allow `/` in the `settingName`. Instead we can check for potentially illegal characters and bail early.