### PR TITLE
fix: NPE when tree has no children [BISERVER-15190]

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
@@ -1501,8 +1501,8 @@ public class FileService {
       logger.error( e.getCause() );
     }
 
-    if ( tree == null ) {
-      return null;
+    if ( tree == null || tree.getChildren() == null || tree.getChildren().isEmpty() ) {
+      return tree;
     }
 
     // translating /home and /public folders titles
@@ -1513,6 +1513,7 @@ public class FileService {
         dto.getFile().setTitle( Messages.getInstance().getString( "FileResource.PUBLIC_FOLDER_DISPLAY_TITLE" ) );
       }
     }
+
     // BISERVER-9599 - Use special sort order
     if ( isShowingTitle( repositoryRequest ) ) {
       Collator collator = getCollatorInstance();
@@ -1525,7 +1526,7 @@ public class FileService {
 
   public void sortByLocaleTitle( final Collator collator, final RepositoryFileTreeDto tree ) {
 
-    if ( tree == null || tree.getChildren() == null || tree.getChildren().size() <= 0 ) {
+    if ( tree == null || tree.getChildren() == null || tree.getChildren().isEmpty() ) {
       return;
     }
 
@@ -1955,7 +1956,7 @@ public class FileService {
 
   public void sortByLocaleTitle( final Collator collator, final List<RepositoryFileDto> repositoryFileDtoList ) {
 
-    if ( repositoryFileDtoList == null || repositoryFileDtoList.size() <= 0 ) {
+    if ( repositoryFileDtoList == null || repositoryFileDtoList.isEmpty() ) {
       return;
     }
 


### PR DESCRIPTION
This pull request includes changes to the `FileService.java` file to improve the handling of null or empty collections. The most important changes include updating conditional checks to use the `isEmpty` method for better readability and consistency.

Improvements to null or empty collection handling:

* Updated the null or empty check for `tree.getChildren()` in the `doGetTree` method to use `isEmpty()` instead of checking the size.
* Added a new line to separate the block of code in the `doGetTree` method for better readability.
* Updated the null or empty check for `tree.getChildren()` in the `sortByLocaleTitle` method to use `isEmpty()` instead of checking the size.
* Updated the null or empty check for `repositoryFileDtoList` in the `sortByLocaleTitle` method to use `isEmpty()` instead of checking the size.

@pentaho/millenniumfalcon please review