### PR TITLE
[BACKLOG-43874]-Fix JDK21 test pipeline(test1) build failures

### DIFF
--- a/user-console/pom.xml
+++ b/user-console/pom.xml
@@ -407,9 +407,9 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy file="${project.basedir}/../LICENSE.TXT" tofile="${project.build.directory}/classes/org/pentaho/mantle/public/LICENSE.TXT"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
[BACKLOG-43874]-Fix JDK21 test pipeline(test1) build failures

[BACKLOG-43874]: https://hv-eng.atlassian.net/browse/BACKLOG-43874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ