### PR TITLE
fix: fix behavior that prevents that a catalog already load to the cache to be updated when used override as true [SME-849]

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/engine/ICacheManager.java
+++ b/api/src/main/java/org/pentaho/platform/api/engine/ICacheManager.java
@@ -170,7 +170,7 @@ public interface ICacheManager extends ILogoutListener {
    *          The data to store in the cache.
    * 
    */
-  public void putInRegionCache( String reqion, Object key, Object value );
+  public void putInRegionCache( String region, Object key, Object value );
 
   /**
    * Gets an object from the cache within a specific region


### PR DESCRIPTION
## Addressed Issue(s)
SME-849

## Description
This PR fixes the behavior that prevents that a catalog already load to the cache to be updated when used override as true. Currently, when a catalog is loaded to the cache is not possible to update it.

Main keys:
- init is always performed at add catalog, despite the configuration used.
- loadCatalogIntoCache when used with overwrite = true, complete the full function workflow, not returning immediatelly


## Checklist
- [X] Relevant tests have been added
- [ ] This PR should not be squashed