### PR TITLE
test: revise MondrianCatalogHelper integration tests [SME-1082]

### DIFF
--- a/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
@@ -10,59 +10,50 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.platform.plugin.action.mondrian.catalog;
 
+import mondrian.i18n.LocalizingDynamicSchemaProcessor;
 import mondrian.olap.CacheControl;
 import mondrian.olap.Connection;
-import mondrian.olap.MondrianException;
 import mondrian.olap.Schema;
 import mondrian.olap.Util.PropertyList;
 import mondrian.spi.DynamicSchemaProcessor;
-import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
 import org.olap4j.OlapConnection;
-import org.pentaho.database.model.DatabaseConnection;
-import org.pentaho.database.model.IDatabaseConnection;
-import org.pentaho.database.service.DatabaseDialectService;
-import org.pentaho.database.service.IDatabaseDialectService;
 import org.pentaho.platform.api.engine.ICacheManager;
-import org.pentaho.platform.api.engine.IPentahoDefinableObjectFactory.Scope;
+import org.pentaho.platform.api.engine.IPentahoDefinableObjectFactory;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.IUserRoleListService;
 import org.pentaho.platform.api.repository2.unified.IAclNodeHelper;
 import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
-import org.pentaho.platform.api.repository2.unified.MondrianSchemaAnnotator;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
-import org.pentaho.platform.api.util.IPasswordService;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
-import org.pentaho.platform.engine.core.system.SystemSettings;
 import org.pentaho.platform.plugin.action.olap.IOlapService;
-import org.pentaho.platform.plugin.services.cache.CacheManager;
 import org.pentaho.platform.plugin.services.importexport.legacy.MondrianCatalogRepositoryHelper;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
 import org.pentaho.platform.repository2.unified.UnifiedRepositoryTestUtils;
-import org.pentaho.platform.util.KettlePasswordService;
 import org.pentaho.platform.util.messages.LocaleHelper;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
-import org.pentaho.test.platform.plugin.UserRoleMapperIT.TestUserRoleListService;
+import org.pentaho.test.platform.plugin.UserRoleMapperIT;
 import org.pentaho.test.platform.utils.TestResourceLocation;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.PrintWriter;
-import java.util.Arrays;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -76,88 +67,123 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
+
+/**
+ * This class tests the MondrianCatalogHelper integrated at a (Micro)Platform environment.
+ */
 @SuppressWarnings( "nls" )
 public class MondrianCatalogHelperIT {
 
   private static final String CATALOG_NAME = "SteelWheels";
+  private static final String mondrianFolderPath =
+    ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "mondrian";
+
 
   // ~ Instance fields
   // =================================================================================================
 
-  private static MicroPlatform booter;
+  /**
+   * Catalogs repository.
+   * SolutionRepositoryVfsFileObject (see
+   * https://github.com/pentaho/pentaho-platform/blob/535817c1a4dac371e7d5f53cba4af8aac3aa2a1a/repository/src/main
+   * /java/org/pentaho/platform/repository/solution/filebased/SolutionRepositoryVfsFileObject.java#L54)
+   * uses the catalog as a static instance. As a consequence, we need to have the catalog defined statically and
+   * reset it before each test setup.
+   */
+  static IUnifiedRepository repo;
+
+  // Micro platform used to support the tests/code execution. Is initialized and loaded at test setup phase
+  private static MicroPlatform testPlatform;
+  // Cache manager. Used at the platform setup
   private ICacheManager cacheMgr;
-
+  // Pentaho session
+  private IPentahoSession session;
+  // Instance of the MondrianCatalogHelper used for the tests. It is initialized with the platform value (set at
+  // setup phase)
   private MondrianCatalogHelper helper;
-
-  @Mock private IUnifiedRepository repo;
-
+  // Olap service
   @Mock private  IOlapService olapService;
 
   @Mock private CacheControl mondrianCacheControl;
 
+  // Mondrian schema returned by the mondrian connection
   @Mock private Schema mondrianSchema;
 
-  @Mock private OlapConnection olapConn;
-
-  @Mock private Connection rolapConn;
-
-
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks( this );
-
-    when( olapService.getConnection( any( String.class ), any( IPentahoSession.class ) ) )
-      .thenReturn( olapConn );
-    when( rolapConn.getSchema() ).thenReturn( mondrianSchema );
-    when( rolapConn.getCacheControl( any( PrintWriter.class ) ) )
-      .thenReturn( mondrianCacheControl );
-    when( olapConn.unwrap( Connection.class ) )
-      .thenReturn( rolapConn );
-
-    booter = new MicroPlatform( TestResourceLocation.TEST_RESOURCES + "/solution" );
-    booter.define( IPasswordService.class, KettlePasswordService.class, Scope.GLOBAL );
-    booter.define( IDatabaseConnection.class, DatabaseConnection.class, Scope.GLOBAL );
-    booter.define( IDatabaseDialectService.class, DatabaseDialectService.class, Scope.GLOBAL );
-    booter.define( IAclAwareMondrianCatalogService.class, MondrianCatalogHelper.class, Scope.GLOBAL );
-    booter.define( ICacheManager.class, CacheManager.class, Scope.GLOBAL );
-    booter.define( IUserRoleListService.class, TestUserRoleListService.class, Scope.GLOBAL );
-    booter.defineInstance( IUnifiedRepository.class, repo );
-    booter.defineInstance( IOlapService.class, olapService );
-    booter.defineInstance(
-        "inlineModeling",
-      (MondrianSchemaAnnotator) ( schemaInputStream, annotationsInputStream ) -> schemaInputStream );
-    booter.setSettingsProvider( new SystemSettings() );
-    booter.start();
-
-    cacheMgr = PentahoSystem.getCacheManager( null );
-    helper = (MondrianCatalogHelper) PentahoSystem.get( IAclAwareMondrianCatalogService.class );
+  @BeforeClass
+  public static void setUpClass() {
+    repo = mock( IUnifiedRepository.class );
   }
+
 
   @AfterClass
   public static void tearDownClass() {
   }
 
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks( this );
+
+    // Olap4j connection
+    var olapConn = Mockito.mock( OlapConnection.class );
+    var rolapConn = Mockito.mock( Connection.class );
+    when( olapService.getConnection( any( String.class ), any() ) )
+      .thenReturn( olapConn );
+    when( rolapConn.getSchema() ).thenReturn( mondrianSchema );
+    when( rolapConn.getCacheControl( any() ) )
+      .thenReturn( mondrianCacheControl );
+    when( olapConn.unwrap( any() ) )
+      .thenReturn( rolapConn );
+
+    testPlatform = new MicroPlatform( TestResourceLocation.TEST_RESOURCES + "/solution" );
+
+    var localizingDynamicSchemaProcessor = mock( LocalizingDynamicSchemaProcessor.class );
+    doAnswer( invocation -> new String( ( (InputStream) invocation.getArgument( 2 ) ).readAllBytes() ) )
+      .when( localizingDynamicSchemaProcessor )
+      .filter( nullable( String.class ), any(), any() );
+
+
+    var mondrianCatalogHelper =
+      new MondrianCatalogHelper( false, null, localizingDynamicSchemaProcessor );
+
+    testPlatform.defineInstance( IAclAwareMondrianCatalogService.class, mondrianCatalogHelper );
+
+    testPlatform.define( IUserRoleListService.class, UserRoleMapperIT.TestUserRoleListService.class,
+      IPentahoDefinableObjectFactory.Scope.GLOBAL );
+
+    // repository
+    testPlatform.defineInstance( IUnifiedRepository.class, repo );
+    // OlapService / Mondrian
+    testPlatform.defineInstance( IOlapService.class, olapService );
+    // needed for a correct catalog loading process
+    testPlatform.defineInstance( "singleTenantAdminUserName", "admin" );
+
+    testPlatform.start();
+
+    session = mock( IPentahoSession.class );
+    cacheMgr = PentahoSystem.getCacheManager( session );
+    helper = (MondrianCatalogHelper) PentahoSystem.get( IAclAwareMondrianCatalogService.class );
+  }
+
   @After
-  public void tearDown() throws Exception {
-    reset( repo );
+  public void tearDown() {
+    // cleanup to avoid to leave garbage/mocked definitions
+    Mockito.reset( repo );
     cacheMgr.clearRegionCache( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION );
-    booter.stop();
+    testPlatform.stop();
   }
 
   private void initMondrianCatalogsCache() {
@@ -165,8 +191,54 @@ public class MondrianCatalogHelperIT {
   }
 
   private void initMondrianCatalogsCache( Map<String, MondrianCatalog> map ) {
+    MondrianCatalogCache mondrianCatalogCache = new MondrianCatalogCache();
+    mondrianCatalogCache.setCatalogs( map );
+
     cacheMgr.addCacheRegion( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION );
-    cacheMgr.putInRegionCache( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION, LocaleHelper.getLocale().toString(), map );
+    cacheMgr.putInRegionCache( MondrianCatalogHelper.MONDRIAN_CATALOG_CACHE_REGION, LocaleHelper.getLocale().toString(),
+      mondrianCatalogCache );
+  }
+
+  // This method is used to initialize the olap folder at the repository mock
+  private void repositoryMockOlapServerFolder() {
+    final String olapFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "olap-servers";
+    UnifiedRepositoryTestUtils.stubGetFolder( repo, olapFolderPath );
+    UnifiedRepositoryTestUtils.stubGetChildren( repo, olapFolderPath ); // return no children
+  }
+
+  // This method is used to initialize the repository mock for the mondrian folder
+  private void repositoryMockMondrianFolder( String... elements ) {
+    UnifiedRepositoryTestUtils.stubGetFolder( repo, mondrianFolderPath );
+    UnifiedRepositoryTestUtils.stubGetChildren( repo, mondrianFolderPath, elements );
+  }
+
+  private void repositoryMockSteelWheelsEntry( String dataSourceInfo ) throws IOException {
+    File file1 = new File( TestResourceLocation.TEST_RESOURCES + "/solution/test/charts/steelwheels.mondrian.xml" );
+    String mondrianSchema1 = new String( new FileInputStream( file1 ).readAllBytes() );
+    repositoryMockEntry( "SteelWheels", mondrianSchema1, dataSourceInfo );
+  }
+
+  private void repositoryMockSampleDataEntry() throws IOException {
+    File file2 =
+      new File( TestResourceLocation.TEST_RESOURCES + "/solution/samples/reporting/SampleData.mondrian.xml" );
+    String mondrianSchema2 = new String( new FileInputStream( file2 ).readAllBytes() );
+    repositoryMockEntry( "SampleData", mondrianSchema2, "Provider=mondrian;DataSource=SampleData;" );
+  }
+
+  private void repositoryMockEntry( String entryName, String schemaXML, String dataSourceInfo ) {
+    final String steelWheelsFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + entryName;
+    final String steelWheelsMetadataPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "metadata";
+    final String steelWheelsSchemaPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "schema.xml";
+    UnifiedRepositoryTestUtils.stubGetFile( repo, steelWheelsMetadataPath );
+    // Exclude from JNDI = No DataSource at datasourceInfo
+    UnifiedRepositoryTestUtils.stubGetData( repo, steelWheelsMetadataPath, "catalog",
+      UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/definition",
+        "mondrian:/" + entryName ), UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/datasourceInfo",
+        dataSourceInfo ) );
+    UnifiedRepositoryTestUtils.stubGetFile( repo, steelWheelsSchemaPath );
+    UnifiedRepositoryTestUtils.stubGetData( repo, steelWheelsSchemaPath, schemaXML );
+
+    UnifiedRepositoryTestUtils.stubGetFolder( repo, steelWheelsFolderPath );
   }
 
 
@@ -177,66 +249,40 @@ public class MondrianCatalogHelperIT {
   }
 
   @Test( expected = MondrianCatalogServiceException.class )
-  public void addCatalog_WhenAlreadyExists() {
+  public void testAddCatalog_WhenAlreadyExists() {
     MondrianCatalog cat = createTestCatalog();
     initMondrianCatalogsCache( Collections.singletonMap( CATALOG_NAME, cat ) );
 
     helper = spy( helper );
 
-    IPentahoSession session = mock( IPentahoSession.class );
-    doNothing().when( helper ).init( session );
+    doNothing().when( helper ).initIfNotFullyLoaded( session );
 
     helper.addCatalog( new ByteArrayInputStream( new byte[0] ), cat, false, null, session );
   }
 
-  @Test( expected = MondrianException.class )
-  public void testAddCatalogWithException() {
-    initMondrianCatalogsCache();
-    MondrianCatalogHelper helperSpy = spy( helper );
-    doThrow( new MondrianException() ).when( helperSpy ).reInit( any( IPentahoSession.class ) );
-
-    IPentahoSession session = mock( IPentahoSession.class );
-    doNothing().when( helperSpy ).init( session );
-
-    MondrianCatalog cat = createTestCatalog();
-    MondrianCatalogRepositoryHelper repositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
-    doReturn( repositoryHelper ).when( helperSpy ).getMondrianCatalogRepositoryHelper();
-    try {
-      helperSpy.addCatalog( new ByteArrayInputStream( new byte[0] ), cat, true, null, session );
-    } catch ( MondrianException e ) {
-      // verifying the repository rolled back and the cache reinitialized
-      verify( repositoryHelper, times( 1 ) ).deleteHostedCatalog( nullable( String.class ) );
-      verify( helperSpy, times( 2 ) ).reInit( any( IPentahoSession.class ) );
-    }
-    helperSpy.addCatalog( new ByteArrayInputStream( new byte[0] ), cat, true, null, session );
-  }
-
   @Test
   public void testAddCatalog() throws Exception {
-    final String mondrianFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "mondrian";
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, mondrianFolderPath );
-    UnifiedRepositoryTestUtils.stubGetChildren( repo, mondrianFolderPath ); // return no children
+    repositoryMockMondrianFolder(); // empty - no children
+    repositoryMockOlapServerFolder();
+
     final String steelWheelsFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + CATALOG_NAME;
     UnifiedRepositoryTestUtils.stubGetFileDoesNotExist( repo, steelWheelsFolderPath );
     UnifiedRepositoryTestUtils.stubCreateFolder( repo, steelWheelsFolderPath );
     final String metadataPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "metadata";
     UnifiedRepositoryTestUtils.stubCreateFile( repo, metadataPath );
 
-    final String olapFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "olap-servers";
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, olapFolderPath );
-    UnifiedRepositoryTestUtils.stubGetChildren( repo, olapFolderPath ); // return no children
-
-    IPentahoSession session = new StandaloneSession( "admin" );
+    session = new StandaloneSession( "admin" );
 
     MondrianCatalog cat = createTestCatalog();
     File file = new File( TestResourceLocation.TEST_RESOURCES + "/solution/test/charts/steelwheels.mondrian.xml" );
-    String mondrianSchema = IOUtils.toString( new FileInputStream( file ) );
-    session.setAttribute( "MONDRIAN_SCHEMA_XML_CONTENT", mondrianSchema );
+    session.setAttribute( "MONDRIAN_SCHEMA_XML_CONTENT", new String( new FileInputStream( file ).readAllBytes() ) );
 
     MondrianCatalogHelper helperSpy = spy( helper );
+
     IAclNodeHelper aclNodeHelper = mock( IAclNodeHelper.class );
     doNothing().when( aclNodeHelper ).setAclFor( any( RepositoryFile.class ), any( RepositoryFileAcl.class ) );
     doReturn( aclNodeHelper ).when( helperSpy ).getAclHelper();
+
     doReturn( true ).when( helperSpy ).catalogExists( any( MondrianCatalog.class ), eq( session ) );
 
     helperSpy.addCatalog( cat, true, session );
@@ -259,13 +305,11 @@ public class MondrianCatalogHelperIT {
   }
 
   @Test
-  public void addCatalog_WithAcl() {
+  public void testAddCatalog_WithAcl() {
     initMondrianCatalogsCache();
-
     MondrianCatalogHelper helperSpy = spy( helper );
 
-    IPentahoSession session = mock( IPentahoSession.class );
-    doNothing().when( helperSpy ).init( session );
+    doNothing().when( helperSpy ).initIfNotFullyLoaded( session );
 
     doReturn( Collections.<MondrianCatalog>emptyList() ).when( helperSpy ).getCatalogs( session );
     doReturn( null ).when( helperSpy ).makeSchema( nullable( String.class ) );
@@ -280,6 +324,7 @@ public class MondrianCatalogHelperIT {
     doReturn( true ).when( helperSpy ).catalogExists( any( MondrianCatalog.class ), eq( session ) );
 
     MondrianCatalogRepositoryHelper repositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
+    doReturn( mock( RepositoryFile.class ) ).when( repositoryHelper ).getMondrianCatalogFile( cat.getName() );
     doReturn( repositoryHelper ).when( helperSpy ).getMondrianCatalogRepositoryHelper();
 
     helperSpy.addCatalog( new ByteArrayInputStream( new byte[0] ), cat, true, acl, session );
@@ -287,126 +332,22 @@ public class MondrianCatalogHelperIT {
 
     doNothing().when( aclHelper ).setAclFor( any( RepositoryFile.class ), any( RepositoryFileAcl.class ) );
     helperSpy.addCatalog( new ByteArrayInputStream( new byte[0] ), cat, true, null, session );
-    verify( aclHelper, times( 2 ) ).setAclFor( any( RepositoryFile.class ), any( RepositoryFileAcl.class ) );
-  }
-
-  @Test
-  public void testImportSchemaWithSpaceDoesFlush() {
-    String TMP_FILE_PATH = File.separatorChar + "test" + File.separatorChar + "analysis" + File.separatorChar;
-    String uploadDir = PentahoSystem.getApplicationContext().getSolutionPath( TMP_FILE_PATH );
-    File mondrianFile = new File( uploadDir + File.separatorChar + "SuperBacon.mondrian.xml" );
-
-    final String mondrianFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "mondrian";
-    final String sampleDataFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + "super bacon";
-    final String metadataPath = sampleDataFolderPath + RepositoryFile.SEPARATOR + "metadata";
-
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, mondrianFolderPath );
-    UnifiedRepositoryTestUtils.stubGetChildren( repo, mondrianFolderPath ); // return no children
-
-    UnifiedRepositoryTestUtils.stubGetFileDoesNotExist( repo, sampleDataFolderPath );
-    UnifiedRepositoryTestUtils.stubCreateFolder( repo, sampleDataFolderPath );
-
-    UnifiedRepositoryTestUtils.stubCreateFile( repo, metadataPath );
-
-    final String olapFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "olap-servers";
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, olapFolderPath );
-    UnifiedRepositoryTestUtils.stubGetChildren( repo, olapFolderPath ); // return no children
-
-    helper.importSchema( mondrianFile, "super bacon", "" );
-
-    // cache should be cleared for this schema only
-    verify( olapService, times( 1 ) ).getConnection( "super bacon",  null );
-    verify( mondrianCacheControl, times( 1 ) ).flushSchema( mondrianSchema );
-  }
-
-  @Test
-  public void testImportSchema() {
-    String TMP_FILE_PATH = File.separatorChar + "test" + File.separatorChar + "analysis" + File.separatorChar;
-    String uploadDir = PentahoSystem.getApplicationContext().getSolutionPath( TMP_FILE_PATH );
-    File mondrianFile = new File( uploadDir + File.separatorChar + "SampleData.mondrian.xml" );
-
-    final String mondrianFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "mondrian";
-    final String sampleDataFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + "SampleData";
-    final String metadataPath = sampleDataFolderPath + RepositoryFile.SEPARATOR + "metadata";
-
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, mondrianFolderPath );
-    UnifiedRepositoryTestUtils.stubGetChildren( repo, mondrianFolderPath ); // return no children
-
-    UnifiedRepositoryTestUtils.stubGetFileDoesNotExist( repo, sampleDataFolderPath );
-    UnifiedRepositoryTestUtils.stubCreateFolder( repo, sampleDataFolderPath );
-
-    UnifiedRepositoryTestUtils.stubCreateFile( repo, metadataPath );
-
-    final String olapFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "olap-servers";
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, olapFolderPath );
-    UnifiedRepositoryTestUtils.stubGetChildren( repo, olapFolderPath ); // return no children
-
-    helper.importSchema( mondrianFile, "SampleData", "" );
-
-    verify( repo ).createFile( eq( UnifiedRepositoryTestUtils.makeIdObject( sampleDataFolderPath ) ),
-        argThat( UnifiedRepositoryTestUtils.isLikeFile( UnifiedRepositoryTestUtils.makeFileObject( metadataPath ) ) ), argThat(
-                    UnifiedRepositoryTestUtils.hasData( UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/definition", "mondrian:/" + "SampleData" ),
-                            UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/datasourceInfo", "Provider=mondrian;DataSource=SampleData" ) ) ),
-        nullable( String.class ) );
-    verify( repo ).createFile( eq( UnifiedRepositoryTestUtils.makeIdObject( sampleDataFolderPath ) ),
-        argThat( UnifiedRepositoryTestUtils.isLikeFile( UnifiedRepositoryTestUtils.makeFileObject( sampleDataFolderPath + RepositoryFile.SEPARATOR + "schema.xml" ) ) ),
-        any( IRepositoryFileData.class ), nullable( String.class ) );
-
-    // cache should be cleared for this schema only
-    verify( olapService, times( 1 ) ).getConnection( "SampleData",  null );
-    verify( mondrianCacheControl, times( 1 ) ).flushSchema( mondrianSchema );
+    verify( aclHelper, times( 1 ) ).setAclFor( any( RepositoryFile.class ), eq( null ) );
   }
 
   @Test
   public void testListCatalog() throws Exception {
-    File file1 = new File( TestResourceLocation.TEST_RESOURCES + "/solution/test/charts/steelwheels.mondrian.xml" );
-    String mondrianSchema1 = IOUtils.toString( new FileInputStream( file1 ) );
-    File file2 = new File( TestResourceLocation.TEST_RESOURCES + "/solution/samples/reporting/SampleData.mondrian.xml" );
-    String mondrianSchema2 = IOUtils.toString( new FileInputStream( file2 ) );
+    repositoryMockMondrianFolder( "SampleData/", "SteelWheels/" );
+    repositoryMockOlapServerFolder();
+    repositoryMockSteelWheelsEntry( "Provider=mondrian;" );
+    repositoryMockSampleDataEntry();
 
-    final String mondrianFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "mondrian";
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, mondrianFolderPath );
-    UnifiedRepositoryTestUtils.stubGetChildren( repo, mondrianFolderPath, "SampleData/", "SteelWheels/" ); // return two child folders
-
-    final String olapFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "olap-servers";
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, olapFolderPath );
-    UnifiedRepositoryTestUtils.stubGetChildren( repo, olapFolderPath ); // return no children
-
-    final String sampleDataFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + "SampleData";
-    final String sampleDataMetadataPath = sampleDataFolderPath + RepositoryFile.SEPARATOR + "metadata";
-    final String sampleDataSchemaPath = sampleDataFolderPath + RepositoryFile.SEPARATOR + "schema.xml";
-    UnifiedRepositoryTestUtils.stubGetFile( repo, sampleDataMetadataPath );
-    UnifiedRepositoryTestUtils.stubGetData( repo, sampleDataMetadataPath, "catalog", UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/definition",
-        "mondrian:/SampleData" ), UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/datasourceInfo",
-        "Provider=mondrian;DataSource=SampleData;" ) );
-    UnifiedRepositoryTestUtils.stubGetFile( repo, sampleDataSchemaPath );
-    UnifiedRepositoryTestUtils.stubGetData( repo, sampleDataSchemaPath, mondrianSchema2 );
-
-    final String steelWheelsFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + "SteelWheels";
-    final String steelWheelsMetadataPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "metadata";
-    final String steelWheelsSchemaPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "schema.xml";
-    final String steelWheelsAnnotationsPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "annotations.xml";
-    UnifiedRepositoryTestUtils.stubGetFile( repo, steelWheelsMetadataPath );
-    UnifiedRepositoryTestUtils.stubGetData( repo, steelWheelsMetadataPath, "catalog", UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/definition",
-        "mondrian:/SteelWheels" ), UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/datasourceInfo",
-        "Provider=mondrian;DataSource=SteelWheels;" ) );
-    UnifiedRepositoryTestUtils.stubGetFile( repo, steelWheelsSchemaPath );
-    UnifiedRepositoryTestUtils.stubGetData( repo, steelWheelsSchemaPath, mondrianSchema1 );
-    UnifiedRepositoryTestUtils.stubGetFile( repo, steelWheelsAnnotationsPath );
-    UnifiedRepositoryTestUtils.stubGetData( repo, steelWheelsAnnotationsPath, "<annotations></annotations>" );
-
-    IPentahoSession session = new StandaloneSession( "admin" );
-
-    helper = spy( helper );
+    IPentahoSession testSession = new StandaloneSession( "admin" );
+    MondrianCatalogHelper helperSpy = spy( helper );
 
     IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
-    when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
-    doReturn( aclHelper ).when( helper ).getAclHelper();
-
-    MondrianCatalog[] testCatalogs = new MondrianCatalog[] { spy( createTestCatalog() ), spy( createTestCatalog() ) };
-    doReturn( true ).when( testCatalogs[ 0 ] ).isJndi();
-    doReturn( false ).when( testCatalogs[ 1 ] ).isJndi();
-    doReturn( Arrays.asList( testCatalogs ) ).when( helper ).getCatalogs( session );
+    when( aclHelper.canAccess( any(), any( EnumSet.class ) ) ).thenReturn( true );
+    doReturn( aclHelper ).when( helperSpy ).getAclHelper();
     Answer<String> answer = invocation -> {
       try {
         return (String) invocation.callRealMethod();
@@ -417,91 +358,117 @@ public class MondrianCatalogHelperIT {
         throw throwable;
       }
     };
-    doAnswer( answer ).when( helper ).docAtUrlToString( any( String.class ), any( IPentahoSession.class ) );
+    doAnswer( answer ).when( helperSpy ).docAtUrlToString( any(), any() );
 
-    List<MondrianCatalog> cats = helper.listCatalogs( session, true );
+    List<MondrianCatalog> cats = helper.listCatalogs( new StandaloneSession( "admin" ), true );
     assertEquals( 1, cats.size() );
+    assertEquals( "mondrian:/SampleData", cats.get( 0 ).getDefinition() );
+    assertEquals( "SampleData", cats.get( 0 ).getName() );
 
     verify( mondrianCacheControl, never() ).flushSchema( mondrianSchema );
   }
 
   @Test
-  public void testRemoveCatalog() throws Exception {
-    File file1 = new File( TestResourceLocation.TEST_RESOURCES + "/solution/test/charts/steelwheels.mondrian.xml" );
-    String mondrianSchema1 = IOUtils.toString( new FileInputStream( file1 ) );
+  public void testImportSchemaWithSpaceDoesFlush() {
+    repositoryMockMondrianFolder(); // empty - no children
+    repositoryMockOlapServerFolder();
 
-    final String mondrianFolderPath = ClientRepositoryPaths.getEtcFolderPath() + RepositoryFile.SEPARATOR + "mondrian";
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, mondrianFolderPath );
-    UnifiedRepositoryTestUtils.stubGetChildren( repo, mondrianFolderPath, "SteelWheels/" );
+    String TMP_FILE_PATH = File.separatorChar + "test" + File.separatorChar + "analysis" + File.separatorChar;
+    String uploadDir = PentahoSystem.getApplicationContext().getSolutionPath( TMP_FILE_PATH );
+    File mondrianFile = new File( uploadDir + File.separatorChar + "SuperBacon.mondrian.xml" );
+
+    final String sampleDataFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + "super bacon";
+    final String metadataPath = sampleDataFolderPath + RepositoryFile.SEPARATOR + "metadata";
+
+    UnifiedRepositoryTestUtils.stubGetFileDoesNotExist( repo, sampleDataFolderPath );
+    UnifiedRepositoryTestUtils.stubCreateFolder( repo, sampleDataFolderPath );
+
+    UnifiedRepositoryTestUtils.stubCreateFile( repo, metadataPath );
+
+    helper.importSchema( mondrianFile, "super bacon", "" );
+
+    // cache should be cleared for this schema only
+    verify( olapService, times( 1 ) ).getConnection( "super bacon", null );
+    verify( mondrianCacheControl, times( 1 ) ).flushSchema( mondrianSchema );
+  }
+
+  @Test
+  public void testImportSchema() {
+    repositoryMockMondrianFolder(); // empty - no children
+    repositoryMockOlapServerFolder();
+
+    String TMP_FILE_PATH = File.separatorChar + "test" + File.separatorChar + "analysis" + File.separatorChar;
+    String uploadDir = PentahoSystem.getApplicationContext().getSolutionPath( TMP_FILE_PATH );
+    File mondrianFile = new File( uploadDir + File.separatorChar + "SampleData.mondrian.xml" );
+
+    final String sampleDataFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + "SampleData";
+    final String metadataPath = sampleDataFolderPath + RepositoryFile.SEPARATOR + "metadata";
+
+    UnifiedRepositoryTestUtils.stubGetFileDoesNotExist( repo, sampleDataFolderPath );
+    UnifiedRepositoryTestUtils.stubCreateFolder( repo, sampleDataFolderPath );
+
+    UnifiedRepositoryTestUtils.stubCreateFile( repo, metadataPath );
+
+    helper.importSchema( mondrianFile, "SampleData", "" );
+
+    verify( repo ).createFile( eq( UnifiedRepositoryTestUtils.makeIdObject( sampleDataFolderPath ) ),
+      argThat( UnifiedRepositoryTestUtils.isLikeFile( UnifiedRepositoryTestUtils.makeFileObject( metadataPath ) ) ),
+      argThat(
+        UnifiedRepositoryTestUtils.hasData(
+          UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/definition", "mondrian:/" + "SampleData" ),
+          UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/datasourceInfo",
+            "Provider=mondrian;DataSource=SampleData" ) ) ),
+      nullable( String.class ) );
+    verify( repo ).createFile( eq( UnifiedRepositoryTestUtils.makeIdObject( sampleDataFolderPath ) ),
+      argThat( UnifiedRepositoryTestUtils.isLikeFile(
+        UnifiedRepositoryTestUtils.makeFileObject( sampleDataFolderPath + RepositoryFile.SEPARATOR + "schema.xml" ) ) ),
+      any( IRepositoryFileData.class ), nullable( String.class ) );
+
+    // cache should be cleared for this schema only
+    verify( olapService, times( 1 ) ).getConnection( "SampleData", null );
+    verify( mondrianCacheControl, times( 1 ) ).flushSchema( mondrianSchema );
+  }
+
+  @Test
+  public void testRemoveCatalog() throws Exception {
+    repositoryMockMondrianFolder( "SteelWheels/" );
 
     final String steelWheelsFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + "SteelWheels";
-    final String steelWheelsMetadataPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "metadata";
-    final String steelWheelsSchemaPath = steelWheelsFolderPath + RepositoryFile.SEPARATOR + "schema.xml";
-    UnifiedRepositoryTestUtils.stubGetFile( repo, steelWheelsMetadataPath );
-    UnifiedRepositoryTestUtils.stubGetData( repo, steelWheelsMetadataPath, "catalog",
-            UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/definition", "mondrian:/SteelWheels" ),
-            UnifiedRepositoryTestUtils.pathPropertyPair( "/catalog/datasourceInfo", "Provider=mondrian;DataSource=SteelWheels;" ) );
-    UnifiedRepositoryTestUtils.stubGetFile( repo, steelWheelsSchemaPath );
-    UnifiedRepositoryTestUtils.stubGetData( repo, steelWheelsSchemaPath, mondrianSchema1 );
+    repositoryMockSteelWheelsEntry( "Provider=mondrian;DataSource=SteelWheels;" );
 
-    UnifiedRepositoryTestUtils.stubGetFolder( repo, steelWheelsFolderPath );
+    IPentahoSession testSession = new StandaloneSession( "admin" );
 
-    IPentahoSession session = new StandaloneSession( "admin" );
-
-    helper = spy( helper );
+    MondrianCatalogHelper helperSpy = spy( helper );
     IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
-    when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
-    doReturn( aclHelper ).when( helper ).getAclHelper();
+    when( aclHelper.canAccess( any(), any( EnumSet.class ) ) ).thenReturn( true );
+    doReturn( aclHelper ).when( helperSpy ).getAclHelper();
 
     MondrianCatalogRepositoryHelper repositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
-    doReturn( repositoryHelper ).when( helper ).getMondrianCatalogRepositoryHelper();
+    doReturn( mock( RepositoryFile.class ) ).when( repositoryHelper )
+      .getMondrianCatalogFile( any() );
+    doReturn( repositoryHelper ).when( helperSpy ).getMondrianCatalogRepositoryHelper();
 
-    helper.removeCatalog( "mondrian:/SteelWheels", session );
+    helperSpy.removeCatalog( "mondrian:/SteelWheels", testSession );
 
     verify( repo ).deleteFile( eq( UnifiedRepositoryTestUtils.makeIdObject( steelWheelsFolderPath ) ), eq( true ), nullable( String.class ) );
 
     // cache should be cleared for this schema only
-    verify( olapService, times( 1 ) ).getConnection( CATALOG_NAME, session );
+    verify( olapService, times( 1 ) ).getConnection( CATALOG_NAME, testSession );
     verify( mondrianCacheControl, times( 1 ) ).flushSchema( this.mondrianSchema );
-  }
-
-  @Test
-  public void removeCatalog_WithAcl() {
-    IPentahoSession session = mock( IPentahoSession.class );
-
-    helper = spy( helper );
-    doReturn( createTestCatalog() ).when( helper ).getCatalog( eq( CATALOG_NAME ), eq( session ) );
-    doNothing().when( helper ).reInit( eq( session ) );
-
-    MondrianCatalogRepositoryHelper repositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
-    doReturn( repositoryHelper ).when( helper ).getMondrianCatalogRepositoryHelper();
-
-    IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
-    when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
-    doReturn( aclHelper ).when( helper ).getAclHelper();
-
-    RepositoryFile file = mock( RepositoryFile.class );
-    when( file.getId() ).thenReturn( "1" );
-    when( repo.getFile( "/etc/mondrian/" + CATALOG_NAME ) ).thenReturn( file );
-
-    helper.removeCatalog( CATALOG_NAME, session );
-
     verify( aclHelper ).removeAclFor( any( RepositoryFile.class ) );
   }
 
   @Test( expected = MondrianCatalogServiceException.class )
   public void removeCatalog_WhenProhibited() {
-    IPentahoSession session = mock( IPentahoSession.class );
-
     helper = spy( helper );
-    doReturn( createTestCatalog() ).when( helper ).getCatalog( eq( CATALOG_NAME ), eq( session ) );
-    doNothing().when( helper ).reInit( eq( session ) );
+    doReturn( createTestCatalog() ).when( helper ).getCatalog( CATALOG_NAME, session );
+    doNothing().when( helper ).reInit( session );
 
     MondrianCatalogRepositoryHelper repositoryHelper = mock( MondrianCatalogRepositoryHelper.class );
     doReturn( repositoryHelper ).when( helper ).getMondrianCatalogRepositoryHelper();
 
     IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
-    when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( false );
+    when( aclHelper.canAccess( any(), any( EnumSet.class ) ) ).thenReturn( false );
     doReturn( aclHelper ).when( helper ).getAclHelper();
 
     helper.removeCatalog( CATALOG_NAME, session );
@@ -516,11 +483,11 @@ public class MondrianCatalogHelperIT {
     final String SCHEMA_MOCK = "Test Schema Mock " + replaceTemplate;
 
     MondrianCatalogHelper helperSpy = spy( helper );
-    IPentahoSession session = new StandaloneSession( "admin" );
-    String schema = helperSpy.applyDSP( session, DATA_SOURCE_INFO_WITH_DSP, SCHEMA_MOCK );
+    IPentahoSession testSession = new StandaloneSession( "admin" );
+    String schema = helperSpy.applyDSP( testSession, DATA_SOURCE_INFO_WITH_DSP, SCHEMA_MOCK );
     assertNotNull( schema );
     assertTrue( schema.contains( "REPLACE_TOKEN" ) );
-    verify( helperSpy, never() ).docAtUrlToString( nullable( String.class ), any( IPentahoSession.class ) );
+    verify( helperSpy, never() ).docAtUrlToString( nullable( String.class ), nullable( IPentahoSession.class ) );
 
   }
 
@@ -531,12 +498,13 @@ public class MondrianCatalogHelperIT {
     final String SCHEMA_MOCK = "Test Schema Mock " + replaceTemplate;
 
     MondrianCatalogHelper helperSpy = spy( helper );
-    doReturn( SCHEMA_MOCK ).when( helperSpy ).docAtUrlToString( nullable( String.class ), any( IPentahoSession.class ) );
+    doReturn( SCHEMA_MOCK ).when( helperSpy )
+      .docAtUrlToString( nullable( String.class ), nullable( IPentahoSession.class ) );
 
-    IPentahoSession session = new StandaloneSession( "admin" );
-    String schema = helperSpy.applyDSP( session, DATA_SOURCE_INFO_WITHOUT_DSP, SCHEMA_MOCK );
+    IPentahoSession testSession = new StandaloneSession( "admin" );
+    String schema = helperSpy.applyDSP( testSession, DATA_SOURCE_INFO_WITHOUT_DSP, SCHEMA_MOCK );
     assertNotNull( schema );
-    verify( helperSpy ).docAtUrlToString( nullable( String.class ), any( IPentahoSession.class ) );
+    verify( helperSpy ).docAtUrlToString( nullable( String.class ), nullable( IPentahoSession.class ) );
     assertFalse( schema.contains( "REPLACE_TOKEN" ) );
 
   }
@@ -547,31 +515,21 @@ public class MondrianCatalogHelperIT {
 
     MondrianCatalog cat = mock( MondrianCatalog.class );
     doReturn( catalogName ).when( cat ).getName();
-    IPentahoSession session = mock( IPentahoSession.class );
 
     MondrianCatalogHelper helperSpy = spy( helper );
     doReturn( true ).when( helperSpy ).hasAccess( eq( cat ), any( RepositoryFilePermission.class ) );
-    doNothing().when( helperSpy ).init( session );
+    doNothing().when( helperSpy ).initIfNotFullyLoaded( session );
     doReturn( cat ).when( helperSpy ).getCatalogFromCache( nullable( String.class ), eq( session ) );
 
-    assertEquals( helperSpy.getCatalog( catalogName, session ).getName(), catalogName );
+    assertEquals( catalogName, helperSpy.getCatalog( catalogName, session ).getName() );
     verify( helperSpy ).hasAccess( eq( cat ), any( RepositoryFilePermission.class ) );
 
     doReturn( false ).when( helperSpy ).hasAccess( eq( cat ), any( RepositoryFilePermission.class ) );
     assertNull( helperSpy.getCatalog( catalogName, session ) );
   }
 
-  public static class DynamicDSPTest implements DynamicSchemaProcessor {
-
-    @Override
-    public String processSchema( String s, PropertyList propertylist ) {
-      return s.replaceAll( "REPLACE_TEMPLATE", "REPLACE_TOKEN" );
-    }
-
-  }
-
   @Test
-  public void testGenerateInMemoryDatasourcesXml_NullEtcMondrianFolder() {
+  public void testGenerateInMemoryDataSourcesXml_NullEtcMondrianFolder() {
     MondrianCatalogHelper helperMock = mock( MondrianCatalogHelper.class );
     IUnifiedRepository unifiedRepositoryMock = mock( IUnifiedRepository.class );
 
@@ -580,5 +538,14 @@ public class MondrianCatalogHelperIT {
 
     String result = helperMock.generateInMemoryDatasourcesXml( unifiedRepositoryMock );
     assertNull( result, null );
+  }
+
+  // used at testDspApplied_WhenDataSourceInfoContainsDynamicSchemaProcessorParameter
+  public static class DynamicDSPTest implements DynamicSchemaProcessor {
+
+    @Override
+    public String processSchema( String s, PropertyList propertylist ) {
+      return s.replaceAll( "REPLACE_TEMPLATE", "REPLACE_TOKEN" );
+    }
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperTest.java
@@ -81,12 +81,12 @@ public class MondrianCatalogHelperTest {
 
   private static final String DEFINITION = "mondrian:";
 
-  private IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
+  private final IUnifiedRepository unifiedRepository = mock( IUnifiedRepository.class );
 
-  private MondrianCatalogRepositoryHelper mcrh = mock( MondrianCatalogRepositoryHelper.class );
+  private final MondrianCatalogRepositoryHelper mcrh = mock( MondrianCatalogRepositoryHelper.class );
 
 
-  private MondrianCatalogHelper mch = Mockito.spy( new MondrianCatalogHelper() {
+  private final MondrianCatalogHelper mch = Mockito.spy( new MondrianCatalogHelper() {
     protected boolean hasAccess( MondrianCatalog cat, RepositoryFilePermission permission ) {
       return true;
     }
@@ -103,9 +103,7 @@ public class MondrianCatalogHelperTest {
 
   //  private Object cacheValue = null;
 
-  private ArrayMap<Object, Object> catalogs = new ArrayMap<>();
-
-  ICacheManager cm;
+  private final ArrayMap<Object, Object> catalogs = new ArrayMap<>();
 
   DataSourcesConfig.DataSources dsList;
 
@@ -119,8 +117,6 @@ public class MondrianCatalogHelperTest {
   DataNode metadataNode;
   @Mock
   NodeRepositoryFileData mockIRepositoryFileData;
-  @Mock
-  MondrianCatalogRepositoryHelper mockMondrianCatalogRepositoryHelper;
 
   @Test
   public void testLoadCatalogsIntoCache() {
@@ -135,11 +131,11 @@ public class MondrianCatalogHelperTest {
       Object cacheValue =
         testCacheManager.getFromRegionCache( MONDRIAN_CATALOG_CACHE_REGION, Locale.getDefault().toString() );
 
-      Assert.assertTrue( MondrianCatalogCache.class.isInstance( cacheValue ) );
+      Assert.assertTrue( cacheValue instanceof MondrianCatalogCache );
       Map<?, ?> map = ( (MondrianCatalogCache) cacheValue ).getCatalogs();
 
       for ( Object item : map.values() ) {
-        Assert.assertTrue( MondrianCatalog.class.isInstance( item ) );
+        Assert.assertTrue( item instanceof MondrianCatalog );
         MondrianCatalog catalog = (MondrianCatalog) item;
         assertEquals( DEFINITION, catalog.getDefinition() );
       }


### PR DESCRIPTION
## Addressed Issue(s)
[SME-1082]

## Description
- This PR fix the issues related with the execution of integration tests. Currently tests are not runnable as one method was renamed and they have broken scenarios.
- Minor fixes were also added to the main and unit test class files
- testAddCatalogWithException was removed as no longer applies after this PR https://github.com/pentaho/pentaho-platform/pull/5900

## Checklist
- [] Relevant tests have been added
- [ ] This PR should not be squashed

[SME-1082]: https://hv-eng.atlassian.net/browse/SME-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ