### PR TITLE
feat: add description property to authorization actions [PPUC-64]

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/engine/IAuthorizationAction.java
+++ b/api/src/main/java/org/pentaho/platform/api/engine/IAuthorizationAction.java
@@ -28,10 +28,41 @@ public interface IAuthorizationAction {
   String getName();
 
   /**
-   * Get the localized display name of action for a specific locale. If null is passed then default locale will be used
+   * Get the localized display name of the action for the default locale.
+
+   * @return The localized name
+   */
+  default String getLocalizedDisplayName() {
+    return getLocalizedDisplayName( null );
+  }
+
+  /**
+   * Get the localized display name of the action for a specific locale.
+   * If `locale` is invalid, then the default locale will be used.
    * 
-   * @param locale
-   * @return localized name
+   * @param locale The locale to use for localization
+   * @return The localized name
    */
   String getLocalizedDisplayName( String locale );
+
+  /**
+   * Get the localized description of the action for the default locale.
+
+   * @return The localized description
+   */
+  default String getLocalizedDescription() {
+    return getLocalizedDescription( null );
+  }
+
+  /**
+   * Get the localized description of the action for a specific locale.
+   * The key used is composed by the action name appended with ".description".
+   * For example, if the action name is "org.pentaho.action" then
+   * the description key will be "org.pentaho.action.description".
+   * If `locale` is invalid, then the default locale will be used.
+   *
+   * @param locale The locale to use for localization
+   * @return The localized description
+   */
+  String getLocalizedDescription( String locale );
 }

--- a/api/src/main/java/org/pentaho/platform/api/engine/IAuthorizationAction.java
+++ b/api/src/main/java/org/pentaho/platform/api/engine/IAuthorizationAction.java
@@ -10,26 +10,22 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.platform.api.engine;
 
 /**
- * 
  * Represents a Logical Role name used by some IAuthorizationPolicy implementations. Also known as Action-Based Security
- * 
- * User: nbaker Date: 3/19/13
  */
 public interface IAuthorizationAction {
   /**
    * Get the name of the action
-   * 
+   *
    * @return action name
    */
   String getName();
 
   /**
    * Get the localized display name of the action for the default locale.
-
+   *
    * @return The localized name
    */
   default String getLocalizedDisplayName() {
@@ -39,7 +35,7 @@ public interface IAuthorizationAction {
   /**
    * Get the localized display name of the action for a specific locale.
    * If `locale` is invalid, then the default locale will be used.
-   * 
+   *
    * @param locale The locale to use for localization
    * @return The localized name
    */
@@ -47,7 +43,7 @@ public interface IAuthorizationAction {
 
   /**
    * Get the localized description of the action for the default locale.
-
+   *
    * @return The localized description
    */
   default String getLocalizedDescription() {

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/AbstractAuthorizationAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/AbstractAuthorizationAction.java
@@ -10,38 +10,61 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
-/**
- * 
- */
 package org.pentaho.platform.security.policy.rolebased.actions;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
 import org.pentaho.platform.api.engine.IAuthorizationAction;
 import org.pentaho.platform.security.policy.rolebased.messages.Messages;
+import org.pentaho.platform.util.StringUtil;
+import org.pentaho.platform.util.messages.LocaleHelper;
 
 /**
- * 
- *
+ * Abstract base class for authorization actions. This class provides
+ * convenience methods for localization and resource bundle management.
  */
 public abstract class AbstractAuthorizationAction implements IAuthorizationAction {
 
   protected ResourceBundle getResourceBundle( String localeString ) {
-    final String UNDERSCORE = "_"; //$NON-NLS-1$
-    Locale locale;
-    if ( localeString == null ) {
-      return Messages.getInstance().getBundle();
-    } else {
-      String[] tokens = localeString.split( UNDERSCORE );
-      if ( tokens.length == 3 ) {
-        locale = new Locale( tokens[0], tokens[1], tokens[2] );
-      } else if ( tokens.length == 2 ) {
-        locale = new Locale( tokens[0], tokens[1] );
-      } else {
-        locale = new Locale( tokens[0] );
-      }
-      return Messages.getInstance().getBundle( locale );
+    return getResourceBundle( parseLocale( localeString ) );
+  }
+
+  protected ResourceBundle getResourceBundle( Locale locale ) {
+    if ( locale == null ) {
+      return Messages.getInstance().getBundle( LocaleHelper.getLocale( ) );
     }
+
+    return Messages.getInstance().getBundle( locale );
+  }
+
+  protected Locale parseLocale( String localeString ) {
+    final String UNDERSCORE = "_";
+
+    if ( StringUtil.isEmpty( localeString ) ) {
+      return LocaleHelper.getLocale();
+    }
+
+    String[] tokens = localeString.split( UNDERSCORE );
+    if ( tokens.length == 3 ) {
+      return new Locale( tokens[0], tokens[1], tokens[2] );
+    } else if ( tokens.length == 2 ) {
+      return new Locale( tokens[0], tokens[1] );
+    } else {
+      return new Locale( tokens[0] );
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public String getLocalizedDisplayName( String localeString ) {
+    return getResourceBundle( localeString ).getString( getName() );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public String getLocalizedDescription( String localeString ) {
+    return getResourceBundle( localeString ).getString( getName() + ".description" );
   }
 }

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/AbstractAuthorizationAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/AbstractAuthorizationAction.java
@@ -14,6 +14,7 @@ package org.pentaho.platform.security.policy.rolebased.actions;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
+
 import org.pentaho.platform.api.engine.IAuthorizationAction;
 import org.pentaho.platform.security.policy.rolebased.messages.Messages;
 import org.pentaho.platform.util.StringUtil;
@@ -31,7 +32,7 @@ public abstract class AbstractAuthorizationAction implements IAuthorizationActio
 
   protected ResourceBundle getResourceBundle( Locale locale ) {
     if ( locale == null ) {
-      return Messages.getInstance().getBundle( LocaleHelper.getLocale( ) );
+      return Messages.getInstance().getBundle( LocaleHelper.getLocale() );
     }
 
     return Messages.getInstance().getBundle( locale );
@@ -46,11 +47,11 @@ public abstract class AbstractAuthorizationAction implements IAuthorizationActio
 
     String[] tokens = localeString.split( UNDERSCORE );
     if ( tokens.length == 3 ) {
-      return new Locale( tokens[0], tokens[1], tokens[2] );
+      return new Locale( tokens[ 0 ], tokens[ 1 ], tokens[ 2 ] );
     } else if ( tokens.length == 2 ) {
-      return new Locale( tokens[0], tokens[1] );
+      return new Locale( tokens[ 0 ], tokens[ 1 ] );
     } else {
-      return new Locale( tokens[0] );
+      return new Locale( tokens[ 0 ] );
     }
   }
 

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/AdministerSecurityAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/AdministerSecurityAction.java
@@ -13,23 +13,14 @@
 
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-import java.util.ResourceBundle;
-
 /**
  * User: nbaker Date: 3/19/13
  */
 public class AdministerSecurityAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.security.administerSecurity";
-  ResourceBundle resourceBundle;
 
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public String getLocalizedDisplayName( String localeString ) {
-    resourceBundle = getResourceBundle( localeString );
-    return resourceBundle.getString( NAME );
   }
 }

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/AdministerSecurityAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/AdministerSecurityAction.java
@@ -10,12 +10,8 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-/**
- * User: nbaker Date: 3/19/13
- */
 public class AdministerSecurityAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.security.administerSecurity";
 

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/PublishAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/PublishAction.java
@@ -13,23 +13,14 @@
 
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-import java.util.ResourceBundle;
-
 /**
  * User: nbaker Date: 3/30/13
  */
 public class PublishAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.security.publish";
-  ResourceBundle resourceBundle;
 
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public String getLocalizedDisplayName( String localeString ) {
-    resourceBundle = getResourceBundle( localeString );
-    return resourceBundle.getString( NAME );
   }
 }

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/PublishAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/PublishAction.java
@@ -10,12 +10,8 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-/**
- * User: nbaker Date: 3/30/13
- */
 public class PublishAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.security.publish";
 

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryCreateAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryCreateAction.java
@@ -13,23 +13,14 @@
 
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-import java.util.ResourceBundle;
-
 /**
  * User: nbaker Date: 3/19/13
  */
 public class RepositoryCreateAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.repository.create";
-  ResourceBundle resourceBundle;
 
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public String getLocalizedDisplayName( String localeString ) {
-    resourceBundle = getResourceBundle( localeString );
-    return resourceBundle.getString( NAME );
   }
 }

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryCreateAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryCreateAction.java
@@ -10,12 +10,8 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-/**
- * User: nbaker Date: 3/19/13
- */
 public class RepositoryCreateAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.repository.create";
 

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryReadAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryReadAction.java
@@ -10,12 +10,8 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-/**
- * User: nbaker Date: 3/19/13
- */
 public class RepositoryReadAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.repository.read";
 

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryReadAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryReadAction.java
@@ -13,23 +13,14 @@
 
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-import java.util.ResourceBundle;
-
 /**
  * User: nbaker Date: 3/19/13
  */
 public class RepositoryReadAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.repository.read";
-  ResourceBundle resourceBundle;
 
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public String getLocalizedDisplayName( String localeString ) {
-    resourceBundle = getResourceBundle( localeString );
-    return resourceBundle.getString( NAME );
   }
 }

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerAction.java
@@ -10,12 +10,8 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-/**
- * User: nbaker Date: 3/19/13
- */
 public class SchedulerAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.scheduler.manage";
 

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerAction.java
@@ -13,23 +13,14 @@
 
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-import java.util.ResourceBundle;
-
 /**
  * User: nbaker Date: 3/19/13
  */
 public class SchedulerAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.scheduler.manage";
-  ResourceBundle resourceBundle;
 
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public String getLocalizedDisplayName( String localeString ) {
-    resourceBundle = getResourceBundle( localeString );
-    return resourceBundle.getString( NAME );
   }
 }

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerExecuteAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerExecuteAction.java
@@ -10,7 +10,6 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.platform.security.policy.rolebased.actions;
 
 public class SchedulerExecuteAction extends AbstractAuthorizationAction {

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerExecuteAction.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerExecuteAction.java
@@ -13,20 +13,11 @@
 
 package org.pentaho.platform.security.policy.rolebased.actions;
 
-import java.util.ResourceBundle;
-
 public class SchedulerExecuteAction extends AbstractAuthorizationAction {
   public static final String NAME = "org.pentaho.scheduler.execute";
-  ResourceBundle resourceBundle;
 
   @Override
   public String getName() {
     return NAME;
-  }
-
-  @Override
-  public String getLocalizedDisplayName( String localeString ) {
-    resourceBundle = getResourceBundle( localeString );
-    return resourceBundle.getString( NAME );
   }
 }

--- a/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/AbstractAuthorizationActionTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/AbstractAuthorizationActionTest.java
@@ -1,0 +1,145 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.security.policy.rolebased.actions;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.pentaho.platform.security.policy.rolebased.messages.Messages;
+import org.pentaho.platform.util.messages.LocaleHelper;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AbstractAuthorizationActionTest {
+  private ResourceBundle resourceBundle;
+  private AbstractAuthorizationAction action;
+
+  @Before
+  public void setUp() {
+    action = mock( AbstractAuthorizationAction.class, Mockito.CALLS_REAL_METHODS );
+    String ACTION_NAME = "org.pentaho.action";
+    when( action.getName() ).thenReturn( ACTION_NAME );
+
+    resourceBundle = mock( ResourceBundle.class );
+    when( resourceBundle.getString( ACTION_NAME ) ).thenReturn( "Action Name" );
+    when( resourceBundle.getString( ACTION_NAME + ".description" ) ).thenReturn( "Action Description" );
+  }
+
+  @Test
+  public void testGetResourceBundleLocaleString() {
+    try ( MockedStatic<Messages> messagesMockedStatic = Mockito.mockStatic( Messages.class ) ) {
+      Messages messagesMock = mock( Messages.class );
+      when( messagesMock.getBundle( Locale.US ) ).thenReturn( resourceBundle );
+      messagesMockedStatic.when( Messages::getInstance ).thenReturn( messagesMock );
+
+      Assert.assertNotNull( action.getResourceBundle( Locale.US.toString() ) );
+      verify( messagesMock ).getBundle( Locale.US );
+    }
+  }
+
+  @Test
+  public void testGetResourceBundleLocale() {
+    try ( MockedStatic<Messages> messagesMockedStatic = Mockito.mockStatic( Messages.class ) ) {
+      Messages messagesMock = mock( Messages.class );
+      when( messagesMock.getBundle( Locale.US ) ).thenReturn( resourceBundle );
+      messagesMockedStatic.when( Messages::getInstance ).thenReturn( messagesMock );
+
+      Assert.assertNotNull( action.getResourceBundle( Locale.US ) );
+      verify( messagesMock ).getBundle( Locale.US );
+    }
+  }
+
+  @Test
+  public void testGetResourceBundleWithNullLocale() {
+    try ( MockedStatic<Messages> messagesMockedStatic = Mockito.mockStatic( Messages.class ) ) {
+      Messages messagesMock = mock( Messages.class );
+      when( messagesMock.getBundle( LocaleHelper.getLocale() ) ).thenReturn( resourceBundle );
+      messagesMockedStatic.when( Messages::getInstance ).thenReturn( messagesMock );
+
+      Assert.assertNotNull( action.getResourceBundle( (String) null ) );
+      verify( messagesMock ).getBundle( LocaleHelper.getLocale() );
+
+      Assert.assertNotNull( action.getResourceBundle( (Locale) null ) );
+      verify( messagesMock, times( 2 ) ).getBundle( LocaleHelper.getLocale() );
+    }
+  }
+
+  @Test
+  public void testGetResourceBundleWithEmptyLocale() {
+    try ( MockedStatic<Messages> messagesMockedStatic = Mockito.mockStatic( Messages.class ) ) {
+      Messages messagesMock = mock( Messages.class );
+      when( messagesMock.getBundle( LocaleHelper.getLocale() ) ).thenReturn( resourceBundle );
+      messagesMockedStatic.when( Messages::getInstance ).thenReturn( messagesMock );
+
+      Assert.assertNotNull( action.getResourceBundle( "" ) );
+      verify( messagesMock ).getBundle( LocaleHelper.getLocale() );
+    }
+  }
+
+  @Test
+  public void testParseLocaleNull() {
+    Assert.assertEquals( LocaleHelper.getLocale(), action.parseLocale( null ) );
+  }
+
+  @Test
+  public void testParseLocaleEmpty() {
+    Assert.assertEquals( LocaleHelper.getLocale(), action.parseLocale( "" ) );
+  }
+
+  @Test
+  public void testParseLocaleOneToken() {
+    Assert.assertEquals( Locale.ENGLISH, action.parseLocale( "en" ) );
+  }
+
+  @Test
+  public void testParseLocaleTwoTokens() {
+    Assert.assertEquals( Locale.FRANCE, action.parseLocale( "fr_FR" ) );
+  }
+
+  @Test
+  public void testParseLocaleThreeTokens() {
+    Assert.assertEquals( "de_DE_DE", action.parseLocale( "de_DE_DE" ).toString() );
+  }
+
+  @Test
+  public void testGetLocalizedDisplayName() {
+    try ( MockedStatic<Messages> messagesMockedStatic = Mockito.mockStatic( Messages.class ) ) {
+      Messages messagesMock = mock( Messages.class );
+      when( messagesMock.getBundle( Locale.US ) ).thenReturn( resourceBundle );
+      messagesMockedStatic.when( Messages::getInstance ).thenReturn( messagesMock );
+
+      Assert.assertEquals( "Action Name", action.getLocalizedDisplayName( Locale.US.toString() ) );
+      verify( messagesMock ).getBundle( Locale.US );
+    }
+  }
+
+  @Test
+  public void testGetLocalizedDescription() {
+    try ( MockedStatic<Messages> messagesMockedStatic = Mockito.mockStatic( Messages.class ) ) {
+      Messages messagesMock = mock( Messages.class );
+      when( messagesMock.getBundle( Locale.US ) ).thenReturn( resourceBundle );
+      messagesMockedStatic.when( Messages::getInstance ).thenReturn( messagesMock );
+
+      Assert.assertEquals( "Action Description", action.getLocalizedDescription( Locale.US.toString() ) );
+      verify( messagesMock ).getBundle( Locale.US );
+    }
+  }
+}

--- a/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/AdministerSecurityActionTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/AdministerSecurityActionTest.java
@@ -1,0 +1,24 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.security.policy.rolebased.actions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AdministerSecurityActionTest {
+  @Test
+  public void testGetName() {
+    AdministerSecurityAction action = new AdministerSecurityAction();
+    Assert.assertEquals( "org.pentaho.security.administerSecurity", action.getName() );
+  }
+}

--- a/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/PublishActionTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/PublishActionTest.java
@@ -1,0 +1,24 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.security.policy.rolebased.actions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PublishActionTest {
+  @Test
+  public void testGetName() {
+    PublishAction action = new PublishAction();
+    Assert.assertEquals( "org.pentaho.security.publish", action.getName() );
+  }
+}

--- a/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryCreateActionTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryCreateActionTest.java
@@ -1,0 +1,24 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.security.policy.rolebased.actions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RepositoryCreateActionTest {
+  @Test
+  public void testGetName() {
+    RepositoryCreateAction action = new RepositoryCreateAction();
+    Assert.assertEquals( "org.pentaho.repository.create", action.getName() );
+  }
+}

--- a/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryReadActionTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/RepositoryReadActionTest.java
@@ -1,0 +1,24 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.security.policy.rolebased.actions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RepositoryReadActionTest {
+  @Test
+  public void testGetName() {
+    RepositoryReadAction action = new RepositoryReadAction();
+    Assert.assertEquals( "org.pentaho.repository.read", action.getName() );
+  }
+}

--- a/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerActionTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerActionTest.java
@@ -1,0 +1,24 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.security.policy.rolebased.actions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SchedulerActionTest {
+  @Test
+  public void testGetName() {
+    SchedulerAction action = new SchedulerAction();
+    Assert.assertEquals( "org.pentaho.scheduler.manage", action.getName() );
+  }
+}

--- a/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerExecuteActionTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/actions/SchedulerExecuteActionTest.java
@@ -1,0 +1,24 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.security.policy.rolebased.actions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SchedulerExecuteActionTest {
+  @Test
+  public void testGetName() {
+    SchedulerExecuteAction action = new SchedulerExecuteAction();
+    Assert.assertEquals( "org.pentaho.scheduler.execute", action.getName() );
+  }
+}


### PR DESCRIPTION
This pull request refactors the authorization action classes to improve code reuse and maintainability by introducing default methods for localization in the `IAuthorizationAction` interface and centralizing localization logic in the `AbstractAuthorizationAction` class. Additionally, redundant code in concrete action classes has been removed.

### Enhancements to Localization in `IAuthorizationAction`:

* Added default methods `getLocalizedDisplayName()` and `getLocalizedDescription()` to provide localized strings for the default locale, reducing the need for explicit implementations in subclasses.

### Centralization of Localization Logic in `AbstractAuthorizationAction`:

* Refactored `AbstractAuthorizationAction` to include utility methods for parsing locales (`parseLocale`) and retrieving resource bundles (`getResourceBundle`). This centralizes and simplifies the handling of localization.
* Implemented the `getLocalizedDisplayName(String)` and `getLocalizedDescription(String)` methods to use the centralized localization logic, ensuring consistency across all subclasses.

### Cleanup of Concrete Action Classes:

* Removed redundant `getLocalizedDisplayName(String)` implementations from the following classes, as they now inherit the logic from `AbstractAuthorizationAction`:
  - `AdministerSecurityAction`
  - `PublishAction`
  - `RepositoryCreateAction`
  - `RepositoryReadAction`
  - `SchedulerAction`
  - `SchedulerExecuteAction`

@pentaho/millenniumfalcon please review