### PR TITLE
feat: select User or API auth entry point based on Sec-Fetch-User request header [PPUC-108][BISERVER-14841]

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
@@ -38,7 +38,7 @@
                                    anonymousProcessingFilter,
                                    sessionMgmtFilter,
                                    mdcFilter,
-                                   exceptionTranslationFilterForWS,
+                                   exceptionTranslationFilter,
                                    filterInvocationInterceptorForWS" />
 
         <sec:filter-chain pattern="/api/repos/**"
@@ -69,7 +69,7 @@
                                    anonymousProcessingFilter,
                                    sessionMgmtFilter,
                                    mdcFilter,
-                                   exceptionTranslationFilterForWS,
+                                   exceptionTranslationFilter,
                                    filterInvocationInterceptorForWS" />
 
         <sec:filter-chain pattern="/plugin/reporting/api/jobs/**"
@@ -84,7 +84,7 @@
                                    anonymousProcessingFilter,
                                    sessionMgmtFilter,
                                    mdcFilter,
-                                   exceptionTranslationFilterForWS,
+                                   exceptionTranslationFilter,
                                    filterInvocationInterceptorForWS,
                                    preFlightFilter" />
 
@@ -100,7 +100,7 @@
                                    anonymousProcessingFilter,
                                    sessionMgmtFilter,
                                    mdcFilter,
-                                   exceptionTranslationFilterForWS,
+                                   exceptionTranslationFilter,
                                    filterInvocationInterceptorForWS" />
 
         <sec:filter-chain pattern="/**"
@@ -155,6 +155,8 @@
         class="org.pentaho.platform.web.http.security.PentahoBasicAuthenticationEntryPoint">
     <property name="realmName" value="Pentaho Realm" />
   </bean>
+
+  <bean id="unauthorizedEntryPoint" class="org.pentaho.platform.web.http.security.Http401UnauthorizedEntryPoint" />
 
   <!-- custom Pentaho begin -->
 
@@ -238,15 +240,17 @@
   <!--
       ===================== HTTP REQUEST SECURITY ====================
   -->
-  <bean id="exceptionTranslationFilter" class="org.springframework.security.web.access.ExceptionTranslationFilter">
-    <constructor-arg ref="authenticationProcessingFilterEntryPoint"/>
-    <property name="accessDeniedHandler">
-      <bean class="org.springframework.security.web.access.AccessDeniedHandlerImpl" />
-    </property>
+  <bean id="userNavigationRequestMatcher" class="org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher" />
+  <bean id="webBrowserRequestMatcher"  class="org.pentaho.platform.web.servlet.matchers.WebBrowserRequestMatcher" />
+
+  <bean id="httpSessionRequestCache" class="org.springframework.security.web.savedrequest.HttpSessionRequestCache">
+    <!-- After login, only send the user back to "user navigation" requests. Otherwise, go back /Home -->
+    <property name="requestMatcher" ref="userNavigationRequestMatcher" />
   </bean>
 
-  <bean id="exceptionTranslationFilterForWS" class="org.springframework.security.web.access.ExceptionTranslationFilter">
-    <constructor-arg ref="basicProcessingFilterEntryPoint"/>
+  <bean id="exceptionTranslationFilter" class="org.springframework.security.web.access.ExceptionTranslationFilter">
+    <constructor-arg ref="userNavigationAwareAuthenticationEntryPoint"/>
+    <constructor-arg ref="httpSessionRequestCache"/>
     <property name="accessDeniedHandler">
       <bean class="org.springframework.security.web.access.AccessDeniedHandlerImpl" />
     </property>
@@ -264,23 +268,23 @@
     <constructor-arg ref="loginAttemptService"/>
   </bean>
 
+  <bean id="authenticationSuccessHandler"
+        class="org.pentaho.platform.web.http.security.PreventBruteForceSavedRequestAwareAuthenticationSuccessHandler">
+    <constructor-arg ref="loginAttemptService"/>
+    <property name="defaultTargetUrl" value="/Home" />
+    <property name="requestCache" ref="httpSessionRequestCache"/>
+  </bean>
+  <bean id="authenticationFailureHandler"
+        class="org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler">
+    <constructor-arg type="java.lang.String" value="/Login?login_error=1" />
+  </bean>
+
   <bean id="authenticationProcessingFilter"
         class="org.pentaho.platform.web.http.security.PreventBruteForceUsernamePasswordAuthenticationFilter">
     <constructor-arg ref="loginAttemptService"/>
-    <property name="authenticationManager">
-      <ref bean="authenticationManager" />
-    </property>
-    <property name="authenticationSuccessHandler">
-      <bean class="org.pentaho.platform.web.http.security.PreventBruteForceSavedRequestAwareAuthenticationSuccessHandler">
-        <constructor-arg ref="loginAttemptService"/>
-        <property name="defaultTargetUrl" value="/Home" />
-      </bean>
-    </property>
-    <property name="authenticationFailureHandler">
-      <bean class="org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler">
-        <constructor-arg type="java.lang.String" value="/Login?login_error=1" />
-      </bean>
-    </property>
+    <property name="authenticationManager" ref="authenticationManager" />
+    <property name="authenticationSuccessHandler" ref="authenticationSuccessHandler" />
+    <property name="authenticationFailureHandler" ref="authenticationFailureHandler" />
     <property name="filterProcessesUrl" value="/j_spring_security_check" />
     <property name="usernameParameter" value="j_username" />
     <property name="passwordParameter" value="j_password" />
@@ -290,6 +294,22 @@
   <bean id="authenticationProcessingFilterEntryPoint" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
     <constructor-arg value="/Login" />
     <property name="forceHttps" value="false" />
+  </bean>
+
+  <bean id="userNavigationAwareAuthenticationEntryPoint"
+        class="org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint">
+    <constructor-arg>
+      <util:map>
+        <!-- 1. Browser - User Navigation: redirect to the /Login page -->
+        <entry key-ref="userNavigationRequestMatcher" value-ref="authenticationProcessingFilterEntryPoint" />
+
+        <!-- 2. Browser - Other: reject with 401, but with no challenge in WWW-Authenticate header -->
+        <entry key-ref="webBrowserRequestMatcher" value-ref="unauthorizedEntryPoint" />
+      </util:map>
+    </constructor-arg>
+
+    <!-- 3. Non-Browser: reject with 401 and a basic auth challenge in WWW-Authenticate header -->
+    <property name="defaultEntryPoint" ref="basicProcessingFilterEntryPoint" />
   </bean>
 
   <bean id="httpRequestAccessDecisionManager" class="org.springframework.security.access.vote.AffirmativeBased">

--- a/extensions/src/main/java/org/pentaho/platform/web/http/security/Http401UnauthorizedEntryPoint.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/security/Http401UnauthorizedEntryPoint.java
@@ -1,0 +1,38 @@
+package org.pentaho.platform.web.http.security;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * An entry point that always returns an HTTP 401 Unauthorized status code.
+ * <p>
+ * This entry point differs from {@link PentahoBasicAuthenticationEntryPoint}, which also returns a 401 status code, by
+ * not sending a `WWW-Authenticate` header. This non-standard (albeit de facto) behavior is used to prevent some web
+ * browsers (e.g. Chrome) from prompting the user for credentials, even if the request is made by a script in a web
+ * browser. This way it is possible to mitigate the risks of using Basic Authentication in a web browser context, which
+ * can cause credentials leakage during a client session that crosses server sessions.
+ * <p>
+ * Basic Authentication handling is reserved for non-browser clients, such as tools or scripts, which can explicitly
+ * control the lifetime of the credentials stored on the client side.
+ */
+public class Http401UnauthorizedEntryPoint implements AuthenticationEntryPoint {
+
+  private static final Log logger = LogFactory.getLog( Http401UnauthorizedEntryPoint.class );
+
+  /**
+   * Always returns a 401 error code to the client.
+   */
+  @Override
+  public void commence( HttpServletRequest request, HttpServletResponse response, AuthenticationException arg2 )
+    throws IOException {
+    logger.debug( "HTTP-401 entry point called. Rejecting access" );
+    response.sendError( HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED.getReasonPhrase());
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/UserNavigationRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/UserNavigationRequestMatcher.java
@@ -1,0 +1,143 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.web.servlet.matchers;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+/**
+ * The {@code UserNavigationRequestMatcher} determines if a request can be considered a user navigation request,
+ * based on the presence of the `sec-fetch-user` HTTP request header, or on other related headers, such as
+ * `sec-fetch-dest`, `sec-fetch-mode` and `sec-fetch-site`.
+ * <p>
+ * If the `sec-fetch-user` header is set to `?1`, it indicates that the request was initiated by a user and has
+ * user activation, and is considered a user navigation request.
+ * <p>
+ * Otherwise, other navigation request headers are checked to determine if it is a safe navigation request.
+ * Specifically, the following headers are considered to also indicate safe user navigation requests:
+ * <ul>
+ *   <li>sec-fetch-dest: document / embed / frame / iframe / object</li>
+ *   <li>sec-fetch-mode: navigate</li>
+ *   <li>sec-fetch-site: same-origin / none</li>
+ * </ul>
+ * <p>
+ * These header combinations can happen due to either meta refreshes or 302-redirects:
+ * <ul>
+ *   <li>
+ *     <pre>
+ *       <META HTTP-EQUIV="refresh" CONTENT="0;URL=./Home">
+ *     <pre>
+ *   </li>
+ *   <li>HTTP 302 redirects with a Location header.</li>
+ * </ul>
+ * <p>
+ * In Pentaho, this can happen when the user navigates to localhost:8080.
+ * The response is meta-redirected to localhost:8080/pentaho.
+ * Then, the server 302-redirects to localhost:8080/pentaho/.
+ * Finally, the response is meta-redirected to localhost:8080/pentaho/Home.
+ */
+public class UserNavigationRequestMatcher implements RequestMatcher {
+  /**
+   * The `sec-fetch-user` HTTP request header is included by web browsers to indicate that a request was initiated by
+   * a <i>user navigation</i> and having a user activation state.
+   * <p>
+   * See
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User">MDN Sec-Fetch-User Header</a>.
+   */
+  static final String HEADER_SEC_FETCH_USER = "sec-fetch-user";
+
+  /**
+   * The `sec-fetch-dest` HTTP request header is included by web browsers to indicate the destination of the request.
+   * <p>
+   * This header is used to determine if the request is a navigation request, when `sec-fetch-user` is not set to `?1`.
+   * <p>
+   * See
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest">MDN Sec-Fetch-Dest Header</a>.
+   */
+  static final String HEADER_SEC_FETCH_DEST = "sec-fetch-dest";
+
+  /**
+   * The `sec-fetch-mode` HTTP request header is included by web browsers to indicate the mode of the request.
+   * <p>
+   * This header is used to determine if the request is a navigation request, when `sec-fetch-user` is not set to `?1`.
+   * <p>
+   * See
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode">MDN Sec-Fetch-Mode Header</a>.
+   */
+  static final String HEADER_SEC_FETCH_MODE = "sec-fetch-mode";
+
+  /**
+   * The `sec-fetch-site` HTTP request header is included by web browsers to indicate the relationship between the
+   * origin of the request and the origin of the resource being requested.
+   * <p>
+   * This header is used to determine if the request is a safe navigation request, when `sec-fetch-user` is not set
+   * to `?1`.
+   * <p>
+   * See
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site">MDN Sec-Fetch-Site Header</a>.
+   */
+  static final String HEADER_SEC_FETCH_SITE = "sec-fetch-site";
+
+  /**
+   * The value of the `sec-fetch-user` request header is a Structured Field Boolean.
+   * <p>
+   * See
+   * <a href="https://www.rfc-editor.org/rfc/rfc9651.html#name-abnf">Structured Field Values for HTTP specification</a>.
+   */
+  static final String HEADER_SF_TRUE = "?1";
+
+  /**
+   * The possible values of the `sec-fetch-dest` request header for a navigation request.
+   * <p>
+   * See
+   * <a href="https://fetch.spec.whatwg.org/#navigation-request">Navigation Requests Destinations</a>.
+   */
+  static final List<String> HEADER_SF_DEST_NAVIGATION = List.of( "document", "embed", "frame", "iframe", "object" );
+
+  /**
+   * The value of the `sec-fetch-mode` request header for a navigate request.
+   * <p>
+   * See
+   * <a href="https://fetch.spec.whatwg.org/#concept-request-mode">Request Mode</a>.
+   */
+  static final String HEADER_SF_MODE_NAVIGATE = "navigate";
+
+  /**
+   * The possible values of the `sec-fetch-site` request header for a safe navigation request.
+   * <p>
+   * Safe navigation requests are those that are same-origin or have no origin.
+   * <p>
+   * See
+   * <a href="https://fetch.spec.whatwg.org/#concept-request-site">Request Site</a>.
+   */
+  static final List<String> HEADER_SF_SITE_SAFE = List.of( "same-origin", "none" );
+
+  @Override
+  public boolean matches( @NonNull HttpServletRequest request ) {
+    if ( HEADER_SF_TRUE.equals( request.getHeader( HEADER_SEC_FETCH_USER ) ) ) {
+      return true;
+    }
+
+    return contains( HEADER_SF_DEST_NAVIGATION, request.getHeader( HEADER_SEC_FETCH_DEST ) )
+      && HEADER_SF_MODE_NAVIGATE.equals( request.getHeader( HEADER_SEC_FETCH_MODE ) )
+      && contains( HEADER_SF_SITE_SAFE, request.getHeader( HEADER_SEC_FETCH_SITE ) );
+  }
+
+  protected boolean contains( @NonNull List<String> list, @Nullable String value ) {
+    return value != null && list.contains( value );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/WebBrowserRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/WebBrowserRequestMatcher.java
@@ -1,0 +1,45 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.web.servlet.matchers;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * The {@code WebBrowserRequestMatcher} determines if a request is made by a web browser.
+ * <p>
+ * The matcher does not distinguish whether the request is a user navigation request or not. The only criterion is
+ * whether the request is made by a web browser. To test if a request is a user navigation request, the
+ * {@link UserNavigationRequestMatcher} can be used.
+ * <p>
+ * The implementation checks the presence of the `sec-fetch-dest` HTTP request header, which is web-browser-specific.
+ * <p>
+ * In Pentaho, this matcher is used to select an appropriate authentication failure response, depending on whether the
+ * request is made by a web browser or a tool.
+ */
+public class WebBrowserRequestMatcher implements RequestMatcher {
+  /**
+   * The `sec-fetch-dest` HTTP request header is included by web browsers to indicate the destination of the request.
+   * <p>
+   * See
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest">MDN Sec-Fetch-Dest Header</a>.
+   */
+  static final String HEADER_SEC_FETCH_DEST = "sec-fetch-dest";
+
+  @Override
+  public boolean matches( @NonNull HttpServletRequest request ) {
+    return request.getHeader( HEADER_SEC_FETCH_DEST ) != null;
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/http/security/Http401UnauthorizedEntryPointTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/security/Http401UnauthorizedEntryPointTest.java
@@ -1,0 +1,42 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.web.http.security;
+
+import org.junit.Test;
+import org.springframework.security.core.AuthenticationException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class Http401UnauthorizedEntryPointTest {
+
+  @Test
+  public void test_commence_shouldSend401WithoutWwwAuthenticateHeader() throws IOException {
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    HttpServletResponse response = mock( HttpServletResponse.class );
+    AuthenticationException authException = mock( AuthenticationException.class );
+
+    Http401UnauthorizedEntryPoint entryPoint = new Http401UnauthorizedEntryPoint();
+    entryPoint.commence( request, response, authException );
+
+    verify( response ).sendError( 401, "Unauthorized" );
+    verify( response, never() ).addHeader( eq( "WWW-Authenticate" ), anyString() );
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/UserNavigationRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/UserNavigationRequestMatcherTest.java
@@ -1,0 +1,85 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.web.servlet.matchers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SEC_FETCH_DEST;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SEC_FETCH_MODE;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SEC_FETCH_SITE;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SEC_FETCH_USER;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SF_TRUE;
+
+public class UserNavigationRequestMatcherTest {
+
+  private static final String HEADER_SF_FALSE = "?0";
+
+  private HttpServletRequest request;
+
+  @Before
+  public void setUp() {
+    request = mock( HttpServletRequest.class );
+  }
+
+  private void expectMatch(
+    String secFetchUser,
+    String secFetchDest,
+    String secFetchMode,
+    String secFetchSite,
+    boolean expectMatches
+  ) {
+    when( request.getHeader( HEADER_SEC_FETCH_USER ) ).thenReturn( secFetchUser );
+    when( request.getHeader( HEADER_SEC_FETCH_DEST ) ).thenReturn( secFetchDest );
+    when( request.getHeader( HEADER_SEC_FETCH_MODE ) ).thenReturn( secFetchMode );
+    when( request.getHeader( HEADER_SEC_FETCH_SITE ) ).thenReturn( secFetchSite );
+
+    var requestMatcher = new UserNavigationRequestMatcher();
+
+    assertEquals( expectMatches, requestMatcher.matches( request ) );
+  }
+
+  @Test
+  public void test_False_WhenNoSecFetchHeadersArePresent() {
+    expectMatch( null, null, null, null, false );
+  }
+
+  @Test
+  public void test_False_WhenSecFetchUserHeaderIsPresentWithFalseValueAndNoOtherHeadersPresent() {
+    expectMatch( HEADER_SF_FALSE, null, null, null, false );
+  }
+
+  @Test
+  public void test_True_WhenSecFetchUserHeaderIsPresentWithTrueValue() {
+    expectMatch( HEADER_SF_TRUE, null, null, null, true );
+  }
+
+  @Test
+  public void test_True_OtherUserNavigationCasesWhenSecFetchUserIsNotPresent() {
+    expectMatch( null, "document", "navigate", "same-origin", true );
+    expectMatch( null, "iframe", "navigate", "none", true );
+  }
+
+  @Test
+  public void test_False_OtherNotUserNavigationCasesWhenSecFetchUserIsNotPresent() {
+    expectMatch( null, "image", "navigate", "same-origin", false );
+    expectMatch( null, "document", null, "same-origin", false );
+    expectMatch( null, "document", "cors", "same-origin", false );
+    expectMatch( null, "document", "navigate", "cross-site", false );
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/WebBrowserRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/WebBrowserRequestMatcherTest.java
@@ -1,0 +1,43 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.web.servlet.matchers;
+
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WebBrowserRequestMatcherTest {
+
+  @Test
+  public void test_True_WhenSecFetchDestHeaderIsPresent() {
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getHeader( WebBrowserRequestMatcher.HEADER_SEC_FETCH_DEST ) ).thenReturn( "document" );
+
+    WebBrowserRequestMatcher matcher = new WebBrowserRequestMatcher();
+    assertTrue( matcher.matches( request ) );
+  }
+
+  @Test
+  public void test_False_WhenSecFetchDestHeaderIsAbsent() {
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getHeader( WebBrowserRequestMatcher.HEADER_SEC_FETCH_DEST ) ).thenReturn( null );
+
+    WebBrowserRequestMatcher matcher = new WebBrowserRequestMatcher();
+    assertFalse( matcher.matches( request ) );
+  }
+}


### PR DESCRIPTION
Issues: [PPUC-108](https://hv-eng.atlassian.net/browse/PPUC-108) (and [BISERVER-14841](https://github.com/pentaho/pentaho-platform-ee/pull/1852/commits/a68e67c65f1f85b712b9d47325ba5898f7a3a847))

To be merged with:
- https://github.com/pentaho/pentaho-platform-ee/pull/1852
- https://github.com/pentaho/pentaho-analyzer/pull/2716
- https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/901
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/1147

---

This pull request introduces significant changes to the security configuration in the Pentaho platform, focusing on improving authentication handling for web browser and non-browser clients. Key updates include replacing the `exceptionTranslationFilterForWS` with a unified `exceptionTranslationFilter`, adding new matchers for request types, and implementing a new entry point for unauthorized access. Additionally, new classes and tests have been added to support these changes.

### Security Configuration Updates:
* Replaced `exceptionTranslationFilterForWS` with a unified `exceptionTranslationFilter` across multiple filter chains in `applicationContext-spring-security.xml`. This simplifies the configuration and ensures consistent handling of exceptions. [[1]](diffhunk://#diff-a99193a27c355569d677ca5a75267eef9c18a742a25110824b5a4ae3f42e17f8L41-R41) [[2]](diffhunk://#diff-a99193a27c355569d677ca5a75267eef9c18a742a25110824b5a4ae3f42e17f8L72-R72) [[3]](diffhunk://#diff-a99193a27c355569d677ca5a75267eef9c18a742a25110824b5a4ae3f42e17f8L87-R87) [[4]](diffhunk://#diff-a99193a27c355569d677ca5a75267eef9c18a742a25110824b5a4ae3f42e17f8L103-R103)
* Added a new bean `unauthorizedEntryPoint` to handle HTTP 401 Unauthorized responses without a `WWW-Authenticate` header, mitigating risks associated with basic authentication in web browsers. [[1]](diffhunk://#diff-a99193a27c355569d677ca5a75267eef9c18a742a25110824b5a4ae3f42e17f8R159-R160) [[2]](diffhunk://#diff-ec85ce78b43da9fb4476d4f0cc42c5a18e2a88e2d9b7c8044a9f72f9cfc4d0dfR1-R38)
* Introduced `userNavigationRequestMatcher` and `webBrowserRequestMatcher` beans to differentiate between user navigation requests and web browser requests, enhancing authentication logic. [[1]](diffhunk://#diff-a99193a27c355569d677ca5a75267eef9c18a742a25110824b5a4ae3f42e17f8L241-R253) [[2]](diffhunk://#diff-1b5f08ec87cdaed4f3e3753d2fc217012729d8b470bde358e00fe72000bd3a6fR1-R143) [[3]](diffhunk://#diff-ea0915d9acabb7b0e6a33879747f64f6fa753fc9125cb2ee5f62121072df37c0R1-R45)
* Updated `exceptionTranslationFilter` to use the new matchers and request cache for tailored authentication failure responses based on request type.
* Added `userNavigationAwareAuthenticationEntryPoint` to delegate authentication entry points based on request type, providing better handling for browser and non-browser clients.

### New Classes:
* Added `Http401UnauthorizedEntryPoint` class to handle unauthorized access by sending a 401 status code without a `WWW-Authenticate` header. This prevents browsers from prompting for credentials unnecessarily.
* Implemented `UserNavigationRequestMatcher` to identify user navigation requests based on specific HTTP headers like `sec-fetch-user`, `sec-fetch-dest`, `sec-fetch-mode`, and `sec-fetch-site`.
* Implemented `WebBrowserRequestMatcher` to detect requests made by web browsers using the `sec-fetch-dest` header.

### Tests:
* Added `UserNavigationRequestMatcherTest` to verify the behavior of `UserNavigationRequestMatcher` under various header configurations, ensuring accurate detection of user navigation requests.

[PPUC-108]: https://hv-eng.atlassian.net/browse/PPUC-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BISERVER-14841]: https://hv-eng.atlassian.net/browse/BISERVER-14841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ