### PR TITLE
chore: remove unused localization keys

### DIFF
--- a/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages.properties
@@ -25,7 +25,6 @@ org.pentaho.repository.execute=Execute
 org.pentaho.repository.execute.description=Allows execution of Pentaho Data Integration transformations (.ktr) and jobs (.kjb), either directly or via schedules.
 org.pentaho.security.administerSecurity=Administer Security
 org.pentaho.security.administerSecurity.description=Grants full operational permissions - access to every perspective, all content, all schedules (including block-out times), and every underlying permission, regardless of checkbox settings.
-org.pentaho.security.administerSystem=Manage System
 org.pentaho.security.publish=Publish Content
 org.pentaho.security.publish.description=Unlocks designer tools (Report Designer, Schema Workbench, Metadata Editor, etc.) to publish or update content and data models in the repository.
 org.pentaho.scheduler.manage=Schedule Content

--- a/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_CN.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_CN.properties
@@ -21,7 +21,6 @@ org.pentaho.repository.read=\u8b80\u53d6\u5167\u5bb9
 org.pentaho.repository.create=\u5efa\u7acb\u5167\u5bb9
 org.pentaho.repository.execute=\u57f7\u884c
 org.pentaho.security.administerSecurity=\u7ba1\u7406\u5b89\u5168\u6027
-org.pentaho.security.administerSystem=\u7ba1\u7406\u7cfb\u7d71
 org.pentaho.security.publish=\u767c\u884c\u5167\u5bb9
 org.pentaho.scheduler.manage=\u6392\u7a0b\u5167\u5bb9
 RepositoryTenantManager.publicFolderDisplayName=\u516c\u7528

--- a/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_de.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_de.properties
@@ -21,7 +21,6 @@ org.pentaho.repository.read=Inhalt lesen
 org.pentaho.repository.create=Inhalt erstellen
 org.pentaho.repository.execute=Ausf\u00fchren
 org.pentaho.security.administerSecurity=Sicherheit verwalten
-org.pentaho.security.administerSystem=System verwalten
 org.pentaho.security.publish=Inhalt ver\u00f6ffentlichen
 org.pentaho.scheduler.manage=Inhalt planen
 RepositoryTenantManager.publicFolderDisplayName=\u00d6ffentlich

--- a/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_fr.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_fr.properties
@@ -21,7 +21,6 @@ org.pentaho.repository.read=Lire le contenu
 org.pentaho.repository.create=Cr\u00e9er le contenu
 org.pentaho.repository.execute=Ex\u00e9cuter
 org.pentaho.security.administerSecurity=Administrer la s\u00e9curit\u00e9
-org.pentaho.security.administerSystem=G\u00e9rer le syst\u00e8me
 org.pentaho.security.publish=Publier le contenu
 org.pentaho.scheduler.manage=Planifier le contenu
 RepositoryTenantManager.publicFolderDisplayName=Public

--- a/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_ja.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_ja.properties
@@ -21,7 +21,6 @@ org.pentaho.repository.read=\u30b3\u30f3\u30c6\u30f3\u30c4\u306e\u8aad\u307f\u8f
 org.pentaho.repository.create=\u30b3\u30f3\u30c6\u30f3\u30c4\u306e\u4f5c\u6210
 org.pentaho.repository.execute=\u5b9f\u884c
 org.pentaho.security.administerSecurity=\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u7ba1\u7406
-org.pentaho.security.administerSystem=\u30b7\u30b9\u30c6\u30e0\u7ba1\u7406
 org.pentaho.security.publish=\u30b3\u30f3\u30c6\u30f3\u30c4\u306e\u30d1\u30d6\u30ea\u30c3\u30b7\u30e5
 org.pentaho.scheduler.manage=\u30b3\u30f3\u30c6\u30f3\u30c4\u306e\u30b9\u30b1\u30b8\u30e5\u30fc\u30ea\u30f3\u30b0
 RepositoryTenantManager.publicFolderDisplayName=\u30d1\u30d6\u30ea\u30c3\u30af

--- a/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_zh_CN.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages_zh_CN.properties
@@ -21,7 +21,6 @@ org.pentaho.repository.read=\u9605\u8bfb\u5185\u5bb9
 org.pentaho.repository.create=\u521b\u5efa\u5185\u5bb9
 org.pentaho.repository.execute=\u6267\u884c
 org.pentaho.security.administerSecurity=\u7ba1\u7406\u5b89\u5168\u6027
-org.pentaho.security.administerSystem=\u7ba1\u7406\u7cfb\u7edf
 org.pentaho.security.publish=\u53d1\u5e03\u5185\u5bb9
 org.pentaho.scheduler.manage=\u8ba1\u5212\u5185\u5bb9
 RepositoryTenantManager.publicFolderDisplayName=\u516c\u5171

--- a/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages.properties
@@ -38,15 +38,6 @@ UserRoleWebService.ERROR_0006_ROLE_UPDATE_FAILED=Failed to update role: {0}
 UserRoleWebService.ERROR_0007_ROLE_DELETION_FAILED_NO_ROLE=Deletion of role failed, role does not exist: {0}
 UserRoleWebService.ERROR_0008_ROLE_UPDATE_FAILED_DOES_NOT_EXIST=Role being updated does not exist: {0}
 
-org.pentaho.repository.read=Read Content
-org.pentaho.repository.create=Create Content
-org.pentaho.repository.execute=Execute
-org.pentaho.security.administerSecurity=Manage Tenant
-org.pentaho.security.administerSystem=Manage System
-org.pentaho.security.publish=Publish Content
-org.pentaho.scheduler.manage=Schedule Content
-org.pentaho.scheduler.execute=Execute Schedules
-
 AbstractJcrBackedUserRoleDao.ERROR_0001_LAST_ADMIN_ROLE=Removing last admin user from role {0} is not allowed.
 AbstractJcrBackedUserRoleDao.ERROR_0002_ROLE_NOT_FOUND=Role not found.
 AbstractJcrBackedUserRoleDao.ERROR_0003_USER_NOT_FOUND=User not found.

--- a/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_CN.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_CN.properties
@@ -38,14 +38,6 @@ UserRoleWebService.ERROR_0006_ROLE_UPDATE_FAILED=\u7121\u6cd5\u66f4\u65b0\u89d2\
 UserRoleWebService.ERROR_0007_ROLE_DELETION_FAILED_NO_ROLE=\u522a\u9664\u89d2\u8272\u5931\u6557\uff0c\u89d2\u8272\u4e0d\u5b58\u5728\uff1a{0}
 UserRoleWebService.ERROR_0008_ROLE_UPDATE_FAILED_DOES_NOT_EXIST=\u8981\u66f4\u65b0\u7684\u89d2\u8272\u4e0d\u5b58\u5728\uff1a{0}
 
-org.pentaho.repository.read=\u8b80\u53d6\u5167\u5bb9
-org.pentaho.repository.create=\u5efa\u7acb\u5167\u5bb9
-org.pentaho.repository.execute=\u57f7\u884c
-org.pentaho.security.administerSecurity=\u7ba1\u7406\u79df\u7528\u6236
-org.pentaho.security.administerSystem=\u7ba1\u7406\u7cfb\u7d71
-org.pentaho.security.publish=\u767c\u884c\u5167\u5bb9
-org.pentaho.scheduler.manage=\u6392\u7a0b\u5167\u5bb9
-
 AbstractJcrBackedUserRoleDao.ERROR_0001_LAST_ADMIN_ROLE=\u4e0d\u5141\u8a31\u5f9e\u89d2\u8272 {0} \u79fb\u9664\u6700\u5f8c\u4e00\u500b\u7cfb\u7d71\u7ba1\u7406\u4f7f\u7528\u8005\u3002
 AbstractJcrBackedUserRoleDao.ERROR_0002_ROLE_NOT_FOUND=\u627e\u4e0d\u5230\u89d2\u8272\u3002
 AbstractJcrBackedUserRoleDao.ERROR_0003_USER_NOT_FOUND=\u627e\u4e0d\u5230\u4f7f\u7528\u8005\u3002

--- a/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_de.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_de.properties
@@ -38,14 +38,6 @@ UserRoleWebService.ERROR_0006_ROLE_UPDATE_FAILED=Rolle konnte nicht aktualisiert
 UserRoleWebService.ERROR_0007_ROLE_DELETION_FAILED_NO_ROLE=Rolle konnte nicht gel\u00f6scht werden, Rolle existiert nicht: {0}
 UserRoleWebService.ERROR_0008_ROLE_UPDATE_FAILED_DOES_NOT_EXIST=Aktualisierte Rolle existiert nicht: {0}
 #
-org.pentaho.repository.read=Inhalt lesen
-org.pentaho.repository.create=Inhalt erstellen
-org.pentaho.repository.execute=Ausf\u00fchren
-org.pentaho.security.administerSecurity=Mandant verwalten
-org.pentaho.security.administerSystem=System verwalten
-org.pentaho.security.publish=Inhalt ver\u00f6ffentlichen
-org.pentaho.scheduler.manage=Inhalt planen
-#
 AbstractJcrBackedUserRoleDao.ERROR_0001_LAST_ADMIN_ROLE=L\u00f6schen des letzten Admin-Benutzers von der Rolle {0} ist nicht zul\u00e4ssig.
 AbstractJcrBackedUserRoleDao.ERROR_0002_ROLE_NOT_FOUND=Rolle nicht gefunden.
 AbstractJcrBackedUserRoleDao.ERROR_0003_USER_NOT_FOUND=Benutzer nicht gefunden.

--- a/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_fr.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_fr.properties
@@ -38,14 +38,6 @@ UserRoleWebService.ERROR_0006_ROLE_UPDATE_FAILED=\u00c9chec lors de la mise \u00
 UserRoleWebService.ERROR_0007_ROLE_DELETION_FAILED_NO_ROLE=La suppression du r\u00f4le a \u00e9chou\u00e9, car le r\u00f4le n'existe pas : {0}
 UserRoleWebService.ERROR_0008_ROLE_UPDATE_FAILED_DOES_NOT_EXIST=Le r\u00f4le \u00e0 mettre \u00e0 jour n'existe pas : {0}
 #
-org.pentaho.repository.read=Lire le contenu
-org.pentaho.repository.create=Cr\u00e9er le contenu
-org.pentaho.repository.execute=Ex\u00e9cuter
-org.pentaho.security.administerSecurity=G\u00e9rer le client
-org.pentaho.security.administerSystem=G\u00e9rer le syst\u00e8me
-org.pentaho.security.publish=Publier le contenu
-org.pentaho.scheduler.manage=Planifier le contenu
-#
 AbstractJcrBackedUserRoleDao.ERROR_0001_LAST_ADMIN_ROLE=La suppression du dernier utilisateur administrateur du r\u00f4le {0} n'est pas autoris\u00e9e.
 AbstractJcrBackedUserRoleDao.ERROR_0002_ROLE_NOT_FOUND=R\u00f4le introuvable.
 AbstractJcrBackedUserRoleDao.ERROR_0003_USER_NOT_FOUND=Utilisateur introuvable.

--- a/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_ja.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_ja.properties
@@ -38,14 +38,6 @@ UserRoleWebService.ERROR_0006_ROLE_UPDATE_FAILED=Failed to update role: {0}
 UserRoleWebService.ERROR_0007_ROLE_DELETION_FAILED_NO_ROLE=Deletion of role failed, role does not exist: {0}
 UserRoleWebService.ERROR_0008_ROLE_UPDATE_FAILED_DOES_NOT_EXIST=Role being updated does not exist: {0}
 #
-org.pentaho.repository.read=\u30b3\u30f3\u30c6\u30f3\u30c4\u306e\u8aad\u307f\u8fbc\u307f
-org.pentaho.repository.create=\u30b3\u30f3\u30c6\u30f3\u30c4\u306e\u4f5c\u6210
-org.pentaho.repository.execute=\u5b9f\u884c
-org.pentaho.security.administerSecurity=\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u7ba1\u7406
-org.pentaho.security.administerSystem=\u30b7\u30b9\u30c6\u30e0\u7ba1\u7406
-org.pentaho.security.publish=\u30b3\u30f3\u30c6\u30f3\u30c4\u306e\u30d1\u30d6\u30ea\u30c3\u30b7\u30e5
-org.pentaho.scheduler.manage=\u30b3\u30f3\u30c6\u30f3\u30c4\u306e\u30b9\u30b1\u30b8\u30e5\u30fc\u30ea\u30f3\u30b0
-#
 AbstractJcrBackedUserRoleDao.ERROR_0001_LAST_ADMIN_ROLE=Removing last admin user from role {0} is not allowed.
 AbstractJcrBackedUserRoleDao.ERROR_0002_ROLE_NOT_FOUND=Role not found.
 AbstractJcrBackedUserRoleDao.ERROR_0003_USER_NOT_FOUND=User not found.

--- a/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_zh_CN.properties
+++ b/repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages_zh_CN.properties
@@ -38,14 +38,6 @@ UserRoleWebService.ERROR_0006_ROLE_UPDATE_FAILED=\u66f4\u65b0\u89d2\u8272\u5931\
 UserRoleWebService.ERROR_0007_ROLE_DELETION_FAILED_NO_ROLE=\u5220\u9664\u89d2\u8272\u5931\u8d25\uff0c\u89d2\u8272\u4e0d\u5b58\u5728\uff1a{0}
 UserRoleWebService.ERROR_0008_ROLE_UPDATE_FAILED_DOES_NOT_EXIST=\u6b63\u5728\u66f4\u65b0\u7684\u89d2\u8272\u4e0d\u5b58\u5728\uff1a{0}
 #
-org.pentaho.repository.read=\u9605\u8bfb\u5185\u5bb9
-org.pentaho.repository.create=\u521b\u5efa\u5185\u5bb9
-org.pentaho.repository.execute=\u6267\u884c
-org.pentaho.security.administerSecurity=\u7ba1\u7406\u79df\u6237
-org.pentaho.security.administerSystem=\u7ba1\u7406\u7cfb\u7edf
-org.pentaho.security.publish=\u53d1\u5e03\u5185\u5bb9
-org.pentaho.scheduler.manage=\u8ba1\u5212\u5185\u5bb9
-#
 AbstractJcrBackedUserRoleDao.ERROR_0001_LAST_ADMIN_ROLE=\u4e0d\u5141\u8bb8\u4ece\u89d2\u8272 {0} \u4e2d\u5220\u9664\u6700\u540e\u4e00\u4e2a\u7ba1\u7406\u5458\u7528\u6237\u3002
 AbstractJcrBackedUserRoleDao.ERROR_0002_ROLE_NOT_FOUND=\u627e\u4e0d\u5230\u89d2\u8272\u3002
 AbstractJcrBackedUserRoleDao.ERROR_0003_USER_NOT_FOUND=\u627e\u4e0d\u5230\u7528\u6237\u3002


### PR DESCRIPTION
This pull request removes the `org.pentaho.security.administerSystem` property across multiple language-specific files and deletes several role-related properties from the `UserRoleWebService` section in multiple language-specific files. These changes streamline the security configuration by eliminating unused or redundant properties.

### Removal of `org.pentaho.security.administerSystem` property:
* [`repository/src/main/resources/org/pentaho/platform/security/policy/rolebased/messages/messages.properties`](diffhunk://#diff-2d9422238f8a4741014f8dda8843c4d7eccb8a10269d4fe09e04771cbeefa422L28): Removed `org.pentaho.security.administerSystem` property from the English messages file.
* Language-specific files (`messages_CN.properties`, `messages_de.properties`, `messages_fr.properties`, `messages_ja.properties`, `messages_zh_CN.properties`): Removed the equivalent `org.pentaho.security.administerSystem` property in Chinese, German, French, Japanese, and Simplified Chinese translations. [[1]](diffhunk://#diff-fe9376a6c286f56b0cc019dc45ec1fff4cfcc37ef781cf7d135e407fefe6d5b5L24) [[2]](diffhunk://#diff-15671dbdded481a1d7c3bcc4af831171b74fb7477a2e65c172c1ae0855e21582L24) [[3]](diffhunk://#diff-666b2255728691503bd72a14603910b28420db1a64e5bc6bf998bdf69bf002f5L24) [[4]](diffhunk://#diff-4a0840f3a864161743981722b278e0b817eec35e35f38fe7b00d0a560e2d2d5dL24) [[5]](diffhunk://#diff-9749b6a878cfcbf575cbc59ae8daeee81d178c63843aacf83f3c2958cf98ba51L24)

### Deletion of role-related properties in `UserRoleWebService`:
* [`repository/src/main/resources/org/pentaho/platform/security/userroledao/messages/messages.properties`](diffhunk://#diff-6338fa66b7d447b8b7fb4698473e3171b75e13345afce899ea1fc61e4145ba58L41-L49): Removed multiple properties related to roles, including `org.pentaho.repository.read`, `org.pentaho.repository.create`, `org.pentaho.repository.execute`, `org.pentaho.security.administerSecurity`, `org.pentaho.security.administerSystem`, `org.pentaho.security.publish`, `org.pentaho.scheduler.manage`, and `org.pentaho.scheduler.execute`.
* Language-specific files (`messages_CN.properties`, `messages_de.properties`, `messages_fr.properties`, `messages_ja.properties`, `messages_zh_CN.properties`): Removed the same set of role-related properties in Chinese, German, French, Japanese, and Simplified Chinese translations. [[1]](diffhunk://#diff-46bfd1e9aea6e6959888fb0c2cc8c316770f17eef18da0fd075bf8b9be82c8f2L41-L48) [[2]](diffhunk://#diff-4c44a92d7e29971daf6a9e19ad85fecf4d55e6387eb85ed9f45fedf30d8c6d82L41-L48) [[3]](diffhunk://#diff-f5ea1d557a769d8d0061827e0c88f06630dcf5e15d8c8afdd1276fc39137d35bL41-L48) [[4]](diffhunk://#diff-167723ba2be25285b98407d6628db1cd00c824702346ad6b2b0332f94db37d5eL41-L48) [[5]](diffhunk://#diff-69c666b75de56af053ce3408d9eda9c4db38800db337f0f05ae14877a6f25de3L41-L48)

@pentaho/millenniumfalcon please review