### PR TITLE
[BACKLOG-44147]-Schedule Job API fails schema validation due to missing @type and incorrect field types

### DIFF
--- a/api/src/main/java/org/pentaho/platform/scheduler2/recur/RecurrenceList.java
+++ b/api/src/main/java/org/pentaho/platform/scheduler2/recur/RecurrenceList.java
@@ -16,7 +16,9 @@ package org.pentaho.platform.scheduler2.recur;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -38,6 +40,12 @@ public class RecurrenceList implements ITimeRecurrence {
 
   public List<Integer> getValues() {
     return values;
+  }
+  @JsonProperty( "values" )
+  public List<String> valuesAsStrings() {
+    return values.stream()
+      .map( String::valueOf )
+      .collect( Collectors.toList() );
   }
 
   public void setValues( List<Integer> values ) {


### PR DESCRIPTION
[BACKLOG-44147]-Schedule Job API fails schema validation due to missing @type and incorrect field types

[BACKLOG-44147]: https://hv-eng.atlassian.net/browse/BACKLOG-44147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ