### PR TITLE
fix(UserRoleListService): list corruption and sorting [PPUC-123]

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/UserRoleListService.java
@@ -13,20 +13,20 @@
 
 package org.pentaho.platform.web.http.api.resources.services;
 
-import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IUserRoleListService;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
-import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
-import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
-import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
 import org.pentaho.platform.web.http.api.resources.RoleListWrapper;
 import org.pentaho.platform.web.http.api.resources.UserListWrapper;
+import org.pentaho.platform.web.http.api.resources.utils.SystemUtils;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class UserRoleListService {
 
@@ -49,7 +49,7 @@ public class UserRoleListService {
       throw new UnauthorizedException();
     }
 
-    return getRolesForUser( user );
+    return sortRoles( getRolesForUser( user ) );
   }
 
   public List<String> doGetUsersInRole( String role ) throws UnauthorizedException {
@@ -57,18 +57,15 @@ public class UserRoleListService {
       throw new UnauthorizedException();
     }
 
-    return getUsersInRole( role );
+    return sortUsers( getUsersInRole( role ) );
   }
 
   public UserListWrapper getUsers() {
     IUserRoleListService service = getUserRoleListService();
 
-    List<String> allUsers = service.getAllUsers();
-    if ( userComparator != null ) {
-      allUsers.sort( userComparator );
-    }
+    List<String> allUsers = new ArrayList<>( service.getAllUsers() );
 
-    return new UserListWrapper( allUsers );
+    return new UserListWrapper( sortUsers( allUsers ) );
   }
 
   public RoleListWrapper getRoles() {
@@ -76,17 +73,18 @@ public class UserRoleListService {
   }
 
   public RoleListWrapper getRoles( boolean includeExtraRoles ) {
-    List<String> roles = getUserRoleListService().getAllRoles();
+    List<String> roles = new ArrayList<>( getUserRoleListService().getAllRoles() );
     /* If we need to exclude extra roles from the list of roles, we will remove it here.
     /  One thing to note that if a user has a role which is same as the extra role, that
     /  role will be removed as well. So we do not recommend user having same roles as the
     /  extra roles */
-    if ( !includeExtraRoles ) {
-      for ( String role : getExtraRoles() ) {
+    if ( !includeExtraRoles && extraRoles != null ) {
+      for ( String role : extraRoles ) {
         roles.remove( role );
       }
     }
-    return new RoleListWrapper( roles );
+
+    return new RoleListWrapper( sortRoles( roles ) );
   }
 
   public RoleListWrapper getAllRoles() {
@@ -96,26 +94,23 @@ public class UserRoleListService {
   public RoleListWrapper getAllRoles( boolean excludeAnonymous ) {
     Set<String> existingRoles = new HashSet<>( getUserRoleListService().getAllRoles() );
 
-    List<String> allRoles = getExtraRoles();
-    if ( allRoles == null ) {
-      allRoles = new ArrayList<>();
+    if ( extraRoles != null ) {
+      existingRoles.addAll( extraRoles );
     }
 
     if ( systemRoles != null ) {
-      allRoles.addAll( systemRoles );
+      existingRoles.addAll( systemRoles );
     }
-
-    existingRoles.addAll( allRoles );
 
     if ( excludeAnonymous && getAnonymousRole() != null ) {
       existingRoles.remove( getAnonymousRole() );
     }
 
-    return new RoleListWrapper( existingRoles );
+    return new RoleListWrapper( sortRoles( existingRoles ) );
   }
 
   public RoleListWrapper getSystemRoles() {
-    return new RoleListWrapper( systemRoles );
+    return new RoleListWrapper( sortRoles( systemRoles ) );
   }
 
   /**
@@ -124,7 +119,7 @@ public class UserRoleListService {
    * @return A list of roles.
    */
   public RoleListWrapper getPermissionRoles() {
-    List<String> allRoles = getUserRoleListService().getAllRoles();
+    List<String> allRoles = new ArrayList<>( getUserRoleListService().getAllRoles() );
 
     // We will not allow user to update permission for Administrator.
     // Using getAdminRole() to support mocking in unit tests.
@@ -142,22 +137,15 @@ public class UserRoleListService {
       }
     }
 
-    if ( roleComparator != null ) {
-      allRoles.sort( roleComparator );
-    }
-
-    return new RoleListWrapper( allRoles );
+    return new RoleListWrapper( sortRoles( allRoles ) );
   }
 
   public RoleListWrapper getExtraRolesList() {
-    return new RoleListWrapper( getExtraRoles() );
+    return new RoleListWrapper( sortRoles( getExtraRoles() ) );
   }
 
   protected boolean canAdminister() {
-    IAuthorizationPolicy policy = PentahoSystem.get( IAuthorizationPolicy.class );
-    return policy.isAllowed( RepositoryReadAction.NAME )
-      && policy.isAllowed( RepositoryCreateAction.NAME )
-      && ( policy.isAllowed( AdministerSecurityAction.NAME ) );
+    return SystemUtils.canAdminister();
   }
 
   public IUserRoleListService getUserRoleListService() {
@@ -210,6 +198,26 @@ public class UserRoleListService {
 
   public void setAnonymousRole( String anonymousRole ) {
     this.anonymousRole = anonymousRole;
+  }
+
+  protected List<String> sortRoles( Collection<String> roles ) {
+    Stream<String> rolesStream = roles.stream();
+
+    if ( roleComparator != null ) {
+      rolesStream = rolesStream.sorted( roleComparator );
+    }
+
+    return rolesStream.collect( Collectors.toList() );
+  }
+
+  protected List<String> sortUsers( Collection<String> users ) {
+    Stream<String> usersStream = users.stream();
+
+    if ( userComparator != null ) {
+      usersStream = usersStream.sorted( userComparator );
+    }
+
+    return usersStream.collect( Collectors.toList() );
   }
 
   public static class UnauthorizedException extends Exception {

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/UserRoleListServiceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/UserRoleListServiceTest.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -122,6 +122,30 @@ public class UserRoleListServiceTest {
   }
 
   @Test
+  public void testDoGetRolesWithoutExtraRoles() {
+    List<String> roles = new ArrayList<String>();
+    roles.add( "ROLE1" );
+    roles.add( "ROLE2" );
+    roles.add( "EXTRA_ROLE1" );
+
+    ArrayList<String> extraRoles = new ArrayList<>();
+    extraRoles.add( "EXTRA_ROLE1" );
+    extraRoles.add( "EXTRA_ROLE2" );
+    userRoleListService.setExtraRoles( extraRoles );
+
+    IUserRoleListService userRoleListService1 = mock( IUserRoleListService.class );
+    doReturn( userRoleListService1 ).when( userRoleListService ).getUserRoleListService();
+    doReturn( roles ).when( userRoleListService1 ).getAllRoles();
+
+    RoleListWrapper roleListWrapper = userRoleListService.getRoles( false );
+
+    verify( userRoleListService ).getUserRoleListService();
+    verify( userRoleListService1 ).getAllRoles();
+
+    assertEquals( List.of( "ROLE1", "ROLE2" ), roleListWrapper.getRoles() );
+  }
+
+  @Test
   public void testGetPermissionRoles() {
 
     List<String> roles = new ArrayList<String>();
@@ -145,28 +169,51 @@ public class UserRoleListServiceTest {
   }
 
   @Test
-  public void testDoGetAllRoles() {
-    List<String> roles = new ArrayList<String>();
+  public void testDoGetAllRolesWithExtraAndSystemRolesSet() {
+    List<String> roles = new ArrayList<>();
     roles.add( "ROLE1" );
     roles.add( "ROLE2" );
 
-    List<String> extraRoles = new ArrayList<String>();
+    List<String> extraRoles = new ArrayList<>();
     extraRoles.add( "ROLE3" );
     extraRoles.add( "ROLE4" );
+    userRoleListService.setExtraRoles( extraRoles );
+
+    List<String> systemRoles = new ArrayList<>( extraRoles );
+    extraRoles.add( "ROLE5" );
+
+    userRoleListService.setSystemRoles( systemRoles );
 
     IUserRoleListService userRoleListService1 = mock( IUserRoleListService.class );
 
     doReturn( userRoleListService1 ).when( userRoleListService ).getUserRoleListService();
     doReturn( roles ).when( userRoleListService1 ).getAllRoles();
-    doReturn( extraRoles ).when( userRoleListService ).getExtraRoles();
 
     RoleListWrapper roleListWrapper = userRoleListService.getAllRoles();
 
     verify( userRoleListService ).getUserRoleListService();
     verify( userRoleListService1 ).getAllRoles();
-    verify( userRoleListService ).getExtraRoles();
 
-    assertEquals( 4, roleListWrapper.getRoles().size() );
+    assertEquals( 5, roleListWrapper.getRoles().size() );
+  }
+
+  @Test
+  public void testDoGetAllRolesWithoutExtraAndSystemRolesSet() {
+    List<String> roles = new ArrayList<>();
+    roles.add( "ROLE1" );
+    roles.add( "ROLE2" );
+
+    IUserRoleListService userRoleListService1 = mock( IUserRoleListService.class );
+
+    doReturn( userRoleListService1 ).when( userRoleListService ).getUserRoleListService();
+    doReturn( roles ).when( userRoleListService1 ).getAllRoles();
+
+    RoleListWrapper roleListWrapper = userRoleListService.getAllRoles();
+
+    verify( userRoleListService ).getUserRoleListService();
+    verify( userRoleListService1 ).getAllRoles();
+
+    assertEquals( 2, roleListWrapper.getRoles().size() );
   }
 
   @Test
@@ -177,7 +224,7 @@ public class UserRoleListServiceTest {
     extraRoles.add( "ROLE3" );
     extraRoles.add( "ROLE4" );
 
-    doReturn( extraRoles ).when( userRoleListService ).getExtraRoles();
+    userRoleListService.setExtraRoles( extraRoles );
 
     RoleListWrapper roleListWrapper = userRoleListService.getExtraRolesList();
 
@@ -185,6 +232,21 @@ public class UserRoleListServiceTest {
 
     assertEquals( 4, roleListWrapper.getRoles().size() );
     assertEquals( extraRoles, roleListWrapper.getRoles() );
+  }
+
+  @Test
+  public void testGetSystemRoles() {
+    List<String> systemRoles = new ArrayList<String>();
+    systemRoles.add( "ROLE1" );
+    systemRoles.add( "ROLE2" );
+    systemRoles.add( "ROLE3" );
+
+    userRoleListService.setSystemRoles( systemRoles );
+
+    RoleListWrapper roleListWrapper = userRoleListService.getSystemRoles();
+
+    assertEquals( 3, roleListWrapper.getRoles().size() );
+    assertEquals( systemRoles, roleListWrapper.getRoles() );
   }
 
   @Test


### PR DESCRIPTION
- Extra Roles list would become polluted with all system roles, as many times as `getAllRoles()` was called
- Sorting for roles and users was only being applied to some of the operations

TODO:
- [x] Check unit tests

/cc @pentaho/millenniumfalcon, please, review.