### PR TITLE
[BACKLOG-44362] Azure Docker Image - Old oracle jar is causing issues…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,6 @@
     <webservices.version>2.3.1</webservices.version>
     <wadl-resourcedoc-doclet.version>1.19.1</wadl-resourcedoc-doclet.version>
     <asm.version>7.1</asm.version>
-    <quartz-oracle.version>1.7.2</quartz-oracle.version>
     <edtftpj.version>2.1.0</edtftpj.version>
     <jzlib.version>1.0.7</jzlib.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
@@ -187,7 +186,6 @@
     <maven-failsafe-plugin.reuseForks>false</maven-failsafe-plugin.reuseForks>
     <jt400.version>6.1</jt400.version>
     <sac.version>1.3</sac.version>
-    <quartz.version>1.7.2</quartz.version>
     <hibernate-jpa-2.1-api.version>1.0.2.Final</hibernate-jpa-2.1-api.version>
     <hsqldb.version>2.3.2</hsqldb.version>
     <websocket-api.version>1.0</websocket-api.version>


### PR DESCRIPTION
… to allow connection to the Oracle databases (jackrabbit, hibernate, quartz, pentaho_dilogs, pentaho_operations_mart) -- quartz-oracle is no longer needed since upgrading quartz to 2.3.2. Also, quartz.version 1.7.2 was never used AND we've upgraded quartz to 2.3.2