### PR TITLE
feat[PPP-5649]: add httpclient5 and httpcore5 dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>pentaho-platform-ce-parent</artifactId>
     <version>10.3.0.0-SNAPSHOT</version>
   </parent>
-  <groupId>pentaho</groupId>
   <artifactId>pentaho-platform-core</artifactId>
   <version>10.3.0.0-SNAPSHOT</version>
   <properties>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -157,6 +157,16 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.owasp.encoder</groupId>
       <artifactId>encoder</artifactId>
       <version>${owasp.encoder.version}</version>


### PR DESCRIPTION
While these dependencies are marked as optional, vfs2 2.10.0 's default provider is Http5FileProvider that needs them

@pentaho/tatooine_dev 