### PR TITLE
fix: server setups where browsers withhold Sec-Fetch headers [PPUC-108][BISERVER-14841]

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/applicationContext-spring-security.xml
@@ -240,8 +240,96 @@
   <!--
       ===================== HTTP REQUEST SECURITY ====================
   -->
-  <bean id="userNavigationRequestMatcher" class="org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher" />
-  <bean id="webBrowserRequestMatcher"  class="org.pentaho.platform.web.servlet.matchers.WebBrowserRequestMatcher" />
+  <bean id="webBrowserRequestMatcher" class="org.springframework.security.web.util.matcher.OrRequestMatcher">
+    <constructor-arg>
+      <util:list>
+        <ref bean="webBrowserRequestMatcherSecFetch" />
+
+        <!--
+          This matcher is for requests considered insecure by the web browser, where the server is accessed via public
+          IP with HTTP, or private IP (even with HTTPS), or HTTPS with an invalid SSL certificate, causing `sec-fetch-*`
+          headers not to be sent. If the server is always accessed via a domain, either via HTTP, or via HTTPS with a
+          valid SSL certificate, then it should be possible to remove this, for added security.
+        -->
+        <ref bean="webBrowserRequestMatcherFallback" />
+      </util:list>
+    </constructor-arg>
+  </bean>
+
+  <bean id="webBrowserRequestMatcherSecFetch"
+        class="org.pentaho.platform.web.servlet.matchers.WebBrowserSecFetchRequestMatcher" />
+  <bean id="webBrowserRequestMatcherFallback"
+        class="org.pentaho.platform.web.servlet.matchers.WebBrowserUserAgentRequestMatcher">
+    <!-- If needed, browser and non-browser `user-agent` header patterns may be changed from defaults:
+    <constructor-arg>
+      <util:list>
+        <value>\bchrome/\b</value>
+        <value>\bheadlesschrome/\b</value>
+        <value>\bfirefox/\b</value>
+        <value>\bsafari/\b</value>
+        <value>\bedge/\b</value>
+        <value>\btrident/\b</value>
+        <value>\bmsie/\b</value>
+        <value>\bopera/\b</value>
+        <value>\bopr/\b</value>
+      </util:list>
+    </constructor-arg>
+    <constructor-arg>
+      <util:list>
+        <value>\bcurl/\b</value>
+        <value>\bwget/\b</value>
+        <value>\bpostmanruntime/\b</value>
+        <value>\bpython-requests/\b</value>
+        <value>\bbot\b</value>
+        <value>\bcrawler\b</value>
+        <value>\bspider\b</value>
+        <value>\bjava/\b</value>
+        <value>\bphp/\b</value>
+        <value>\bruby/\b</value>
+      </util:list>
+    </constructor-arg>
+    -->
+  </bean>
+
+  <bean id="userNavigationRequestMatcher" class="org.springframework.security.web.util.matcher.OrRequestMatcher">
+    <constructor-arg>
+      <util:list>
+        <ref bean="userNavigationRequestMatcherSecFetch" />
+
+        <!--
+          This matcher is for requests considered insecure by the web browser, where the server is accessed via public
+          IP with HTTP, or private IP (even with HTTPS), or HTTPS with an invalid SSL certificate, causing `sec-fetch-*`
+          headers not to be sent. If the server is always accessed via a domain, either via HTTP, or via HTTPS with a
+          valid SSL certificate, then it should be possible to remove this, for added security.
+        -->
+        <ref bean="userNavigationRequestMatcherFallback" />
+      </util:list>
+    </constructor-arg>
+  </bean>
+
+  <bean id="userNavigationRequestMatcherSecFetch"
+        class="org.pentaho.platform.web.servlet.matchers.UserNavigationSecFetchRequestMatcher" />
+  <bean id="userNavigationRequestMatcherFallback" class="org.springframework.security.web.util.matcher.AndRequestMatcher">
+    <constructor-arg>
+      <util:list>
+        <!-- Only use `accept` header matcher if `sec-fetch-*` headers are not present. -->
+        <bean class="org.springframework.security.web.util.matcher.NegatedRequestMatcher">
+          <constructor-arg ref="webBrowserRequestMatcherSecFetch" />
+        </bean>
+        <ref bean="webBrowserRequestMatcherFallback" />
+        <bean class="org.pentaho.platform.web.servlet.matchers.UserNavigationAcceptRequestMatcher">
+          <!-- If needed, matching `accept` header patterns may be changed from defaults:
+          <constructor-arg>
+            <util:list>
+              <value>\btext/html\b</value>
+              <value>\bapplication/xhtml\+xml\b</value>
+            </util:list>
+          </constructor-arg>
+          -->
+        </bean>
+      </util:list>
+    </constructor-arg>
+  </bean>
 
   <bean id="httpSessionRequestCache" class="org.springframework.security.web.savedrequest.HttpSessionRequestCache">
     <!-- After login, only send the user back to "user navigation" requests. Otherwise, go back /Home -->

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/UserNavigationAcceptRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/UserNavigationAcceptRequestMatcher.java
@@ -1,0 +1,78 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.web.servlet.matchers;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * The {@code UserNavigationAcceptRequestMatcher} determines if a request can be considered a user navigation request,
+ * based on the presence and value of the `accept` HTTP request header.
+ * <p>
+ * By default, if the `accept` header contains one of the values `text/html` or `application/xhtml+xml`,
+ * it indicates that the request likely targets a web browser's document, frame, iframe, or object tags. These requests
+ * typically correspond to user navigation actions.
+ */
+public class UserNavigationAcceptRequestMatcher implements RequestMatcher {
+  /**
+   * The `accept` HTTP request header is included by web browsers to indicate the mime types that the response may use.
+   * <p>
+   * See
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept">MDN Accept Header</a>.
+   */
+  static final String HEADER_ACCEPT = "accept";
+
+  /**
+   * The patterns of the `accept` request header that are considered navigation requests.
+   */
+  static final List<String> DEFAULT_HEADER_ACCEPT_NAVIGATION_PATTERNS = List.of(
+    "\\btext/html\\b",
+    "\\bapplication/xhtml\\+xml\\b"
+  );
+
+  @NonNull
+  private final Pattern acceptNavigationPattern;
+
+  public UserNavigationAcceptRequestMatcher() {
+    this( DEFAULT_HEADER_ACCEPT_NAVIGATION_PATTERNS );
+  }
+
+  public UserNavigationAcceptRequestMatcher( @NonNull List<String> acceptNavigationPatterns ) {
+    super();
+
+    Objects.requireNonNull( acceptNavigationPatterns );
+
+    this.acceptNavigationPattern = Pattern.compile(
+      String.join( "|", acceptNavigationPatterns ),
+      Pattern.CASE_INSENSITIVE );
+  }
+
+  protected boolean isNavigationContent( String accept ) {
+    if ( StringUtils.isEmpty( accept ) ) {
+      return false;
+    }
+
+    return acceptNavigationPattern.matcher( accept ).find();
+  }
+
+  @Override
+  public boolean matches( @NonNull HttpServletRequest request ) {
+    return isNavigationContent( request.getHeader( HEADER_ACCEPT ) );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/UserNavigationSecFetchRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/UserNavigationSecFetchRequestMatcher.java
@@ -20,7 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 /**
- * The {@code UserNavigationRequestMatcher} determines if a request can be considered a user navigation request,
+ * The {@code UserNavigationSecFetchRequestMatcher} determines if a request can be considered a user navigation request,
  * based on the presence of the `sec-fetch-user` HTTP request header, or on other related headers, such as
  * `sec-fetch-dest`, `sec-fetch-mode` and `sec-fetch-site`.
  * <p>
@@ -49,14 +49,22 @@ import java.util.List;
  * The response is meta-redirected to localhost:8080/pentaho.
  * Then, the server 302-redirects to localhost:8080/pentaho/.
  * Finally, the response is meta-redirected to localhost:8080/pentaho/Home.
+ * <p>
+ * Unfortunately, the {@code sec-fetch-*} headers are not always present in requests a web browser considers insecure.
+ * Examples of such requests include the server being accessed via an IP address, of public or private range, without
+ * HTTPS, or without a valid SSL certificate. For the case of private IP addresses, there are also special protections
+ * as determined by the
+ * <a href="https://wicg.github.io/private-network-access">Private Network Access (PNA) specification</a>.
+ * For these cases, consider using the {@link UserNavigationAcceptRequestMatcher} as a fallback matcher.
  */
-public class UserNavigationRequestMatcher implements RequestMatcher {
+public class UserNavigationSecFetchRequestMatcher implements RequestMatcher {
   /**
    * The `sec-fetch-user` HTTP request header is included by web browsers to indicate that a request was initiated by
    * a <i>user navigation</i> and having a user activation state.
    * <p>
    * See
-   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User">MDN Sec-Fetch-User Header</a>.
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-User">MDN Sec-Fetch-User
+   * Header</a>.
    */
   static final String HEADER_SEC_FETCH_USER = "sec-fetch-user";
 
@@ -66,7 +74,8 @@ public class UserNavigationRequestMatcher implements RequestMatcher {
    * This header is used to determine if the request is a navigation request, when `sec-fetch-user` is not set to `?1`.
    * <p>
    * See
-   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest">MDN Sec-Fetch-Dest Header</a>.
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest">MDN Sec-Fetch-Dest
+   * Header</a>.
    */
   static final String HEADER_SEC_FETCH_DEST = "sec-fetch-dest";
 
@@ -76,7 +85,8 @@ public class UserNavigationRequestMatcher implements RequestMatcher {
    * This header is used to determine if the request is a navigation request, when `sec-fetch-user` is not set to `?1`.
    * <p>
    * See
-   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode">MDN Sec-Fetch-Mode Header</a>.
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Mode">MDN Sec-Fetch-Mode
+   * Header</a>.
    */
   static final String HEADER_SEC_FETCH_MODE = "sec-fetch-mode";
 
@@ -88,7 +98,8 @@ public class UserNavigationRequestMatcher implements RequestMatcher {
    * to `?1`.
    * <p>
    * See
-   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site">MDN Sec-Fetch-Site Header</a>.
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site">MDN Sec-Fetch-Site
+   * Header</a>.
    */
   static final String HEADER_SEC_FETCH_SITE = "sec-fetch-site";
 

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/WebBrowserSecFetchRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/WebBrowserSecFetchRequestMatcher.java
@@ -18,23 +18,33 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * The {@code WebBrowserRequestMatcher} determines if a request is made by a web browser.
+ * The {@code WebBrowserSecFetchRequestMatcher} determines if a request is made by a web browser, based on the presence
+ * of the `sec-fetch-dest` HTTP request header.
  * <p>
  * The matcher does not distinguish whether the request is a user navigation request or not. The only criterion is
  * whether the request is made by a web browser. To test if a request is a user navigation request, the
- * {@link UserNavigationRequestMatcher} can be used.
+ * {@link UserNavigationSecFetchRequestMatcher} can be used.
  * <p>
- * The implementation checks the presence of the `sec-fetch-dest` HTTP request header, which is web-browser-specific.
+ * The implementation checks the presence of the `sec-fetch-dest` HTTP request header, which is a header specific to
+ * web-browsers.
+ * <p>
+ * Unfortunately, the {@code sec-fetch-dest} header is not always present in requests a web browser considers insecure.
+ * Examples of such requests include the server being accessed via an IP address, of public or private range, without
+ * HTTPS, or without a valid SSL certificate. For the case of private IP addresses, there are also special protections
+ * as determined by the
+ * <a href="https://wicg.github.io/private-network-access">Private Network Access (PNA) specification</a>.
+ * For these cases, consider using the {@link WebBrowserUserAgentRequestMatcher} as a fallback matcher.
  * <p>
  * In Pentaho, this matcher is used to select an appropriate authentication failure response, depending on whether the
  * request is made by a web browser or a tool.
  */
-public class WebBrowserRequestMatcher implements RequestMatcher {
+public class WebBrowserSecFetchRequestMatcher implements RequestMatcher {
   /**
    * The `sec-fetch-dest` HTTP request header is included by web browsers to indicate the destination of the request.
    * <p>
    * See
-   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest">MDN Sec-Fetch-Dest Header</a>.
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest">MDN Sec-Fetch-Dest
+   * Header</a>.
    */
   static final String HEADER_SEC_FETCH_DEST = "sec-fetch-dest";
 

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/WebBrowserUserAgentRequestMatcher.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/matchers/WebBrowserUserAgentRequestMatcher.java
@@ -1,0 +1,107 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.web.servlet.matchers;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * The {@code WebBrowserUserAgentRequestMatcher} determines if a request is made by a web browser based on the
+ * presence and value of the `User-Agent` HTTP request header.
+ * <p>
+ * The matcher does not distinguish whether the request is a user navigation request or not. The only criterion is
+ * whether the request is made by a web browser. To test if a request is a user navigation request, the corresponding
+ * weak matcher, {@link UserNavigationAcceptRequestMatcher} can be used.
+ * <p>
+ * This matcher immediately returns `false` if the `sec-fetch-dest` is present in the request, as in that case, the
+ * "weaker" logic should not be used. Instead, this matcher should be combined
+ * <p>
+ * In Pentaho, this matcher is used to select an appropriate authentication failure response, depending on whether the
+ * request is made by a web browser or a tool.
+ */
+public class WebBrowserUserAgentRequestMatcher implements RequestMatcher {
+  /**
+   * The `user-agent` HTTP request header is included by web browsers to indicate the type of web browser.
+   * <p>
+   * See
+   * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/User-Agent">MDN User-Agent Header</a>.
+   */
+  static final String HEADER_USER_AGENT = "user-agent";
+
+  /**
+   * Default patterns for matching web browsers in the `User-Agent` header.
+   * This includes common web browsers and headless browsers.
+   */
+  private static final List<String> DEFAULT_BROWSER_PATTERNS = List.of(
+    "\\bchrome/\\b", "\\bheadlesschrome/\\b", "\\bfirefox/\\b", "\\bsafari/\\b", "\\bedge/\\b",
+    "\\btrident/\\b", "\\bmsie/\\b", "\\bopera/\\b", "\\bopr/\\b"
+  );
+
+  /**
+   * Default patterns for matching non-browser user agents in the `User-Agent` header.
+   * This includes common tools and libraries that are not web browsers.
+   * This exclusion list is important because non-browser user agents sometimes preserve browser tokens.
+   */
+  private static final List<String> DEFAULT_NON_BROWSER_PATTERNS = List.of(
+    "\\bcurl/\\b", "\\bwget/\\b", "\\bpostmanruntime/\\b", "\\bpython-requests/\\b",
+    "\\bbot\\b", "\\bcrawler\\b", "\\bspider\\b", "\\bjava/\\b", "\\bphp/\\b", "\\bruby/\\b"
+  );
+
+  @NonNull
+  private final Pattern browserPattern;
+  @NonNull
+  private final Pattern nonBrowserPattern;
+
+  public WebBrowserUserAgentRequestMatcher() {
+    this( DEFAULT_BROWSER_PATTERNS, DEFAULT_NON_BROWSER_PATTERNS );
+  }
+
+  public WebBrowserUserAgentRequestMatcher( @NonNull List<String> browserPatterns,
+                                            @NonNull List<String> nonBrowserPatterns ) {
+
+    Objects.requireNonNull( browserPatterns );
+    Objects.requireNonNull( nonBrowserPatterns );
+
+    // Compile browser tokens into a single regex (e.g., \bchrome/\b|\bheadlesschrome/\b|...)
+    this.browserPattern = Pattern.compile(
+      String.join( "|", browserPatterns ),
+      Pattern.CASE_INSENSITIVE
+    );
+
+    // Compile non-browser tokens into a single regex (e.g., \bcurl/\b|\bbot\b|...)
+    this.nonBrowserPattern = Pattern.compile(
+      String.join( "|", nonBrowserPatterns ),
+      Pattern.CASE_INSENSITIVE
+    );
+  }
+
+  protected boolean isBrowser( String userAgent ) {
+    if ( StringUtils.isEmpty( userAgent  ) ) {
+      return false;
+    }
+
+    return browserPattern.matcher( userAgent ).find()
+      && !nonBrowserPattern.matcher( userAgent ).find();
+  }
+
+  @Override
+  public boolean matches( @NonNull HttpServletRequest request ) {
+    return isBrowser( request.getHeader( HEADER_USER_AGENT ) );
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/UserNavigationAcceptRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/UserNavigationAcceptRequestMatcherTest.java
@@ -1,0 +1,102 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.web.servlet.matchers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UserNavigationAcceptRequestMatcherTest {
+
+  private UserNavigationAcceptRequestMatcher matcher;
+
+  @Before
+  public void setUp() {
+    matcher = new UserNavigationAcceptRequestMatcher();
+  }
+
+  private void assertAcceptHeaderMatch( String acceptHeader, boolean shouldMatch ) {
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getHeader( "accept" ) ).thenReturn( acceptHeader );
+    if ( shouldMatch ) {
+      assertTrue( matcher.matches( request ) );
+    } else {
+      assertFalse( matcher.matches( request ) );
+    }
+  }
+
+  @Test
+  public void testMatchesWithTextHtml() {
+    assertAcceptHeaderMatch( "text/html", true );
+  }
+
+  @Test
+  public void testMatchesWithApplicationXhtmlXml() {
+    assertAcceptHeaderMatch( "application/xhtml+xml", true );
+  }
+
+  @Test
+  public void testMatchesWithMultipleAcceptsIncludingHtml() {
+    assertAcceptHeaderMatch( "application/xml,text/html;q=0.9,image/webp,*/*;q=0.8", true );
+  }
+
+  @Test
+  public void testMatchesWithMultipleAcceptsIncludingXhtml() {
+    assertAcceptHeaderMatch( "application/xml,application/xhtml+xml;q=0.9,image/webp,*/*;q=0.8", true );
+  }
+
+  @Test
+  public void testDoesNotMatchWithJson() {
+    assertAcceptHeaderMatch( "application/json", false );
+  }
+
+  @Test
+  public void testDoesNotMatchWithXmlOnly() {
+    assertAcceptHeaderMatch( "application/xml", false );
+  }
+
+  @Test
+  public void testDoesNotMatchWithEmptyHeader() {
+    assertAcceptHeaderMatch( "", false );
+  }
+
+  @Test
+  public void testDoesNotMatchWithNullHeader() {
+    assertAcceptHeaderMatch( null, false );
+  }
+
+  @Test
+  public void testMatchesWithCustomPattern() {
+    List<String> customPatterns = List.of( "\\bapplication/custom\\b" );
+    UserNavigationAcceptRequestMatcher customMatcher = new UserNavigationAcceptRequestMatcher( customPatterns );
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getHeader( "accept" ) ).thenReturn( "application/custom" );
+    assertTrue( customMatcher.matches( request ) );
+  }
+
+  @Test
+  public void testDoesNotMatchWithCustomPattern() {
+    List<String> customPatterns = List.of( "\\bapplication/custom\\b" );
+    UserNavigationAcceptRequestMatcher customMatcher = new UserNavigationAcceptRequestMatcher( customPatterns );
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getHeader( "accept" ) ).thenReturn( "application/other" );
+    assertFalse( customMatcher.matches( request ) );
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/UserNavigationSecFetchRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/UserNavigationSecFetchRequestMatcherTest.java
@@ -20,13 +20,13 @@ import javax.servlet.http.HttpServletRequest;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SEC_FETCH_DEST;
-import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SEC_FETCH_MODE;
-import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SEC_FETCH_SITE;
-import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SEC_FETCH_USER;
-import static org.pentaho.platform.web.servlet.matchers.UserNavigationRequestMatcher.HEADER_SF_TRUE;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationSecFetchRequestMatcher.HEADER_SEC_FETCH_DEST;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationSecFetchRequestMatcher.HEADER_SEC_FETCH_MODE;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationSecFetchRequestMatcher.HEADER_SEC_FETCH_SITE;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationSecFetchRequestMatcher.HEADER_SEC_FETCH_USER;
+import static org.pentaho.platform.web.servlet.matchers.UserNavigationSecFetchRequestMatcher.HEADER_SF_TRUE;
 
-public class UserNavigationRequestMatcherTest {
+public class UserNavigationSecFetchRequestMatcherTest {
 
   private static final String HEADER_SF_FALSE = "?0";
 
@@ -49,7 +49,7 @@ public class UserNavigationRequestMatcherTest {
     when( request.getHeader( HEADER_SEC_FETCH_MODE ) ).thenReturn( secFetchMode );
     when( request.getHeader( HEADER_SEC_FETCH_SITE ) ).thenReturn( secFetchSite );
 
-    var requestMatcher = new UserNavigationRequestMatcher();
+    var requestMatcher = new UserNavigationSecFetchRequestMatcher();
 
     assertEquals( expectMatches, requestMatcher.matches( request ) );
   }

--- a/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/WebBrowserSecFetchRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/WebBrowserSecFetchRequestMatcherTest.java
@@ -21,23 +21,23 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class WebBrowserRequestMatcherTest {
+public class WebBrowserSecFetchRequestMatcherTest {
 
   @Test
   public void test_True_WhenSecFetchDestHeaderIsPresent() {
     HttpServletRequest request = mock( HttpServletRequest.class );
-    when( request.getHeader( WebBrowserRequestMatcher.HEADER_SEC_FETCH_DEST ) ).thenReturn( "document" );
+    when( request.getHeader( WebBrowserSecFetchRequestMatcher.HEADER_SEC_FETCH_DEST ) ).thenReturn( "document" );
 
-    WebBrowserRequestMatcher matcher = new WebBrowserRequestMatcher();
+    WebBrowserSecFetchRequestMatcher matcher = new WebBrowserSecFetchRequestMatcher();
     assertTrue( matcher.matches( request ) );
   }
 
   @Test
   public void test_False_WhenSecFetchDestHeaderIsAbsent() {
     HttpServletRequest request = mock( HttpServletRequest.class );
-    when( request.getHeader( WebBrowserRequestMatcher.HEADER_SEC_FETCH_DEST ) ).thenReturn( null );
+    when( request.getHeader( WebBrowserSecFetchRequestMatcher.HEADER_SEC_FETCH_DEST ) ).thenReturn( null );
 
-    WebBrowserRequestMatcher matcher = new WebBrowserRequestMatcher();
+    WebBrowserSecFetchRequestMatcher matcher = new WebBrowserSecFetchRequestMatcher();
     assertFalse( matcher.matches( request ) );
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/WebBrowserUserAgentRequestMatcherTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/servlet/matchers/WebBrowserUserAgentRequestMatcherTest.java
@@ -1,0 +1,143 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.web.servlet.matchers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WebBrowserUserAgentRequestMatcherTest {
+
+  private WebBrowserUserAgentRequestMatcher matcher;
+
+  @Before
+  public void setUp() {
+    matcher = new WebBrowserUserAgentRequestMatcher();
+  }
+
+  private void assertUserAgentMatch( String userAgent, boolean shouldMatch ) {
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getHeader( "user-agent" ) ).thenReturn( userAgent );
+    if ( shouldMatch ) {
+      assertTrue( matcher.matches( request ) );
+    } else {
+      assertFalse( matcher.matches( request ) );
+    }
+  }
+
+  // region Normal Browsers
+  @Test
+  public void testMatchesWithChromeUserAgent() {
+    assertUserAgentMatch(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0 Safari/537.36", true );
+  }
+
+  @Test
+  public void testMatchesWithFirefoxUserAgent() {
+    assertUserAgentMatch(
+
+      "Mozilla/5.0 (Windows NT 10.0; rv:109.0) Gecko/20100101 Firefox/109.0", true );
+  }
+
+  @Test
+  public void testMatchesWithEdgeUserAgent() {
+    assertUserAgentMatch(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+        + "Chrome/120.0.6099.71 Safari/537.36 Edg/120.0.6094.50",
+      true );
+  }
+
+  @Test
+  public void testMatchesWithSafariUserAgent() {
+    assertUserAgentMatch(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 "
+        + "Safari/605.1.15",
+      true );
+  }
+  // endregion
+
+  // region Headless Browsers
+  @Test
+  public void testMatchesWithHeadlessChromeUserAgent() {
+    assertUserAgentMatch(
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+        + "HeadlessChrome/120.0.6099.71 Safari/537.36",
+      true );
+  }
+
+  @Test
+  public void testMatchesWithHeadlessFirefoxUserAgent() {
+    assertUserAgentMatch(
+      "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/109.0 Headless",
+      true );
+  }
+  // endregion
+
+  // region Non-browser User Agents
+  @Test
+  public void testDoesNotMatchWithCurlUserAgent() {
+    assertUserAgentMatch( "curl/7.68.0", false );
+  }
+
+  @Test
+  public void testDoesNotMatchWithWgetUserAgent() {
+    assertUserAgentMatch( "Wget/1.20.3 (linux-gnu)", false );
+  }
+
+  @Test
+  public void testDoesNotMatchWithBotUserAgent() {
+    assertUserAgentMatch( "Googlebot/2.1 (+http://www.google.com/bot.html)", false );
+  }
+  // endregion
+
+  @Test
+  public void testDoesNotMatchWithEmptyUserAgent() {
+    assertUserAgentMatch( "", false );
+  }
+
+  @Test
+  public void testDoesNotMatchWithNullUserAgent() {
+    assertUserAgentMatch( null, false );
+  }
+
+  @Test
+  public void testMatchesWithCustomBrowserPatterns() {
+    List<String> customBrowserPatterns = List.of( "\\bmybrowser/\\b" );
+    List<String> customNonBrowserPatterns = List.of( "\\bnotabrowser/\\b" );
+    WebBrowserUserAgentRequestMatcher customMatcher =
+      new WebBrowserUserAgentRequestMatcher( customBrowserPatterns, customNonBrowserPatterns );
+
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getHeader( "user-agent" ) ).thenReturn( "MyBrowser/1.0" );
+    assertTrue( customMatcher.matches( request ) );
+  }
+
+  @Test
+  public void testDoesNotMatchWithCustomNonBrowserPattern() {
+    List<String> customBrowserPatterns = List.of( "\\bmybrowser/\\b" );
+    List<String> customNonBrowserPatterns = List.of( "\\bnotabrowser/\\b" );
+    WebBrowserUserAgentRequestMatcher customMatcher =
+      new WebBrowserUserAgentRequestMatcher( customBrowserPatterns, customNonBrowserPatterns );
+
+    HttpServletRequest request = mock( HttpServletRequest.class );
+    when( request.getHeader( "user-agent" ) ).thenReturn( "MyBrowser/1.0 NotABrowser/2.0" );
+    assertFalse( customMatcher.matches( request ) );
+  }
+}


### PR DESCRIPTION
- allows the server to be accessed via an IP address, without HTTPS or without a valid certificate
- uses alternative means to infer web browser and user navigation requests

To be merged with:
- https://github.com/pentaho/pentaho-platform-ee/pull/1865

@pentaho/millenniumfalcon, please, review.