### PR TITLE
test: Fix MondrianCatalogHelperIT tests [SME-1164] 

### DIFF
--- a/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
@@ -438,6 +438,12 @@ public class MondrianCatalogHelperIT {
 
   @Test
   public void testRemoveCatalog() throws Exception {
+    MondrianCatalog cat = createTestCatalog();
+    var catalogMap = new HashMap<String, MondrianCatalog>() {{
+      put(CATALOG_NAME, cat);
+    }};
+    initMondrianCatalogsCache( catalogMap );
+
     repositoryMockMondrianFolder( "SteelWheels/" );
 
     final String steelWheelsFolderPath = mondrianFolderPath + RepositoryFile.SEPARATOR + "SteelWheels";
@@ -455,7 +461,7 @@ public class MondrianCatalogHelperIT {
       .getMondrianCatalogFile( any() );
     doReturn( repositoryHelper ).when( helperSpy ).getMondrianCatalogRepositoryHelper();
 
-    helperSpy.removeCatalog( "mondrian:/SteelWheels", testSession );
+    helperSpy.removeCatalog( CATALOG_NAME, testSession );
 
     verify( repo ).deleteFile( eq( UnifiedRepositoryTestUtils.makeIdObject( steelWheelsFolderPath ) ), eq( true ), nullable( String.class ) );
 

--- a/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
@@ -155,6 +155,8 @@ public class MondrianCatalogHelperIT {
       .when( localizingDynamicSchemaProcessor )
       .filter( nullable( String.class ), any(), any() );
 
+    // repository
+    testPlatform.defineInstance( IUnifiedRepository.class, repo );
 
     var mondrianCatalogHelper =
       new MondrianCatalogHelper( false, null, localizingDynamicSchemaProcessor );
@@ -164,8 +166,6 @@ public class MondrianCatalogHelperIT {
     testPlatform.define( IUserRoleListService.class, UserRoleMapperIT.TestUserRoleListService.class,
       IPentahoDefinableObjectFactory.Scope.GLOBAL );
 
-    // repository
-    testPlatform.defineInstance( IUnifiedRepository.class, repo );
     // OlapService / Mondrian
     testPlatform.defineInstance( IOlapService.class, olapService );
     // needed for a correct catalog loading process

--- a/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
@@ -38,6 +38,7 @@ import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
 import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.util.IPasswordService;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.platform.plugin.action.olap.IOlapService;
@@ -66,7 +67,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
@@ -170,6 +173,11 @@ public class MondrianCatalogHelperIT {
     testPlatform.defineInstance( IOlapService.class, olapService );
     // needed for a correct catalog loading process
     testPlatform.defineInstance( "singleTenantAdminUserName", "admin" );
+
+    // Password service
+    var mockPasswordService = mock( IPasswordService.class );
+    when( mockPasswordService.encrypt( anyString() ) ).then( returnsFirstArg() );
+    testPlatform.defineInstance( IPasswordService.class, mockPasswordService );
 
     testPlatform.start();
 

--- a/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/plugin/action/mondrian/catalog/MondrianCatalogHelperIT.java
@@ -161,14 +161,6 @@ public class MondrianCatalogHelperIT {
     // repository
     testPlatform.defineInstance( IUnifiedRepository.class, repo );
 
-    var mondrianCatalogHelper =
-      new MondrianCatalogHelper( false, null, localizingDynamicSchemaProcessor );
-
-    testPlatform.defineInstance( IAclAwareMondrianCatalogService.class, mondrianCatalogHelper );
-
-    testPlatform.define( IUserRoleListService.class, UserRoleMapperIT.TestUserRoleListService.class,
-      IPentahoDefinableObjectFactory.Scope.GLOBAL );
-
     // OlapService / Mondrian
     testPlatform.defineInstance( IOlapService.class, olapService );
     // needed for a correct catalog loading process
@@ -178,6 +170,14 @@ public class MondrianCatalogHelperIT {
     var mockPasswordService = mock( IPasswordService.class );
     when( mockPasswordService.encrypt( anyString() ) ).then( returnsFirstArg() );
     testPlatform.defineInstance( IPasswordService.class, mockPasswordService );
+
+    var mondrianCatalogHelper =
+      new MondrianCatalogHelper( false, null, localizingDynamicSchemaProcessor );
+
+    testPlatform.defineInstance( IAclAwareMondrianCatalogService.class, mondrianCatalogHelper );
+
+    testPlatform.define( IUserRoleListService.class, UserRoleMapperIT.TestUserRoleListService.class,
+      IPentahoDefinableObjectFactory.Scope.GLOBAL );
 
     testPlatform.start();
 


### PR DESCRIPTION
Fix failing tests.
The majority of the tests was fixed by defining the mock for the `IUnifiedRepository` before instantiating the `MondrianCatalogHelper` class, that needs that dependency to be present in the system.
Also added mock for `IPasswordService`.