### PR TITLE
test: fix UserRoleMapperIT tests [SME-1165]

### DIFF
--- a/extensions/src/it/java/org/pentaho/test/platform/plugin/UserRoleMapperIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/plugin/UserRoleMapperIT.java
@@ -76,11 +76,13 @@ public class UserRoleMapperIT {
   public void init0() {
     IAclNodeHelper aclHelper = mock( IAclNodeHelper.class );
     when( aclHelper.canAccess( any( RepositoryFile.class ), any( EnumSet.class ) ) ).thenReturn( true );
-    MondrianCatalogHelper catalogService = new MondrianCatalogHelper( aclHelper );
 
     microPlatform = new MicroPlatform( TestResourceLocation.TEST_RESOURCES + "/solution" );
     microPlatform.define( ISolutionEngine.class, SolutionEngine.class );
     microPlatform.define( IUnifiedRepository.class, FileSystemBackedUnifiedRepository.class, Scope.GLOBAL );
+
+    MondrianCatalogHelper catalogService = new MondrianCatalogHelper( aclHelper );
+
     microPlatform.defineInstance( IMondrianCatalogService.class, catalogService );
     microPlatform.define( "connection-SQL", SQLConnection.class );
     microPlatform.define( "connection-MDX", MDXConnection.class );


### PR DESCRIPTION
Moved the creation of the `IUnifiedRepository` mock and its addition to the test platform before instantiating the `MondrianCatalogHelper` class, that needs that dependency in the system.