### PR TITLE
[BACKLOG-41543] Added mimetype "backup" to the ImportHandlerMimeTypeD…

### DIFF
--- a/extensions/src/test/resources/MimeTypeFactoryTest/ImportHandlerMimeTypeDefinitions.xml
+++ b/extensions/src/test/resources/MimeTypeFactoryTest/ImportHandlerMimeTypeDefinitions.xml
@@ -54,6 +54,7 @@
         <extension>xjpivot</extension>
         <extension>xml</extension>
         <extension>xreportspec</extension>
+        <extension>backup</extension>
       </MimeTypeDefinition>      
     </MimeTypeDefinitions>
   </ImportHandler>


### PR DESCRIPTION
…efinitions.xml file. The backup file gets added

whenever the configType that are defined in shared.xml changes, it creates a .backup file before updating the shared.xml. As the projects can be added to repository, this backup file will be added to the project folder.