### PR TITLE
[BACKLOG-45029] - Missing Data Source SampleData of type JDBC

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseConnection.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/exportManifest/bindings/DatabaseConnection.java
@@ -184,7 +184,6 @@ public class DatabaseConnection {
   protected String dataTablespace;
   protected String databaseName;
   protected String databasePort;
-  @XmlElement( namespace = "http://www.pentaho.com/schema/" )
   protected DatabaseType databaseType;
   @XmlElement( required = true )
   protected DatabaseConnection.ExtraOptions extraOptions;


### PR DESCRIPTION
The root cause of the issue lies in the stricter enforcement introduced by the jakarta.xml.bind API.

Pentaho attempts to load all sample data source configurations as part of the default-content. These configurations, including JDBC resources, are defined within the exportManifest.xml files inside the default-content ZIP archives. While processing each ZIP file, the export XML content is unmarshalled into Java DTOs using JAXB.

The problem arises specifically due to the @XmlElement annotation on the databaseType field in DatabaseConnection.java. This annotation includes a schema URL reference. However, the corresponding databaseType element in the exportManifest.xml does not provide a matching schema URL. As a result, JAXB fails to bind the value correctly, setting databaseType to null. Consequently, the data source creation fails.

This issue did not occur before the Tomcat upgrade because the older javax.xml.bind implementation was more lenient and did not strictly enforce the presence of the schema URL during unmarshalling.