### PR TITLE
fix[BISERVER-15341]: revert username char validation, add "-" to allowed password chars and fix error message

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/UserRoleDaoService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/UserRoleDaoService.java
@@ -65,7 +65,7 @@ public class UserRoleDaoService {
   private static final String PASS_VALIDATION_ERROR_WRONG_PASS = "UserRoleDaoService.PassValidationError_WrongPass";
   public static final String PUC_USER_PASSWORD_LENGTH = "PUC_USER_PASSWORD_LENGTH";
   public static final String PUC_USER_PASSWORD_REQUIRE_SPECIAL_CHARACTER = "PUC_USER_PASSWORD_REQUIRE_SPECIAL_CHARACTER";
-  private static final String ALLOWED_CHARS = "^[a-zA-Z0-9_.,:;<>|!@#$%^&*()\\[\\]]+$";
+  private static final String ALLOWED_CHARS = "^[a-zA-Z0-9_.,:;<>|!@#$%^&*()\\[\\]-]+$";
   private static final String SPEC_CHARS = "((?=.*[@#$%!]).{0,100})";
   private final Pattern allowedCharsPattern = Pattern.compile( ALLOWED_CHARS );
   private final Pattern specCharsPattern = Pattern.compile( SPEC_CHARS );

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/UserRoleDaoService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/UserRoleDaoService.java
@@ -66,6 +66,7 @@ public class UserRoleDaoService {
   public static final String PUC_USER_PASSWORD_LENGTH = "PUC_USER_PASSWORD_LENGTH";
   public static final String PUC_USER_PASSWORD_REQUIRE_SPECIAL_CHARACTER = "PUC_USER_PASSWORD_REQUIRE_SPECIAL_CHARACTER";
   private static final String ALLOWED_CHARS = "^[a-zA-Z0-9_.,:;<>|!@#$%^&*()\\[\\]-]+$";
+  private static final String ALLOWED_CHARS_LIST = "a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ] -";
   private static final String SPEC_CHARS = "((?=.*[@#$%!]).{0,100})";
   private final Pattern allowedCharsPattern = Pattern.compile( ALLOWED_CHARS );
   private final Pattern specCharsPattern = Pattern.compile( SPEC_CHARS );
@@ -243,7 +244,7 @@ public class UserRoleDaoService {
     }
 
     if ( !allowedCharsMatcher.matches() ) {
-      validationCriteria.add( Messages.getInstance().getString( "UserRoleDaoService.PassValidationError_PermittedChars" ) );
+      validationCriteria.add( Messages.getInstance().getString( "UserRoleDaoService.PassValidationError_PermittedChars", ALLOWED_CHARS_LIST ) );
     }
 
     errorMsg = errorMsg + String.join( ", ", validationCriteria ) + ".";

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages.properties
@@ -411,7 +411,7 @@ ZIPFILE.ExceptionOccurred=Exception occurred when processing Zip:
 
 UserRoleDaoService.PassValidationError_Length=have at least {0} characters
 UserRoleDaoService.PassValidationError_SpecChar=have at least one special character
-UserRoleDaoService.PassValidationError_PermittedChars=only contain the following characters: a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ] -
+UserRoleDaoService.PassValidationError_PermittedChars=only contain the following characters: {0}
 UserRoleDaoService.PassValidationError_WrongPass=You entered the wrong old password.
 UserRoleDaoService.PassValidationError_ReadingSecProperties=There was an error reading the security.properties file.
 

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages.properties
@@ -411,7 +411,7 @@ ZIPFILE.ExceptionOccurred=Exception occurred when processing Zip:
 
 UserRoleDaoService.PassValidationError_Length=have at least {0} characters
 UserRoleDaoService.PassValidationError_SpecChar=have at least one special character
-UserRoleDaoService.PassValidationError_PermittedChars=only contain the following characters: a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ]
+UserRoleDaoService.PassValidationError_PermittedChars=only contain the following characters: a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ] -
 UserRoleDaoService.PassValidationError_WrongPass=You entered the wrong old password.
 UserRoleDaoService.PassValidationError_ReadingSecProperties=There was an error reading the security.properties file.
 

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordByUserDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordByUserDialog.java
@@ -193,7 +193,7 @@ public class ChangePasswordByUserDialog extends GwtDialog implements ServiceCall
       GwtMessageBox messageBox = new GwtMessageBox();
       messageBox.setTitle( Messages.getString( "error" ) );
       messageBox.setMessage( Messages.getString( "allowedNameCharacters", value, allowedCharacters ) );
-      messageBox.setButtons( new Object[ACCEPT] );
+      messageBox.setButtons( new Object[ ACCEPT ] );
       messageBox.setWidth( 300 );
       messageBox.show();
     }

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordByUserDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordByUserDialog.java
@@ -34,6 +34,9 @@ import org.pentaho.mantle.client.ui.xul.MantleController;
 import org.pentaho.ui.xul.gwt.tags.GwtDialog;
 import org.pentaho.ui.xul.gwt.tags.GwtMessageBox;
 
+import java.util.HashSet;
+import java.util.Set;
+
 //This rule is triggered when the class has more than 5 parents. in this case most of the parents are third party classes that can't be changed.
 @SuppressWarnings( "squid:S110" )
 public class ChangePasswordByUserDialog extends GwtDialog implements ServiceCallback {
@@ -176,10 +179,12 @@ public class ChangePasswordByUserDialog extends GwtDialog implements ServiceCall
     }
 
     private String getNonMatchingCharacters( String value, String allowedCharacters ) {
+      Set<Character> seen = new HashSet<>(); // Allows to identify unique non matching characters
       StringBuilder nonMatchingChars = new StringBuilder();
+
       for ( char c : value.toCharArray() ) {
-        if ( !String.valueOf( c ).matches( allowedCharacters )
-          && nonMatchingChars.indexOf( String.valueOf( c ) ) < 0 ) {
+        if ( !ALLOWED_CHARS_REGEXP.test( String.valueOf( c ) )
+          && seen.add( c ) ) {
           if (nonMatchingChars.length() > 0) {
             nonMatchingChars.append(" ");
           }

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordByUserDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordByUserDialog.java
@@ -47,9 +47,9 @@ public class ChangePasswordByUserDialog extends GwtDialog implements ServiceCall
   private static final String TEXT_BOX_WIDTH = "260px";
   private static final String SPACER_STYLE_NAME = "spacer";
   private boolean acceptBtnEnabled = false;
-  private static final String ALLOWED_CHARS = "^[a-zA-Z0-9_.,:;<>|!@#$%^&*()\\[\\]]+$";
+  private static final String ALLOWED_CHARS = "^[a-zA-Z0-9_.,:;<>|!@#$%^&*()\\[\\]-]+$";
   private static final RegExp ALLOWED_CHARS_REGEXP = RegExp.compile( ALLOWED_CHARS );
-  private static final String ALLOWED_CHARS_LIST = "a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ]";
+  private static final String ALLOWED_CHARS_LIST = "a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ] -";
 
   public ChangePasswordByUserDialog( MantleController controller ) {
     setWidth( 260 );
@@ -162,7 +162,8 @@ public class ChangePasswordByUserDialog extends GwtDialog implements ServiceCall
         String oldPassword = oldPasswordTextBox.getText();
 
         if ( !isValidPassword( newPassword ) ) {
-          showErrorMessage( newPassword, ALLOWED_CHARS_LIST );
+          String nonMatchingChars = getNonMatchingCharacters( newPassword, ALLOWED_CHARS );
+          showErrorMessage( nonMatchingChars, ALLOWED_CHARS_LIST );
           return;
         }
 
@@ -174,10 +175,24 @@ public class ChangePasswordByUserDialog extends GwtDialog implements ServiceCall
       return ALLOWED_CHARS_REGEXP.test( password );
     }
 
-    private void showErrorMessage( String userName, String allowedCharacters ) {
+    private String getNonMatchingCharacters( String value, String allowedCharacters ) {
+      StringBuilder nonMatchingChars = new StringBuilder();
+      for ( char c : value.toCharArray() ) {
+        if ( !String.valueOf( c ).matches( allowedCharacters )
+          && nonMatchingChars.indexOf( String.valueOf( c ) ) < 0 ) {
+          if (nonMatchingChars.length() > 0) {
+            nonMatchingChars.append(" ");
+          }
+          nonMatchingChars.append( c );
+        }
+      }
+      return nonMatchingChars.toString();
+    }
+
+    private void showErrorMessage( String value, String allowedCharacters ) {
       GwtMessageBox messageBox = new GwtMessageBox();
       messageBox.setTitle( Messages.getString( "error" ) );
-      messageBox.setMessage( Messages.getString( "allowedNameCharacters", userName, allowedCharacters ) );
+      messageBox.setMessage( Messages.getString( "allowedNameCharacters", value, allowedCharacters ) );
       messageBox.setButtons( new Object[ACCEPT] );
       messageBox.setWidth( 300 );
       messageBox.show();

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordDialog.java
@@ -33,6 +33,9 @@ import org.pentaho.mantle.client.messages.Messages;
 import org.pentaho.ui.xul.gwt.tags.GwtDialog;
 import org.pentaho.ui.xul.gwt.tags.GwtMessageBox;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class ChangePasswordDialog extends GwtDialog implements ServiceCallback {
 
   private UpdatePasswordController controller;
@@ -172,10 +175,12 @@ public class ChangePasswordDialog extends GwtDialog implements ServiceCallback {
     }
 
     private String getNonMatchingCharacters( String value, String allowedCharacters ) {
+      Set<Character> seen = new HashSet<>(); // Allows to identify unique non matching characters
       StringBuilder nonMatchingChars = new StringBuilder();
+
       for ( char c : value.toCharArray() ) {
-        if ( !String.valueOf( c ).matches( allowedCharacters )
-          && nonMatchingChars.indexOf( String.valueOf( c ) ) < 0 ) {
+        if ( !ALLOWED_CHARS_REGEXP.test( String.valueOf( c ) )
+          && seen.add( c ) ) {
           if (nonMatchingChars.length() > 0) {
             nonMatchingChars.append(" ");
           }

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordDialog.java
@@ -42,9 +42,9 @@ public class ChangePasswordDialog extends GwtDialog implements ServiceCallback {
   private Button acceptBtn = new Button( Messages.getString( "ok" ) );
   private Button cancelBtn = new Button( Messages.getString( "cancel" ) );
   private boolean acceptBtnEnabled = false;
-  private static final String ALLOWED_CHARS = "^[a-zA-Z0-9_.,:;<>|!@#$%^&*()\\[\\]]+$";
+  private static final String ALLOWED_CHARS = "^[a-zA-Z0-9_.,:;<>|!@#$%^&*()\\[\\]-]+$";
   private static final RegExp ALLOWED_CHARS_REGEXP = RegExp.compile( ALLOWED_CHARS );
-  private static final String ALLOWED_CHARS_LIST = "a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ]";
+  private static final String ALLOWED_CHARS_LIST = "a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ] -";
 
   public ChangePasswordDialog( UpdatePasswordController controller ) {
     setWidth( 260 );
@@ -158,7 +158,8 @@ public class ChangePasswordDialog extends GwtDialog implements ServiceCallback {
         String administratorPassword = administratorPasswordTextBox.getText();
 
         if ( !isValidPassword( newPassword ) ) {
-          showErrorMessage( newPassword, ALLOWED_CHARS_LIST );
+          String nonMatchingChars = getNonMatchingCharacters( newPassword, ALLOWED_CHARS );
+          showErrorMessage( nonMatchingChars, ALLOWED_CHARS_LIST );
           return;
         }
 
@@ -170,10 +171,24 @@ public class ChangePasswordDialog extends GwtDialog implements ServiceCallback {
       return ALLOWED_CHARS_REGEXP.test( password );
     }
 
-    private void showErrorMessage( String userName, String allowedCharacters ) {
+    private String getNonMatchingCharacters( String value, String allowedCharacters ) {
+      StringBuilder nonMatchingChars = new StringBuilder();
+      for ( char c : value.toCharArray() ) {
+        if ( !String.valueOf( c ).matches( allowedCharacters )
+          && nonMatchingChars.indexOf( String.valueOf( c ) ) < 0 ) {
+          if (nonMatchingChars.length() > 0) {
+            nonMatchingChars.append(" ");
+          }
+          nonMatchingChars.append( c );
+        }
+      }
+      return nonMatchingChars.toString();
+    }
+
+    private void showErrorMessage( String value, String allowedCharacters ) {
       GwtMessageBox messageBox = new GwtMessageBox();
       messageBox.setTitle( Messages.getString( "error" ) );
-      messageBox.setMessage( Messages.getString( "allowedNameCharacters", userName, allowedCharacters ) );
+      messageBox.setMessage( Messages.getString( "allowedNameCharacters", value, allowedCharacters ) );
       messageBox.setButtons( new Object[ACCEPT] );
       messageBox.setWidth( 300 );
       messageBox.show();

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/ChangePasswordDialog.java
@@ -189,7 +189,7 @@ public class ChangePasswordDialog extends GwtDialog implements ServiceCallback {
       GwtMessageBox messageBox = new GwtMessageBox();
       messageBox.setTitle( Messages.getString( "error" ) );
       messageBox.setMessage( Messages.getString( "allowedNameCharacters", value, allowedCharacters ) );
-      messageBox.setButtons( new Object[ACCEPT] );
+      messageBox.setButtons( new Object[ ACCEPT ] );
       messageBox.setWidth( 300 );
       messageBox.show();
     }

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/UserDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/UserDialog.java
@@ -49,12 +49,9 @@ public class UserDialog extends GwtDialog {
   private PasswordTextBox reTypePasswordTextBox;
   private Button acceptBtn = new Button( Messages.getString( "ok" ) );
   private Button cancelBtn = new Button( Messages.getString( "cancel" ) );
-  private static final String USER_ALLOWED_CHARS = "^[a-zA-Z0-9_.,;<>|!@#$%^&*()\\[\\]]+$";
-  private static final RegExp USER_ALLOWED_CHARS_REGEXP = RegExp.compile( USER_ALLOWED_CHARS );
-  private static final String USER_ALLOWED_CHARS_LIST = "a-z A-Z 0-9 _ . , ; < > | ! @ # $ % ^ & * ( ) [ ]";
-  private static final String ALLOWED_CHARS = "^[a-zA-Z0-9_.,:;<>|!@#$%^&*()\\[\\]]+$";
+  private static final String ALLOWED_CHARS = "^[a-zA-Z0-9_.,:;<>|!@#$%^&*()\\[\\]-]+$";
   private static final RegExp ALLOWED_CHARS_REGEXP = RegExp.compile( ALLOWED_CHARS );
-  private static final String ALLOWED_CHARS_LIST = "a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ]";
+  private static final String ALLOWED_CHARS_LIST = "a-z A-Z 0-9 _ . , : ; < > | ! @ # $ % ^ & * ( ) [ ] -";
 
   public UserDialog( UserRolesAdminPanelController controller ) {
     setWidth( 260 );
@@ -136,11 +133,11 @@ public class UserDialog extends GwtDialog {
     return !StringUtils.containsAnyChars( name, reservedSymbols );
   }
 
-  private void showErrorMessage( String userName, String reservedCharacters ) {
+  private void showErrorMessage( String value, String reservedCharacters, String message ) {
     GwtMessageBox messageBox = new GwtMessageBox();
     messageBox.setTitle( Messages.getString( "error" ) );
-    messageBox.setMessage( Messages.getString( "allowedNameCharacters", userName, reservedCharacters ) );
-    messageBox.setButtons( new Object[ACCEPT] );
+    messageBox.setMessage( Messages.getString( message, value, reservedCharacters ) );
+    messageBox.setButtons( new Object[ GwtMessageBox.ACCEPT ] );
     messageBox.setWidth( 300 );
     messageBox.show();
   }
@@ -156,13 +153,14 @@ public class UserDialog extends GwtDialog {
         String password = passwordTextBox.getText();
         String reservedCharacters = response.getText();
 
-        if ( !isValidUsername( userName, reservedCharacters )) {
-          showErrorMessage( userName, USER_ALLOWED_CHARS_LIST );
+        if ( !isValidName( userName, reservedCharacters ) ) {
+          showErrorMessage( userName, reservedCharacters, "prohibitedNameSymbols" );
           return;
         }
 
         if ( !isValidPassword( password ) ) {
-          showErrorMessage( password, ALLOWED_CHARS_LIST );
+          String nonMatchingChars = getNonMatchingCharacters( password, ALLOWED_CHARS );
+          showErrorMessage( nonMatchingChars, ALLOWED_CHARS_LIST, "allowedNameCharacters" );
           return;
         }
 
@@ -174,8 +172,18 @@ public class UserDialog extends GwtDialog {
         return ALLOWED_CHARS_REGEXP.test( password );
       }
 
-      private boolean isValidUsername( String userName, String reservedCharacters ) {
-        return isValidName( userName, reservedCharacters ) && USER_ALLOWED_CHARS_REGEXP.test( userName );
+      private String getNonMatchingCharacters( String value, String allowedCharacters ) {
+        StringBuilder nonMatchingChars = new StringBuilder();
+        for ( char c : value.toCharArray() ) {
+          if ( !String.valueOf( c ).matches( allowedCharacters )
+            && nonMatchingChars.indexOf( String.valueOf( c ) ) < 0 ) {
+            if (nonMatchingChars.length() > 0) {
+              nonMatchingChars.append(" ");
+            }
+            nonMatchingChars.append( c );
+          }
+        }
+        return nonMatchingChars.toString();
       }
 
       @Override
@@ -192,7 +200,7 @@ public class UserDialog extends GwtDialog {
         performSave();
       } catch ( RequestException e ) {
         MessageDialogBox dialogBox = new MessageDialogBox( Messages.getString( "error" ), e.toString(), //$NON-NLS-1$
-            false, false, true );
+          false, false, true );
         dialogBox.center();
       }
     }
@@ -210,7 +218,7 @@ public class UserDialog extends GwtDialog {
       String password = passwordTextBox.getText();
       String reTypePassword = reTypePasswordTextBox.getText();
       boolean isEnabled =
-          !StringUtils.isEmpty( name ) && !StringUtils.isEmpty( password ) && password.equals( reTypePassword );
+        !StringUtils.isEmpty( name ) && !StringUtils.isEmpty( password ) && password.equals( reTypePassword );
       acceptBtn.setEnabled( isEnabled );
     }
   }

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/UserDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/UserDialog.java
@@ -41,6 +41,9 @@ import org.pentaho.mantle.client.messages.Messages;
 import org.pentaho.ui.xul.gwt.tags.GwtDialog;
 import org.pentaho.ui.xul.gwt.tags.GwtMessageBox;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class UserDialog extends GwtDialog {
 
   private UserRolesAdminPanelController controller;
@@ -173,10 +176,12 @@ public class UserDialog extends GwtDialog {
       }
 
       private String getNonMatchingCharacters( String value, String allowedCharacters ) {
+        Set<Character> seen = new HashSet<>(); // Allows to identify unique non matching characters
         StringBuilder nonMatchingChars = new StringBuilder();
+
         for ( char c : value.toCharArray() ) {
-          if ( !String.valueOf( c ).matches( allowedCharacters )
-            && nonMatchingChars.indexOf( String.valueOf( c ) ) < 0 ) {
+          if ( !ALLOWED_CHARS_REGEXP.test( String.valueOf( c ) )
+            && seen.add( c ) ) {
             if (nonMatchingChars.length() > 0) {
               nonMatchingChars.append(" ");
             }

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/UserDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/UserDialog.java
@@ -137,7 +137,7 @@ public class UserDialog extends GwtDialog {
     GwtMessageBox messageBox = new GwtMessageBox();
     messageBox.setTitle( Messages.getString( "error" ) );
     messageBox.setMessage( Messages.getString( message, value, reservedCharacters ) );
-    messageBox.setButtons( new Object[ GwtMessageBox.ACCEPT ] );
+    messageBox.setButtons( new Object[ ACCEPT ] );
     messageBox.setWidth( 300 );
     messageBox.show();
   }


### PR DESCRIPTION
This pull request updates the allowed password characters, expanding it to include the hyphen (`-`). It also improves error messaging by showing users which specific characters in their password are not permitted, rather than simply displaying the whole password. 

Additionally, the behaviour added to user creation dialog in https://github.com/pentaho/pentaho-platform/pull/5839 and https://github.com/pentaho/pentaho-platform/pull/5849 restricting allowed username characters was reverted.

@pentaho/tatooine_dev