### PR TITLE
build[PDI-20311]: remove declaration of unused dependency trilead-ssh2

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -1437,18 +1437,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>trilead-ssh2</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-      <version>${trilead-ssh2.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>ftp4che</groupId>
       <artifactId>ftp4che</artifactId>
       <version>${ftp4che.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,6 @@
     <se-jcr.version>0.9</se-jcr.version>
     <secondstring.version>20060615</secondstring.version>
     <pentaho-cwm.version>1.5.4</pentaho-cwm.version>
-    <trilead-ssh2.version>build213</trilead-ssh2.version>
     <saaj.version>1.3</saaj.version>
     <fontbox.version>0.1.0</fontbox.version>
     <ldapjdk.version>20000524</ldapjdk.version>


### PR DESCRIPTION
Remove unused trilead-ssh2 dependency declarations

## Problem
The dependency trilead-ssh2 is declared in the pentaho-platform project:

- [pom.xml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) contains a dependency declaration for trilead-ssh2
- [pom.xml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) defines the version property trilead-ssh2.version

However, maven-dependency-plugin:analyze identifies trilead-ssh2 as an "Unused declared dependency" in the extensions module, indicating the dependency is not actually used in the codebase.

## Solution
This PR removes all trilead-ssh2 dependency declarations from the affected POMs.

## Verification
- Confirmed no actual usage of trilead-ssh2 classes in the codebase via code search
- Verified all modules still compile successfully after removal
- Dependency analysis no longer reports trilead-ssh2 as unused

## Context
This cleanup is part of PDI-20311, where trilead-ssh2 will be replaced with other SSH client tools. Since this dependency is unused in the pentaho-platform project, it can be safely removed.