### PR TITLE
fix: change bean scope of GFS providers to session [PPUC-124]

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/pentahoObjects.spring.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/pentahoObjects.spring.xml
@@ -486,7 +486,7 @@ not directly from the PentahoObjectFactory. -->
     <pen:publish as-type="INTERFACES"/>
   </bean>
 
-  <bean class="org.pentaho.platform.genericfile.providers.repository.RepositoryFileProvider">
+  <bean class="org.pentaho.platform.genericfile.providers.repository.RepositoryFileProvider" scope="session">
     <pen:publish as-type="INTERFACES">
       <pen:attributes>
         <pen:attr key="priority" value="20"/>


### PR DESCRIPTION
- the scope had been lost when moving configs from Browse Files plugin

To be merged with: https://github.com/pentaho/pentaho-platform-ee/pull/1892