### PR TITLE
fix: incorrect GFS snapshot version number [PPUC-124]

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -24,7 +24,7 @@
     <pentaho-server.kettle.plugins.directory>${pentaho-server.system.directory}/kettle/plugins</pentaho-server.kettle.plugins.directory>
     <package.id>pentaho-server</package.id>
     <pentaho-server.directory>${project.build.directory}/${package.id}</pentaho-server.directory>
-    <pentaho-generic-file-system.version>11.0.0-SNAPSHOT</pentaho-generic-file-system.version>
+    <pentaho-generic-file-system.version>11.0.0.0-SNAPSHOT</pentaho-generic-file-system.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION

To be merged with:
- https://github.com/pentaho/pentaho-platform-ee/pull/1893
- https://github.com/pentaho/pentaho-generic-file-system/pull/34
- https://github.com/pentaho/pentaho-generic-file-system-ee/pull/26