### PR TITLE
feat: principal-based authorization request builder [PPUC-89]

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/engine/security/authorization/IAuthorizationRequest.java
+++ b/api/src/main/java/org/pentaho/platform/api/engine/security/authorization/IAuthorizationRequest.java
@@ -15,15 +15,19 @@ package org.pentaho.platform.api.engine.security.authorization;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.IAuthorizationAction;
 
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
 /**
- * The {@code IAuthorizationRequest} interface represents an authorization request for a user to perform an action.
+ * The {@code IAuthorizationRequest} interface represents an authorization request for a principal to perform an action.
  * <p>
  * This type can be derived to include any additional information characterizing an authorization request. In this case,
  * the {@link #withAction(IAuthorizationAction)} method should be overridden to ensure that the new request includes all
  * properties of the original request, except for the action, which will be replaced by the new one.
  * <p>
- * Equality is based on the user, action and any other key properties, meaning two requests are considered
- * equal if they have the same user, action and value of the other key properties.
+ * Equality is based on the principal, action and any other key properties, meaning two requests are considered
+ * equal if they have the same principal, action and value of the other key properties.
  * The {@link Object#equals(Object)} and {@link Object#hashCode()} methods must ensure this behavior.
  * <p>
  * The string representation of this request should be appropriate for logging and debugging purposes. Inheritors should
@@ -31,12 +35,55 @@ import org.pentaho.platform.api.engine.IAuthorizationAction;
  */
 public interface IAuthorizationRequest {
   /**
-   * Gets the user for whom the authorization is being evaluated.
+   * Gets the principal for whom the authorization is being evaluated.
    *
-   * @return The user.
+   * @return The principal (user, role, etc.).
    */
   @NonNull
-  IAuthorizationUser getUser();
+  IAuthorizationPrincipal getPrincipal();
+
+  /**
+   * Gets the user for whom the authorization is being evaluated.
+   *
+   * @return The user or {@code null} if the principal is not a user.
+   */
+  @NonNull
+  default Optional<IAuthorizationUser> getPrincipalAsUser() {
+    IAuthorizationPrincipal principal = getPrincipal();
+    return Optional.ofNullable( principal instanceof IAuthorizationUser ? (IAuthorizationUser) principal : null );
+  }
+
+  /**
+   * Gets the role for which the authorization is being evaluated.
+   *
+   * @return The role or {@code null} if the principal is not a role.
+   */
+  @NonNull
+  default Optional<IAuthorizationRole> getPrincipalAsRole() {
+    IAuthorizationPrincipal principal = getPrincipal();
+    return Optional.ofNullable( principal instanceof IAuthorizationRole ? (IAuthorizationRole) principal : null );
+  }
+
+  /**
+   * Gets all roles associated with the principal for whom the authorization is being evaluated.
+   * <p>
+   * If the principal is a user, this method returns all roles assigned to that user.
+   * If the principal is a role, this method returns a set containing only that role.
+   * If the principal is neither a user nor a role, this method returns an empty set.
+   *
+   * @return A set of roles associated with the principal, never {@code null}.
+   */
+  @NonNull
+  default Set<IAuthorizationRole> getAllRoles() {
+    Optional<IAuthorizationUser> user = getPrincipalAsUser();
+    if ( user.isPresent() ) {
+      return user.get().getRoles();
+    }
+
+    Optional<IAuthorizationRole> role = getPrincipalAsRole();
+    return role.map( Set::of )
+      .orElse( Collections.emptySet() );
+  }
 
   /**
    * Gets the action to be evaluated.
@@ -47,11 +94,10 @@ public interface IAuthorizationRequest {
   IAuthorizationAction getAction();
 
   /**
-   * Creates a new instance of {@code IAuthorizationRequest} with the same user but with a different action.
+   * Creates a new instance of {@code IAuthorizationRequest} with the same principal but with a different action.
    *
-   * @param action The action to be evaluated.
-   * @return The new instance.
-   * @throws IllegalArgumentException if the action is null.
+   * @param action The new action.
+   * @return A new request with the same principal but different action.
    */
   @NonNull
   IAuthorizationRequest withAction( @NonNull IAuthorizationAction action );

--- a/api/src/main/java/org/pentaho/platform/api/engine/security/authorization/IAuthorizationRule.java
+++ b/api/src/main/java/org/pentaho/platform/api/engine/security/authorization/IAuthorizationRule.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * Implementations should override the {@link Object#toString()} method to provide a meaningful description of the rule,
  * appropriate for including in exception messages, and for logging and debugging purposes.
  *
- * @param <T> The specific type of authorization request this rule can handle, must extend {@link IAuthorizationRequest}
+ * @param <T> The specific type of authorization request this rule can handle, must extend {@link IAuthorizationRequest}.
  */
 public interface IAuthorizationRule<T extends IAuthorizationRequest> {
   /**

--- a/api/src/main/java/org/pentaho/platform/api/engine/security/authorization/resources/IResourceAuthorizationRequest.java
+++ b/api/src/main/java/org/pentaho/platform/api/engine/security/authorization/resources/IResourceAuthorizationRequest.java
@@ -39,7 +39,7 @@ public interface IResourceAuthorizationRequest extends IAuthorizationRequest {
    *
    * @param resource The resource to be evaluated.
    * @return The new instance.
-   * @throws IllegalArgumentException if the resource is null.
+   * @throws IllegalArgumentException if the resource is {@code null}.
    */
   @NonNull
   IResourceAuthorizationRequest withResource( @NonNull IAuthorizationResource resource );

--- a/api/src/test/java/org/pentaho/platform/api/engine/security/authorization/IAuthorizationRequestTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/security/authorization/IAuthorizationRequestTest.java
@@ -1,0 +1,129 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.api.engine.security.authorization;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pentaho.platform.api.engine.IAuthorizationAction;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+class IAuthorizationRequestTest {
+  private IAuthorizationUser mockUser;
+  private IAuthorizationRole mockRole;
+  private IAuthorizationAction mockAction;
+
+  @BeforeEach
+  public void setUp() {
+    mockUser = mock( IAuthorizationUser.class );
+    mockRole = mock( IAuthorizationRole.class );
+    mockAction = mock( IAuthorizationAction.class );
+  }
+
+  @Test
+  void testGetPrincipalAsUser() {
+    IAuthorizationRequest request = spy( new TestAuthorizationRequest( mockUser, mockAction ) );
+
+    Optional<IAuthorizationUser> user = request.getPrincipalAsUser();
+
+    assertTrue( user.isPresent() );
+    assertSame( mockUser, user.get() );
+  }
+
+  @Test
+  void testGetPrincipalAsUserWhenRole() {
+    IAuthorizationRequest request = spy( new TestAuthorizationRequest( mockRole, mockAction ) );
+
+    assertSame( Optional.empty(), request.getPrincipalAsUser() );
+  }
+
+  @Test
+  void testGetPrincipalAsRole() {
+    IAuthorizationRequest request = spy( new TestAuthorizationRequest( mockRole, mockAction ) );
+
+    Optional<IAuthorizationRole> role = request.getPrincipalAsRole();
+
+    assertTrue( role.isPresent() );
+    assertSame( mockRole, role.get() );
+  }
+
+  @Test
+  void testGetPrincipalAsRoleWhenUser() {
+    IAuthorizationRequest request = spy( new TestAuthorizationRequest( mockUser, mockAction ) );
+
+    assertSame( Optional.empty(), request.getPrincipalAsRole() );
+  }
+
+  @Test
+  void testGetAllRolesWhenUser() {
+    IAuthorizationRole role1 = mock( IAuthorizationRole.class );
+    IAuthorizationRole role2 = mock( IAuthorizationRole.class );
+    Set<IAuthorizationRole> userRoles = Set.of( role1, role2 );
+    when( mockUser.getRoles() ).thenReturn( userRoles );
+    IAuthorizationRequest request = spy( new TestAuthorizationRequest( mockUser, mockAction ) );
+
+    assertEquals( userRoles, request.getAllRoles() );
+  }
+
+  @Test
+  void testGetAllRolesWhenRole() {
+    IAuthorizationRequest request = spy( new TestAuthorizationRequest( mockRole, mockAction ) );
+
+    assertEquals( Set.of( mockRole ), request.getAllRoles() );
+  }
+
+  @Test
+  void testGetAllRolesWhenOtherPrincipal() {
+    IAuthorizationPrincipal otherPrincipal = mock( IAuthorizationPrincipal.class );
+    IAuthorizationRequest request = spy( new TestAuthorizationRequest( otherPrincipal, mockAction ) );
+
+    assertTrue( request.getAllRoles().isEmpty() );
+  }
+
+  private static class TestAuthorizationRequest implements IAuthorizationRequest {
+    private final IAuthorizationPrincipal principal;
+    private final IAuthorizationAction action;
+
+    public TestAuthorizationRequest( IAuthorizationPrincipal principal, IAuthorizationAction action ) {
+      this.principal = principal;
+      this.action = action;
+    }
+
+    @Override
+    @NonNull
+    public IAuthorizationPrincipal getPrincipal() {
+      return principal;
+    }
+
+    @Override
+    @NonNull
+    public IAuthorizationAction getAction() {
+      return action;
+    }
+
+    @Override
+    @NonNull
+    public IAuthorizationRequest withAction( @NonNull IAuthorizationAction action ) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/AuthorizationServiceAuthorizationPolicy.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/AuthorizationServiceAuthorizationPolicy.java
@@ -16,8 +16,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.IAuthorizationAction;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationActionService;
+import org.pentaho.platform.api.engine.security.authorization.IAuthorizationPrincipal;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationService;
-import org.pentaho.platform.api.engine.security.authorization.IAuthorizationUser;
 import org.pentaho.platform.engine.security.authorization.core.AuthorizationRequest;
 import org.springframework.util.Assert;
 
@@ -44,25 +44,25 @@ public class AuthorizationServiceAuthorizationPolicy implements IAuthorizationPo
   private final IAuthorizationService authorizationService;
 
   @NonNull
-  private final Supplier<IAuthorizationUser> currentUserSupplier;
+  private final Supplier<IAuthorizationPrincipal> currentPrincipalSupplier;
 
   public AuthorizationServiceAuthorizationPolicy(
     @NonNull IAuthorizationActionService authorizationActionService,
     @NonNull IAuthorizationService authorizationService,
-    @NonNull Supplier<IAuthorizationUser> currentUserSupplier ) {
+    @NonNull Supplier<IAuthorizationPrincipal> currentPrincipalSupplier ) {
 
     Assert.notNull( authorizationActionService, "Argument 'authorizationActionService' is required" );
     Assert.notNull( authorizationService, "Argument 'authorizationService' is required" );
-    Assert.notNull( currentUserSupplier, "Argument 'currentUserSupplier' is required" );
+    Assert.notNull( currentPrincipalSupplier, "Argument 'currentPrincipalSupplier' is required" );
 
     this.authorizationActionService = authorizationActionService;
     this.authorizationService = authorizationService;
-    this.currentUserSupplier = currentUserSupplier;
+    this.currentPrincipalSupplier = currentPrincipalSupplier;
   }
 
   @NonNull
-  private IAuthorizationUser getCurrentUser() {
-    return Objects.requireNonNull( currentUserSupplier.get() );
+  private IAuthorizationPrincipal getCurrentPrincipal() {
+    return Objects.requireNonNull( currentPrincipalSupplier.get() );
   }
 
   @Override
@@ -76,7 +76,7 @@ public class AuthorizationServiceAuthorizationPolicy implements IAuthorizationPo
 
   private boolean isAllowed( @NonNull IAuthorizationAction action ) {
     return authorizationService
-      .authorize( new AuthorizationRequest( getCurrentUser(), action ) )
+      .authorize( new AuthorizationRequest( getCurrentPrincipal(), action ) )
       .isGranted();
   }
 

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/PentahoAuthorizationRuleLevel.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/PentahoAuthorizationRuleLevel.java
@@ -24,10 +24,10 @@ import org.pentaho.platform.api.engine.security.authorization.decisions.IAuthori
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.security.authorization.core.rules.AllAuthorizationRule;
 import org.pentaho.platform.engine.security.authorization.core.rules.AnyAuthorizationRule;
+import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -99,10 +99,14 @@ public class PentahoAuthorizationRuleLevel implements IAuthorizationRule<IAuthor
     @NonNull
     Supplier<List<IPentahoObjectReference<IAuthorizationRule>>> authorizationRuleReferencesSupplier ) {
 
-    this.ruleLevelType = Objects.requireNonNull( ruleLevelType );
-    this.levelRulePredicate = Objects.requireNonNull( levelRulePredicate );
+    Assert.notNull( ruleLevelType, "Argument 'ruleLevelType' is required" );
+    Assert.notNull( levelRulePredicate, "Argument 'levelRulePredicate' is required" );
+    Assert.notNull( authorizationRuleReferencesSupplier, "Argument 'authorizationRuleReferencesSupplier' is required" );
+
+    this.ruleLevelType = ruleLevelType;
+    this.levelRulePredicate = levelRulePredicate;
     this.postRules = List.copyOf( postRules );
-    this.authorizationRuleReferencesSupplier = Objects.requireNonNull( authorizationRuleReferencesSupplier );
+    this.authorizationRuleReferencesSupplier = authorizationRuleReferencesSupplier;
 
     this.updateDelegateRule();
 

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/PentahoSystemAuthorizationActionService.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/PentahoSystemAuthorizationActionService.java
@@ -19,6 +19,7 @@ import org.pentaho.platform.api.engine.IPentahoObjectReference;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationActionService;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.objfac.spring.Const;
+import org.springframework.util.Assert;
 
 import java.util.Objects;
 import java.util.Set;
@@ -42,7 +43,10 @@ public class PentahoSystemAuthorizationActionService implements IAuthorizationAc
 
   public PentahoSystemAuthorizationActionService(
     @NonNull Supplier<Stream<IPentahoObjectReference<IAuthorizationAction>>> authorizationActionsSupplier ) {
-    this.authorizationActionsSupplier = Objects.requireNonNull( authorizationActionsSupplier );
+
+    Assert.notNull( authorizationActionsSupplier, "Argument 'authorizationActionsSupplier' is required" );
+
+    this.authorizationActionsSupplier = authorizationActionsSupplier;
   }
 
   // region Helper methods

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationDecisionDNFNormalizer.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationDecisionDNFNormalizer.java
@@ -22,11 +22,11 @@ import org.pentaho.platform.api.engine.security.authorization.decisions.IOpposed
 import org.pentaho.platform.engine.security.authorization.core.decisions.AllAuthorizationDecision;
 import org.pentaho.platform.engine.security.authorization.core.decisions.AnyAuthorizationDecision;
 import org.pentaho.platform.engine.security.authorization.core.decisions.OpposedAuthorizationDecision;
+import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -339,7 +339,7 @@ public class AuthorizationDecisionDNFNormalizer {
   // NOTE: Consider an option for strict DNF output, enforcing OR(And(...)) structure.
   @NonNull
   public IAuthorizationDecision normalize( @NonNull IAuthorizationDecision decision ) {
-    Objects.requireNonNull( decision );
+    Assert.notNull( decision, "Argument 'decision' is required" );
 
     decision = new MoveNotInwardsTransformer().visit( decision );
     decision = new MoveAndInwardsTransformer().visit( decision );

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationOptions.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationOptions.java
@@ -15,6 +15,7 @@ package org.pentaho.platform.engine.security.authorization.core;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.security.authorization.AuthorizationDecisionReportingMode;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationOptions;
+import org.springframework.util.Assert;
 
 import java.util.Objects;
 
@@ -38,10 +39,12 @@ public class AuthorizationOptions implements IAuthorizationOptions {
    * Constructs an {@code AuthorizationOptions} instance with the specified decision reporting mode.
    *
    * @param decisionReportingMode The decision reporting mode.
-   * @throws NullPointerException if the decision reporting mode is {@code null}.
+   * @throws IllegalArgumentException if the decision reporting mode is {@code null}.
    */
   public AuthorizationOptions( @NonNull AuthorizationDecisionReportingMode decisionReportingMode ) {
-    this.decisionReportingMode = Objects.requireNonNull( decisionReportingMode );
+    Assert.notNull( decisionReportingMode, "Argument 'decisionReportingMode' is required" );
+
+    this.decisionReportingMode = decisionReportingMode;
   }
 
   /**

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationOptions.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationOptions.java
@@ -38,7 +38,7 @@ public class AuthorizationOptions implements IAuthorizationOptions {
    * Constructs an {@code AuthorizationOptions} instance with the specified decision reporting mode.
    *
    * @param decisionReportingMode The decision reporting mode.
-   * @throws NullPointerException if the decision reporting mode is null.
+   * @throws NullPointerException if the decision reporting mode is {@code null}.
    */
   public AuthorizationOptions( @NonNull AuthorizationDecisionReportingMode decisionReportingMode ) {
     this.decisionReportingMode = Objects.requireNonNull( decisionReportingMode );

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationRequest.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationRequest.java
@@ -14,8 +14,9 @@ package org.pentaho.platform.engine.security.authorization.core;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.IAuthorizationAction;
+import org.pentaho.platform.api.engine.security.authorization.IAuthorizationPrincipal;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRequest;
-import org.pentaho.platform.api.engine.security.authorization.IAuthorizationUser;
+import org.springframework.util.Assert;
 
 import java.util.Objects;
 
@@ -24,27 +25,30 @@ import java.util.Objects;
  */
 public class AuthorizationRequest implements IAuthorizationRequest {
   @NonNull
-  private final IAuthorizationUser user;
+  private final IAuthorizationPrincipal principal;
 
   @NonNull
   private final IAuthorizationAction action;
 
   /**
-   * Constructs an {@code AuthorizationRequest} with the specified user and action name.
+   * Constructs an {@code AuthorizationRequest} with the specified principal and action.
    *
-   * @param user   The user for whom the authorization is being evaluated.
+   * @param principal The principal (user, role, etc.) for whom the authorization is being evaluated.
    * @param action The action to be evaluated.
-   * @throws IllegalArgumentException if the user or action are null.
+   * @throws IllegalArgumentException if the principal or action are {@code null}.
    */
-  public AuthorizationRequest( @NonNull IAuthorizationUser user, @NonNull IAuthorizationAction action ) {
-    this.user = Objects.requireNonNull( user );
-    this.action = Objects.requireNonNull( action );
+  public AuthorizationRequest( @NonNull IAuthorizationPrincipal principal, @NonNull IAuthorizationAction action ) {
+    Assert.notNull( principal, "Argument 'principal' is required" );
+    Assert.notNull( action, "Argument 'action' is required" );
+
+    this.principal = principal;
+    this.action = action;
   }
 
   @NonNull
   @Override
-  public IAuthorizationUser getUser() {
-    return user;
+  public IAuthorizationPrincipal getPrincipal() {
+    return principal;
   }
 
   @NonNull
@@ -53,12 +57,11 @@ public class AuthorizationRequest implements IAuthorizationRequest {
     return action;
   }
 
-  // Helper method so that rules can easily evaluate dependent permissions, for the same user.
-
+  // Helper method so that rules can easily evaluate dependent permissions, for the same principal.
   @NonNull
   @Override
   public IAuthorizationRequest withAction( @NonNull IAuthorizationAction action ) {
-    return new AuthorizationRequest( user, action );
+    return new AuthorizationRequest( principal, action );
   }
 
   @Override
@@ -68,21 +71,21 @@ public class AuthorizationRequest implements IAuthorizationRequest {
     }
 
     AuthorizationRequest that = (AuthorizationRequest) o;
-    return Objects.equals( user, that.user )
+    return Objects.equals( principal, that.principal )
       && Objects.equals( action, that.getAction() );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash( user, action );
+    return Objects.hash( principal, action );
   }
 
   @Override
   public String toString() {
     return String.format(
-      "%s [user=`%s`, action='%s']",
+      "%s [principal=`%s`, action='%s']",
       getClass().getSimpleName(),
-      user.getName(),
+      principal.getName(),
       action );
   }
 }

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationService.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationService.java
@@ -56,7 +56,9 @@ public class AuthorizationService implements IAuthorizationService {
     private final IAuthorizationOptions options;
 
     public AuthorizationContext( @NonNull IAuthorizationOptions options ) {
-      this.options = Objects.requireNonNull( options );
+      Assert.notNull( options, "Argument 'options' is required" );
+
+      this.options = options;
     }
 
     @NonNull
@@ -74,10 +76,9 @@ public class AuthorizationService implements IAuthorizationService {
     @NonNull
     @Override
     public IAuthorizationDecision authorize( @NonNull IAuthorizationRequest request ) {
+      Assert.notNull( request, "Argument 'request' is required" );
 
       // Handles logging, error handling and resolving the request's action.
-
-      Objects.requireNonNull( request );
 
       if ( logger.isDebugEnabled() ) {
         logger.debug( String.format(

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/decisions/AbstractAuthorizationDecision.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/decisions/AbstractAuthorizationDecision.java
@@ -16,8 +16,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRequest;
 import org.pentaho.platform.api.engine.security.authorization.decisions.IAuthorizationDecision;
 import org.pentaho.platform.engine.security.messages.Messages;
-
-import java.util.Objects;
+import org.springframework.util.Assert;
 
 public abstract class AbstractAuthorizationDecision implements IAuthorizationDecision {
 
@@ -29,7 +28,9 @@ public abstract class AbstractAuthorizationDecision implements IAuthorizationDec
   private final boolean granted;
 
   protected AbstractAuthorizationDecision( @NonNull IAuthorizationRequest request, boolean granted ) {
-    this.request = Objects.requireNonNull( request );
+    Assert.notNull( request, "Argument 'request' is required" );
+
+    this.request = request;
     this.granted = granted;
   }
 

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/decisions/AuthorizationErrorDecision.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/decisions/AuthorizationErrorDecision.java
@@ -16,8 +16,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRequest;
 import org.pentaho.platform.api.engine.security.authorization.decisions.IAuthorizationErrorDecision;
 import org.pentaho.platform.engine.security.messages.Messages;
-
-import java.util.Objects;
+import org.springframework.util.Assert;
 
 /**
  * The {@code AuthorizationErrorDecision} class is a basic implementation of the
@@ -38,7 +37,9 @@ public class AuthorizationErrorDecision extends AbstractAuthorizationDecision
 
     super( request, false );
 
-    this.cause = Objects.requireNonNull( cause );
+    Assert.notNull( cause, "Argument 'cause' is required" );
+
+    this.cause = cause;
   }
 
   @NonNull

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/decisions/MatchedRoleAuthorizationDecision.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/decisions/MatchedRoleAuthorizationDecision.java
@@ -16,9 +16,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRequest;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRole;
 import org.pentaho.platform.engine.security.messages.Messages;
+import org.springframework.util.Assert;
 
 import java.text.MessageFormat;
-import java.util.Objects;
 
 /**
  * The {@code MatchedRoleAuthorizationDecision} class represents an authorization decision that is granted when the user
@@ -36,7 +36,9 @@ public class MatchedRoleAuthorizationDecision extends AbstractAuthorizationDecis
                                            @NonNull IAuthorizationRole role ) {
     super( request, granted );
 
-    this.role = Objects.requireNonNull( role );
+    Assert.notNull( role, "Argument 'role' is required" );
+
+    this.role = role;
   }
 
   @NonNull

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/exceptions/AuthorizationRequestCycleException.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/exceptions/AuthorizationRequestCycleException.java
@@ -15,12 +15,12 @@ package org.pentaho.platform.engine.security.authorization.core.exceptions;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationContext;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRequest;
+import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * The {@code AuthorizationRequestCycleException} exception is used to signal when a cycle is detected during the
@@ -40,8 +40,8 @@ public class AuthorizationRequestCycleException extends Exception {
   @NonNull
   private static String createMessage( @NonNull Collection<IAuthorizationRequest> pendingRequests,
                                        @NonNull IAuthorizationRequest cycleRequest ) {
-    Objects.requireNonNull( pendingRequests );
-    Objects.requireNonNull( cycleRequest );
+    Assert.notNull( pendingRequests, "Argument 'pendingRequests' is required" );
+    Assert.notNull( cycleRequest, "Argument 'cycleRequest' is required" );
 
     StringBuilder builder = new StringBuilder();
     builder

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/exceptions/AuthorizationRequestUndefinedActionException.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/exceptions/AuthorizationRequestUndefinedActionException.java
@@ -14,8 +14,7 @@ package org.pentaho.platform.engine.security.authorization.core.exceptions;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRequest;
-
-import java.util.Objects;
+import org.springframework.util.Assert;
 
 /**
  * The {@code AuthorizationRequestCycleException} exception is used to signal when the authorization process receives
@@ -32,7 +31,7 @@ public class AuthorizationRequestUndefinedActionException extends Exception {
 
   @NonNull
   private static String createMessage( @NonNull IAuthorizationRequest request ) {
-    Objects.requireNonNull( request );
+    Assert.notNull( request, "Argument 'request' is required" );
 
     return String.format( "Authorization request references an undefined action: '%s'.",
       request.getAction() );

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/resources/ResourceAuthorizationRequest.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/resources/ResourceAuthorizationRequest.java
@@ -14,17 +14,18 @@ package org.pentaho.platform.engine.security.authorization.core.resources;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.engine.IAuthorizationAction;
+import org.pentaho.platform.api.engine.security.authorization.IAuthorizationPrincipal;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRequest;
 import org.pentaho.platform.api.engine.security.authorization.resources.IAuthorizationResource;
-import org.pentaho.platform.api.engine.security.authorization.IAuthorizationUser;
 import org.pentaho.platform.api.engine.security.authorization.resources.IResourceAuthorizationRequest;
 import org.pentaho.platform.engine.security.authorization.core.AuthorizationRequest;
+import org.springframework.util.Assert;
 
 import java.util.Objects;
 
 /**
- * The {@code ResourceAuthorizationRequest} class is a basic implementation of the {@link IResourceAuthorizationRequest}
- * interface.
+ * The {@code ResourceAuthorizationRequest} class represents an authorization request for a specific resource.
+ * It extends the basic authorization request to include resource-specific authorization context.
  */
 public class ResourceAuthorizationRequest extends AuthorizationRequest
   implements IResourceAuthorizationRequest {
@@ -33,20 +34,28 @@ public class ResourceAuthorizationRequest extends AuthorizationRequest
   private final IAuthorizationResource resource;
 
   /**
-   * Constructs an {@code ResourceAuthorizationRequest} with the specified user and action name.
+   * Constructs a new resource authorization request.
    *
-   * @param user     The user for whom the authorization is being evaluated.
-   * @param action   The action to be evaluated.
-   * @param resource The resource for which the authorization is being evaluated.
+   * @param principal The principal (user, role, etc.) requesting authorization.
+   * @param action    The action to be authorized.
+   * @param resource  The resource for which authorization is requested.
+   * @throws IllegalArgumentException if any parameter is {@code null}.
    */
-  public ResourceAuthorizationRequest( @NonNull IAuthorizationUser user,
+  public ResourceAuthorizationRequest( @NonNull IAuthorizationPrincipal principal,
                                        @NonNull IAuthorizationAction action,
                                        @NonNull IAuthorizationResource resource ) {
-    super( user, action );
+    super( principal, action );
 
-    this.resource = Objects.requireNonNull( resource );
+    Assert.notNull( resource, "Argument 'resource' is required" );
+
+    this.resource = resource;
   }
 
+  /**
+   * Gets the resource for which authorization is being requested.
+   *
+   * @return The authorization resource.
+   */
   @NonNull
   @Override
   public IAuthorizationResource getResource() {
@@ -58,19 +67,19 @@ public class ResourceAuthorizationRequest extends AuthorizationRequest
   @NonNull
   @Override
   public IResourceAuthorizationRequest withAction( @NonNull IAuthorizationAction action ) {
-    return new ResourceAuthorizationRequest( getUser(), action, getResource() );
+    return new ResourceAuthorizationRequest( getPrincipal(), action, getResource() );
   }
 
   @NonNull
   @Override
   public IResourceAuthorizationRequest withResource( @NonNull IAuthorizationResource resource ) {
-    return new ResourceAuthorizationRequest( getUser(), getAction(), resource );
+    return new ResourceAuthorizationRequest( getPrincipal(), getAction(), resource );
   }
 
   @NonNull
   @Override
   public IAuthorizationRequest asGeneral() {
-    return new AuthorizationRequest( getUser(), getAction() );
+    return new AuthorizationRequest( getPrincipal(), getAction() );
   }
 
   @Override
@@ -91,9 +100,9 @@ public class ResourceAuthorizationRequest extends AuthorizationRequest
   @Override
   public String toString() {
     return String.format(
-      "%s [user: `%s`, action: '%s', resource: %s]",
+      "%s [principal: `%s`, action: '%s', resource: %s]",
       getClass().getSimpleName(),
-      getUser().getName(),
+      getPrincipal().getName(),
       getAction(),
       getResource() );
   }

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/rules/AbstractAuthorizationRule.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/rules/AbstractAuthorizationRule.java
@@ -29,7 +29,7 @@ import java.util.Optional;
  * <p>
  * It provides a default implementation of the {@link #toString()} method, which returns the class's simple name.
  *
- * @param <T> The specific type of authorization request this rule can handle, must extend {@link IAuthorizationRequest}
+ * @param <T> The specific type of authorization request this rule can handle, must extend {@link IAuthorizationRequest}.
  */
 public abstract class AbstractAuthorizationRule<T extends IAuthorizationRequest> implements IAuthorizationRule<T> {
 

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/rules/DerivedActionAuthorizationRule.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/rules/DerivedActionAuthorizationRule.java
@@ -18,6 +18,7 @@ import org.pentaho.platform.api.engine.security.authorization.IAuthorizationCont
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRequest;
 import org.pentaho.platform.api.engine.security.authorization.decisions.IAuthorizationDecision;
 import org.pentaho.platform.engine.security.authorization.core.decisions.DerivedActionAuthorizationDecision;
+import org.springframework.util.Assert;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -52,7 +53,9 @@ public class DerivedActionAuthorizationRule extends AbstractAuthorizationRule<IA
 
   public DerivedActionAuthorizationRule( @NonNull IAuthorizationAction baseAction,
                                          @NonNull Set<IAuthorizationAction> derivedActions ) {
-    this.baseAction = Objects.requireNonNull( baseAction );
+    Assert.notNull( baseAction, "Argument 'baseAction' is required" );
+
+    this.baseAction = baseAction;
     this.derivedActions = Set.copyOf( derivedActions );
   }
 

--- a/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/rules/OpposedAuthorizationRule.java
+++ b/core/src/main/java/org/pentaho/platform/engine/security/authorization/core/rules/OpposedAuthorizationRule.java
@@ -19,8 +19,8 @@ import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRule
 import org.pentaho.platform.api.engine.security.authorization.decisions.IAuthorizationDecision;
 import org.pentaho.platform.api.engine.security.authorization.decisions.IOpposedAuthorizationDecision;
 import org.pentaho.platform.engine.security.authorization.core.decisions.OpposedAuthorizationDecision;
+import org.springframework.util.Assert;
 
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -37,7 +37,9 @@ public class OpposedAuthorizationRule<T extends IAuthorizationRequest> extends A
   private final IAuthorizationRule<T> opposedToRule;
 
   public OpposedAuthorizationRule( @NonNull IAuthorizationRule<T> opposedToRule ) {
-    this.opposedToRule = Objects.requireNonNull( opposedToRule );
+    Assert.notNull( opposedToRule, "Argument 'opposedToRule' is required" );
+
+    this.opposedToRule = opposedToRule;
   }
 
   @NonNull

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/AuthorizationServiceAuthorizationPolicyTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/AuthorizationServiceAuthorizationPolicyTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.platform.api.engine.IAuthorizationAction;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationActionService;
+import org.pentaho.platform.api.engine.security.authorization.IAuthorizationPrincipal;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationRequest;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationService;
 import org.pentaho.platform.api.engine.security.authorization.IAuthorizationUser;
@@ -46,7 +47,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
 
   private IAuthorizationActionService mockActionService;
   private IAuthorizationService mockAuthorizationService;
-  private Supplier<IAuthorizationUser> mockCurrentUserSupplier;
+  private Supplier<IAuthorizationPrincipal> mockCurrentPrincipalSupplier;
   private IAuthorizationUser mockUser;
 
   private IAuthorizationAction mockAction1;
@@ -62,10 +63,10 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     mockActionService = mock( IAuthorizationActionService.class );
     mockAuthorizationService = mock( IAuthorizationService.class );
 
-    mockCurrentUserSupplier = (Supplier<IAuthorizationUser>) mock( Supplier.class );
+    mockCurrentPrincipalSupplier = (Supplier<IAuthorizationPrincipal>) mock( Supplier.class );
 
     mockUser = createTestUser();
-    when( mockCurrentUserSupplier.get() ).thenReturn( mockUser );
+    when( mockCurrentPrincipalSupplier.get() ).thenReturn( mockUser );
 
     // Create mock actions
     mockAction1 = createTestAction( "action1" );
@@ -86,7 +87,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     new AuthorizationServiceAuthorizationPolicy(
       null,
       mockAuthorizationService,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
   }
 
@@ -96,12 +97,12 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
       null,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
   }
 
   @Test( expected = IllegalArgumentException.class )
-  public void testConstructorWithNullCurrentUserSupplierThrows() {
+  public void testConstructorWithNullCurrentPrincipalSupplierThrows() {
     //noinspection DataFlowIssue
     new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
@@ -120,7 +121,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     var policy = new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
       mockAuthorizationService,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
 
     boolean result = policy.isAllowed( "unknown-action" );
@@ -140,7 +141,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     var policy = new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
       mockAuthorizationService,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
 
     policy.isAllowed( "action1" );
@@ -157,7 +158,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     var policy = new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
       mockAuthorizationService,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
 
     boolean result = policy.isAllowed( "action1" );
@@ -174,7 +175,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     var policy = new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
       mockAuthorizationService,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
 
     boolean result = policy.isAllowed( "action1" );
@@ -183,7 +184,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
   }
 
   @Test
-  public void testIsAllowedCreatesCorrectAuthorizationRequestWithCurrentUser() {
+  public void testIsAllowedCreatesCorrectAuthorizationRequestWithCurrentPrincipal() {
     when( mockActionService.getAction( "action1" ) ).thenReturn( Optional.of( mockAction1 ) );
     when( mockAuthorizationService.authorize( any( AuthorizationRequest.class ) ) )
       .thenReturn( mockGrantedDecision );
@@ -191,7 +192,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     var policy = new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
       mockAuthorizationService,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
 
     policy.isAllowed( "action1" );
@@ -200,10 +201,10 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     verify( mockAuthorizationService ).authorize( requestCaptor.capture() );
 
     var capturedRequest = requestCaptor.getValue();
-    assertSame( mockUser, capturedRequest.getUser() );
+    assertSame( mockUser, capturedRequest.getPrincipal() );
     assertSame( mockAction1, capturedRequest.getAction() );
 
-    verify( mockCurrentUserSupplier, times( 1 ) ).get();
+    verify( mockCurrentPrincipalSupplier, times( 1 ) ).get();
   }
   // endregion
 
@@ -215,7 +216,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     var policy = new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
       mockAuthorizationService,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
 
     List<String> result = policy.getAllowedActions( "empty-namespace" );
@@ -246,7 +247,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     var policy = new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
       mockAuthorizationService,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
 
     List<String> result = policy.getAllowedActions( "test-namespace" );
@@ -272,7 +273,7 @@ public class AuthorizationServiceAuthorizationPolicyTest {
     var policy = new AuthorizationServiceAuthorizationPolicy(
       mockActionService,
       mockAuthorizationService,
-      mockCurrentUserSupplier
+      mockCurrentPrincipalSupplier
     );
 
     List<String> result = policy.getAllowedActions( "test-namespace" );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/PentahoAuthorizationRuleLevelTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/PentahoAuthorizationRuleLevelTest.java
@@ -101,7 +101,7 @@ public class PentahoAuthorizationRuleLevelTest {
     );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRuleLevelTypeThrows() {
     //noinspection DataFlowIssue
     new PentahoAuthorizationRuleLevel(

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationOptionsTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationOptionsTest.java
@@ -33,8 +33,9 @@ public class AuthorizationOptionsTest {
     assertEquals( AuthorizationDecisionReportingMode.FULL, options.getDecisionReportingMode() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullDecisionReportingModeThrows() {
+    //noinspection DataFlowIssue
     new AuthorizationOptions( null );
   }
 

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationRequestTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/AuthorizationRequestTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
@@ -25,50 +26,75 @@ import static org.pentaho.platform.engine.security.authorization.core.Authorizat
 public class AuthorizationRequestTest {
 
   private AuthorizationUser user;
+  private AuthorizationRole role;
 
   @Before
   public void setUp() {
     user = createTestUser();
+    role = new AuthorizationRole( "test-role" );
   }
 
   @Test
-  public void testConstructorAndGetters() {
+  public void testConstructorAndGettersWithUser() {
     var action = createTestAction( "read" );
 
     var request = new AuthorizationRequest( user, action );
 
-    assertEquals( user, request.getUser() );
+    assertEquals( user, request.getPrincipal() );
     assertEquals( action, request.getAction() );
   }
 
-  @Test( expected = NullPointerException.class )
-  public void testConstructorWithNullUserThrows() {
+  @Test
+  public void testConstructorAndGettersWithRole() {
+    var action = createTestAction( "read" );
+
+    var request = new AuthorizationRequest( role, action );
+
+    assertEquals( role, request.getPrincipal() );
+    assertEquals( action, request.getAction() );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void testConstructorWithNullPrincipalThrows() {
     var action = createTestAction( "read" );
     //noinspection DataFlowIssue
     new AuthorizationRequest( null, action );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullActionThrows() {
     //noinspection DataFlowIssue
     new AuthorizationRequest( user, null );
   }
 
   @Test
-  public void testWithAction() {
+  public void testWithActionPreservesPrincipal() {
     var action1 = createTestAction( "read" );
     var action2 = createTestAction( "write" );
 
     var request1 = new AuthorizationRequest( user, action1 );
     var request2 = request1.withAction( action2 );
 
-    assertEquals( user, request2.getUser() );
+    assertEquals( user, request2.getPrincipal() );
     assertEquals( action2, request2.getAction() );
     assertNotSame( request1, request2 );
   }
 
   @Test
-  public void testEqualsAndHashCode() {
+  public void testWithActionWithRolePrincipal() {
+    var action1 = createTestAction( "read" );
+    var action2 = createTestAction( "write" );
+
+    var request1 = new AuthorizationRequest( role, action1 );
+    var request2 = request1.withAction( action2 );
+
+    assertEquals( role, request2.getPrincipal() );
+    assertEquals( action2, request2.getAction() );
+    assertNotSame( request1, request2 );
+  }
+
+  @Test
+  public void testEqualsAndHashCodeWithSamePrincipalTypes() {
     var action1 = createTestAction( "read" );
     var action2 = createTestAction( "read" );
     var action3 = createTestAction( "write" );
@@ -83,13 +109,51 @@ public class AuthorizationRequestTest {
     // Different action.
     assertNotEquals( request1, request3 );
     assertNotEquals( request1.hashCode(), request3.hashCode() );
-
-    var notRequest = new Object();
-    assertNotEquals( request1, notRequest );
   }
 
   @Test
-  public void testToStringFormat() {
+  public void testEqualsAndHashCodeWithDifferentPrincipalTypes() {
+    var action = createTestAction( "read" );
+
+    var userRequest = new AuthorizationRequest( user, action );
+    var roleRequest = new AuthorizationRequest( role, action );
+
+    // Different principal types should not be equal
+    assertNotEquals( userRequest, roleRequest );
+    assertNotEquals( userRequest.hashCode(), roleRequest.hashCode() );
+  }
+
+  @Test
+  public void testEqualsAndHashCodeWithDifferentPrincipalsOfSameType() {
+    var action = createTestAction( "read" );
+    var otherUser = createTestUser( "other-user", "Administrator" );
+
+    var request1 = new AuthorizationRequest( user, action );
+    var request2 = new AuthorizationRequest( otherUser, action );
+
+    // Different principals of same type should not be equal
+    assertNotEquals( request1, request2 );
+    assertNotEquals( request1.hashCode(), request2.hashCode() );
+  }
+
+  @Test
+  public void testEqualsWithNonAuthorizationRequest() {
+    var action = createTestAction( "read" );
+    var request = new AuthorizationRequest( user, action );
+    var notRequest = new Object();
+
+    assertNotEquals( request, notRequest );
+  }
+
+  @Test
+  public void testEqualsWithNull() {
+    var request = new AuthorizationRequest( user, createTestAction( "read" ) );
+    //noinspection SimplifiableJUnitAssertion,ConstantConditions
+    assertFalse( request.equals( null ) );
+  }
+
+  @Test
+  public void testToStringFormatWithUser() {
     var action = createTestAction( "read" );
 
     var request = new AuthorizationRequest( user, action );
@@ -97,6 +161,18 @@ public class AuthorizationRequestTest {
 
     assertTrue( result.contains( "AuthorizationRequest" ) );
     assertTrue( result.contains( "test-user" ) );
+    assertTrue( result.contains( "read" ) );
+  }
+
+  @Test
+  public void testToStringFormatWithRole() {
+    var action = createTestAction( "read" );
+
+    var request = new AuthorizationRequest( role, action );
+    var result = request.toString();
+
+    assertTrue( result.contains( "AuthorizationRequest" ) );
+    assertTrue( result.contains( "test-role" ) );
     assertTrue( result.contains( "read" ) );
   }
 }

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AbstractAuthorizationDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AbstractAuthorizationDecisionTest.java
@@ -56,7 +56,7 @@ public class AbstractAuthorizationDecisionTest {
     assertFalse( deniedDecision.isGranted() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     new TestAuthorizationDecision( null, true );
   }

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AbstractCompositeAuthorizationDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AbstractCompositeAuthorizationDecisionTest.java
@@ -83,7 +83,7 @@ public class AbstractCompositeAuthorizationDecisionTest {
     assertEquals( decisions, deniedComposite.getDecisions() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     new TestCompositeAuthorizationDecision( null, true, decisions );
   }

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AllAuthorizationDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AllAuthorizationDecisionTest.java
@@ -88,7 +88,7 @@ public class AllAuthorizationDecisionTest {
     assertTrue( allDecision.getDecisions().contains( deniedDecision ) );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     //noinspection DataFlowIssue
     new AllAuthorizationDecision( null, Set.of( grantedDecision ) );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AnyAuthorizationDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AnyAuthorizationDecisionTest.java
@@ -73,7 +73,7 @@ public class AnyAuthorizationDecisionTest {
     assertTrue( anyDecision.getDecisions().contains( deniedDecision ) );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     //noinspection DataFlowIssue
     new AnyAuthorizationDecision( null, Set.of( grantedDecision ) );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AuthorizationErrorDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/AuthorizationErrorDecisionTest.java
@@ -47,13 +47,13 @@ public class AuthorizationErrorDecisionTest {
     assertEquals( cause, decision.getCause() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     //noinspection DataFlowIssue
     new AuthorizationErrorDecision( null, cause );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullCauseThrows() {
     //noinspection DataFlowIssue
     new AuthorizationErrorDecision( request, null );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/DerivedActionAuthorizationDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/DerivedActionAuthorizationDecisionTest.java
@@ -76,7 +76,7 @@ public class DerivedActionAuthorizationDecisionTest {
     assertEquals( derivedFromAction, derivedDenied.getDerivedFromAction() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     //noinspection DataFlowIssue
     new DerivedActionAuthorizationDecision( null, grantedDecision );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/DerivedAuthorizationDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/DerivedAuthorizationDecisionTest.java
@@ -73,7 +73,7 @@ public class DerivedAuthorizationDecisionTest {
     assertEquals( deniedDecision, derivedDenied.getDerivedFromDecision() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     //noinspection DataFlowIssue
     new DerivedAuthorizationDecision( null, grantedDecision );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/MatchedRoleAuthorizationDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/MatchedRoleAuthorizationDecisionTest.java
@@ -54,13 +54,13 @@ public class MatchedRoleAuthorizationDecisionTest {
     assertEquals( role, deniedDecision.getRole() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     //noinspection DataFlowIssue
     new MatchedRoleAuthorizationDecision( null, true, role );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRoleThrows() {
     //noinspection DataFlowIssue
     new MatchedRoleAuthorizationDecision( request, true, null );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/ResourceActionGeneralRequirementAuthorizationDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/ResourceActionGeneralRequirementAuthorizationDecisionTest.java
@@ -76,7 +76,7 @@ public class ResourceActionGeneralRequirementAuthorizationDecisionTest {
     assertSame( deniedDecision, deniedRequirementDecision.getDerivedFromDecision() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     //noinspection DataFlowIssue
     new ResourceActionGeneralRequirementAuthorizationDecision( null, grantedDecision );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/SupportedActionResourceTypeAuthorizationDecisionTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/decisions/SupportedActionResourceTypeAuthorizationDecisionTest.java
@@ -53,7 +53,7 @@ public class SupportedActionResourceTypeAuthorizationDecisionTest {
     assertFalse( deniedDecision.isGranted() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     //noinspection DataFlowIssue
     new SupportedActionResourceTypeAuthorizationDecision( null, true );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/resources/ResourceAuthorizationRequestTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/resources/ResourceAuthorizationRequestTest.java
@@ -15,9 +15,9 @@ package org.pentaho.platform.engine.security.authorization.core.resources;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.platform.api.engine.IAuthorizationAction;
+import org.pentaho.platform.api.engine.security.authorization.IAuthorizationPrincipal;
 import org.pentaho.platform.api.engine.security.authorization.resources.IAuthorizationResource;
 import org.pentaho.platform.api.engine.security.authorization.resources.IResourceAuthorizationRequest;
-import org.pentaho.platform.engine.security.authorization.core.AuthorizationUser;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -29,54 +29,54 @@ import static org.pentaho.platform.engine.security.authorization.core.Authorizat
 
 public class ResourceAuthorizationRequestTest {
 
-  private AuthorizationUser user;
+  private IAuthorizationPrincipal principal;
   private IAuthorizationAction action;
   private IAuthorizationResource resource;
 
   @Before
   public void setUp() {
-    user = createTestUser();
+    principal = createTestUser();
     action = createTestAction( "read" );
     resource = new GenericAuthorizationResource( "file", "report123" );
   }
 
   @Test
   public void testConstructorAndGetters() {
-    var request = new ResourceAuthorizationRequest( user, action, resource );
+    var request = new ResourceAuthorizationRequest( principal, action, resource );
 
-    assertEquals( user, request.getUser() );
+    assertEquals( principal, request.getPrincipal() );
     assertEquals( action, request.getAction() );
     assertEquals( resource, request.getResource() );
   }
 
-  @Test( expected = NullPointerException.class )
-  public void testConstructorWithNullUserThrows() {
+  @Test( expected = IllegalArgumentException.class )
+  public void testConstructorWithNullPrincipalThrows() {
     //noinspection DataFlowIssue
     new ResourceAuthorizationRequest( null, action, resource );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullActionThrows() {
     //noinspection DataFlowIssue
-    new ResourceAuthorizationRequest( user, null, resource );
+    new ResourceAuthorizationRequest( principal, null, resource );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullResourceThrows() {
     //noinspection DataFlowIssue
-    new ResourceAuthorizationRequest( user, action, null );
+    new ResourceAuthorizationRequest( principal, action, null );
   }
 
   @Test
   public void testWithAction() {
     var action2 = createTestAction( "write" );
 
-    var request1 = new ResourceAuthorizationRequest( user, action, resource );
+    var request1 = new ResourceAuthorizationRequest( principal, action, resource );
     var request2 = request1.withAction( action2 );
 
     assertNotSame( request1, request2 );
 
-    assertEquals( user, request2.getUser() );
+    assertEquals( principal, request2.getPrincipal() );
     assertEquals( action2, request2.getAction() );
     assertEquals( resource, request2.getResource() );
   }
@@ -85,24 +85,24 @@ public class ResourceAuthorizationRequestTest {
   public void testWithResource() {
     var resource2 = new GenericAuthorizationResource( "folder", "folder456" );
 
-    var request1 = new ResourceAuthorizationRequest( user, action, resource );
+    var request1 = new ResourceAuthorizationRequest( principal, action, resource );
     var request2 = request1.withResource( resource2 );
 
     assertNotSame( request1, request2 );
 
-    assertEquals( user, request2.getUser() );
+    assertEquals( principal, request2.getPrincipal() );
     assertEquals( action, request2.getAction() );
     assertEquals( resource2, request2.getResource() );
   }
 
   @Test
   public void testAsGeneral() {
-    var request = new ResourceAuthorizationRequest( user, action, resource );
+    var request = new ResourceAuthorizationRequest( principal, action, resource );
     var generalRequest = request.asGeneral();
 
     assertNotSame( request, generalRequest );
 
-    assertEquals( user, generalRequest.getUser() );
+    assertEquals( principal, generalRequest.getPrincipal() );
     assertEquals( action, generalRequest.getAction() );
     assertFalse( generalRequest instanceof IResourceAuthorizationRequest );
   }
@@ -112,9 +112,9 @@ public class ResourceAuthorizationRequestTest {
     var resource2 = new GenericAuthorizationResource( "file", "report123" );
     var resource3 = new GenericAuthorizationResource( "folder", "folder456" );
 
-    var request1 = new ResourceAuthorizationRequest( user, action, resource );
-    var request2 = new ResourceAuthorizationRequest( user, action, resource2 );
-    var request3 = new ResourceAuthorizationRequest( user, action, resource3 );
+    var request1 = new ResourceAuthorizationRequest( principal, action, resource );
+    var request2 = new ResourceAuthorizationRequest( principal, action, resource2 );
+    var request3 = new ResourceAuthorizationRequest( principal, action, resource3 );
 
     var notRequest = new Object();
     assertNotEquals( request1, notRequest );
@@ -127,7 +127,7 @@ public class ResourceAuthorizationRequestTest {
 
   @Test
   public void testToStringFormat() {
-    var request = new ResourceAuthorizationRequest( user, action, resource );
+    var request = new ResourceAuthorizationRequest( principal, action, resource );
     var result = request.toString();
 
     assertTrue( result.contains( "ResourceAuthorizationRequest" ) );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/rules/DerivedActionAuthorizationRuleTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/rules/DerivedActionAuthorizationRuleTest.java
@@ -65,8 +65,8 @@ public class DerivedActionAuthorizationRuleTest {
     context = mock( IAuthorizationContext.class );
   }
 
-  // region NPE argument tests
-  @Test( expected = NullPointerException.class )
+  // region null argument tests
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullBaseActionThrows() {
     //noinspection DataFlowIssue
     new DerivedActionAuthorizationRule( null, derivedAction );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/rules/MatchedRoleAuthorizationRuleTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/rules/MatchedRoleAuthorizationRuleTest.java
@@ -38,13 +38,13 @@ public class MatchedRoleAuthorizationRuleTest {
 
   @Before
   public void setUp() {
-    var userWithRole = createTestUser( "test-user", "Administrator" );
-    var userWithoutRole = createTestUser( "other-user", "User" );
+    var principalWithRole = createTestUser( "test-user", "Administrator" );
+    var principalWithoutRole = createTestUser( "other-user", "User" );
 
     var action = createTestAction( "read" );
 
-    requestWithRole = new AuthorizationRequest( userWithRole, action );
-    requestWithoutRole = new AuthorizationRequest( userWithoutRole, action );
+    requestWithRole = new AuthorizationRequest( principalWithRole, action );
+    requestWithoutRole = new AuthorizationRequest( principalWithoutRole, action );
     context = mock( IAuthorizationContext.class );
 
     ruleFromRole = new MatchedRoleAuthorizationRule( new AuthorizationRole( "Administrator" ) );
@@ -57,7 +57,7 @@ public class MatchedRoleAuthorizationRuleTest {
     new MatchedRoleAuthorizationRule( (String) null );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRoleThrows() {
     //noinspection DataFlowIssue
     new MatchedRoleAuthorizationRule( (IAuthorizationRole) null );

--- a/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/rules/OpposedAuthorizationRuleTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/security/authorization/core/rules/OpposedAuthorizationRuleTest.java
@@ -64,7 +64,7 @@ public class OpposedAuthorizationRuleTest {
     assertEquals( IResourceAuthorizationRequest.class, opposedRule.getRequestType() );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRuleThrows() {
     //noinspection DataFlowIssue
     new OpposedAuthorizationRule<>( null );

--- a/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/ActionRoleBindingAuthorizationRule.java
+++ b/repository/src/main/java/org/pentaho/platform/security/policy/rolebased/ActionRoleBindingAuthorizationRule.java
@@ -45,6 +45,23 @@ public class ActionRoleBindingAuthorizationRule extends AbstractAuthorizationRul
     return IAuthorizationRequest.class;
   }
 
+  /**
+   * Authorizes the given request by checking if the principal has the necessary role-action bindings
+   * for the requested action.
+   * <p>
+   * If the principal is a user, this rule checks if any of the user's roles are bound to the action being requested.
+   * If at least one role is bound to the action, the request is granted; otherwise, it is denied.
+   * <p>
+   * If the principal is a role, this rule checks if that specific role is bound to the action being requested.
+   * If it is, the request is granted; otherwise, it is denied.
+   * <p>
+   * If the request is a resource-specific authorization request, this rule abstains from making a decision.
+   *
+   * @param request The authorization request to evaluate.
+   * @param context The authorization context providing additional information for decision-making.
+   * @return An {@code Optional} containing the authorization decision, or empty if the rule abstains.
+   * @throws IllegalArgumentException if the request or context is {@code null}.
+   */
   @NonNull
   @Override
   public Optional<IAuthorizationDecision> authorize( @NonNull IAuthorizationRequest request,
@@ -61,7 +78,7 @@ public class ActionRoleBindingAuthorizationRule extends AbstractAuthorizationRul
 
     Set<IAuthorizationRole> rolesWithBinding = new LinkedHashSet<>();
 
-    for ( IAuthorizationRole role : request.getUser().getRoles() ) {
+    for ( IAuthorizationRole role : request.getAllRoles() ) {
       if ( hasRoleActionBinding( role, actionName ) ) {
         rolesWithBinding.add( role );
 

--- a/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/ActionRoleBindingAuthorizationDecisionTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/policy/rolebased/ActionRoleBindingAuthorizationDecisionTest.java
@@ -98,7 +98,7 @@ public class ActionRoleBindingAuthorizationDecisionTest {
     assertTrue( decision.getBoundRoles().contains( roleManager ) );
   }
 
-  @Test( expected = NullPointerException.class )
+  @Test( expected = IllegalArgumentException.class )
   public void testConstructorWithNullRequestThrows() {
     var roles = orderedSetOf( roleUser );
     //noinspection DataFlowIssue


### PR DESCRIPTION
This pull request refactors the authorization request model to generalize from user-based to principal-based authorization, enabling support for both users and roles as principals throughout the authorization API. Additionally, it improves null checking by using `Assert.notNull` and adds comprehensive unit tests for the new principal-based methods.

### Authorization Model Refactoring

* The `IAuthorizationRequest` interface now uses a generic `IAuthorizationPrincipal` instead of being user-specific, allowing both users and roles to be principals. New helper methods (`getPrincipalAsUser`, `getPrincipalAsRole`, and `getAllRoles`) were added for convenience and type safety. [[1]](diffhunk://#diff-1b7309bb16fca1b042a5b80c3937e37fde051bfbc02d2f9ed59ae002ff310123R18-R86) [[2]](diffhunk://#diff-1b7309bb16fca1b042a5b80c3937e37fde051bfbc02d2f9ed59ae002ff310123L50-R100)
* The `AuthorizationRequest` implementation and related logic have been updated to use `IAuthorizationPrincipal` instead of `IAuthorizationUser`. [[1]](diffhunk://#diff-42cbdc7430c7df7d408568d4b7961c37df8edcd738efb01b5f955c9ed2dbf418R17-R19) [[2]](diffhunk://#diff-42cbdc7430c7df7d408568d4b7961c37df8edcd738efb01b5f955c9ed2dbf418L27-R51)
* The `AuthorizationServiceAuthorizationPolicy` now tracks the current principal, not just the current user, and uses this principal in authorization checks. [[1]](diffhunk://#diff-b8c2c451ff7bbed57c4d22c01c01ea4640fa468797b480be273ddb0e828eb29bR19-L20) [[2]](diffhunk://#diff-b8c2c451ff7bbed57c4d22c01c01ea4640fa468797b480be273ddb0e828eb29bL47-R65) [[3]](diffhunk://#diff-b8c2c451ff7bbed57c4d22c01c01ea4640fa468797b480be273ddb0e828eb29bL79-R79)

### Null Checking Improvements

* Replaced usage of `Objects.requireNonNull` with `Assert.notNull` for more expressive null checks and clearer exception messages in constructors and critical methods across several classes, including `AuthorizationOptions`, `PentahoSystemAuthorizationActionService`, `PentahoAuthorizationRuleLevel`, and `AuthorizationDecisionDNFNormalizer`. [[1]](diffhunk://#diff-c6effe480cc04b4fcad5d17a3d7e090cbf9b95bc9d001db8ef771ad598dc6648R22) [[2]](diffhunk://#diff-c6effe480cc04b4fcad5d17a3d7e090cbf9b95bc9d001db8ef771ad598dc6648L45-R49) [[3]](diffhunk://#diff-9e470a0a624a37d1d2aac3341f3a6ccf272e7376e6891709477406fd8d8c026cR27-L30) [[4]](diffhunk://#diff-9e470a0a624a37d1d2aac3341f3a6ccf272e7376e6891709477406fd8d8c026cL102-R109) [[5]](diffhunk://#diff-44c5ec7c39bd1a893fd8a9641f6bae1b2000f4c41a8f0f8c3890076a475890c4R25-L29) [[6]](diffhunk://#diff-44c5ec7c39bd1a893fd8a9641f6bae1b2000f4c41a8f0f8c3890076a475890c4L342-R342) [[7]](diffhunk://#diff-1a4fa1e86acbc5db483e52e81058cbe4a7ca0537520856f729ce81bc0727f8bdR18) [[8]](diffhunk://#diff-1a4fa1e86acbc5db483e52e81058cbe4a7ca0537520856f729ce81bc0727f8bdL41-R47)

### Testing

* Added a new unit test class `IAuthorizationRequestTest` to verify the behavior of `getPrincipalAsUser`, `getPrincipalAsRole`, and `getAllRoles` methods, ensuring correct handling for users, roles, and other principals.

### Documentation and Minor Cleanups

* Updated Javadoc comments throughout the codebase to reflect the shift from user-based to principal-based authorization and to clarify nullability and exception behavior. [[1]](diffhunk://#diff-1b7309bb16fca1b042a5b80c3937e37fde051bfbc02d2f9ed59ae002ff310123R18-R86) [[2]](diffhunk://#diff-1b7309bb16fca1b042a5b80c3937e37fde051bfbc02d2f9ed59ae002ff310123L50-R100) [[3]](diffhunk://#diff-1e4bf0065bdc293c958db51807e5e316cf05521d7120c43fc563e6bfe1b974dbL42-R42) [[4]](diffhunk://#diff-1a4fa1e86acbc5db483e52e81058cbe4a7ca0537520856f729ce81bc0727f8bdL41-R47) [[5]](diffhunk://#diff-ffa98d5aad751f95c8973607fa3929d8fa8339af0947f5da26d43db0a754d4ebL31-R31)

These changes modernize the authorization API, making it more flexible and robust for scenarios involving both users and roles as principals.

@pentaho/millenniumfalcon please review