### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,6 @@
     <com.github.spotbugs.annotations.version>4.2.3</com.github.spotbugs.annotations.version>
     <jboss-logging.version>3.4.3.Final</jboss-logging.version>
     <classmate.version>1.6.0</classmate.version>
-    <byte-buddy.version>1.12.16</byte-buddy.version>
   </properties>
 
   <dependencyManagement>

--- a/user-console/pom.xml
+++ b/user-console/pom.xml
@@ -415,9 +415,9 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <copy file="${project.basedir}/../LICENSE.TXT" tofile="${project.build.directory}/classes/org/pentaho/mantle/public/LICENSE.TXT"/>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This pull request contains minor updates to the Maven build configuration files. The changes focus on dependency version management and the configuration of build tasks.

Build configuration improvements:

* Removed the `byte-buddy.version` property from the main `pom.xml`, likely because it is no longer needed or has been centralized elsewhere.
* Updated the Ant plugin configuration in `user-console/pom.xml` by replacing the deprecated `<tasks>` element with `<target>`, improving compatibility and clarity in the build process.