### PR TITLE
fix: many broken integration tests due to systemic issues [BACKLOG-45385]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ extensions/localhost.tmp/
 logs/
 target/
 http:/
+c:/
+derby.log
+dumpTestAdminCreate.zip
+repository/src/test/resources/solution/system/data/hibernate.log
+repository/src/test/resources/solution/system/data/hibernate.properties

--- a/extensions/src/it/resources/repository.spring.xml
+++ b/extensions/src/it/resources/repository.spring.xml
@@ -10,9 +10,8 @@
                            http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd"
        default-lazy-init="true">
 
-  <!-- <bean class="org.pentaho.platform.engine.core.system.objfac.spring.ApplicationContextPentahoSystemRegisterer"
-      lazy-init="false"/> -->
-
+  <bean class="org.pentaho.platform.engine.core.system.objfac.spring.ApplicationContextPentahoSystemRegisterer"
+        lazy-init="false"/>
 
   <bean id="propertyPlaceholderConfigurerRepository"
         class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" lazy-init="false">
@@ -590,23 +589,12 @@
     </pen:publish>
   </bean>
 
-    <!-- This is a temporary workaround for a problem where the Actions are not
-    being registered with Pentaho system for unit tests -->
-    <util:list id="AuthorizationActions">
-        <ref bean="RepositoryReadAction"/>
-        <ref bean="RepositoryCreateAction"/>
-        <ref bean="SchedulerExecuteAction"/>
-        <ref bean="SchedulerAction"/>
-        <ref bean="AdministerSecurityAction"/>
-        <ref bean="PublishAction"/>
-    </util:list>
-
   <util:map id="immutableRoleBindingMap">
     <entry key-ref="singleTenantAdminAuthorityName">
-        <ref bean="AuthorizationActions"/>
+      <pen:list class="org.pentaho.platform.api.engine.IAuthorizationAction"/>
     </entry>
     <entry key-ref="superAdminAuthorityName">
-      <ref bean="AuthorizationActions"/>
+      <pen:list class="org.pentaho.platform.api.engine.IAuthorizationAction"/>
     </entry>
   </util:map>
 

--- a/extensions/src/test/resources/repository.spring.xml
+++ b/extensions/src/test/resources/repository.spring.xml
@@ -10,9 +10,8 @@
                            http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd"
        default-lazy-init="true">
 
-  <!-- <bean class="org.pentaho.platform.engine.core.system.objfac.spring.ApplicationContextPentahoSystemRegisterer"
-      lazy-init="false"/> -->
-
+  <bean class="org.pentaho.platform.engine.core.system.objfac.spring.ApplicationContextPentahoSystemRegisterer"
+        lazy-init="false"/>
 
   <bean id="propertyPlaceholderConfigurerRepository"
         class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" lazy-init="false">
@@ -590,23 +589,12 @@
     </pen:publish>
   </bean>
 
-    <!-- This is a temporary workaround for a problem where the Actions are not
-    being registered with Pentaho system for unit tests -->
-    <util:list id="AuthorizationActions">
-        <ref bean="RepositoryReadAction"/>
-        <ref bean="RepositoryCreateAction"/>
-        <ref bean="SchedulerExecuteAction"/>
-        <ref bean="SchedulerAction"/>
-        <ref bean="AdministerSecurityAction"/>
-        <ref bean="PublishAction"/>
-    </util:list>
-
   <util:map id="immutableRoleBindingMap">
     <entry key-ref="singleTenantAdminAuthorityName">
-        <ref bean="AuthorizationActions"/>
+      <pen:list class="org.pentaho.platform.api.engine.IAuthorizationAction"/>
     </entry>
     <entry key-ref="superAdminAuthorityName">
-      <ref bean="AuthorizationActions"/>
+      <pen:list class="org.pentaho.platform.api.engine.IAuthorizationAction"/>
     </entry>
   </util:map>
 

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -21,6 +21,7 @@
     <hamcrest-library.version>2.2</hamcrest-library.version>
     <hamcrest-core.version>2.2</hamcrest-core.version>
     <xmlunit.version>1.3</xmlunit.version>
+    <org.apache.derby.version>10.15.2.0</org.apache.derby.version>
     <maven-surefire-plugin.argLine> --add-opens=java.base/java.lang=ALL-UNNAMED </maven-surefire-plugin.argLine>
     <maven-failsafe-plugin.argLine> --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.management/javax.management.openmbean=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED </maven-failsafe-plugin.argLine>
   </properties>
@@ -523,6 +524,23 @@
           <groupId>*</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbytools</artifactId>
+      <version>${org.apache.derby.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <version>${org.apache.derby.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>aopalliance</groupId>

--- a/repository/src/it/java/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryAuthorizationIT.java
+++ b/repository/src/it/java/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryAuthorizationIT.java
@@ -13,26 +13,6 @@
 
 package org.pentaho.platform.repository2.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.ByteArrayInputStream;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Locale;
-
-import javax.jcr.security.Privilege;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,8 +41,28 @@ import org.pentaho.platform.security.policy.rolebased.actions.PublishAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
 import org.pentaho.platform.security.policy.rolebased.actions.SchedulerAction;
+import org.pentaho.platform.security.policy.rolebased.actions.SchedulerExecuteAction;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.jcr.security.Privilege;
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Integration test. Tests {@link DefaultUnifiedRepository} and {@link org.pentaho.platform.api.engine.IAuthorizationPolicy IAuthorizationPolicy} fully configured
@@ -1013,14 +1013,17 @@ public class DefaultUnifiedRepositoryAuthorizationIT extends DefaultUnifiedRepos
     assertTrue( allowedActions.contains( RepositoryCreateAction.NAME ) );
     // test with scheduler
     allowedActions = authorizationPolicy.getAllowedActions( NAMESPACE_SCHEDULER );
-    assertEquals( 1, allowedActions.size() );
+    assertEquals( 2, allowedActions.size() );
     assertTrue( allowedActions.contains( SchedulerAction.NAME ) );
+    assertTrue( allowedActions.contains( SchedulerExecuteAction.NAME ) );
+
+
     allowedActions = authorizationPolicy.getAllowedActions( NAMESPACE_SECURITY );
     assertEquals( 2, allowedActions.size() );
     assertTrue( allowedActions.contains( AdministerSecurityAction.NAME ) );
 
     allowedActions = authorizationPolicy.getAllowedActions( NAMESPACE_PENTAHO );
-    assertEquals( 5, allowedActions.size() );
+    assertEquals( 6, allowedActions.size() );
   }
 
   @Test
@@ -1043,7 +1046,7 @@ public class DefaultUnifiedRepositoryAuthorizationIT extends DefaultUnifiedRepos
       login( USERNAME_ADMIN, tenantAcme, new String[] { tenantAdminRoleName, tenantAuthenticatedRoleName } );
       userRoleDao.createUser( tenantAcme, USERNAME_SUZY, PASSWORD, "", null );
       userRoleDao.createUser( tenantDuff, USERNAME_PAT, PASSWORD, "", null );
-      assertEquals( 5, authorizationPolicy.getAllowedActions( null ).size() );
+      assertEquals( 6, authorizationPolicy.getAllowedActions( null ).size() );
 
       login( USERNAME_SUZY, tenantAcme, new String[] { tenantAuthenticatedRoleName } );
       assertEquals( 3, authorizationPolicy.getAllowedActions( null ).size() );
@@ -1053,7 +1056,7 @@ public class DefaultUnifiedRepositoryAuthorizationIT extends DefaultUnifiedRepos
       roleBindingDao
           .setRoleBindings( tenantAuthenticatedRoleName, Arrays.asList( RepositoryReadAction.NAME,
               RepositoryCreateAction.NAME, SchedulerAction.NAME, AdministerSecurityAction.NAME ) );
-      assertEquals( 5, authorizationPolicy.getAllowedActions( null ).size() );
+      assertEquals( 6, authorizationPolicy.getAllowedActions( null ).size() );
 
       // login with pat (in tenant duff)
       login( USERNAME_PAT, tenantDuff, new String[] { tenantAuthenticatedRoleName } );
@@ -1155,11 +1158,11 @@ public class DefaultUnifiedRepositoryAuthorizationIT extends DefaultUnifiedRepos
     assertNotNull( struct.bindingMap );
     assertEquals( 3, struct.bindingMap.size() );
     assertEquals( Arrays.asList( new String[] { RepositoryReadAction.NAME, RepositoryCreateAction.NAME,
-      SchedulerAction.NAME, AdministerSecurityAction.NAME, PublishAction.NAME } ), struct.bindingMap
-        .get( superAdminRoleName ) );
+      SchedulerExecuteAction.NAME, SchedulerAction.NAME, AdministerSecurityAction.NAME, PublishAction.NAME } ),
+      struct.bindingMap.get( superAdminRoleName ) );
     assertEquals( Arrays.asList( new String[] { RepositoryReadAction.NAME, RepositoryCreateAction.NAME,
-      SchedulerAction.NAME, AdministerSecurityAction.NAME, PublishAction.NAME } ), struct.bindingMap
-        .get( tenantAdminRoleName ) );
+      SchedulerExecuteAction.NAME, SchedulerAction.NAME, AdministerSecurityAction.NAME, PublishAction.NAME } ),
+      struct.bindingMap.get( tenantAdminRoleName ) );
     assertEquals( Arrays.asList( new String[] { RepositoryReadAction.NAME, RepositoryCreateAction.NAME,
       SchedulerAction.NAME } ), struct.bindingMap.get( tenantAuthenticatedRoleName ) );
     roleBindingDao.setRoleBindings( "whatever", Arrays.asList( "org.pentaho.p1.reader" ) );
@@ -1169,7 +1172,7 @@ public class DefaultUnifiedRepositoryAuthorizationIT extends DefaultUnifiedRepos
     assertEquals( Arrays.asList( new String[] { "org.pentaho.p1.reader" } ), struct.bindingMap.get( "whatever" ) );
 
     assertNotNull( struct.logicalRoleNameMap );
-    assertEquals( 5, struct.logicalRoleNameMap.size() );
+    assertEquals( 6, struct.logicalRoleNameMap.size() );
     assertEquals( "Create Content", struct.logicalRoleNameMap.get( RepositoryCreateAction.NAME ) );
 
     assertNotNull( struct.immutableRoles );

--- a/repository/src/main/resources/repository.spring.xml
+++ b/repository/src/main/resources/repository.spring.xml
@@ -10,8 +10,8 @@
                            http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd"
        default-lazy-init="true">
 
-  <!-- <bean class="org.pentaho.platform.engine.core.system.objfac.spring.ApplicationContextPentahoSystemRegisterer"
-      lazy-init="false"/> -->
+  <bean class="org.pentaho.platform.engine.core.system.objfac.spring.ApplicationContextPentahoSystemRegisterer"
+      lazy-init="false"/>
 
 
   <bean id="propertyPlaceholderConfigurerRepository"
@@ -541,10 +541,9 @@
     <constructor-arg ref="bootstrapRoleBindingMap"/>
     <constructor-arg ref="superAdminAuthorityName"/>
     <constructor-arg ref="tenantedRoleNameUtils"/>
-    <!-- <constructor-arg>
+    <constructor-arg>
       <pen:list class="org.pentaho.platform.api.engine.IAuthorizationAction"/>
-    </constructor-arg> -->
-    <constructor-arg ref="AuthorizationActions" />
+    </constructor-arg>
   </bean>
 
 
@@ -592,23 +591,12 @@
     </pen:publish>
   </bean>
 
-    <!-- This is a temporary workaround for a problem where the Actions are not
-    being registered with Pentaho system for unit tests -->
-    <util:list id="AuthorizationActions">
-        <ref bean="RepositoryReadAction"/>
-        <ref bean="RepositoryCreateAction"/>
-        <ref bean="SchedulerExecuteAction"/>
-        <ref bean="SchedulerAction"/>
-        <ref bean="AdministerSecurityAction"/>
-        <ref bean="PublishAction"/>
-    </util:list>
-
   <util:map id="immutableRoleBindingMap">
     <entry key-ref="singleTenantAdminAuthorityName">
-        <ref bean="AuthorizationActions"/>
+      <pen:list class="org.pentaho.platform.api.engine.IAuthorizationAction"/>
     </entry>
     <entry key-ref="superAdminAuthorityName">
-      <ref bean="AuthorizationActions"/>
+      <pen:list class="org.pentaho.platform.api.engine.IAuthorizationAction"/>
     </entry>
   </util:map>
 

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryBase.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryBase.java
@@ -13,24 +13,6 @@
 
 package org.pentaho.platform.repository2.unified;
 
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-
-import javax.jcr.Repository;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Workspace;
-import javax.jcr.security.AccessControlException;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.api.JackrabbitWorkspace;
 import org.apache.jackrabbit.api.security.authorization.PrivilegeManager;
@@ -81,11 +63,11 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.extensions.jcr.JcrCallback;
 import org.springframework.extensions.jcr.JcrTemplate;
 import org.springframework.extensions.jcr.SessionFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ContextConfiguration;
@@ -93,6 +75,26 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.security.AccessControlException;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Integration test. Tests {@link DefaultUnifiedRepository} and
@@ -297,7 +299,7 @@ public class DefaultUnifiedRepositoryBase implements ApplicationContextAware {
     mp.defineInstance( IUnifiedRepository.class, repo );
     mp.defineInstance( IRepositoryFileAclDao.class, repositoryFileAclDao );
     IUserRoleListService userRoleListService = mock( IUserRoleListService.class );
-    when( userRoleListService.getRolesForUser( any( ITenant.class ), anyString() ) ).thenReturn( Arrays.asList(
+    when( userRoleListService.getRolesForUser( nullable( ITenant.class ), anyString() ) ).thenReturn( Arrays.asList(
         tenantAdminRoleName, AUTHENTICATED_ROLE_NAME ) );
     mp.defineInstance( IUserRoleListService.class, userRoleListService );
     mp.defineInstance( "singleTenantAdminUserName", singleTenantAdminUserName );
@@ -576,6 +578,7 @@ public class DefaultUnifiedRepositoryBase implements ApplicationContextAware {
     repositoryFileAclDao = (IRepositoryFileAclDao) applicationContext.getBean( "repositoryFileAclDao" );
     testUserRoleDao = userRoleDao;
     txnTemplate = (TransactionTemplate) applicationContext.getBean( "jcrTransactionTemplate" );
+
     TestPrincipalProvider.userRoleDao = testUserRoleDao;
     TestPrincipalProvider.adminCredentialsStrategy =
         (CredentialsStrategy) applicationContext.getBean( "jcrAdminCredentialsStrategy" );


### PR DESCRIPTION
- Fixed missing dependencies
- Restored `ApplicationContextPentahoSystemRegisterer` bean in `repository.spring.xml` test files so that it is possible to use `pen:bean` and `pen:list`
- Extensions:
  - Before: Tests run: 542, Failures: 24, Errors: 41, Skipped: 2
  - After: Tests run: 1774, Failures: 4, Errors: 4, Skipped: 1
- Repository:
  - Before: Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
  - After: Tests run: 151, Failures: 1, Errors: 0, Skipped: 0