### PR TITLE
fix[SP-7194]: encode the filenames added in filename list to avoid issues with commas when uploading multiple files

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryImportResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryImportResource.java
@@ -277,7 +277,8 @@ public class RepositoryImportResource {
       for ( int i = 0; i < fileNameOverrides.size(); i++ ) {
         InputStream fileUpload = fileUploads.get( i );
 
-        String fileName = fileNameOverrides.get( i );
+        // URL-decode the filename to restore original name with special characters
+        String fileName = java.net.URLDecoder.decode( fileNameOverrides.get( i ), charSet );
 
         RepositoryFileImportBundle.Builder bundleBuilder = new RepositoryFileImportBundle.Builder();
         bundleBuilder.input( fileUpload );

--- a/user-console/src/main/java/org/pentaho/mantle/client/dialogs/ImportDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/dialogs/ImportDialog.java
@@ -181,7 +181,7 @@ public class ImportDialog extends PromptDialogBox {
           String selectedFiles = getSelectedFiles( upload );
           //Set the fileNameOverride because the fileUpload object can only reliably transmit US-ASCII
           //character set.  See RFC283 section 2.3 for details
-          fileNameOverride.setValue( selectedFiles );
+          fileNameOverride.setValue( getEncodedFilenames( upload ) );
           fileTextBox.setText( selectedFiles );
           okButton.setEnabled( !selectedFiles.isEmpty() );
         } else {
@@ -406,7 +406,16 @@ public class ImportDialog extends PromptDialogBox {
     var files = upload.@com.google.gwt.user.client.ui.FileUpload::getElement()().files;
     var selectedFiles = [];
     for (var i = 0; i < files.length; i++) {
-      // URL-encode each filename to handle special characters like commas
+      selectedFiles.push( files[i].name );
+    }
+    return selectedFiles.join(", ");
+  }-*/;
+
+  // Get URL-encoded filenames for server submission
+  private native String getEncodedFilenames(FileUpload upload) /*-{
+    var files = upload.@com.google.gwt.user.client.ui.FileUpload::getElement()().files;
+    var selectedFiles = [];
+    for (var i = 0; i < files.length; i++) {
       selectedFiles.push( encodeURIComponent(files[i].name) );
     }
     return selectedFiles.join(",");

--- a/user-console/src/main/java/org/pentaho/mantle/client/dialogs/ImportDialog.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/dialogs/ImportDialog.java
@@ -406,7 +406,8 @@ public class ImportDialog extends PromptDialogBox {
     var files = upload.@com.google.gwt.user.client.ui.FileUpload::getElement()().files;
     var selectedFiles = [];
     for (var i = 0; i < files.length; i++) {
-      selectedFiles.push( files[i].name );
+      // URL-encode each filename to handle special characters like commas
+      selectedFiles.push( encodeURIComponent(files[i].name) );
     }
     return selectedFiles.join(",");
   }-*/;


### PR DESCRIPTION
original PRs: https://github.com/pentaho/pentaho-platform/pull/6134, https://github.com/pentaho/pentaho-platform/pull/6140
@pentaho/tatooine_dev 