### PR TITLE
feat[SP-7216]: receive an email when a schedule fails (#6202)

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/email/IEmailConfiguration.java
+++ b/api/src/main/java/org/pentaho/platform/api/email/IEmailConfiguration.java
@@ -62,6 +62,10 @@ public interface IEmailConfiguration {
 
   public void setSmtpQuitWait( final boolean smtpQuitWait );
 
+  public boolean isSmtpSendPartial();
+
+  public void setSmtpSendPartial( final boolean smtpSendPartial );
+
   public String getAuthMechanism();
 
   public void setAuthMechanism( final String authMechanism );

--- a/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
+++ b/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/pentaho.xml
@@ -221,4 +221,19 @@
     Example:
     <default-scheduler-output-path>/public/output</default-scheduler-output-path>
   -->
+
+  <!--
+    Controls whether scheduler-level failure emails are sent for failed scheduled actions
+    (reports, jobs, transformations, etc.).
+    Defaults to disabled.
+
+    When enabled, failure emails are sent to:
+      - The schedule's own email recipients (_SCH_EMAIL_TO/_SCH_EMAIL_CC/_SCH_EMAIL_BCC)
+      - Admin recipients configured in system/scheduler_failure_email.properties (ADMIN_TO/CC/BCC)
+
+    true  = send failure email when a scheduled action fails
+    false = do not send scheduler-level failure emails
+  -->
+  <scheduler.failure.email.enabled>false</scheduler.failure.email.enabled>
+
 </pentaho-system>

--- a/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/scheduler_failure_email.properties
+++ b/assemblies/pentaho-solutions/src/main/resources-filtered/pentaho-solutions/system/scheduler_failure_email.properties
@@ -1,0 +1,11 @@
+# Admin recipients for scheduler failure emails.
+# These addresses will receive a failure notification whenever any scheduled
+# action (report, job, transformation, etc.) fails, regardless of whether
+# the schedule itself has email recipients configured.
+#
+# NOTE: This file is read once on server startup. Changes require a server restart to take effect.
+#
+# Comma-separated email addresses, or leave empty to disable admin notifications.
+ADMIN_TO=
+ADMIN_CC=
+ADMIN_BCC=

--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/smtp-email/email_config.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/smtp-email/email_config.xml
@@ -24,6 +24,9 @@
 		<!--  This is true if the email server requires an SSL connection. Usually 'false'. For GMail this is 'true' -->
 		<mail.smtp.ssl>false</mail.smtp.ssl>
 
+		<!-- If true, send to valid recipients even when some addresses are invalid -->
+		<mail.smtp.sendpartial>true</mail.smtp.sendpartial>
+
    	<!--  Output debug information from the JavaMail API -->
    	<mail.debug>false</mail.debug>
 

--- a/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
+++ b/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
@@ -13,6 +13,19 @@
 
 package org.pentaho.platform.util;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -28,14 +41,12 @@ import org.pentaho.platform.api.scheduler2.IEmailGroupResolver;
 import org.pentaho.platform.api.util.QuartzActionUtil;
 import org.pentaho.platform.api.workitem.IWorkItemLifecycleEventPublisher;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.services.solution.StandardSettings;
 import org.pentaho.platform.util.messages.Messages;
 import org.pentaho.platform.util.web.MimeHelper;
 
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 
 public class ActionUtil {
 
@@ -71,6 +82,26 @@ public class ActionUtil {
   public static final String INVOKER_ASYNC_EXEC = "async"; //$NON-NLS-1$
   public static final String INVOKER_DEFAULT_ASYNC_EXEC_VALUE = "true"; //$NON-NLS-1$
   public static final String INVOKER_SYNC_VALUE = "false";
+
+  public static final String SCH_EMAIL_TO = "_SCH_EMAIL_TO";
+  public static final String SCH_EMAIL_CC = "_SCH_EMAIL_CC";
+  public static final String SCH_EMAIL_BCC = "_SCH_EMAIL_BCC";
+  public static final String SCH_EMAIL_SUBJECT = "_SCH_EMAIL_SUBJECT";
+  public static final String SCH_EMAIL_MESSAGE = "_SCH_EMAIL_MESSAGE";
+
+  private static final String SCHEDULER_FAILURE_EMAIL_ENABLED_PROPERTY = "scheduler.failure.email.enabled";
+  private static final boolean SCHEDULER_FAILURE_EMAIL_ENABLED_DEFAULT = false;
+  private static final String ADMIN_TO = "ADMIN_TO";
+  private static final String ADMIN_CC = "ADMIN_CC";
+  private static final String ADMIN_BCC = "ADMIN_BCC";
+
+  static final String SCHEDULER_FAILURE_EMAIL_PROPERTIES = "system/scheduler_failure_email.properties";
+
+  /**
+   * Admin failure email properties loaded lazily on first access from
+   * {@value #SCHEDULER_FAILURE_EMAIL_PROPERTIES}. Changes to the file require a server restart to take effect.
+   */
+  private static Properties adminFailureEmailProperties;
 
   public static final String WORK_ITEM_UID = "workItemUid"; //$NON-NLS-1$
   public static final String WORK_ITEM_NAME = "workItemName"; //$NON-NLS-1$
@@ -434,9 +465,9 @@ public class ActionUtil {
         addAttachment( actionParams, params, filePath, emailer );
       }
 
-      String to = (String) actionParams.get( "_SCH_EMAIL_TO" );
-      String cc = (String) actionParams.get( "_SCH_EMAIL_CC" );
-      String bcc = (String) actionParams.get( "_SCH_EMAIL_BCC" );
+      String to = (String) actionParams.get( SCH_EMAIL_TO );
+      String cc = (String) actionParams.get( SCH_EMAIL_CC );
+      String bcc = (String) actionParams.get( SCH_EMAIL_BCC );
       if ( ( to == null || "".equals( to ) ) && ( cc == null || "".equals( cc ) )
           && ( bcc == null || "".equals( bcc ) ) ) {
         // no destination
@@ -447,25 +478,25 @@ public class ActionUtil {
       if ( emailGroupResolver == null ) {
         emailGroupResolver = new DefaultEmailGroupResolver();
       }
-      String resolveToList = emailGroupResolver.resolve(to);
-      if (resolveToList != null && resolveToList.length() > 0) {
+      String resolveToList = emailGroupResolver.resolve( to );
+      if ( resolveToList != null && resolveToList.length() > 0 ) {
         emailer.setTo( resolveToList );
-        String resolveCCList = emailGroupResolver.resolve(cc);
-        if (resolveCCList != null && resolveCCList.length() > 0) {
+        String resolveCCList = emailGroupResolver.resolve( cc );
+        if ( resolveCCList != null && resolveCCList.length() > 0 ) {
           emailer.setCc( resolveCCList );
         }
         String resolveBCCList = emailGroupResolver.resolve( bcc );
-        if (resolveBCCList != null && resolveBCCList.length() > 0) {
+        if ( resolveBCCList != null && resolveBCCList.length() > 0 ) {
           emailer.setBcc( resolveBCCList );
         }
-        String subject = ( String ) actionParams.get( "_SCH_EMAIL_SUBJECT" );
-        if (subject != null && !"".equals( subject ) ) {
+        String subject = (String) actionParams.get( SCH_EMAIL_SUBJECT );
+        if ( subject != null && !"".equals( subject ) ) {
           emailer.setSubject( subject );
         } else {
           emailer.setSubject( "Pentaho Scheduler" + ( emailer.getAttachmentName() != null ? " : " + emailer.getAttachmentName() : "" ) );
         }
-        String message = (String) actionParams.get( "_SCH_EMAIL_MESSAGE" );
-        if ( subject != null && !"".equals( subject ) ) {
+        String message = (String) actionParams.get( SCH_EMAIL_MESSAGE );
+        if ( message != null && !"".equals( message ) ) {
           emailer.setBody( message );
         }
         emailer.send();
@@ -475,6 +506,176 @@ public class ActionUtil {
     } catch ( Exception e ) {
       logger.warn( e.getMessage(), e );
     }
+  }
+
+  /**
+   * Sends a scheduler failure email (without attachment) to the same destination fields used by scheduler success
+   * emails. This method is intentionally best-effort and never throws.
+   *
+   * @param actionParams the scheduler action params
+   * @param failureCause the failure that occurred, may be null
+   */
+  public static void sendFailureEmail( Map<String, Object> actionParams, Throwable failureCause ) {
+    if ( actionParams == null || !isSchedulerFailureEmailEnabled() ) {
+      return;
+    }
+
+    try {
+      final Emailer emailer = new Emailer();
+      if ( !emailer.setup() ) {
+        logger.debug( "Failure email skipped: email is not configured." );
+        return;
+      }
+
+      IEmailGroupResolver emailGroupResolver = PentahoSystem.get( IEmailGroupResolver.class );
+      if ( emailGroupResolver == null ) {
+        emailGroupResolver = new DefaultEmailGroupResolver();
+      }
+
+      // Schedule recipients (from the job's own email settings)
+      final String to = (String) actionParams.get( SCH_EMAIL_TO );
+      final String cc = (String) actionParams.get( SCH_EMAIL_CC );
+      final String bcc = (String) actionParams.get( SCH_EMAIL_BCC );
+
+      // Admin recipients loaded once at startup from system/scheduler_failure_email.properties
+      final Properties emailProperties = getAdminFailureEmailProperties();
+      final String adminTo = emailProperties.getProperty( ADMIN_TO, "" );
+      final String adminCc = emailProperties.getProperty( ADMIN_CC, "" );
+      final String adminBcc = emailProperties.getProperty( ADMIN_BCC, "" );
+
+      final String resolvedTo = mergeAddresses( emailGroupResolver.resolve( to ), adminTo );
+      final String resolvedCc = mergeAddresses( emailGroupResolver.resolve( cc ), adminCc );
+      final String resolvedBcc = mergeAddresses( emailGroupResolver.resolve( bcc ), adminBcc );
+
+      if ( StringUtils.isBlank( resolvedTo ) && StringUtils.isBlank( resolvedCc ) && StringUtils.isBlank( resolvedBcc ) ) {
+        logger.debug( "Failure email skipped: no destination provided (schedule or admin)." );
+        return;
+      }
+
+      emailer.setTo( resolvedTo );
+      emailer.setCc( resolvedCc );
+      emailer.setBcc( resolvedBcc );
+
+      String subject = buildFailureSubject( actionParams );
+      emailer.setSubject( subject );
+
+      final String configuredMessage = (String) actionParams.get( SCH_EMAIL_MESSAGE );
+      final StringBuilder messageBuilder = new StringBuilder();
+      if ( StringUtils.isBlank( configuredMessage ) ) {
+        messageBuilder.append( "The scheduled job failed." );
+      } else {
+        messageBuilder.append( configuredMessage ).append( "\n\n" ).append( "The scheduled job failed." );
+      }
+
+      final String failureText = extractFailureMessage( failureCause );
+      if ( !StringUtils.isBlank( failureText ) ) {
+        messageBuilder.append( "\nCause: " ).append( failureText );
+      }
+
+      emailer.setBody( messageBuilder.toString() );
+      emailer.send();
+    } catch ( Exception e ) {
+      logger.warn( "Could not send scheduler failure email.", e );
+    }
+  }
+
+  private static synchronized Properties getAdminFailureEmailProperties() {
+    if ( adminFailureEmailProperties == null ) {
+      loadAdminFailureEmailProperties();
+    }
+    return adminFailureEmailProperties;
+  }
+
+  private static void loadAdminFailureEmailProperties() {
+    final Properties properties = new Properties();
+    try {
+      final String solutionPath = PentahoSystem.getApplicationContext().getSolutionPath( SCHEDULER_FAILURE_EMAIL_PROPERTIES );
+      if ( !StringUtils.isBlank( solutionPath ) ) {
+        final File file = new File( solutionPath );
+        if ( file.isFile() ) {
+          try ( InputStream in = new FileInputStream( file ) ) {
+            properties.load( in );
+            for ( String key : new String[] { ADMIN_TO, ADMIN_CC, ADMIN_BCC } ) {
+              properties.setProperty( key, filterValidAddresses( properties.getProperty( key, "" ) ) );
+            }
+          }
+        }
+      }
+    } catch ( IOException | RuntimeException e ) {
+      logger.warn( "Could not load scheduler failure email admin properties.", e );
+    }
+    adminFailureEmailProperties = properties;
+  }
+
+  private static String filterValidAddresses( final String addresses ) {
+    if ( StringUtils.isBlank( addresses ) ) {
+      return "";
+    }
+    final List<String> valid = new ArrayList<>();
+    for ( final String addr : addresses.split( "," ) ) {
+      final String trimmed = addr.trim();
+      if ( StringUtils.isBlank( trimmed ) ) {
+        continue;
+      }
+      try {
+        InternetAddress.parse( trimmed, true );
+        valid.add( trimmed );
+      } catch ( AddressException e ) {
+        logger.warn( "Ignoring invalid admin failure email address: '" + trimmed + "'" );
+      }
+    }
+    return String.join( ",", valid );
+  }
+
+  private static String mergeAddresses( final String a, final String b ) {
+    if ( StringUtils.isBlank( a ) ) {
+      return StringUtils.isBlank( b ) ? "" : b.trim();
+    }
+    if ( StringUtils.isBlank( b ) ) {
+      return a.trim();
+    }
+    return a.trim() + "," + b.trim();
+  }
+
+  private static boolean isSchedulerFailureEmailEnabled() {
+    final String value = PentahoSystem.getSystemSetting( SCHEDULER_FAILURE_EMAIL_ENABLED_PROPERTY,
+      String.valueOf( SCHEDULER_FAILURE_EMAIL_ENABLED_DEFAULT ) );
+    return Boolean.parseBoolean( value );
+  }
+
+  private static String buildFailureSubject( final Map<String, Object> actionParams ) {
+    final String scheduleName = extractScheduleName( actionParams );
+    if ( StringUtils.isBlank( scheduleName ) ) {
+      return "Schedule failed";
+    }
+
+    return "Schedule '" + scheduleName + "' failed";
+  }
+
+  private static String extractScheduleName( final Map<String, Object> actionParams ) {
+    if ( actionParams == null ) {
+      return null;
+    }
+    final Object value = actionParams.get( StandardSettings.SCHEDULE_NAME );
+    return value != null ? value.toString().trim() : null;
+  }
+
+  private static String extractFailureMessage( Throwable failureCause ) {
+    if ( failureCause == null ) {
+      return null;
+    }
+
+    final String message = failureCause.getMessage();
+    if ( !StringUtils.isBlank( message ) ) {
+      return message;
+    }
+
+    final Throwable nestedCause = failureCause.getCause();
+    if ( nestedCause != null && !StringUtils.isBlank( nestedCause.getMessage() ) ) {
+      return nestedCause.getMessage();
+    }
+
+    return null;
   }
 
   private static void addAttachment( Map<String, Object> actionParams, Map<String, Object> params,

--- a/core/src/main/java/org/pentaho/platform/util/Emailer.java
+++ b/core/src/main/java/org/pentaho/platform/util/Emailer.java
@@ -13,6 +13,13 @@
 
 package org.pentaho.platform.util;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Properties;
+
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -36,12 +43,6 @@ import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
 import jakarta.mail.util.ByteArrayDataSource;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
-import java.util.Properties;
 
 public class Emailer {
 
@@ -189,6 +190,7 @@ public class Emailer {
       props.put( "mail.smtp.ssl", ObjectUtils.toString( service.getEmailConfig().isUseSsl() ) );
       props.put( "mail.smtp.quitwait", ObjectUtils.toString( service.getEmailConfig().isSmtpQuitWait() ) );
       props.put( "mail.from.default", service.getEmailConfig().getDefaultFrom() );
+      props.put( "mail.smtp.sendpartial", ObjectUtils.toString( service.getEmailConfig().isSmtpSendPartial() ) );
       setAuthMechanism( service.getEmailConfig().getAuthMechanism() );
       String fromName = service.getEmailConfig().getFromName();
       if ( StringUtils.isEmpty( fromName ) ) {

--- a/core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java
@@ -14,24 +14,6 @@
 package org.pentaho.platform.util;
 
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.pentaho.platform.api.action.ActionInvocationException;
-import org.pentaho.platform.api.action.IAction;
-import org.pentaho.platform.api.engine.IPluginManager;
-import org.pentaho.platform.api.engine.PluginBeanException;
-import org.pentaho.platform.api.workitem.IWorkItemLifecycleEventPublisher;
-import org.pentaho.platform.engine.core.system.PentahoSystem;
-import org.pentaho.platform.workitem.DummyPublisher;
-
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -41,6 +23,37 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pentaho.platform.api.action.ActionInvocationException;
+import org.pentaho.platform.api.action.IAction;
+import org.pentaho.platform.api.engine.IApplicationContext;
+import org.pentaho.platform.api.engine.IPluginManager;
+import org.pentaho.platform.api.engine.PluginBeanException;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
+import org.pentaho.platform.api.workitem.IWorkItemLifecycleEventPublisher;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.workitem.DummyPublisher;
 
 @RunWith( MockitoJUnitRunner.class )
 public class ActionUtilTest {
@@ -301,5 +314,118 @@ public class ActionUtilTest {
     // verify that the expected keys are no longer present in the map
     Assert.assertNull( map.get( ActionUtil.INVOKER_ACTIONID ) );
     Assert.assertNull( map.get( ActionUtil.QUARTZ_ACTIONID ) );
+  }
+
+  @Test
+  public void testAddAttachment_UsesGeneratedContentNameWhenEnabled() throws Exception {
+    Map<String, Object> actionParams = new HashMap<>();
+    actionParams.put( "_SCH_EMAIL_USE_GENERATED_NAME", "true" );
+    actionParams.put( "_SCH_EMAIL_ATTACHMENT_NAME", "custom-name" );
+
+    Map<String, Object> params = new HashMap<>();
+    params.put( ActionUtil.QUARTZ_LINEAGE_ID, "lineage-id" );
+
+    RepositoryFile sourceFile = mock( RepositoryFile.class );
+    when( sourceFile.getId() ).thenReturn( "file-id" );
+    when( sourceFile.getName() ).thenReturn( "generated-output" );
+
+    IUnifiedRepository repo = mock( IUnifiedRepository.class );
+    when( repo.getFile( "/public/generated/output.*" ) ).thenReturn( sourceFile );
+    when( repo.getFileMetadata( "file-id" ) ).thenReturn( new HashMap<>() );
+    when( repo.getDataForRead( "file-id", SimpleRepositoryFileData.class ) ).thenReturn(
+      new SimpleRepositoryFileData( new ByteArrayInputStream( "x".getBytes() ), "UTF-8", null ) );
+
+    Emailer emailer = mock( Emailer.class );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( IUnifiedRepository.class ) ).thenReturn( repo );
+
+      Method addAttachment = ActionUtil.class.getDeclaredMethod( "addAttachment", Map.class, Map.class,
+        String.class, Emailer.class );
+      addAttachment.setAccessible( true );
+      addAttachment.invoke( null, actionParams, params, "/public/generated/output.*", emailer );
+    }
+
+    verify( emailer ).setAttachmentName( "generated-output.bin" );
+  }
+
+  @Test
+  public void testIsSchedulerFailureEmailEnabled_TrueWhenSystemSettingTrue() throws Exception {
+    try ( MockedStatic<PentahoSystem> pentahoSystem = mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.getSystemSetting( "scheduler.failure.email.enabled", "false" ) )
+        .thenReturn( "true" );
+
+      Method method = ActionUtil.class.getDeclaredMethod( "isSchedulerFailureEmailEnabled" );
+      method.setAccessible( true );
+      assertTrue( (Boolean) method.invoke( null ) );
+    }
+  }
+
+  @Test
+  public void testIsSchedulerFailureEmailEnabled_FalseWhenSystemSettingFalse() throws Exception {
+    try ( MockedStatic<PentahoSystem> pentahoSystem = mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.getSystemSetting( "scheduler.failure.email.enabled", "false" ) )
+        .thenReturn( "false" );
+
+      Method method = ActionUtil.class.getDeclaredMethod( "isSchedulerFailureEmailEnabled" );
+      method.setAccessible( true );
+      assertFalse( (Boolean) method.invoke( null ) );
+    }
+  }
+
+  @Test
+  public void testMergeAddresses_MergesScheduleAndAdminRecipients() throws Exception {
+    Method method = ActionUtil.class.getDeclaredMethod( "mergeAddresses", String.class, String.class );
+    method.setAccessible( true );
+
+    assertEquals( "schedule@acme.com,admin@acme.com",
+      method.invoke( null, "schedule@acme.com", "admin@acme.com" ) );
+    assertEquals( "admin@acme.com", method.invoke( null, "", "admin@acme.com" ) );
+    assertEquals( "schedule@acme.com", method.invoke( null, "schedule@acme.com", "" ) );
+  }
+
+  @Test
+  public void testLoadAdminFailureEmailProperties_MissingFileReturnsEmptyProps() throws Exception {
+    IApplicationContext appContext = mock( IApplicationContext.class );
+    when( appContext.getSolutionPath( ActionUtil.SCHEDULER_FAILURE_EMAIL_PROPERTIES ) )
+      .thenReturn( "C:/does/not/exist/scheduler_failure_email.properties" );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( PentahoSystem::getApplicationContext ).thenReturn( appContext );
+
+      Method method = ActionUtil.class.getDeclaredMethod( "loadAdminFailureEmailProperties" );
+      method.setAccessible( true );
+      method.invoke( null );
+
+      Field field = ActionUtil.class.getDeclaredField( "adminFailureEmailProperties" );
+      field.setAccessible( true );
+      Properties props = (Properties) field.get( null );
+      assertTrue( props.isEmpty() );
+    }
+  }
+
+  @Test
+  public void testLoadAdminFailureEmailProperties_MalformedFileReturnsEmptyProps() throws Exception {
+    Path temp = Files.createTempFile( "scheduler_failure_email", ".properties" );
+    Files.write( temp, "ADMIN_TO=abc\\u00ZZ".getBytes( StandardCharsets.ISO_8859_1 ) );
+
+    IApplicationContext appContext = mock( IApplicationContext.class );
+    when( appContext.getSolutionPath( ActionUtil.SCHEDULER_FAILURE_EMAIL_PROPERTIES ) )
+      .thenReturn( temp.toAbsolutePath().toString() );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( PentahoSystem::getApplicationContext ).thenReturn( appContext );
+
+      Method method = ActionUtil.class.getDeclaredMethod( "loadAdminFailureEmailProperties" );
+      method.setAccessible( true );
+      method.invoke( null );
+
+      Field field = ActionUtil.class.getDeclaredField( "adminFailureEmailProperties" );
+      field.setAccessible( true );
+      Properties props = (Properties) field.get( null );
+      assertTrue( props.isEmpty() );
+    } finally {
+      Files.deleteIfExists( temp );
+    }
   }
 }

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/email/EmailConfiguration.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/email/EmailConfiguration.java
@@ -13,14 +13,15 @@
 
 package org.pentaho.platform.plugin.services.email;
 
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Properties;
+
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.pentaho.platform.api.email.IEmailConfiguration;
 
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.io.Serializable;
-import java.util.Objects;
-import java.util.Properties;
 
 /**
  * Bean which contains all the information for the email configuration
@@ -40,6 +41,7 @@ public class EmailConfiguration implements Serializable, IEmailConfiguration {
   private Integer smtpPort;
   private String smtpProtocol;
   private boolean smtpQuitWait;
+  private boolean smtpSendPartial;
   private String userId;
   private String password;
   private boolean useSsl;
@@ -61,7 +63,7 @@ public class EmailConfiguration implements Serializable, IEmailConfiguration {
 
   public EmailConfiguration( final boolean authenticate, final boolean debug, final String defaultFrom,
       final String fromName, final String smtpHost, final Integer smtpPort, final String smtpProtocol,
-      final boolean smtpQuitWait, final String userId, final String password, final boolean useSsl,
+      final boolean smtpQuitWait, final boolean smtpSendPartial, final String userId, final String password, final boolean useSsl,
       final boolean useStartTls ) {
     this.authenticate = authenticate;
     this.debug = debug;
@@ -71,6 +73,7 @@ public class EmailConfiguration implements Serializable, IEmailConfiguration {
     this.smtpPort = smtpPort;
     this.smtpProtocol = smtpProtocol;
     this.smtpQuitWait = smtpQuitWait;
+    this.smtpSendPartial = smtpSendPartial;
     this.userId = userId;
     this.password = password;
     this.useSsl = useSsl;
@@ -173,6 +176,14 @@ public class EmailConfiguration implements Serializable, IEmailConfiguration {
     this.smtpQuitWait = smtpQuitWait;
   }
 
+  public boolean isSmtpSendPartial() {
+    return smtpSendPartial;
+  }
+
+  public void setSmtpSendPartial( final boolean smtpSendPartial ) {
+    this.smtpSendPartial = smtpSendPartial;
+  }
+
   public String getAuthMechanism() {
     return authMechanism == null ? "" : authMechanism;
   }
@@ -261,7 +272,8 @@ public class EmailConfiguration implements Serializable, IEmailConfiguration {
   public String toString() {
     return "authenticate='" + authenticate + '\'' + ", debug='" + debug + '\'' + ", defaultFrom='" + defaultFrom + '\''
         + ", fromName='" + fromName + '\'' + ", smtpHost='" + smtpHost + '\'' + ", smtpPort=" + smtpPort
-        + ", smtpProtocol='" + smtpProtocol + '\'' + ", smtpQuitWait=" + smtpQuitWait + ", userId='" + userId + '\''
+        + ", smtpProtocol='" + smtpProtocol + '\'' + ", smtpQuitWait=" + smtpQuitWait
+        + ", smtpSendPartial=" + smtpSendPartial + ", userId='" + userId + '\''
         + ", password='" + password + '\'' + ", useSsl=" + useSsl + ", useStartTls=" + useStartTls
         + ", authMechanism='" + authMechanism + '\'' + ", clientID=" + clientId + '\'' + ", clientSecret='" + clientSecret + '\''
         + ", tokenUrl='" + tokenUrl + '\'' + ", scope=" + scope + '\'' + ", grantType=" + grantType + '\'' + ", refreshToken=" + refreshToken + '\''
@@ -278,7 +290,8 @@ public class EmailConfiguration implements Serializable, IEmailConfiguration {
     }
     final EmailConfiguration that = (EmailConfiguration) obj;
     return ( this.authenticate == that.authenticate && this.debug == that.debug
-        && this.smtpQuitWait == that.smtpQuitWait && this.useSsl == that.useSsl && this.useStartTls == that.useStartTls
+        && this.smtpQuitWait == that.smtpQuitWait && this.smtpSendPartial == that.smtpSendPartial
+        && this.useSsl == that.useSsl && this.useStartTls == that.useStartTls
         && ObjectUtils.equals( this.getSmtpPort(), that.getSmtpPort() )
         && isEquals( this.defaultFrom, that.defaultFrom ) && isEquals( this.fromName, that.fromName )
         && isEquals( this.smtpHost, that.smtpHost ) && isEquals( this.smtpProtocol, that.smtpProtocol )
@@ -292,9 +305,9 @@ public class EmailConfiguration implements Serializable, IEmailConfiguration {
 
   @Override
   public int hashCode() {
-    return Objects.hash( authenticate, debug, defaultFrom, fromName, smtpHost, smtpPort, smtpProtocol, smtpQuitWait,
-            userId, password, useSsl, useStartTls, authMechanism, clientId, clientSecret, tokenUrl, scope, grantType,
-            refreshToken, authorizationCode, redirectUri );
+      return Objects.hash( authenticate, debug, defaultFrom, fromName, smtpHost, smtpPort, smtpProtocol, smtpQuitWait,
+            smtpSendPartial, userId, password, useSsl, useStartTls, authMechanism, clientId, clientSecret, tokenUrl,
+            scope, grantType,  refreshToken, authorizationCode, redirectUri );
   }
 
   private boolean isEquals( final String a, final String b ) {

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/email/EmailConfigurationXml.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/email/EmailConfigurationXml.java
@@ -13,7 +13,9 @@
 
 package org.pentaho.platform.plugin.services.email;
 
-import jakarta.xml.bind.annotation.XmlTransient;
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -31,8 +33,7 @@ import org.pentaho.platform.plugin.services.messages.Messages;
 import org.pentaho.platform.util.xml.dom4j.XmlDom4JHelper;
 
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.io.File;
-import java.io.IOException;
+import jakarta.xml.bind.annotation.XmlTransient;
 
 @XmlRootElement
 public class EmailConfigurationXml extends EmailConfiguration {
@@ -49,6 +50,7 @@ public class EmailConfigurationXml extends EmailConfiguration {
   private static final String SMTP_PORT_XPATH = ROOT_ELEMENT + "/properties/mail.smtp.port"; //$NON-NLS-1$
   private static final String SMTP_PROTOCOL_XPATH = ROOT_ELEMENT + "/properties/mail.transport.protocol"; //$NON-NLS-1$
   private static final String SMTP_QUIT_WAIT_XPATH = ROOT_ELEMENT + "/properties/mail.smtp.quitwait"; //$NON-NLS-1$
+  private static final String SMTP_SEND_PARTIAL_XPATH = ROOT_ELEMENT + "/properties/mail.smtp.sendpartial"; //$NON-NLS-1$
   private static final String USER_ID_XPATH = ROOT_ELEMENT + "/mail.userid"; //$NON-NLS-1$
   private static final String USE_SSL_XPATH = ROOT_ELEMENT + "/properties/mail.smtp.ssl"; //$NON-NLS-1$
   private static final String USE_START_TLS_XPATH = ROOT_ELEMENT + "/properties/mail.smtp.starttls.enable"; //$NON-NLS-1$
@@ -112,6 +114,7 @@ public class EmailConfigurationXml extends EmailConfiguration {
     setUseSsl( getBooleanValue( doc, USE_SSL_XPATH ) );
     setDebug( getBooleanValue( doc, DEBUG_XPATH ) );
     setSmtpQuitWait( getBooleanValue( doc, SMTP_QUIT_WAIT_XPATH ) );
+    setSmtpSendPartial( getBooleanValue( doc, SMTP_SEND_PARTIAL_XPATH ) );
 
     setDefaultFrom( getStringValue( doc, DEFAULT_FROM_XPATH ) );
     setFromName( getStringValue( doc, FROM_NAME_XPATH ) );
@@ -164,14 +167,18 @@ public class EmailConfigurationXml extends EmailConfiguration {
   }
 
   private static boolean getBooleanValue( final Document doc, final String xpath ) {
+    return getBooleanValue( doc, xpath, false );
+  }
+
+  private static boolean getBooleanValue( final Document doc, final String xpath, final boolean defaultValue ) {
     try {
       final Element element = (Element) doc.selectSingleNode( xpath );
-      return element != null && Boolean.parseBoolean( element.getText() );
+      return element != null ? Boolean.parseBoolean( element.getText() ) : defaultValue;
     } catch ( Exception e ) {
       logger.error( messages.getErrorString( "EmailConfigurationXml.ERROR_0001_ERROR_PARSING_DATA", e
           .getLocalizedMessage() ) );
     }
-    return false;
+    return defaultValue;
   }
 
   private static void setValue( final Document doc, final String xPath, final String value ) {
@@ -202,6 +209,8 @@ public class EmailConfigurationXml extends EmailConfiguration {
     setValue( document, DEBUG_XPATH, ObjectUtils.toString( emailConfiguration.isDebug(), Boolean.FALSE.toString() ) );
     setValue( document, SMTP_QUIT_WAIT_XPATH, ObjectUtils.toString( emailConfiguration.isSmtpQuitWait(), Boolean.FALSE
         .toString() ) );
+    setValue( document, SMTP_SEND_PARTIAL_XPATH, ObjectUtils.toString( emailConfiguration.isSmtpSendPartial(),
+      Boolean.TRUE.toString() ) );
 
     setValue( document, DEFAULT_FROM_XPATH, ObjectUtils.toString( emailConfiguration.getDefaultFrom() ) );
     setValue( document, FROM_NAME_XPATH, ObjectUtils.toString( emailConfiguration.getFromName() ) );

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/email/EmailConfigurationTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/email/EmailConfigurationTest.java
@@ -20,10 +20,10 @@ public class EmailConfigurationTest extends TestCase {
   public void testEqualsEmailConfig() {
     final EmailConfiguration emailConfigOriginal =
               new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "smtp.com", 36,
-                      "SMTP", true, "user", "password", false, true );
+              "SMTP", true, true, "user", "password", false, true );
     final EmailConfiguration emailConfigNew =
               new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "smtp.com", 36,
-                      "SMTP", true, "user", "password", false, true );
+              "SMTP", true, true, "user", "password", false, true );
     assertEquals( emailConfigOriginal.equals( emailConfigNew ), true );
     emailConfigNew.setAuthenticate( false );
     assertEquals( emailConfigOriginal.equals( emailConfigNew ), false );
@@ -32,10 +32,10 @@ public class EmailConfigurationTest extends TestCase {
   public void testHashCodeEmailConfig() {
     final EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "smtp.com", 36,
-                    "SMTP", true, "user", "password", false, true );
+            "SMTP", true, true, "user", "password", false, true );
     final EmailConfiguration emailConfigNew =
             new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "smtp.com", 36,
-                    "SMTP", true, "user", "password", false, true );
+            "SMTP", true, true, "user", "password", false, true );
     int emailConfigOriginalHashCode = emailConfigOriginal.hashCode();
     int emailConfigNewHashCode = emailConfigNew.hashCode();
     assertEquals( emailConfigOriginalHashCode == emailConfigNewHashCode, true );

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/email/EmailConfigurationXmlTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/email/EmailConfigurationXmlTest.java
@@ -13,14 +13,15 @@
 
 package org.pentaho.platform.plugin.services.email;
 
-import junit.framework.TestCase;
-import org.dom4j.Document;
-import org.pentaho.di.core.KettleEnvironment;
-
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+
+import org.dom4j.Document;
+import org.pentaho.di.core.KettleEnvironment;
+
+import junit.framework.TestCase;
 
 /**
  * Test class for the {@link }EmailConfigurationXml} class
@@ -65,6 +66,7 @@ public class EmailConfigurationXmlTest extends TestCase {
     assertEquals( true, emailConfiguration.isUseSsl() );
     assertEquals( true, emailConfiguration.isDebug() );
     assertEquals( true, emailConfiguration.isSmtpQuitWait() );
+    assertEquals( true, emailConfiguration.isSmtpSendPartial() );
     assertEquals( "sampleuser@sampleserver.com", emailConfiguration.getDefaultFrom() );
     assertEquals( "sampleuser", emailConfiguration.getUserId() );
     assertEquals( "samplepassword", emailConfiguration.getPassword() );
@@ -92,6 +94,7 @@ public class EmailConfigurationXmlTest extends TestCase {
     assertEquals( true, emailConfiguration.isUseSsl() );
     assertEquals( true, emailConfiguration.isDebug() );
     assertEquals( true, emailConfiguration.isSmtpQuitWait() );
+    assertEquals( true, emailConfiguration.isSmtpSendPartial() );
     assertEquals( "sampleuser@sampleserver.com", emailConfiguration.getDefaultFrom() );
     assertEquals( "sampleuser", emailConfiguration.getUserId() );
     assertEquals( "samplepassword", emailConfiguration.getPassword() );
@@ -122,6 +125,7 @@ public class EmailConfigurationXmlTest extends TestCase {
     assertEquals( false, emailConfiguration.isUseSsl() );
     assertEquals( false, emailConfiguration.isDebug() );
     assertEquals( false, emailConfiguration.isSmtpQuitWait() );
+    assertEquals( false, emailConfiguration.isSmtpSendPartial() );
     assertEquals( "", emailConfiguration.getDefaultFrom() );
     assertEquals( "", emailConfiguration.getUserId() );
     assertEquals( "", emailConfiguration.getPassword() );
@@ -150,6 +154,7 @@ public class EmailConfigurationXmlTest extends TestCase {
     assertEquals( false, emailConfiguration.isUseSsl() );
     assertEquals( false, emailConfiguration.isDebug() );
     assertEquals( false, emailConfiguration.isSmtpQuitWait() );
+    assertEquals( false, emailConfiguration.isSmtpSendPartial() );
     assertEquals( "", emailConfiguration.getDefaultFrom() );
     assertEquals( "sampleuser", emailConfiguration.getUserId() );
     assertEquals( "", emailConfiguration.getPassword() );

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/email/EmailServiceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/email/EmailServiceTest.java
@@ -13,10 +13,20 @@
 
 package org.pentaho.platform.plugin.services.email;
 
-import junit.framework.TestCase;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.http.Consts;
 import org.apache.http.HttpException;
@@ -37,19 +47,10 @@ import jakarta.mail.Session;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.ws.rs.HttpMethod;
-import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Map;
-import java.util.Properties;
-import java.util.stream.Collectors;
+import junit.framework.TestCase;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 @RunWith( MockitoJUnitRunner.class )
 public class EmailServiceTest extends TestCase {
@@ -97,7 +98,7 @@ public class EmailServiceTest extends TestCase {
 
     final EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "smtp.com", 36,
-                    EmailConstants.PROTOCOL_SMTP, true, "user", "password", false, true );
+                    EmailConstants.PROTOCOL_SMTP, true, true, "user", "password", false, true );
     boolean response = emailService.isValid( emailConfigOriginal );
     assertTrue( response );
 
@@ -115,7 +116,7 @@ public class EmailServiceTest extends TestCase {
 
     final EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "", 36,
-                    EmailConstants.PROTOCOL_SMTP, true, "user", "password", false, true );
+                    EmailConstants.PROTOCOL_SMTP, true, true, "user", "password", false, true );
 
     emailConfigOriginal.setAuthMechanism( EmailConstants.AUTH_TYPE_XOAUTH2 );
     emailConfigOriginal.setGrantType( EmailConstants.GRANT_TYPE_CLIENT_CREDENTIALS );
@@ -143,7 +144,7 @@ public class EmailServiceTest extends TestCase {
 
     final EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "", 36,
-                    EmailConstants.PROTOCOL_SMTP, true, "user", "password", false, true );
+                    EmailConstants.PROTOCOL_SMTP, true, true, "user", "password", false, true );
 
     emailConfigOriginal.setAuthMechanism( EmailConstants.AUTH_TYPE_XOAUTH2 );
     emailConfigOriginal.setClientId( "cid" );
@@ -175,7 +176,7 @@ public class EmailServiceTest extends TestCase {
 
     final EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "", 36,
-                    EmailConstants.PROTOCOL_SMTP, true, "user", "password", false, true );
+                    EmailConstants.PROTOCOL_SMTP, true, true, "user", "password", false, true );
     emailConfigOriginal.setAuthMechanism( EmailConstants.AUTH_TYPE_XOAUTH2 );
     emailConfigOriginal.setClientId( "cid" );
     emailConfigOriginal.setClientSecret( "clientsecret" );
@@ -210,7 +211,7 @@ public class EmailServiceTest extends TestCase {
 
     final EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( false, false, "test@pentaho.com", "", "smtp.com", 36,
-                    EmailConstants.PROTOCOL_SMTP, true, "", "", false, true );
+                    EmailConstants.PROTOCOL_SMTP, true, true, "", "", false, true );
     boolean response = emailService.isValid( emailConfigOriginal );
     assertEquals( true, response );
   }
@@ -220,7 +221,7 @@ public class EmailServiceTest extends TestCase {
 
     final EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "", "", "smtp.com", 36,
-                    EmailConstants.PROTOCOL_SMTP, true, "", "", false, true );
+                    EmailConstants.PROTOCOL_SMTP, true, true, "", "", false, true );
 
     boolean response = emailService.isValid( emailConfigOriginal );
     assertEquals( false, response );
@@ -230,7 +231,7 @@ public class EmailServiceTest extends TestCase {
   public void testSendEmailTestNoAuth() throws Exception {
     EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( false, false, "test@pentaho.com", "Pentaho Scheduler", "", 25,
-                    EmailConstants.PROTOCOL_SMTP, true, "", "", true, true );
+                    EmailConstants.PROTOCOL_SMTP, true, true, "", "", true, true );
     assertEquals( EmailService.TEST_EMAIL_SUCCESS, emailService.sendEmailTest( emailConfigOriginal ) );
     assertEquals( 1, MockMail.size() );
     final Message message = MockMail.get( 0 );
@@ -256,7 +257,7 @@ public class EmailServiceTest extends TestCase {
 
     EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "", 25,
-                    EmailConstants.PROTOCOL_GRAPH_API, true, "test", "", true, true );
+                    EmailConstants.PROTOCOL_GRAPH_API, true, true, "test", "", true, true );
     emailConfigOriginal.setAuthMechanism( EmailConstants.AUTH_TYPE_XOAUTH2 );
     emailConfigOriginal.setClientId( "cid" );
     emailConfigOriginal.setClientSecret( "secret" );
@@ -300,7 +301,7 @@ public class EmailServiceTest extends TestCase {
     String mockUrlFulToken = server.url( urlPathToken ).toString();
     EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "smtp.office365.com", 587,
-                    EmailConstants.PROTOCOL_SMTP, true, "PentahoBA_mailTest@Hitachivantara.com", "", true, true );
+                    EmailConstants.PROTOCOL_SMTP, true, true, "PentahoBA_mailTest@Hitachivantara.com", "", true, true );
     emailConfigOriginal.setAuthMechanism( EmailConstants.AUTH_TYPE_XOAUTH2 );
 
     Properties emailProperties = new Properties();
@@ -365,7 +366,7 @@ public class EmailServiceTest extends TestCase {
 
     EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "tes@test.com", "Pentaho Scheduler", "", 25,
-                    EmailConstants.PROTOCOL_GRAPH_API, true, "test@test.com", "", true, true );
+                    EmailConstants.PROTOCOL_GRAPH_API, true, true, "test@test.com", "", true, true );
     emailConfigOriginal.setAuthMechanism( EmailConstants.AUTH_TYPE_XOAUTH2 );
     emailConfigOriginal.setClientId( "cid" );
     emailConfigOriginal.setClientSecret( "secret" );
@@ -444,7 +445,7 @@ public class EmailServiceTest extends TestCase {
 
     EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "tes@test.com", "Pentaho Scheduler", "", 25,
-                    EmailConstants.PROTOCOL_GRAPH_API, true, "test@test.com", "", true, true );
+                    EmailConstants.PROTOCOL_GRAPH_API, true, true, "test@test.com", "", true, true );
     emailConfigOriginal.setAuthMechanism( EmailConstants.AUTH_TYPE_XOAUTH2 );
     emailConfigOriginal.setClientId( "cid" );
     emailConfigOriginal.setClientSecret( "secret" );
@@ -472,7 +473,7 @@ public class EmailServiceTest extends TestCase {
     KettleEnvironment.init();
     EmailConfiguration emailConfigOriginal =
             new EmailConfiguration( true, false, "test@pentaho.com", "Pentaho Scheduler", "smtp.com", 25,
-                    EmailConstants.PROTOCOL_SMTP, true, "user", "password", true, true );
+                    EmailConstants.PROTOCOL_SMTP, true, true, "user", "password", true, true );
     emailConfigOriginal.setAuthMechanism( EmailConstants.AUTH_TYPE_BASIC );
 
     emailService.sendEmailTest( emailConfigOriginal );

--- a/extensions/src/test/resources/solution/system/email_config.xml
+++ b/extensions/src/test/resources/solution/system/email_config.xml
@@ -21,6 +21,8 @@
     <!--  This is true if the email server requires an SSL connection. Usually 'false'. For GMail this is 'true' -->
     <mail.smtp.ssl>false</mail.smtp.ssl>
 
+    <mail.smtp.sendpartial>true</mail.smtp.sendpartial>
+
       <!--  Output debug information from the JavaMail API -->
       <mail.debug>false</mail.debug>
 

--- a/extensions/src/test/resources/solution/system/smtp-email/email_config.xml
+++ b/extensions/src/test/resources/solution/system/smtp-email/email_config.xml
@@ -21,6 +21,8 @@
     <!--  This is true if the email server requires an SSL connection. Usually 'false'. For GMail this is 'true' -->
     <mail.smtp.ssl>false</mail.smtp.ssl>
 
+    <mail.smtp.sendpartial>true</mail.smtp.sendpartial>
+
       <!--  Output debug information from the JavaMail API -->
       <mail.debug>false</mail.debug>
 

--- a/extensions/testdata/email_config_1.xml
+++ b/extensions/testdata/email_config_1.xml
@@ -25,6 +25,8 @@
 		<!--  This is true if the email server requires an SSL connection. Usually 'false'. For GMail this is 'true' -->
 		<mail.smtp.ssl>true</mail.smtp.ssl>
 
+		<mail.smtp.sendpartial>true</mail.smtp.sendpartial>
+
    	<!--  Output debug information from the JavaMail API -->
    	<mail.debug>true</mail.debug>
 

--- a/extensions/testdata/email_config_2.xml
+++ b/extensions/testdata/email_config_2.xml
@@ -22,6 +22,8 @@
 		<!--  This is true if the email server requires an SSL connection. Usually 'false'. For GMail this is 'true' -->
 		<mail.smtp.ssl></mail.smtp.ssl>
 
+		<mail.smtp.sendpartial>false</mail.smtp.sendpartial>
+
    	<!--  Output debug information from the JavaMail API -->
    	<mail.debug>false</mail.debug>
 

--- a/user-console/src/main/java/org/pentaho/mantle/client/admin/JsEmailConfiguration.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/admin/JsEmailConfiguration.java
@@ -42,6 +42,8 @@ public class JsEmailConfiguration extends JavaScriptObject {
 
   public final native boolean isSmtpQuitWait() /*-{ return this.smtpQuitWait; }-*/; //
 
+  public final native boolean isSmtpSendPartial() /*-{ return this.smtpSendPartial; }-*/; //
+
   public final native String getUserId() /*-{ return this.userId; }-*/; //
 
   public final native String getPassword() /*-{ return this.password; }-*/; //
@@ -65,6 +67,8 @@ public class JsEmailConfiguration extends JavaScriptObject {
   public final native void setSmtpProtocol( final String smtpProtocol ) /*-{ this.smtpProtocol = smtpProtocol; }-*/; //
 
   public final native void setSmtpQuitWait( final boolean smtpQuitWait ) /*-{ this.smtpQuitWait = smtpQuitWait; }-*/; //
+
+  public final native void setSmtpSendPartial( final boolean smtpSendPartial ) /*-{ this.smtpSendPartial = smtpSendPartial; }-*/; //
 
   public final native void setUserId( final String userId ) /*-{ this.userId = userId; }-*/; //
 


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information

**SP Issue:** [SP-7216 - API's to determine the status of a report execution rather than the state of the schedule](https://hv-eng.atlassian.net/browse/SP-7216)
**Base Case:** [BISERVER-15398 - API's to determine the status of a report execution rather than the state of the schedule](https://hv-eng.atlassian.net/browse/BISERVER-15398)
**Original Master PR:** [pentaho/pentaho-platform#6202](https://github.com/pentaho/pentaho-platform/pull/6202)

## Changes
- Backported schedule-failure email behavior and related API updates from master
- Files: multiple files in `api`, `core`, `extensions`, `assemblies`, and `user-console`
- Commit: 1839cd32f3

## Conflict Resolution
- Initial cherry-pick had conflicts in `core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java`
- Resolved by preserving master-intent changes and keeping test imports/structure consistent
- Final backport commit rebuilt as a single policy-compliant commit message with SP scope

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
- **Code Freeze Status:** Detected (SP2026 - 11.0.0.2), but backport only to maintenance branch per policy
