### PR TITLE
fix[SP-7198]: support defaulting to the generated content name on email attachments

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
+++ b/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
@@ -489,21 +489,27 @@ public class ActionUtil {
     // send email
     SimpleRepositoryFileData data = repo.getDataForRead( sourceFile.getId(), SimpleRepositoryFileData.class );
     emailer.setAttachment( data.getInputStream() );
-    emailer.setAttachmentName( "attachment" );
-    String attachmentName = (String) actionParams.get( "_SCH_EMAIL_ATTACHMENT_NAME" );
-    if ( !StringUtils.isEmpty( attachmentName ) ) {
-      String extension = MimeHelper.getExtension( data.getMimeType(), ".bin" );
-      emailer.setAttachmentName( attachmentName.endsWith( extension ) ?  attachmentName : attachmentName + extension );
-    } else if ( data != null ) {
+    
+    String useGeneratedName = (String) actionParams.get( "_SCH_EMAIL_USE_GENERATED_NAME" );
+    String customAttachmentName = (String) actionParams.get( "_SCH_EMAIL_ATTACHMENT_NAME" );
+    String extension = MimeHelper.getExtension( data.getMimeType(), ".bin" );
+    
+    String finalAttachmentName;
+    
+    if ( "true".equalsIgnoreCase( useGeneratedName ) ) {
+      finalAttachmentName = sourceFile.getName();
+    } else if ( !StringUtils.isEmpty( customAttachmentName ) ) {
+      finalAttachmentName = customAttachmentName;
+    } else {
       String path = filePath;
       if ( path.endsWith( ".*" ) ) {
         path = path.replace( ".*", "" );
       }
-      String extension = MimeHelper.getExtension( data.getMimeType(), ".bin" );
-      path = path.substring( path.lastIndexOf( "/" ) + 1, path.length() );
-      emailer.setAttachmentName( path.endsWith( extension ) ?  path : path + extension );
+      finalAttachmentName = path.substring( path.lastIndexOf( "/" ) + 1, path.length() );
     }
-    if ( data == null || data.getMimeType() == null || "".equals( data.getMimeType() ) ) {
+
+    emailer.setAttachmentName( finalAttachmentName.endsWith( extension ) ? finalAttachmentName : finalAttachmentName + extension );
+    if ( data.getMimeType() == null || "".equals( data.getMimeType() ) ) {
       emailer.setAttachmentMimeType( "binary/octet-stream" );
     } else {
       emailer.setAttachmentMimeType( data.getMimeType() );

--- a/user-console/src/main/resources/org/pentaho/mantle/public/MantleStyle.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/MantleStyle.css
@@ -777,6 +777,21 @@ code {
   width: 100%;
 }
 
+table#email-schedule-panel .gwt-CheckBox {
+  display: inline-block;
+  white-space: nowrap;
+  line-height: normal;
+}
+
+table#email-schedule-panel .gwt-CheckBox input {
+  width: auto !important;
+  margin-bottom: 0 !important;
+}
+
+table#email-schedule-panel .gwt-CheckBox label {
+  line-height: normal;
+}
+
 .timeZonePicker {
   width: 100%;
 }


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
**SP Issue:** [SP-7198 - Backport of BISERVER-15346 - (11.0 Suite) Email Attachment Reports Missing Timestamp in Filename](https://hv-eng.atlassian.net/browse/SP-7198)
**Base Case:** [BISERVER-15346 - Email Attachment Reports Missing Timestamp in Filename](https://hv-eng.atlassian.net/browse/BISERVER-15346)
**Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6171

## Changes
- Cherry-picked original master PR changes from https://github.com/pentaho/pentaho-platform/pull/6171 to maintenance branch 11.0.
- Backport scope matches the original master PR for this repository.
- Commit: 83acd3a58e8689c7d78a295eb386c73ce47de00b (Merge pull request #6171 from miguelappleton/BISERVER-15346)

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
- **Code Freeze Status:** Detected (SP2026 - 11.0 (11.0.0.2)), but backport only to maintenance branch per policy
