### PR TITLE
refactor[SP-7218]: Backport PPP-6114 SearchIndex configuration updates (#6139)

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
@@ -297,10 +297,12 @@
         Search index and the file system it uses.
         class: FQN of class implementing the QueryHandler interface
     -->
+    <!--
     <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
       <param name="path" value="${wsp.home}/index"/>
       <param name="supportHighlighting" value="true"/>
     </SearchIndex>
+    -->
 
 
     <WorkspaceSecurity>

--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
@@ -297,12 +297,10 @@
         Search index and the file system it uses.
         class: FQN of class implementing the QueryHandler interface
     -->
-    <!--
     <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
       <param name="path" value="${wsp.home}/index"/>
       <param name="supportHighlighting" value="true"/>
     </SearchIndex>
-    -->
 
 
     <WorkspaceSecurity>

--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
@@ -299,7 +299,10 @@
     -->
     <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
       <param name="path" value="${wsp.home}/index"/>
-      <param name="supportHighlighting" value="true"/>
+      <param name="extractorPoolSize" value="0"/>
+      <param name="enableConsistencyCheck" value="false"/>
+      <param name="respectDocumentOrder" value="false"/>
+      <param name="initializeHierarchyCache" value="false" />
     </SearchIndex>
 
 


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
**SP Issue:** [SP-7218 - Backport of PPP-6114 - (11.0 Suite) Repository.xml - Workspaces - Lucene](https://hv-eng.atlassian.net/browse/SP-7218)
**Base Case:** [PPP-6114 - Repository.xml - Workspaces - Lucene](https://hv-eng.atlassian.net/browse/PPP-6114)
**Original Master PR:** #6122, #6128, #6139

## Changes
- Removed unused SearchIndex configuration from repository.xml (PR #6122)
- Reverted previous SearchIndex removal (PR #6128)
- Updated SearchIndex parameters in repository.xml for improved configuration (PR #6139)
- Commit: f1b9cf68da0d6c3bc77aa43ad8bc930620111289
- Commit: c1b773261b95573f130c55451b429e8683ead5e0
- Commit: f6b978bb1c0ecc4d066c63df1b4f2c9baf6d9fc8

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
- **Code Freeze Status:** Detected (SP2026 - 11.0 (11.0.0.2)), but backport only to maintenance branch per policy
