### PR TITLE
[BACKLOG-49353] - Filter filenames on repository API

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/pentahoServices.spring.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/pentahoServices.spring.xml
@@ -15,7 +15,16 @@
     <property name="url" value="/webservices/unifiedRepository"/>
     <property name="service">
       <bean class="org.pentaho.platform.web.jaxws.spring.SpringService">
-        <property name="impl" value="org.pentaho.platform.repository2.unified.webservices.jaxws.DiUnifiedRepositoryJaxwsWebService"/>
+        <property name="bean">
+          <bean class="org.pentaho.platform.repository2.unified.webservices.jaxws.DiUnifiedRepositoryJaxwsWebService">
+            <constructor-arg>
+              <pen:bean class="org.pentaho.platform.api.repository2.unified.IUnifiedRepository"/>
+            </constructor-arg>
+            <constructor-arg>
+              <pen:bean class="org.pentaho.platform.api.mimetype.IPlatformMimeResolver"/>
+            </constructor-arg>
+          </bean>
+        </property>
       </bean>
     </property>
   </bean>
@@ -77,7 +86,14 @@
   <!--  GWT services are defined as Spring beans.  The id maps to the request URL like so:
       requests to "/ws/gwt/myService" will be dispatched to a bean with id "ws-gwt-myService"
   -->
-  <bean id="ws-gwt-unifiedRepository" class="org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService"/>
+  <bean id="ws-gwt-unifiedRepository" class="org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService">
+    <constructor-arg>
+      <pen:bean class="org.pentaho.platform.api.repository2.unified.IUnifiedRepository"/>
+    </constructor-arg>
+    <constructor-arg>
+      <pen:bean class="org.pentaho.platform.api.mimetype.IPlatformMimeResolver"/>
+    </constructor-arg>
+  </bean>
 
   <!-- JAX-RS beans -->
   <bean class="org.pentaho.platform.web.http.api.resources.RootResource" scope="request"/>

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/DefaultUnifiedRepositoryWebService.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/DefaultUnifiedRepositoryWebService.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import jakarta.jws.WebService;
 
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.mimetype.IPlatformMimeResolver;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAce;
@@ -58,6 +59,8 @@ public class DefaultUnifiedRepositoryWebService implements IUnifiedRepositoryWeb
 
   protected IUnifiedRepository repo;
 
+  protected IPlatformMimeResolver platformMimeResolver;
+
   protected RepositoryFileAdapter repositoryFileAdapter = new RepositoryFileAdapter();
 
   protected NodeRepositoryFileDataAdapter nodeRepositoryFileDataAdapter = new NodeRepositoryFileDataAdapter();
@@ -80,14 +83,21 @@ public class DefaultUnifiedRepositoryWebService implements IUnifiedRepositoryWeb
     super();
     // repo = new MockUnifiedRepository();
     repo = PentahoSystem.get( IUnifiedRepository.class );
+    platformMimeResolver = PentahoSystem.get( IPlatformMimeResolver.class );
     if ( repo == null ) {
       throw new IllegalStateException();
     }
   }
 
   public DefaultUnifiedRepositoryWebService( final IUnifiedRepository repo ) {
+    this( repo, PentahoSystem.get( IPlatformMimeResolver.class ) );
+  }
+
+  public DefaultUnifiedRepositoryWebService( final IUnifiedRepository repo,
+      final IPlatformMimeResolver platformMimeResolver ) {
     super();
     this.repo = repo;
+    this.platformMimeResolver = platformMimeResolver;
   }
 
   public static Logger getLogger() {
@@ -251,10 +261,16 @@ public class DefaultUnifiedRepositoryWebService implements IUnifiedRepositoryWeb
   }
 
   public void moveFile( String fileId, String destAbsPath, String versionMessage ) {
+    if ( !isEtcChildPath( destAbsPath ) && !isExistingFolderPath( destAbsPath ) ) {
+      validateMimeTypeForWriteOperation( destAbsPath );
+    }
     repo.moveFile( fileId, destAbsPath, versionMessage );
   }
 
   public void copyFile( String fileId, String destAbsPath, String versionMessage ) {
+    if ( !isEtcChildPath( destAbsPath ) && !isExistingFolderPath( destAbsPath ) ) {
+      validateMimeTypeForWriteOperation( destAbsPath );
+    }
     repo.copyFile( fileId, destAbsPath, versionMessage );
   }
 
@@ -269,6 +285,9 @@ public class DefaultUnifiedRepositoryWebService implements IUnifiedRepositoryWeb
   public RepositoryFileDto createFile( String parentFolderId, RepositoryFileDto file, NodeRepositoryFileDataDto data,
       String versionMessage ) {
     validateEtcWriteAccess( parentFolderId );
+    if ( !file.isFolder() && !isEtcChildFolderId( parentFolderId ) ) {
+      validateMimeTypeForWriteOperation( file.getName() );
+    }
     return repositoryFileAdapter.marshal( repo.createFile( parentFolderId, repositoryFileAdapter.unmarshal( file ),
         nodeRepositoryFileDataAdapter.unmarshal( data ), versionMessage ) );
   }
@@ -276,6 +295,9 @@ public class DefaultUnifiedRepositoryWebService implements IUnifiedRepositoryWeb
   public RepositoryFileDto createFileWithAcl( String parentFolderId, RepositoryFileDto file,
       NodeRepositoryFileDataDto data, RepositoryFileAclDto acl, String versionMessage ) {
     validateEtcWriteAccess( parentFolderId );
+    if ( !file.isFolder() && !isEtcChildFolderId( parentFolderId ) ) {
+      validateMimeTypeForWriteOperation( file.getName() );
+    }
     return repositoryFileAdapter.marshal( repo.createFile( parentFolderId, repositoryFileAdapter.unmarshal( file ),
         nodeRepositoryFileDataAdapter.unmarshal( data ), repositoryFileAclAdapter.unmarshal( acl ), versionMessage ) );
   }
@@ -391,6 +413,35 @@ public class DefaultUnifiedRepositoryWebService implements IUnifiedRepositoryWeb
         throw new RuntimeException( "This service is not allowed to access the ETC folder in JCR." );
       }
     }
+  }
+
+  protected void validateMimeTypeForWriteOperation( String fileName ) {
+    if ( platformMimeResolver == null ) {
+      throw new IllegalStateException( "No platformMimeResolver available to validate mime types." );
+    }
+    if ( platformMimeResolver.resolveMimeForFileName( fileName ) == null ) {
+      throw new RuntimeException( "This service is not allowed to write unsupported file types." );
+    }
+  }
+
+  protected boolean isEtcChildPath( String path ) {
+    return path != null && path.startsWith( "/etc/" );
+  }
+
+  protected boolean isExistingFolderPath( String path ) {
+    if ( repo == null || path == null ) {
+      return false;
+    }
+    RepositoryFile destination = repo.getFile( path );
+    return destination != null && destination.isFolder();
+  }
+
+  protected boolean isEtcChildFolderId( String parentFolderId ) {
+    if ( repo == null || parentFolderId == null ) {
+      return false;
+    }
+    RepositoryFile parentFolder = repo.getFileById( parentFolderId );
+    return parentFolder != null && isEtcChildPath( parentFolder.getPath() );
   }
 
   protected void validateEtcReadAccess( String path ) {

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/jaxws/DefaultUnifiedRepositoryJaxwsWebService.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/jaxws/DefaultUnifiedRepositoryJaxwsWebService.java
@@ -13,11 +13,12 @@
 
 package org.pentaho.platform.repository2.unified.webservices.jaxws;
 
+import org.pentaho.platform.api.mimetype.IPlatformMimeResolver;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
-import org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService;
 import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileAclDto;
 import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
+import org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService;
 
 import jakarta.jws.WebService;
 import java.util.ArrayList;
@@ -44,9 +45,20 @@ public class DefaultUnifiedRepositoryJaxwsWebService extends DefaultUnifiedRepos
     super( repo );
   }
 
+  /**
+   * Used in unit test.
+   */
+  public DefaultUnifiedRepositoryJaxwsWebService( final IUnifiedRepository repo,
+      final IPlatformMimeResolver platformMimeResolver ) {
+    super( repo, platformMimeResolver );
+  }
+
   public RepositoryFileDto createBinaryFileWithAcl( final String parentFolderId, final RepositoryFileDto file,
       final SimpleRepositoryFileDataDto simpleJaxWsData, final RepositoryFileAclDto acl, final String versionMessage ) {
     validateEtcWriteAccess( parentFolderId );
+    if ( !file.isFolder() && !isEtcChildFolderId( parentFolderId ) ) {
+      validateMimeTypeForWriteOperation( file.getName() );
+    }
     return repositoryFileAdapter.marshal( repo.createFile( parentFolderId, repositoryFileAdapter.unmarshal( file ),
         SimpleRepositoryFileDataDto.convert( simpleJaxWsData ), repositoryFileAclAdapter.unmarshal( acl ),
         versionMessage ) );
@@ -55,6 +67,9 @@ public class DefaultUnifiedRepositoryJaxwsWebService extends DefaultUnifiedRepos
   public RepositoryFileDto createBinaryFile( final String parentFolderId, final RepositoryFileDto file,
       final SimpleRepositoryFileDataDto simpleJaxWsData, final String versionMessage ) {
     validateEtcWriteAccess( parentFolderId );
+    if ( !file.isFolder() && !isEtcChildFolderId( parentFolderId ) ) {
+      validateMimeTypeForWriteOperation( file.getName() );
+    }
     return repositoryFileAdapter.marshal( repo.createFile( parentFolderId, repositoryFileAdapter.unmarshal( file ),
         SimpleRepositoryFileDataDto.convert( simpleJaxWsData ), versionMessage ) );
   }

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/jaxws/DiUnifiedRepositoryJaxwsWebService.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/jaxws/DiUnifiedRepositoryJaxwsWebService.java
@@ -18,6 +18,8 @@ import java.util.List;
 import jakarta.jws.WebService;
 
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.mimetype.IPlatformMimeResolver;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadAction;
@@ -25,8 +27,16 @@ import org.pentaho.platform.security.policy.rolebased.actions.RepositoryReadActi
 
 @WebService ( endpointInterface = "org.pentaho.platform.repository2.unified.webservices.jaxws.IUnifiedRepositoryJaxwsWebService",
   serviceName = "unifiedRepository", portName = "unifiedRepositoryPort", targetNamespace = "http://www.pentaho.org/ws/1.0" )
-public class DiUnifiedRepositoryJaxwsWebService extends DefaultUnifiedRepositoryJaxwsWebService implements
-  IUnifiedRepositoryJaxwsWebService {
+public class DiUnifiedRepositoryJaxwsWebService extends DefaultUnifiedRepositoryJaxwsWebService {
+
+  public DiUnifiedRepositoryJaxwsWebService() {
+    super();
+  }
+
+  public DiUnifiedRepositoryJaxwsWebService( final IUnifiedRepository repo,
+      final IPlatformMimeResolver platformMimeResolver ) {
+    super( repo, platformMimeResolver );
+  }
 
   @Override
   protected void validateEtcReadAccess( String path ) {

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/webservices/DefaultUnifiedRepositoryWebServiceTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/webservices/DefaultUnifiedRepositoryWebServiceTest.java
@@ -13,10 +13,23 @@
 
 package org.pentaho.platform.repository2.unified.webservices;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import junit.framework.TestCase;
+import org.pentaho.platform.api.mimetype.IPlatformMimeResolver;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.data.node.DataNode;
+import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFileData;
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.webservices.NodeRepositoryFileDataDto;
+import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
 import org.pentaho.platform.api.repository2.unified.webservices.StringKeyStringValueDto;
 import org.pentaho.test.platform.repository2.unified.MockUnifiedRepository;
 
@@ -101,6 +114,172 @@ public class DefaultUnifiedRepositoryWebServiceTest extends TestCase {
     List<RepositoryFile> list = repository.getDeletedFiles();
     assertEquals( 2, list.size() );
     assertEquals( list, expectedList );
+  }
+
+  public void testCreateFileFiltersUnsupportedMimeType() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "blocked.unknown" ) ).thenReturn( null );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+    RepositoryFileDto fileDto = new RepositoryFileAdapter().marshal( new RepositoryFile.Builder( "blocked.unknown" ).build() );
+
+    try {
+      ws.createFile( "parent", fileDto, createNodeRepositoryFileDataDto(), "msg" );
+      fail( "Expected createFile to reject unsupported mime type" );
+    } catch ( RuntimeException e ) {
+      assertTrue( e.getMessage().contains( "unsupported file types" ) );
+    }
+
+    verify( repositoryMock, never() ).createFile( anyString(), any( RepositoryFile.class ),
+      any( NodeRepositoryFileData.class ), anyString() );
+  }
+
+  public void testCreateFileAllowsSupportedMimeType() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "allowed.prpt" ) ).thenReturn( "text/prpt" );
+    RepositoryFile createdFile = new RepositoryFile.Builder( "allowed.prpt" ).build();
+    when( repositoryMock.createFile( eq( "parent" ), any( RepositoryFile.class ), any( NodeRepositoryFileData.class ),
+      eq( "msg" ) ) ).thenReturn( createdFile );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+    RepositoryFileDto fileDto = new RepositoryFileAdapter().marshal( new RepositoryFile.Builder( "allowed.prpt" ).build() );
+
+    RepositoryFileDto result = ws.createFile( "parent", fileDto, createNodeRepositoryFileDataDto(), "msg" );
+
+    assertNotNull( result );
+    verify( repositoryMock ).createFile( eq( "parent" ), any( RepositoryFile.class ),
+      any( NodeRepositoryFileData.class ), eq( "msg" ) );
+  }
+
+  public void testCreateFileAllowsUnsupportedMimeTypeUnderEtcChildFolder() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "blocked.unknown" ) ).thenReturn( null );
+    when( repositoryMock.getFileById( "etc-child-id" ) )
+      .thenReturn( new RepositoryFile.Builder( "etc-child" ).path( "/etc/custom" ).folder( true ).build() );
+    RepositoryFile createdFile = new RepositoryFile.Builder( "blocked.unknown" ).build();
+    when( repositoryMock.createFile( eq( "etc-child-id" ), any( RepositoryFile.class ), any( NodeRepositoryFileData.class ),
+      eq( "msg" ) ) ).thenReturn( createdFile );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+    RepositoryFileDto fileDto = new RepositoryFileAdapter().marshal( new RepositoryFile.Builder( "blocked.unknown" ).build() );
+
+    RepositoryFileDto result = ws.createFile( "etc-child-id", fileDto, createNodeRepositoryFileDataDto(), "msg" );
+
+    assertNotNull( result );
+    verify( repositoryMock ).createFile( eq( "etc-child-id" ), any( RepositoryFile.class ),
+      any( NodeRepositoryFileData.class ), eq( "msg" ) );
+  }
+
+  public void testCopyFileFiltersUnsupportedMimeType() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "/public/blocked.unknown" ) ).thenReturn( null );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+
+    try {
+      ws.copyFile( "file-id", "/public/blocked.unknown", "msg" );
+      fail( "Expected copyFile to reject unsupported mime type" );
+    } catch ( RuntimeException e ) {
+      assertTrue( e.getMessage().contains( "unsupported file types" ) );
+    }
+
+    verify( repositoryMock, never() ).copyFile( anyString(), anyString(), anyString() );
+  }
+
+  public void testCopyFileAllowsSupportedMimeType() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "/public/allowed.prpt" ) ).thenReturn( "text/prpt" );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+    ws.copyFile( "file-id", "/public/allowed.prpt", "msg" );
+
+    verify( repositoryMock ).copyFile( "file-id", "/public/allowed.prpt", "msg" );
+  }
+
+  public void testCopyFileAllowsWhenDestinationIsExistingFolder() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( repositoryMock.getFile( "/public" ) )
+      .thenReturn( new RepositoryFile.Builder( "public" ).path( "/public" ).folder( true ).build() );
+    when( mimeResolver.resolveMimeForFileName( "/public" ) ).thenReturn( null );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+    ws.copyFile( "file-id", "/public", "msg" );
+
+    verify( repositoryMock ).copyFile( "file-id", "/public", "msg" );
+  }
+
+  public void testCopyFileAllowsUnsupportedMimeTypeUnderEtcChildDestination() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "/etc/custom/blocked.unknown" ) ).thenReturn( null );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+    ws.copyFile( "file-id", "/etc/custom/blocked.unknown", "msg" );
+
+    verify( repositoryMock ).copyFile( "file-id", "/etc/custom/blocked.unknown", "msg" );
+  }
+
+  public void testMoveFileFiltersUnsupportedMimeType() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "/public/blocked.unknown" ) ).thenReturn( null );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+
+    try {
+      ws.moveFile( "file-id", "/public/blocked.unknown", "msg" );
+      fail( "Expected moveFile to reject unsupported mime type" );
+    } catch ( RuntimeException e ) {
+      assertTrue( e.getMessage().contains( "unsupported file types" ) );
+    }
+
+    verify( repositoryMock, never() ).moveFile( anyString(), anyString(), anyString() );
+  }
+
+  public void testMoveFileAllowsSupportedMimeType() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "/public/allowed.prpt" ) ).thenReturn( "text/prpt" );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+    ws.moveFile( "file-id", "/public/allowed.prpt", "msg" );
+
+    verify( repositoryMock ).moveFile( "file-id", "/public/allowed.prpt", "msg" );
+  }
+
+  public void testMoveFileAllowsWhenDestinationIsExistingFolder() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( repositoryMock.getFile( "/public" ) )
+      .thenReturn( new RepositoryFile.Builder( "public" ).path( "/public" ).folder( true ).build() );
+    when( mimeResolver.resolveMimeForFileName( "/public" ) ).thenReturn( null );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+    ws.moveFile( "file-id", "/public", "msg" );
+
+    verify( repositoryMock ).moveFile( "file-id", "/public", "msg" );
+  }
+
+  public void testMoveFileAllowsUnsupportedMimeTypeUnderEtcChildDestination() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "/etc/custom/blocked.unknown" ) ).thenReturn( null );
+
+    DefaultUnifiedRepositoryWebService ws = new DefaultUnifiedRepositoryWebService( repositoryMock, mimeResolver );
+    ws.moveFile( "file-id", "/etc/custom/blocked.unknown", "msg" );
+
+    verify( repositoryMock ).moveFile( "file-id", "/etc/custom/blocked.unknown", "msg" );
+  }
+
+  private NodeRepositoryFileDataDto createNodeRepositoryFileDataDto() {
+    NodeRepositoryFileDataAdapter adapter = new NodeRepositoryFileDataAdapter();
+    return adapter.marshal( new NodeRepositoryFileData( new DataNode( "root" ), 0 ) );
   }
 
   /**

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/webservices/jaxws/DefaultUnifiedRepositoryJaxwsWebServiceTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/webservices/jaxws/DefaultUnifiedRepositoryJaxwsWebServiceTest.java
@@ -1,0 +1,102 @@
+package org.pentaho.platform.repository2.unified.webservices.jaxws;
+
+import org.pentaho.platform.api.mimetype.IPlatformMimeResolver;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileAclAceDto;
+import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileAclDto;
+import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+
+import junit.framework.TestCase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DefaultUnifiedRepositoryJaxwsWebServiceTest extends TestCase {
+
+  public void testCreateBinaryFileFiltersUnsupportedMimeType() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "blocked.unknown" ) ).thenReturn( null );
+
+    DefaultUnifiedRepositoryJaxwsWebService ws =
+      new DefaultUnifiedRepositoryJaxwsWebService( repositoryMock, mimeResolver );
+
+    try {
+      ws.createBinaryFile( "parent", fileDto( "blocked.unknown" ), binaryDataDto(), "msg" );
+      fail( "Expected createBinaryFile to reject unsupported mime type" );
+    } catch ( RuntimeException e ) {
+      assertTrue( e.getMessage().contains( "unsupported file types" ) );
+    }
+
+    verify( repositoryMock, never() ).createFile( anyString(), any( RepositoryFile.class ),
+      any( SimpleRepositoryFileData.class ), anyString() );
+  }
+
+  public void testCreateBinaryFileAllowsUnsupportedMimeTypeUnderEtcChildFolder() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "blocked.unknown" ) ).thenReturn( null );
+    when( repositoryMock.getFileById( "etc-child-id" ) )
+      .thenReturn( new RepositoryFile.Builder( "etc-child" ).path( "/etc/custom" ).folder( true ).build() );
+    when( repositoryMock.createFile( eq( "etc-child-id" ), any( RepositoryFile.class ),
+      any( SimpleRepositoryFileData.class ), eq( "msg" ) ) )
+      .thenReturn( new RepositoryFile.Builder( "blocked.unknown" ).build() );
+
+    DefaultUnifiedRepositoryJaxwsWebService ws =
+      new DefaultUnifiedRepositoryJaxwsWebService( repositoryMock, mimeResolver );
+
+    RepositoryFileDto result = ws.createBinaryFile( "etc-child-id", fileDto( "blocked.unknown" ), binaryDataDto(), "msg" );
+
+    assertNotNull( result );
+    verify( repositoryMock ).createFile( eq( "etc-child-id" ), any( RepositoryFile.class ),
+      any( SimpleRepositoryFileData.class ), eq( "msg" ) );
+  }
+
+  public void testCreateBinaryFileWithAclFiltersUnsupportedMimeType() {
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    IPlatformMimeResolver mimeResolver = mock( IPlatformMimeResolver.class );
+    when( mimeResolver.resolveMimeForFileName( "blocked.unknown" ) ).thenReturn( null );
+
+    DefaultUnifiedRepositoryJaxwsWebService ws =
+      new DefaultUnifiedRepositoryJaxwsWebService( repositoryMock, mimeResolver );
+
+    try {
+      ws.createBinaryFileWithAcl( "parent", fileDto( "blocked.unknown" ), binaryDataDto(), emptyAclDto(), "msg" );
+      fail( "Expected createBinaryFileWithAcl to reject unsupported mime type" );
+    } catch ( RuntimeException e ) {
+      assertTrue( e.getMessage().contains( "unsupported file types" ) );
+    }
+
+    verify( repositoryMock, never() ).createFile( anyString(), any( RepositoryFile.class ),
+      any( SimpleRepositoryFileData.class ), any(), anyString() );
+  }
+
+  private RepositoryFileDto fileDto( String name ) {
+    RepositoryFileDto file = new RepositoryFileDto();
+    file.setName( name );
+    file.setFolder( false );
+    return file;
+  }
+
+  private SimpleRepositoryFileDataDto binaryDataDto() {
+    SimpleRepositoryFileData data = new SimpleRepositoryFileData(
+      new ByteArrayInputStream( "test".getBytes() ), "UTF-8", "text/plain" );
+    return SimpleRepositoryFileDataDto.convert( data );
+  }
+
+  private RepositoryFileAclDto emptyAclDto() {
+    RepositoryFileAclDto acl = new RepositoryFileAclDto();
+    acl.setAces( new ArrayList<RepositoryFileAclAceDto>(), false );
+    return acl;
+  }
+}


### PR DESCRIPTION
Use the same filtering rules we use for PUC/import