### PR TITLE
fix[SP-7199]: support defaulting to the generated content name on email attachments

### DIFF
--- a/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
+++ b/core/src/main/java/org/pentaho/platform/util/ActionUtil.java
@@ -690,21 +690,27 @@ public class ActionUtil {
     // send email
     SimpleRepositoryFileData data = repo.getDataForRead( sourceFile.getId(), SimpleRepositoryFileData.class );
     emailer.setAttachment( data.getInputStream() );
-    emailer.setAttachmentName( "attachment" );
-    String attachmentName = (String) actionParams.get( "_SCH_EMAIL_ATTACHMENT_NAME" );
-    if ( !StringUtils.isEmpty( attachmentName ) ) {
-      String extension = MimeHelper.getExtension( data.getMimeType(), ".bin" );
-      emailer.setAttachmentName( attachmentName.endsWith( extension ) ?  attachmentName : attachmentName + extension );
-    } else if ( data != null ) {
+    
+    String useGeneratedName = (String) actionParams.get( "_SCH_EMAIL_USE_GENERATED_NAME" );
+    String customAttachmentName = (String) actionParams.get( "_SCH_EMAIL_ATTACHMENT_NAME" );
+    String extension = MimeHelper.getExtension( data.getMimeType(), ".bin" );
+    
+    String finalAttachmentName;
+    
+    if ( "true".equalsIgnoreCase( useGeneratedName ) ) {
+      finalAttachmentName = sourceFile.getName();
+    } else if ( !StringUtils.isEmpty( customAttachmentName ) ) {
+      finalAttachmentName = customAttachmentName;
+    } else {
       String path = filePath;
       if ( path.endsWith( ".*" ) ) {
         path = path.replace( ".*", "" );
       }
-      String extension = MimeHelper.getExtension( data.getMimeType(), ".bin" );
-      path = path.substring( path.lastIndexOf( "/" ) + 1, path.length() );
-      emailer.setAttachmentName( path.endsWith( extension ) ?  path : path + extension );
+      finalAttachmentName = path.substring( path.lastIndexOf( "/" ) + 1, path.length() );
     }
-    if ( data == null || data.getMimeType() == null || "".equals( data.getMimeType() ) ) {
+
+    emailer.setAttachmentName( finalAttachmentName.endsWith( extension ) ? finalAttachmentName : finalAttachmentName + extension );
+    if ( data.getMimeType() == null || "".equals( data.getMimeType() ) ) {
       emailer.setAttachmentMimeType( "binary/octet-stream" );
     } else {
       emailer.setAttachmentMimeType( data.getMimeType() );

--- a/core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java
@@ -48,6 +48,9 @@ import org.pentaho.platform.api.action.IAction;
 import org.pentaho.platform.api.engine.IApplicationContext;
 import org.pentaho.platform.api.engine.IPluginManager;
 import org.pentaho.platform.api.engine.PluginBeanException;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
 import org.pentaho.platform.api.workitem.IWorkItemLifecycleEventPublisher;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.workitem.DummyPublisher;
@@ -391,5 +394,38 @@ public class ActionUtilTest {
     } finally {
       Files.deleteIfExists( temp );
     }
+  }
+
+  @Test
+  public void testAddAttachment_UsesGeneratedContentNameWhenEnabled() throws Exception {
+    Map<String, Object> actionParams = new HashMap<>();
+    actionParams.put( "_SCH_EMAIL_USE_GENERATED_NAME", "true" );
+    actionParams.put( "_SCH_EMAIL_ATTACHMENT_NAME", "custom-name" );
+
+    Map<String, Object> params = new HashMap<>();
+    params.put( ActionUtil.QUARTZ_LINEAGE_ID, "lineage-id" );
+
+    RepositoryFile sourceFile = mock( RepositoryFile.class );
+    when( sourceFile.getId() ).thenReturn( "file-id" );
+    when( sourceFile.getName() ).thenReturn( "generated-output" );
+
+    IUnifiedRepository repo = mock( IUnifiedRepository.class );
+    when( repo.getFile( "/public/generated/output.*" ) ).thenReturn( sourceFile );
+    when( repo.getFileMetadata( "file-id" ) ).thenReturn( new HashMap<>() );
+    when( repo.getDataForRead( "file-id", SimpleRepositoryFileData.class ) ).thenReturn(
+      new SimpleRepositoryFileData( new ByteArrayInputStream( "x".getBytes() ), "UTF-8", null ) );
+
+    Emailer emailer = mock( Emailer.class );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( IUnifiedRepository.class ) ).thenReturn( repo );
+
+      Method addAttachment = ActionUtil.class.getDeclaredMethod( "addAttachment", Map.class, Map.class,
+        String.class, Emailer.class );
+      addAttachment.setAccessible( true );
+      addAttachment.invoke( null, actionParams, params, "/public/generated/output.*", emailer );
+    }
+
+    verify( emailer ).setAttachmentName( "generated-output.bin" );
   }
 }

--- a/user-console/src/main/resources/org/pentaho/mantle/public/MantleStyle.css
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/MantleStyle.css
@@ -777,6 +777,21 @@ code {
   width: 100%;
 }
 
+table#email-schedule-panel .gwt-CheckBox {
+  display: inline-block;
+  white-space: nowrap;
+  line-height: normal;
+}
+
+table#email-schedule-panel .gwt-CheckBox input {
+  width: auto !important;
+  margin-bottom: 0 !important;
+}
+
+table#email-schedule-panel .gwt-CheckBox label {
+  line-height: normal;
+}
+
 .timeZonePicker {
   width: 100%;
 }


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7199 - Backport of BISERVER-15346 - (10.2 Suite) Email Attachment Reports Missing Timestamp in Filename](https://hv-eng.atlassian.net/browse/SP-7199)
- **Base Case:** [BISERVER-15346 - Email Attachment Reports Missing Timestamp in Filename](https://hv-eng.atlassian.net/browse/BISERVER-15346)
- **Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6171

## Changes
- Support defaulting to the generated content name on email attachments (ActionUtil.java)
- Added UI styling for the email attachment checkbox (MantleStyle.css)
- Added test for addAttachment using generated content name (ActionUtilTest.java)
- Commit: not provided

## Conflict Resolution
- Manual conflict in core/src/test/java/org/pentaho/platform/util/ActionUtilTest.java: imports were reorganized in 10.2 (static imports first, then java, then org). Resolved by merging both import sets (preserving 10.2 additions: IApplicationContext, Field, Files, Path, Properties, StandardCharsets) and adding the new test testAddAttachment_UsesGeneratedContentNameWhenEnabled alongside the existing 10.2 tests.

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
