### PR TITLE
build[PPP-6390][PPP-6391]: use maven-parent-pom bouncycastle managed version

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -712,7 +712,6 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.barbecue</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2610,7 +2610,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk15to18</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This pull request makes a minor update to `pom.xml` files to use the `bouncycastle` version declared in `maven-parent-poms` `dependencyManagement`: https://github.com/pentaho/maven-parent-poms/pull/843