### PR TITLE
refactor[SP-7219]: update SearchIndex parameters in repository.xml for improved configuration

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
@@ -297,10 +297,12 @@
         Search index and the file system it uses.
         class: FQN of class implementing the QueryHandler interface
     -->
+    <!--
     <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
       <param name="path" value="${wsp.home}/index"/>
       <param name="supportHighlighting" value="true"/>
     </SearchIndex>
+    -->
 
 
     <WorkspaceSecurity>

--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
@@ -297,12 +297,10 @@
         Search index and the file system it uses.
         class: FQN of class implementing the QueryHandler interface
     -->
-    <!--
     <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
       <param name="path" value="${wsp.home}/index"/>
       <param name="supportHighlighting" value="true"/>
     </SearchIndex>
-    -->
 
 
     <WorkspaceSecurity>

--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/jackrabbit/repository.xml
@@ -299,7 +299,10 @@
     -->
     <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
       <param name="path" value="${wsp.home}/index"/>
-      <param name="supportHighlighting" value="true"/>
+      <param name="extractorPoolSize" value="0"/>
+      <param name="enableConsistencyCheck" value="false"/>
+      <param name="respectDocumentOrder" value="false"/>
+      <param name="initializeHierarchyCache" value="false" />
     </SearchIndex>
 
 


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7219 - Backport of PPP-6114 - (10.2 Suite) Repository.xml - Workspaces - Lucene](https://hv-eng.atlassian.net/browse/SP-7219)
- **Base Case:** [PPP-6114 - Repository.xml - Workspaces - Lucene](https://hv-eng.atlassian.net/browse/PPP-6114)
- **Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6139

## Changes
- Cherry-picked PR #6122 (refactor[PPP-6114]: remove unused SearchIndex configuration from repository.xml).
- Cherry-picked PR #6128 (Revert remove unused SearchIndex configuration from repository.xml).
- Cherry-picked PR #6139 (refactor[PPP-6114]: update SearchIndex parameters in repository.xml for improved configuration).
- Commit: 399f53027
- Commit: aac28d110
- Commit: 6fcf66e2990c478d3d00bab867a8f187d560482d

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
