### PR TITLE
fix: repository download endpoint returns 403 when file not found [BISERVER-15515][SP-7124]

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
@@ -637,8 +637,6 @@ public class FileService {
       throw new IllegalSelectorException();
     }
 
-    validateDownloadAccess( path );
-
     // check if entity exists in repo
     RepositoryFile repositoryFile = getRepository().getFile( path );
 
@@ -646,6 +644,9 @@ public class FileService {
       // file does not exist or is not readable but we can't tell at this point
       throw new FileNotFoundException( path );
     }
+
+    // validate if the user has permissions to download the file/folder
+    validateDownloadAccess( path );
 
     // send zip with manifest by default
     boolean withManifest = "false".equals( strWithManifest ) ? false : true;


### PR DESCRIPTION
This pull request improves the robustness and test coverage of the `doGetFileOrDirAsDownload` method in `FileService`. It refactors the order of access validation, adds comprehensive unit tests for various download scenarios (including error cases and edge cases), and introduces helper methods to simplify test setup.

**Access Validation Refactor:**

* The call to `validateDownloadAccess(path)` was moved to occur after verifying the file exists in the repository, ensuring permissions are only checked on existing files. [[1]](diffhunk://#diff-83d99cd4d9b00ce681f04d9d90e33c17b93d5d9f66b86a518fcc2587fbf3c24bL640-L641) [[2]](diffhunk://#diff-83d99cd4d9b00ce681f04d9d90e33c17b93d5d9f66b86a518fcc2587fbf3c24bR648-R650)

**Test Coverage Improvements:**

* Added extensive unit tests for `doGetFileOrDirAsDownload` covering:
  - Null, empty, and invalid path handling.
  - File not found scenarios.
  - Permission denied cases.
  - Downloading files and folders with and without manifests.
  - Handling of special characters in filenames.
  - Various values for the `strWithManifest` parameter (null, empty, true, false).

**Test Utilities and Imports:**

* Introduced a `setupRepositoryMock` helper method to streamline repository mocking in tests.
* Added necessary imports for new test cases and mocking.

These changes make the download logic more reliable and ensure that edge cases and error conditions are properly handled and tested.

@pentaho/millenniumfalcon please review