### PR TITLE
fix[SP-7148]: fix properties in message files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 # Auto detect text files and perform LF normalization
 #* text=auto
 
+extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages*.properties text eol=lf
+

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages.properties
@@ -247,43 +247,43 @@ CommandLineProcessor.INFO_PRINTHELP_CMDLINE=importexport
 CommandLineProcessor.INFO_PRINTHELP_HEADER=Unified repository command line import/export tool
 CommandLineProcessor.INFO_PRINTHELP_FOOTER=Common options for import & export using REST Services\n\
   Example arguments for import:\n\
---import --url=http://localhost:8080/pentaho --username=admin\n\
---password=password --charset=UTF-8 --path=/public\n\
---file-path=c:/temp/steel-wheels.zip\n\
---logfile=c:/temp/logfile.log\n\
+--import --url=<server-url> --username=<username>\n\
+--password=<password> --charset=<charset> --path=<path-to-import-to>\n\
+--file-path=<path-to-import-file>\n\
+--logfile=<path-to-log-file>\n\
 --permission=true\n\
 --overwrite=true\n\
 --retainOwnership=true\n\n\
 \n\n\
 Example arguments for import metadata datasource:\n\
---import --url=http://localhost:8080/pentaho\n\
---username=admin --password=password\n\
---file-path=metadata.xmi --resource-type=DATASOURCE\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-metadata-file> --resource-type=DATASOURCE\n\
 --datasource-type=METADATA --overwrite=true\n\
---metadata-domain-id=steel-wheels\n\n\
+--metadata-domain-id=<metadata-domain-id>\n\n\
 \n\n\
 Example arguments for import analysis datasource:\n\
---import --url=http://localhost:8080/pentaho\n\
---username=admin --password=password\n\
---file-path=analysis/steelwheels.mondrian.xml --resource-type=DATASOURCE\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-analysis-file> --resource-type=DATASOURCE\n\
 --datasource-type=ANALYSIS --overwrite=true\n\
---analysis-datasource=steelwheels\n\n\
+--analysis-datasource=<analysis-datasource>\n\n\
 \n\n\
 Example arguments for export:\n\
---export --url=http://localhost:8080/pentaho --username=admin --password=password \n\
---file-path=c:/temp/export.zip --charset=UTF-8 --path=/public/steel-wheels\n --withManifest=true --logfile=c:/temp/logfile.log\n\
+--export --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-export-file> --charset=<charset> --path=<path-to-export-from>\n--withManifest=true --logfile=<path-to-log-file>\n\
 \n\n\
 Example arguments for backup:\n\
---backup --url=http://localhost:8080/pentaho --username=admin --password=password \n\
---file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\
+--backup --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-backup-file> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
   \n\n\
 Example arguments for restore:\n\
---restore --url=http://localhost:8080/pentaho --username=admin --password=password \n\
---overwrite=true --file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\
+--restore --url=<server-url> --username=<username> --password=<password> \n\
+--overwrite=true --file-path=<path-to-restore-from> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
 Example arguments for running REST services:\n\
---rest --url=http://localhost:8080/pentaho --username=admin --password=password \n\
-  --path=/public/pentaho-solutions/steel-wheels/reports\n\
-  --logfile=c:/temp/logfile.log --service=acl\n
+--rest --url=<server-url> --username=<username> --password=<password> \n\
+  --path=<path-for-rest-service>\n\
+  --logfile=<path-to-log-file> --service=acl\n
 
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=Import resource type (eg DATASOURCE)
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=datasource type

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_cn.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_cn.properties
@@ -205,45 +205,45 @@ CommandLineProcessor.INFO_EXPORT_WRITTEN_TO=\u532f\u51fa\u5df2\u5beb\u5165\uff1a
 CommandLineProcessor.INFO_RESPONSE_STATUS=\u56de\u61c9\u72c0\u614b\uff1a{0}
 CommandLineProcessor.INFO_PRINTHELP_CMDLINE=importexport
 CommandLineProcessor.INFO_PRINTHELP_HEADER=\u7d71\u4e00\u5b58\u653e\u5eab\u547d\u4ee4\u5217\u532f\u5165/\u532f\u51fa\u5de5\u5177
-CommandLineProcessor.INFO_PRINTHELP_FOOTER=\u9069\u7528\u65bc\u532f\u5165\u7684\u5e38\u898b\u9078\u9805\n\
-  Example arguments for import:\n\
---import --url=http://localhost:8080/pentaho --username=admin\n\
---password=password --charset=UTF-8 --path=/public\n\
---file-path=c:/temp/steel-wheels.zip\n\
---logfile=c:/temp/logfile.log\n\
+CommandLineProcessor.INFO_PRINTHELP_FOOTER=\u4f7f\u7528 REST \u670d\u52d9\u9032\u884c\u532f\u5165\u8207\u532f\u51fa\u7684\u5e38\u898b\u9078\u9805\n\
+  \u532f\u5165\u7684\u7bc4\u4f8b\u5f15\u6578\uff1a\n\
+--import --url=<server-url> --username=<username>\n\
+--password=<password> --charset=<charset> --path=<path-to-import-to>\n\
+--file-path=<path-to-import-file>\n\
+--logfile=<path-to-log-file>\n\
 --permission=true\n\
 --overwrite=true\n\
 --retainOwnership=true\n\n\
 \n\n\
-Example arguments for import metadata datasource:\n\
---import --url=http://localhost:8080/pentaho\n\
---username=admin --password=password\n\
---file-path=metadata.xmi --resource-type=DATASOURCE\n\
+\u532f\u5165\u4e2d\u7e7c\u8cc7\u6599\u8cc7\u6599\u4f86\u6e90\u7684\u7bc4\u4f8b\u5f15\u6578\uff1a\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-metadata-file> --resource-type=DATASOURCE\n\
 --datasource-type=METADATA --overwrite=true\n\
---metadata-domain-id=steel-wheels\n\n\
+--metadata-domain-id=<metadata-domain-id>\n\n\
 \n\n\
-Example arguments for import analysis datasource:\n\
---import --url=http://localhost:8080/pentaho\n\
---username=admin --password=password\n\
---file-path=analysis/steelwheels.mondrian.xml --resource-type=DATASOURCE\n\
+\u532f\u5165\u5206\u6790\u8cc7\u6599\u4f86\u6e90\u7684\u7bc4\u4f8b\u5f15\u6578\uff1a\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-analysis-file> --resource-type=DATASOURCE\n\
 --datasource-type=ANALYSIS --overwrite=true\n\
---analysis-datasource=steelwheels\n\n\
+--analysis-datasource=<analysis-datasource>\n\n\
 \n\n\
-Example arguments for export:\n\
---export --url=http://localhost:8080/pentaho --username=admin --password=password \n\
---file-path=c:/temp/export.zip --charset=UTF-8 --path=/public/steel-wheels\n --withManifest=true --logfile=c:/temp/logfile.log\n\
+\u532f\u51fa\u7684\u7bc4\u4f8b\u5f15\u6578\uff1a\n\
+--export --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-export-file> --charset=<charset> --path=<path-to-export-from>\n--withManifest=true --logfile=<path-to-log-file>\n\
 \n\n\
-Example arguments for backup:\n\
---backup --url=http://localhost:8080/pentaho --username=admin --password=password \n\
---file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\
+\u5099\u4efd\u7684\u7bc4\u4f8b\u5f15\u6578\uff1a\n\
+--backup --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-backup-file> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
   \n\n\
-Example arguments for restore:\n\
---restore --url=http://localhost:8080/pentaho --username=admin --password=password \n\
---overwrite=true --file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\
-Example arguments for running REST services:\n\
---rest --url=http://localhost:8080/pentaho --username=admin --password=password \n\
-  --path=/public/pentaho-solutions/steel-wheels/reports\n\
-  --logfile=c:/temp/logfile.log --service=acl\n
+\u9084\u539f\u7684\u7bc4\u4f8b\u5f15\u6578\uff1a\n\
+--restore --url=<server-url> --username=<username> --password=<password> \n\
+--overwrite=true --file-path=<path-to-restore-from> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
+\u57f7\u884c REST \u670d\u52d9\u7684\u7bc4\u4f8b\u5f15\u6578\uff1a\n\
+--rest --url=<server-url> --username=<username> --password=<password> \n\
+  --path=<path-for-rest-service>\n\
+  --logfile=<path-to-log-file> --service=acl\n
 
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=\u532f\u5165\u8cc7\u6e90\u985e\u578b (\u4f8b\u5982\u8cc7\u6599\u4f86\u6e90)
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=\u8cc7\u6599\u4f86\u6e90\u985e\u578b

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_de.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_de.properties
@@ -328,6 +328,6 @@ PentahoPlatformExporter.ERROR.ExportingMetaStore=Fehler beim Export von MetaStor
 ERROR.ImportingUserSetting=Die Benutzereinstellungen f\u00fcr den Benutzer {0} konnten nicht importiert werden.
 PentahoPlatformImporter.ERROR_0008_PUBLISH_JOB_OR_TRANS_WITH_MISSING_PLUGINS=Importieren nicht m\u00f6glich: Fehlende Plugins
 CommandLineProcessor.ERROR_0008_INVALID_PARAMETER=Ung\u00fcltige Parameter-Syntax: {0}
---datasource-type=METADATEN --\u00fcberschreiben=true\n--metadata-domain-id=<metadata-domain-id>\n\n--datasource-type=ANALYSE--\u00fcberschreiben=true\n--analysis-datasource=<analysis-datasource>\n\nCommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=ACL-Einstellungen f\u00fcr neu erstellte Dateien anwenden (nur Import)
+CommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=ACL-Einstellungen f\u00fcr neu erstellte Dateien anwenden (nur Import)
 CommandLineProcessor.INFO_OPTION_OVERWRITE_ACL_SETTINGS=ACL-Einstellungen f\u00fcr vorhandene Dateien \u00fcberschreiben (nur Import)
 #

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_de.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_de.properties
@@ -254,7 +254,45 @@ CommandLineProcessor.INFO_RESPONSE_STATUS=Antwortstatus: {0}
 #
 CommandLineProcessor.INFO_PRINTHELP_CMDLINE=importexport
 CommandLineProcessor.INFO_PRINTHELP_HEADER=Vereinheitlichtes Repository-Import-/Exportwerkzeug in der Befehlszeile
-CommandLineProcessor.INFO_PRINTHELP_FOOTER=Allgemeine Optionen f\u00fcr Import und Export unter Verwendung von Beispielargumenten des REST-Dienstes f\u00fcr Import:\n--import --url=http://localhost:8080/pentaho --username=admin\n--password=password --charset=UTF-8 --path=/public\n--file-path=c:/temp/steel-wheels\n--logfile=c:/temp/logfile.log\n--permission=true\n&quot; + &quot;--overwrite=true\n--retainOwnership=true\n\n\n\nBeispielargumente f\u00fcr Export:\n--export --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --charset=UTF-8 --path=/public\n --withManifest=true--logfile=c:/temp/logfile.log\n\n\nBeispielargumente f\u00fcr Backup:\n--backup --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\n\nExample arguments for restore:\n--restore --url=http://localhost:8080/pentaho --username=admin --password=password \n--overwrite=true --file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\nBeispielargumente f\u00fcr das Ausf\u00fchren von REST-Diensten:\n--rest --url=http://localhost:8080/pentaho --username=admin --password=password \n-path=/public/pentaho-solutions/steel-wheels/reports\n--logfile=c:/temp/logfile.log --service=acl\n
+CommandLineProcessor.INFO_PRINTHELP_FOOTER=Allgemeine Optionen f\u00fcr Import und Export mit REST-Services\n\
+	Beispielargumente f\u00fcr den Import:\n\
+--import --url=<server-url> --username=<username>\n\
+--password=<password> --charset=<charset> --path=<path-to-import-to>\n\
+--file-path=<path-to-import-file>\n\
+--logfile=<path-to-log-file>\n\
+--permission=true\n\
+--overwrite=true\n\
+--retainOwnership=true\n\n\
+\n\n\
+Beispielargumente f\u00fcr den Import einer Metadaten-Datenquelle:\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-metadata-file> --resource-type=DATASOURCE\n\
+--datasource-type=METADATA --overwrite=true\n\
+--metadata-domain-id=<metadata-domain-id>\n\n\
+\n\n\
+Beispielargumente f\u00fcr den Import einer Analyse-Datenquelle:\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-analysis-file> --resource-type=DATASOURCE\n\
+--datasource-type=ANALYSIS --overwrite=true\n\
+--analysis-datasource=<analysis-datasource>\n\n\
+\n\n\
+Beispielargumente f\u00fcr den Export:\n\
+--export --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-export-file> --charset=<charset> --path=<path-to-export-from>\n--withManifest=true --logfile=<path-to-log-file>\n\
+\n\n\
+Beispielargumente f\u00fcr das Backup:\n\
+--backup --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-backup-file> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
+	\n\n\
+Beispielargumente f\u00fcr die Wiederherstellung:\n\
+--restore --url=<server-url> --username=<username> --password=<password> \n\
+--overwrite=true --file-path=<path-to-restore-from> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
+Beispielargumente f\u00fcr das Ausf\u00fchren von REST-Services:\n\
+--rest --url=<server-url> --username=<username> --password=<password> \n\
+	--path=<path-for-rest-service>\n\
+	--logfile=<path-to-log-file> --service=acl\n
 #
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=Import/Export-Ressourcentyp
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=Datenquellentyp
@@ -290,6 +328,6 @@ PentahoPlatformExporter.ERROR.ExportingMetaStore=Fehler beim Export von MetaStor
 ERROR.ImportingUserSetting=Die Benutzereinstellungen f\u00fcr den Benutzer {0} konnten nicht importiert werden.
 PentahoPlatformImporter.ERROR_0008_PUBLISH_JOB_OR_TRANS_WITH_MISSING_PLUGINS=Importieren nicht m\u00f6glich: Fehlende Plugins
 CommandLineProcessor.ERROR_0008_INVALID_PARAMETER=Ung\u00fcltige Parameter-Syntax: {0}
---datasource-type=METADATEN --\u00fcberschreiben=true\n--metadata-domain-id=steel-wheels\n\n--datasource-type=ANALYSE--\u00fcberschreiben=true\n--analysis-datasource=steelwheels\n\nCommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=ACL-Einstellungen f\u00fcr neu erstellte Dateien anwenden (nur Import)
+--datasource-type=METADATEN --\u00fcberschreiben=true\n--metadata-domain-id=<metadata-domain-id>\n\n--datasource-type=ANALYSE--\u00fcberschreiben=true\n--analysis-datasource=<analysis-datasource>\n\nCommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=ACL-Einstellungen f\u00fcr neu erstellte Dateien anwenden (nur Import)
 CommandLineProcessor.INFO_OPTION_OVERWRITE_ACL_SETTINGS=ACL-Einstellungen f\u00fcr vorhandene Dateien \u00fcberschreiben (nur Import)
 #

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_fr.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_fr.properties
@@ -255,6 +255,44 @@ CommandLineProcessor.INFO_RESPONSE_STATUS=\u00c9tat de r\u00e9ponse : {0}
 CommandLineProcessor.INFO_PRINTHELP_CMDLINE=importexport
 CommandLineProcessor.INFO_PRINTHELP_HEADER=Outil unifi\u00e9 d''importation/exportation du r\u00e9f\u00e9rentiel en ligne de commande
 CommandLineProcessor.INFO_PRINTHELP_FOOTER=Options courantes d''importation/exportation utilisant les services REST. Arguments d''exemple pour l''importation :\n--import --url=http://localhost:8080/pentaho --username=admin\n--password=password --charset=UTF-8 --path=/public\n--file-path=c:/temp/steel-wheels\n--logfile=c:/temp/logfile.log\n--permission=true\n&quot; + &quot;--overwrite=true\n--retainOwnership=true\n\n\n\nArguments d''exemple pour l''exportation :\n--export --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --charset=UTF-8 --path=/public\n --withManifest=true--logfile=c:/temp/logfile.log\n\n\nArguments d''exemple pour la sauvegarde :\n--backup --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\n\nArguments d''exemple pour la restauration :\n--restore --url=http://localhost:8080/pentaho --username=admin --password=password \n--overwrite=true --file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\nArguments d''exemple pour l''ex\u00e9cution des services REST :\n--rest --url=http://localhost:8080/pentaho --username=admin --password=password \n-path=/public/pentaho-solutions/steel-wheels/reports\n--logfile=c:/temp/logfile.log --service=acl\n
+	Arguments d''exemple pour l''importation :\n\
+--import --url=<server-url> --username=<username>\n\
+--password=<password> --charset=<charset> --path=<path-to-import-to>\n\
+--file-path=<path-to-import-file>\n\
+--logfile=<path-to-log-file>\n\
+--permission=true\n\
+--overwrite=true\n\
+--retainOwnership=true\n\n\
+\n\n\
+Arguments d''exemple pour l''importation d''une source de donn\u00e9es de m\u00e9tadonn\u00e9es :\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-metadata-file> --resource-type=DATASOURCE\n\
+--datasource-type=METADATA --overwrite=true\n\
+--metadata-domain-id=<metadata-domain-id>\n\n\
+\n\n\
+Arguments d''exemple pour l''importation d''une source de donn\u00e9es d''analyse :\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-analysis-file> --resource-type=DATASOURCE\n\
+--datasource-type=ANALYSIS --overwrite=true\n\
+--analysis-datasource=<analysis-datasource>\n\n\
+\n\n\
+Arguments d''exemple pour l''exportation :\n\
+--export --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-export-file> --charset=<charset> --path=<path-to-export-from>\n--withManifest=true --logfile=<path-to-log-file>\n\
+\n\n\
+Arguments d''exemple pour la sauvegarde :\n\
+--backup --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-backup-file> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
+	\n\n\
+Arguments d''exemple pour la restauration :\n\
+--restore --url=<server-url> --username=<username> --password=<password> \n\
+--overwrite=true --file-path=<path-to-restore-from> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
+Arguments d''exemple pour l''ex\u00e9cution des services REST :\n\
+--rest --url=<server-url> --username=<username> --password=<password> \n\
+	--path=<path-for-rest-service>\n\
+	--logfile=<path-to-log-file> --service=acl\n
 #
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=Type de source \u00e0 importer/exporter
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=type de source de donn\u00e9es
@@ -290,6 +328,6 @@ PentahoPlatformExporter.ERROR.ExportingMetaStore=Erreur pendant l''exportation d
 ERROR.ImportingUserSetting=Impossible d''importer les param\u00e8tres de l''utilisateur pour l''utilisateur {0}.
 PentahoPlatformImporter.ERROR_0008_PUBLISH_JOB_OR_TRANS_WITH_MISSING_PLUGINS=Impossible d''importer\u00a0: Plugins manquants
 CommandLineProcessor.ERROR_0008_INVALID_PARAMETER=Syntaxe de param\u00e8tre non valide : \u00ab\u00a0{0}\u00a0\u00bb
---datasource-type=METADATA --overwrite=true\n--metadata-domain-id=steel-wheels\n\n--datasource-type=ANALYSIS --overwrite=true\n--analysis-datasource=steelwheels\n\nCommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=Appliquer les param\u00e8tres ACL aux nouveaux fichiers cr\u00e9\u00e9s (importation uniquement)
+--datasource-type=METADATA --overwrite=true\n--metadata-domain-id=<metadata-domain-id>\n\n--datasource-type=ANALYSIS --overwrite=true\n--analysis-datasource=<analysis-datasource>\n\nCommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=Appliquer les param\u00e8tres ACL aux nouveaux fichiers cr\u00e9\u00e9s (importation uniquement)
 CommandLineProcessor.INFO_OPTION_OVERWRITE_ACL_SETTINGS=Remplacer les param\u00e8tres ACL pour les fichiers d\u00e9j\u00e0 existants (importation uniquement)
 #

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_fr.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_fr.properties
@@ -328,6 +328,6 @@ PentahoPlatformExporter.ERROR.ExportingMetaStore=Erreur pendant l''exportation d
 ERROR.ImportingUserSetting=Impossible d''importer les param\u00e8tres de l''utilisateur pour l''utilisateur {0}.
 PentahoPlatformImporter.ERROR_0008_PUBLISH_JOB_OR_TRANS_WITH_MISSING_PLUGINS=Impossible d''importer\u00a0: Plugins manquants
 CommandLineProcessor.ERROR_0008_INVALID_PARAMETER=Syntaxe de param\u00e8tre non valide : \u00ab\u00a0{0}\u00a0\u00bb
---datasource-type=METADATA --overwrite=true\n--metadata-domain-id=<metadata-domain-id>\n\n--datasource-type=ANALYSIS --overwrite=true\n--analysis-datasource=<analysis-datasource>\n\nCommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=Appliquer les param\u00e8tres ACL aux nouveaux fichiers cr\u00e9\u00e9s (importation uniquement)
+CommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=Appliquer les param\u00e8tres ACL aux nouveaux fichiers cr\u00e9\u00e9s (importation uniquement)
 CommandLineProcessor.INFO_OPTION_OVERWRITE_ACL_SETTINGS=Remplacer les param\u00e8tres ACL pour les fichiers d\u00e9j\u00e0 existants (importation uniquement)
 #

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_ja.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_ja.properties
@@ -328,6 +328,6 @@ PentahoPlatformExporter.ERROR.ExportingMetaStore=MetaStore\u306e\u30a8\u30af\u30
 ERROR.ImportingUserSetting=\u30e6\u30fc\u30b6\u30fc{0}\u306e\u30e6\u30fc\u30b6\u30fc\u8a2d\u5b9a\u3092\u30a4\u30f3\u30dd\u30fc\u30c8\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f\u3002
 PentahoPlatformImporter.ERROR_0008_PUBLISH_JOB_OR_TRANS_WITH_MISSING_PLUGINS=\u30a4\u30f3\u30dd\u30fc\u30c8\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f: \u6b20\u843d\u3057\u3066\u3044\u308b\u30d7\u30e9\u30b0\u30a4\u30f3
 CommandLineProcessor.ERROR_0008_INVALID_PARAMETER=\u7121\u52b9\u306a\u30d1\u30e9\u30e1\u30fc\u30bf\u30fc\u69cb\u6587: "{0}"
---datasource-type=METADATA --overwrite=true\n--metadata-domain-id=<metadata-domain-id>\n\n--datasource-type=ANALYSIS --overwrite=true\n--analysis-datasource=<analysis-datasource>\n\nCommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=\u65b0\u3057\u304f\u4f5c\u6210\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u306bACL\u8a2d\u5b9a\u3092\u9069\u7528\u3059\u308b (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
+CommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=\u65b0\u3057\u304f\u4f5c\u6210\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u306bACL\u8a2d\u5b9a\u3092\u9069\u7528\u3059\u308b (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
 CommandLineProcessor.INFO_OPTION_OVERWRITE_ACL_SETTINGS=\u65e2\u5b58\u306e\u30d5\u30a1\u30a4\u30eb\u306eACL\u8a2d\u5b9a\u3092\u4e0a\u66f8\u304d\u3059\u308b (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
 #

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_ja.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_ja.properties
@@ -254,7 +254,45 @@ CommandLineProcessor.INFO_RESPONSE_STATUS=\u30ec\u30b9\u30dd\u30f3\u30b9\u30b9\u
 #
 CommandLineProcessor.INFO_PRINTHELP_CMDLINE=\u30a4\u30f3\u30dd\u30fc\u30c8\u30a8\u30af\u30b9\u30dd\u30fc\u30c8
 CommandLineProcessor.INFO_PRINTHELP_HEADER=\u7d71\u5408\u30ea\u30dd\u30b8\u30c8\u30ea\u30fc\u30b3\u30de\u30f3\u30c9\u30e9\u30a4\u30f3\u30a4\u30f3\u30dd\u30fc\u30c8/\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u30c4\u30fc\u30eb
-CommandLineProcessor.INFO_PRINTHELP_FOOTER=\u30a4\u30f3\u30dd\u30fc\u30c8\u7528\u306eREST ServicesExample\u5f15\u6570\u3092\u4f7f\u7528\u3059\u308b\u3001\u30a4\u30f3\u30dd\u30fc\u30c8\u304a\u3088\u3073\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u306e\u5171\u901a\u30aa\u30d7\u30b7\u30e7\u30f3:\n--import --url=http://localhost:8080/pentaho --username=admin\n--password=password --charset=UTF-8 --path=/public\n--file-path=c:/temp/steel-wheels\n--logfile=c:/temp/logfile.log\n--permission=true\n&quot; + &quot;--overwrite=true\n--retainOwnership=true\n\n\n\n\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u7528\u306e\u5f15\u6570\u4f8b:\n--export --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --charset=UTF-8 --path=/public\n --withManifest=true--logfile=c:/temp/logfile.log\n\n\n\u30d0\u30c3\u30af\u30a2\u30c3\u30d7\u7528\u306e\u5f15\u6570\u4f8b:\n--backup --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n\n\n\u30ea\u30b9\u30c8\u30a2\u7528\u306e\u5f15\u6570\u4f8b:\n--restore --url=http://localhost:8080/pentaho --username=admin --password=password \n--overwrite=true --file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\nREST\u30b5\u30fc\u30d3\u30b9\u5b9f\u884c\u7528\u306e\u5f15\u6570\u4f8b:\n--rest --url=http://localhost:8080/pentaho --username=admin --password=password \n-path=/public/pentaho-solutions/steel-wheels/reports\n--logfile=c:/temp/logfile.log --service=acl\n
+CommandLineProcessor.INFO_PRINTHELP_FOOTER=REST \u30b5\u30fc\u30d3\u30b9\u3092\u4f7f\u7528\u3057\u305f\u30a4\u30f3\u30dd\u30fc\u30c8\u3068\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u306e\u5171\u901a\u30aa\u30d7\u30b7\u30e7\u30f3\n\
+	\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u5f15\u6570\u4f8b:\n\
+--import --url=<server-url> --username=<username>\n\
+--password=<password> --charset=<charset> --path=<path-to-import-to>\n\
+--file-path=<path-to-import-file>\n\
+--logfile=<path-to-log-file>\n\
+--permission=true\n\
+--overwrite=true\n\
+--retainOwnership=true\n\n\
+\n\n\
+\u30e1\u30bf\u30c7\u30fc\u30bf\u30c7\u30fc\u30bf\u30bd\u30fc\u30b9\u306e\u30a4\u30f3\u30dd\u30fc\u30c8\u5f15\u6570\u4f8b:\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-metadata-file> --resource-type=DATASOURCE\n\
+--datasource-type=METADATA --overwrite=true\n\
+--metadata-domain-id=<metadata-domain-id>\n\n\
+\n\n\
+\u5206\u6790\u30c7\u30fc\u30bf\u30bd\u30fc\u30b9\u306e\u30a4\u30f3\u30dd\u30fc\u30c8\u5f15\u6570\u4f8b:\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-analysis-file> --resource-type=DATASOURCE\n\
+--datasource-type=ANALYSIS --overwrite=true\n\
+--analysis-datasource=<analysis-datasource>\n\n\
+\n\n\
+\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u306e\u5f15\u6570\u4f8b:\n\
+--export --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-export-file> --charset=<charset> --path=<path-to-export-from>\n--withManifest=true --logfile=<path-to-log-file>\n\
+\n\n\
+\u30d0\u30c3\u30af\u30a2\u30c3\u30d7\u306e\u5f15\u6570\u4f8b:\n\
+--backup --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-backup-file> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
+	\n\n\
+\u30ea\u30b9\u30c8\u30a2\u306e\u5f15\u6570\u4f8b:\n\
+--restore --url=<server-url> --username=<username> --password=<password> \n\
+--overwrite=true --file-path=<path-to-restore-from> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
+REST \u30b5\u30fc\u30d3\u30b9\u5b9f\u884c\u306e\u5f15\u6570\u4f8b:\n\
+--rest --url=<server-url> --username=<username> --password=<password> \n\
+	--path=<path-for-rest-service>\n\
+	--logfile=<path-to-log-file> --service=acl\n
 #
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=\u30a4\u30f3\u30dd\u30fc\u30c8/\u30a8\u30af\u30b9\u30dd\u30fc\u30c8\u306e\u30ea\u30bd\u30fc\u30b9\u30bf\u30a4\u30d7
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=\u30c7\u30fc\u30bf\u30bd\u30fc\u30b9\u30bf\u30a4\u30d7
@@ -290,6 +328,6 @@ PentahoPlatformExporter.ERROR.ExportingMetaStore=MetaStore\u306e\u30a8\u30af\u30
 ERROR.ImportingUserSetting=\u30e6\u30fc\u30b6\u30fc{0}\u306e\u30e6\u30fc\u30b6\u30fc\u8a2d\u5b9a\u3092\u30a4\u30f3\u30dd\u30fc\u30c8\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f\u3002
 PentahoPlatformImporter.ERROR_0008_PUBLISH_JOB_OR_TRANS_WITH_MISSING_PLUGINS=\u30a4\u30f3\u30dd\u30fc\u30c8\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f: \u6b20\u843d\u3057\u3066\u3044\u308b\u30d7\u30e9\u30b0\u30a4\u30f3
 CommandLineProcessor.ERROR_0008_INVALID_PARAMETER=\u7121\u52b9\u306a\u30d1\u30e9\u30e1\u30fc\u30bf\u30fc\u69cb\u6587: "{0}"
---datasource-type=METADATA --overwrite=true\n--metadata-domain-id=steel-wheels\n\n--datasource-type=ANALYSIS --overwrite=true\n--analysis-datasource=steelwheels\n\nCommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=\u65b0\u3057\u304f\u4f5c\u6210\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u306bACL\u8a2d\u5b9a\u3092\u9069\u7528\u3059\u308b (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
+--datasource-type=METADATA --overwrite=true\n--metadata-domain-id=<metadata-domain-id>\n\n--datasource-type=ANALYSIS --overwrite=true\n--analysis-datasource=<analysis-datasource>\n\nCommandLineProcessor.INFO_OPTION_APPLY_ACL_SETTINGS=\u65b0\u3057\u304f\u4f5c\u6210\u3055\u308c\u305f\u30d5\u30a1\u30a4\u30eb\u306bACL\u8a2d\u5b9a\u3092\u9069\u7528\u3059\u308b (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
 CommandLineProcessor.INFO_OPTION_OVERWRITE_ACL_SETTINGS=\u65e2\u5b58\u306e\u30d5\u30a1\u30a4\u30eb\u306eACL\u8a2d\u5b9a\u3092\u4e0a\u66f8\u304d\u3059\u308b (\u30a4\u30f3\u30dd\u30fc\u30c8\u306e\u307f)
 #

--- a/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_zh_CN.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/plugin/services/messages/messages_zh_CN.properties
@@ -235,7 +235,45 @@ CommandLineProcessor.INFO_RESPONSE_STATUS=\u54cd\u5e94\u72b6\u6001\uff1a{0}
 #
 CommandLineProcessor.INFO_PRINTHELP_CMDLINE=\u5bfc\u5165\u5bfc\u51fa
 CommandLineProcessor.INFO_PRINTHELP_HEADER=\u7edf\u4e00\u5b58\u50a8\u5e93\u547d\u4ee4\u884c\u5bfc\u5165/\u5bfc\u51fa\u5de5\u5177
-CommandLineProcessor.INFO_PRINTHELP_FOOTER=\u4f7f\u7528 REST \u670d\u52a1\u5bfc\u5165\u6216\u5bfc\u51fa\u7684\u5e38\u89c1\u9009\u9879\n# \u7528\u4e8e\u5bfc\u5165\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n--import --url=http://localhost:8080/pentaho --username=admin\n--password=password --charset=UTF-8 --path=/public\n--file-path=c:/temp/steel-wheels\n--logfile=c:/temp/logfile.log\n--permission=true\n--overwrite=true\n--retainOwnership=true\n\n#\n\n# \u7528\u4e8e\u5bfc\u5165\u5143\u6570\u636e\u6570\u636e\u6e90\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n--import --url=http://localhost:8080/pentaho\n--username=admin --password=password\n--file-path=metadata.xmi --resource-type=DATASOURCE\n--datasource-type=METADATA --overwrite=true\n--metadata-domain-id=steel-wheels\n\n#\n\n# \u7528\u4e8e\u5bfc\u5165\u5206\u6790\u6570\u636e\u6e90\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n--import --url=http://localhost:8080/pentaho\n--username=admin --password=password\n--file-path=analysis/steelwheels.mondrian.xml --resource-type=DATASOURCE\n--datasource-type=ANALYSIS --overwrite=true\n--analysis-datasource=steelwheels\n\n#\n\n# \u7528\u4e8e\u5bfc\u51fa\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n--export --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --charset=UTF-8 --path=/public\n --withManifest=true --logfile=c:/temp/logfile.log\n#\n\n# \u7528\u4e8e\u5907\u4efd\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n--backup --url=http://localhost:8080/pentaho --username=admin --password=password \n--file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n#  \n\n# \u7528\u4e8e\u8fd8\u539f\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n--restore --url=http://localhost:8080/pentaho --username=admin --password=password \n--overwrite=true --file-path=c:/temp/export.zip --logfile=c:/temp/logfile.log\n#\u7528\u4e8e\u8fd0\u884c REST \u670d\u52a1\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n--rest --url=http://localhost:8080/pentaho --username=admin --password=password \n--path=/public/pentaho-solutions/steel-wheels/reports\n--logfile=c:/temp/logfile.log --service=acl\n
+CommandLineProcessor.INFO_PRINTHELP_FOOTER=\u4f7f\u7528 REST \u670d\u52a1\u8fdb\u884c\u5bfc\u5165\u6216\u5bfc\u51fa\u7684\u5e38\u89c1\u9009\u9879\n\
+	\u7528\u4e8e\u5bfc\u5165\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n\
+--import --url=<server-url> --username=<username>\n\
+--password=<password> --charset=<charset> --path=<path-to-import-to>\n\
+--file-path=<path-to-import-file>\n\
+--logfile=<path-to-log-file>\n\
+--permission=true\n\
+--overwrite=true\n\
+--retainOwnership=true\n\n\
+\n\n\
+\u7528\u4e8e\u5bfc\u5165\u5143\u6570\u636e\u6570\u636e\u6e90\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-metadata-file> --resource-type=DATASOURCE\n\
+--datasource-type=METADATA --overwrite=true\n\
+--metadata-domain-id=<metadata-domain-id>\n\n\
+\n\n\
+\u7528\u4e8e\u5bfc\u5165\u5206\u6790\u6570\u636e\u6e90\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n\
+--import --url=<server-url>\n\
+--username=<username> --password=<password>\n\
+--file-path=<path-to-analysis-file> --resource-type=DATASOURCE\n\
+--datasource-type=ANALYSIS --overwrite=true\n\
+--analysis-datasource=<analysis-datasource>\n\n\
+\n\n\
+\u7528\u4e8e\u5bfc\u51fa\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n\
+--export --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-export-file> --charset=<charset> --path=<path-to-export-from>\n--withManifest=true --logfile=<path-to-log-file>\n\
+\n\n\
+\u7528\u4e8e\u5907\u4efd\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n\
+--backup --url=<server-url> --username=<username> --password=<password> \n\
+--file-path=<path-to-backup-file> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
+	\n\n\
+\u7528\u4e8e\u8fd8\u539f\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n\
+--restore --url=<server-url> --username=<username> --password=<password> \n\
+--overwrite=true --file-path=<path-to-restore-from> --logfile=<path-to-log-file> --logLevel=DEBUG \n\
+\u7528\u4e8e\u8fd0\u884c REST \u670d\u52a1\u7684\u53c2\u6570\u793a\u4f8b\uff1a\n\
+--rest --url=<server-url> --username=<username> --password=<password> \n\
+	--path=<path-for-rest-service>\n\
+	--logfile=<path-to-log-file> --service=acl\n
 #
 CommandLineProcessor.INFO_OPTION_RESOURCE_TYPE_DESCRIPTION=\u5bfc\u5165\u8d44\u6e90\u7c7b\u578b\uff08\u4f8b\u5982\uff1aDATASOURCE\uff09
 CommandLineProcessor.INFO_OPTION_DATASOURCE_TYPE_DESCRIPTION=\u6570\u636e\u6e90\u7c7b\u578b


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7148 - Backport of BISERVER-15535 - Import-Export gives example instructions with wrong folder name on export of Steel Wheels (11.0 Suite)](https://hv-eng.atlassian.net/browse/SP-7148)
- **Base Case:** [BISERVER-15535 - Import-Export gives example instructions with wrong folder name on export of Steel Wheels](https://hv-eng.atlassian.net/browse/BISERVER-15535)
- **Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6181

## Changes
- Cherry-picked PR #6179 (fix[BISERVER-15535]: Update CLI help messages to use placeholder values) — commit 9880bbfe3 (already on branch).
- Cherry-picked merge commit 44e2f2edcd4475742b7efef30122a4460467fad4 from PR #6181 (fix: fix properties in message files) — commit 6bf7062c6; normalizes message bundle line endings to LF and corrects ACL settings message in Japanese properties file.
- Commit: 9880bbfe3dcefbaa73dc6d8337589817a77a0928
- Commit: 6bf7062c6

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
