### PR TITLE
build[SP-7261]: update Hibernate groupId

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -828,7 +828,7 @@
       <version>${commons-io.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-jcache</artifactId>
       <version>${hibernate-jcache.version}</version>
       <exclusions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -377,7 +377,7 @@
       <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate-core.version}</version>
       <scope>compile</scope>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -602,7 +602,7 @@
       <version>${jersey.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate-core.version}</version>
       <scope>compile</scope>
@@ -614,7 +614,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-jcache</artifactId>
       <version>${hibernate-jcache.version}</version>
       <exclusions>
@@ -685,7 +685,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <version>${hibernate-validator.version}</version>
       <scope>compile</scope>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -336,7 +336,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate-core.version}</version>
       <exclusions>
@@ -347,7 +347,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-jcache</artifactId>
       <version>${hibernate-jcache.version}</version>
       <exclusions>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7261 - Backport of PPP-6248 - (11.0 Suite) CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/SP-7261)
- **Base Case:** [PPP-6248 - CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/PPP-6248)
- **Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6204

## Changes
- Cherry-picked PR #6204 (build[PPP-6248]: update Hibernate groupId).
- Commit: 6cc7849fc2bd879234bb4c84a94be044ad64ee87

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
