### PR TITLE
build[SP-7260]: update Hibernate groupId

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -357,7 +357,7 @@
       <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate-core.version}</version>
       <scope>compile</scope>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -477,7 +477,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate-core.version}</version>
       <scope>compile</scope>
@@ -560,7 +560,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <version>${hibernate-validator.version}</version>
       <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
     <hamcrest-core.version>1.3</hamcrest-core.version>
     <servlet-api.version>2.5</servlet-api.version>
     <joda-time.version>2.10.2</joda-time.version>
-    <hibernate-validator.version>5.4.3.Final</hibernate-validator.version>
     <hibernate-ehcache.version>5.4.24.Final</hibernate-ehcache.version>
     <jaybird.version>2.1.6</jaybird.version>
     <resolver.version>20050927</resolver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,6 @@
     <barbecue.version>1.5-beta1</barbecue.version>
     <jaxws-spring.version>1.8</jaxws-spring.version>
     <antlr-complete.version>3.5.2</antlr-complete.version>
-    <hibernate-core.version>5.4.24.Final</hibernate-core.version>
     <license.inception.year>2002</license.inception.year>
     <jsr181-api.version>1.0-MR1</jsr181-api.version>
     <ascsapjco3wrp.version>20100529</ascsapjco3wrp.version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -407,7 +407,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate-core.version}</version>
       <exclusions>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7260 - Backport of PPP-6248 - (10.2 Suite) CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/SP-7260)
- **Base Case:** [PPP-6248 - CVE-2026-0603 | pdia-master has a security violation in Hibernate](https://hv-eng.atlassian.net/browse/PPP-6248)
- **Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6204

## Changes
- Cherry-picked PR #6204 (build[PPP-6248]: update Hibernate groupId).
- Commit: b79533ffe

## Conflict Resolution
- Conflicts in assemblies/pentaho-war/pom.xml, extensions/pom.xml, repository/pom.xml: hibernate-jcache absent in 10.2 (uses hibernate-ehcache); kept hibernate-ehcache dependencies unchanged and applied hibernate-core/hibernate-validator groupId updates. Jersey dependencies present in master (commit 6cc7849fc2bd879234bb4c84a94be044ad64ee87) were not added as they do not exist in 10.2.

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
