### PR TITLE
fix[SP-7209]: Add LastExecutionTime Scheduler reserved map key

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/scheduler2/IScheduler.java
+++ b/api/src/main/java/org/pentaho/platform/api/scheduler2/IScheduler.java
@@ -34,6 +34,15 @@ public interface IScheduler {
   String RESERVEDMAPKEY_APPEND_DATE_FORMAT = QuartzActionUtil.QUARTZ_APPEND_DATE_FORMAT;
   String RESERVEDMAPKEY_AUTO_CREATE_UNIQUE_FILENAME = QuartzActionUtil.QUARTZ_AUTO_CREATE_UNIQUE_FILENAME;
   String RESERVEDMAPKEY_LINEAGE_ID = QuartzActionUtil.QUARTZ_LINEAGE_ID;
+  String RESERVEDMAPKEY_LAST_EXECUTION_TIME = QuartzActionUtil.QUARTZ_LAST_EXECUTION_TIME;
+  /**
+   * @deprecated since 2026-02
+   * 
+   * This reserved map key is no longer used by the scheduler and should not be used by callers.
+   * Can only remove if we ensure that no clients have schedules with this property set in their jobParams.
+   * Otherwise, it will appear in the UI variable list.
+   */
+  @Deprecated( since = "2026-02", forRemoval = false )
   String RESERVEDMAPKEY_PREVIOUS_TRIGGER_NOW = QuartzActionUtil.QUARTZ_PREVIOUS_TRIGGER_NOW;
   String RESERVEDMAPKEY_RESTART_FLAG = QuartzActionUtil.QUARTZ_RESTART_FLAG;
   String RESERVEDMAPKEY_START_TIME = QuartzActionUtil.QUARTZ_START_TIME;

--- a/api/src/main/java/org/pentaho/platform/api/util/QuartzActionUtil.java
+++ b/api/src/main/java/org/pentaho/platform/api/util/QuartzActionUtil.java
@@ -20,6 +20,15 @@ public class QuartzActionUtil {
   public static final String QUARTZ_APPEND_DATE_FORMAT = "appendDateFormat"; //$NON-NLS-1$
   public static final String QUARTZ_AUTO_CREATE_UNIQUE_FILENAME = "autoCreateUniqueFilename"; //$NON-NLS-1$
   public static final String QUARTZ_LINEAGE_ID = "lineage-id"; //$NON-NLS-1$
+  public static final String QUARTZ_LAST_EXECUTION_TIME = "QuartzScheduler-LastExecutionTime"; //$NON-NLS-1$
+    /**
+   * @deprecated since 2026-02
+   * 
+   * This reserved map key is no longer used by the scheduler and should not be used by callers.
+   * Can only remove if we ensure that no clients have schedules with this property set in their jobParams.
+   * Otherwise, it will appear in the UI variable list.
+   */
+  @Deprecated( since = "2026-02", forRemoval = false )
   public static final String QUARTZ_PREVIOUS_TRIGGER_NOW = "previousTriggerNow"; //$NON-NLS-1$
   public static final String QUARTZ_RESTART_FLAG = "ActionAdapterQuartzJob-Restart"; //$NON-NLS-1$
   public static final String QUARTZ_START_TIME = "startTime"; //$NON-NLS-1$


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7209](https://hv-eng.atlassian.net/browse/SP-7209)
- **Base Case:** [BISERVER-15240](https://hv-eng.atlassian.net/browse/BISERVER-15240)
- **Original Master PR:** [#6173](https://github.com/pentaho/pentaho-platform/pull/6173)

## Changes
- Cherry-picked commit 1e820f3 (eb6172c7 on SP-7209): Add RESERVEDMAPKEY_LAST_EXECUTION_TIME constant to IScheduler and expose it in QuartzActionUtil as QUARTZ_LAST_EXECUTION_TIME.
- This is a prerequisite for pentaho-scheduler-plugin SP-7209, which reads the constant from the platform API artifact.

## Conflict Resolution
No manual conflict resolution required.

## Target
- **Target branch:** 11.0
- **Code freeze status:** Informational only -- backport targets maintenance branch 11.0 regardless.


[SP-7209]: https://hv-eng.atlassian.net/browse/SP-7209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BISERVER-15240]: https://hv-eng.atlassian.net/browse/BISERVER-15240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ