### PR TITLE
build[SP-7277]: use maven-parent-pom bouncycastle managed version

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -685,7 +685,6 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.barbecue</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -2631,7 +2631,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk15to18</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7277 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7277)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6222

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-platform/pull/6222
- Commit: adf0f1112fa834c007f3327745bfdeda1a78aaf0

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
