### PR TITLE
feat: add reloadable config for oauth runtime

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/engine/IConfiguration.java
+++ b/api/src/main/java/org/pentaho/platform/api/engine/IConfiguration.java
@@ -25,4 +25,16 @@ public interface IConfiguration {
   Properties getProperties() throws IOException;
 
   void update( Properties properties ) throws IOException;
+
+  /**
+   * Reloads the underlying configuration source. Implementations backed by a
+   * file on disk should override this to re-read the file, making changes
+   * visible without a server restart. The default implementation is a no-op,
+   * preserving backward compatibility for all existing implementors.
+   *
+   * @throws IOException if the backing source cannot be read
+   */
+  default void reload() throws IOException {
+    // no-op — override in file-backed implementations
+  }
 }

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -1323,6 +1323,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.pentaho</groupId>
+      <artifactId>pentaho-oauth-client</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-ui-swt</artifactId>
       <version>${pdi.version}</version>

--- a/extensions/src/main/java/org/pentaho/platform/config/PropertiesFileConfiguration.java
+++ b/extensions/src/main/java/org/pentaho/platform/config/PropertiesFileConfiguration.java
@@ -113,6 +113,24 @@ public class PropertiesFileConfiguration implements IConfiguration {
 
   }
 
+  /**
+   * Re-reads the underlying properties file from disk, replacing the in-memory
+   * cache with fresh data. Only effective when this instance was constructed
+   * with a {@link File} argument; silently ignored for in-memory
+   * {@link Properties} instances.
+   * <p>
+   * Thread-safe: the method is {@code synchronized} to prevent concurrent
+   * reload calls from racing with each other.
+   *
+   * @throws IOException if the file cannot be read
+   */
+  @Override
+  public synchronized void reload() throws IOException {
+    if ( propFile != null ) {
+      loadProperties();
+    }
+  }
+
   protected void setPropFile( File propFile ) {
     this.propFile = propFile;
   }


### PR DESCRIPTION

Depends on: https://github.com/pentaho/pentaho-plugin-oauth-ee/pull/2

This pull request introduces enhancements to the configuration management system, focusing on improving the ability to reload configuration files at runtime and adding a new dependency. The main changes include extending the `IConfiguration` interface to support reloading, implementing this capability in the file-backed configuration class, and updating the project dependencies.

### Configuration reload support

* Added a default `reload()` method to the `IConfiguration` interface, allowing implementations to reload their configuration source. The default implementation is a no-op for backward compatibility, but file-backed implementations are expected to override it.
* Implemented the `reload()` method in `PropertiesFileConfiguration` to re-read the properties file from disk and update the in-memory cache. This method is thread-safe and only effective for instances backed by a file.

### Dependency updates

* Added the `pentaho-oauth-client` as a compile-time dependency in `extensions/pom.xml`.