### PR TITLE
build[SP-7224]: Add javax.validation:validation-api jar to pentaho war

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -102,14 +102,6 @@
           <groupId>cglib</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>validation-api</artifactId>
-          <groupId>javax.validation</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>validation-api</artifactId>
-          <groupId>javax.validation</groupId>
-        </exclusion>
-        <exclusion>
           <artifactId>hsqldb</artifactId>
           <groupId>org.hsqldb</groupId>
         </exclusion>


### PR DESCRIPTION
### Context
PUC was failing during MQL Editor GWT RPC handling with java.lang.NoClassDefFoundError: javax/validation/Path. The advanced mode changes expanded the GWT serialization graph, and the Pentaho webapp runtime did not include the legacy javax.validation API required by the loaded classes.
___
### Changes
Adds javax.validation:validation-api to the Pentaho WAR assembly so the jar is packaged into tomcat/webapps/pentaho/WEB-INF/lib. This makes javax.validation.Path available to the webapp classloader and prevents the RPC failure.

