### PR TITLE
build[SP-7224]: Bump version of validation-api dependency to 1.1.0.Final

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -574,7 +574,6 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
-      <version>${validation-api.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
     <annogen.version>0.1.0</annogen.version>
     <jcifs.version>1.3.3</jcifs.version>
     <persistence-api.version>1.0</persistence-api.version>
-    <validation-api.version>1.0.0.GA</validation-api.version>
     <avalon.version>4.1.5</avalon.version>
     <jta.version>1.1</jta.version>
     <jxl.version>2.6.12</jxl.version>

--- a/user-console/pom.xml
+++ b/user-console/pom.xml
@@ -10,7 +10,6 @@
   <artifactId>pentaho-user-console</artifactId>
   <version>10.2.0.0-SNAPSHOT</version>
   <properties>
-    <validation-api.version>1.0.0.GA</validation-api.version>
     <license.header.file>${basedir}/../license/templates/LGPL-2.1.txt</license.header.file>
     <gwt.outputDirectory>${project.build.directory}/${project.artifactId}-gwt-${project.version}</gwt.outputDirectory>
     <json-simple.version>1.1</json-simple.version>
@@ -301,7 +300,6 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
-      <version>${validation-api.version}</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -312,7 +310,6 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
-      <version>${validation-api.version}</version>
       <classifier>sources</classifier>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
## Summary
- remove repo-local javax.validation:validation-api version ownership
- inherit javax.validation:validation-api 1.1.0.Final from pentaho-parent-pom on 10.2