### PR TITLE
build[BACKLOG-50098]: Bump version of org.aspectj dependencies to 1.9.25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
     <modelVersion>4.0.0</modelVersion>
     <barcode4j.version>2.0</barcode4j.version>
     <commons-validator.version>1.3.1</commons-validator.version>
-    <aspectjweaver.version>1.7.2</aspectjweaver.version>
     <jmockit.version>1.8</jmockit.version>
     <ognl.version>2.6.9</ognl.version>
     <oro.version>2.0.8</oro.version>
@@ -83,7 +82,6 @@
     <maven-surefire-plugin.reuseForks>false</maven-surefire-plugin.reuseForks>
     <sapdbc.version>7.4.4</sapdbc.version>
     <jcr.version>2.0</jcr.version>
-    <aspectjrt.version>1.6.6</aspectjrt.version>
     <bsf.version>2.4.0</bsf.version>
     <lucene-core.version>3.6.0</lucene-core.version>
     <jmock-junit4.version>2.5.1</jmock-junit4.version>


### PR DESCRIPTION
## Summary
- remove the repo-local `aspectjrt.version` and `aspectjweaver.version` overrides
- inherit `org.aspectj` version `1.9.25.1` from `pentaho-parent-pom`

## Validation
- `mvn -B -nsu -Dmaven.test.skip=true clean install`
