### PR TITLE
fix[BISERVER-15545]: enhance doSetMetadata to handle invalid or unparseable XML payloads

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -2169,16 +2169,22 @@ public class FileResource extends AbstractJaxRSResource {
   @Produces( {MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON} )
   @Consumes( {MediaType.APPLICATION_XML} )
   @StatusCodes( {
-    @ResponseCode( code = 200, condition = "Successfully retrieved metadata." ),
+    @ResponseCode( code = 200, condition = "Successfully stored metadata." ),
     @ResponseCode( code = 403, condition = "Invalid path." ),
     @ResponseCode( code = 400, condition = "Invalid payload." ),
+    @ResponseCode( code = 415, condition = "Invalid, missing or unparseable XML payload." ),
     @ResponseCode( code = 500, condition = "Server Error." )} )
   public Response doSetMetadata( @PathParam( "pathId" ) String pathId, StreamSource metadataXml ) {
+    if ( metadataXml == null ) {
+      return Response.status( Response.Status.UNSUPPORTED_MEDIA_TYPE ).entity( "Missing XML payload." ).build();
+    }
     XMLStreamReader xsr = null;
     try {
-      Unmarshaller unmarshaller = getUnmarshaller( StringKeyStringValueDtoWrapper.class );
       xsr = getSecureXmlStreamReader( metadataXml );
-      StringKeyStringValueDtoWrapper metadata = (StringKeyStringValueDtoWrapper) unmarshaller.unmarshal( xsr );
+      if ( xsr == null ) {
+        return Response.status( Response.Status.UNSUPPORTED_MEDIA_TYPE ).entity( "Invalid XML payload." ).build();
+      }
+      StringKeyStringValueDtoWrapper metadata = unmarshalMetadata( xsr );
       if ( metadata == null || metadata.getStringKeyStringValueDtoes() == null ) {
         return Response.status( Response.Status.BAD_REQUEST ).entity( "Invalid payload." ).build();
       }
@@ -2186,16 +2192,40 @@ public class FileResource extends AbstractJaxRSResource {
       return buildOkResponse();
     } catch ( GeneralSecurityException e ) {
       return buildStatusResponse( Response.Status.UNAUTHORIZED );
+    } catch ( InvalidXmlPayloadException | JAXBException | XMLStreamException e ) {
+      return Response.status( Response.Status.UNSUPPORTED_MEDIA_TYPE ).entity( "Invalid or unparseable XML payload." ).build();
     } catch ( Throwable t ) {
       return buildServerErrorResponse( t.getMessage() );
     } finally {
-      if ( xsr != null ) {
-        try {
-          xsr.close();
-        } catch ( XMLStreamException e ) {
-          logger.warn( "Failed to close XMLStreamReader", e );
-        }
+      closeXmlStreamReader( xsr );
+    }
+  }
+
+  private StringKeyStringValueDtoWrapper unmarshalMetadata( XMLStreamReader xsr ) throws JAXBException, InvalidXmlPayloadException {
+    try {
+      Unmarshaller unmarshaller = getUnmarshaller( StringKeyStringValueDtoWrapper.class );
+      return (StringKeyStringValueDtoWrapper) unmarshaller.unmarshal( xsr );
+    } catch ( RuntimeException e ) {
+      if ( e.getCause() instanceof XMLStreamException ) {
+        throw new InvalidXmlPayloadException( e );
       }
+      throw e;
+    }
+  }
+
+  private void closeXmlStreamReader( XMLStreamReader xsr ) {
+    if ( xsr != null ) {
+      try {
+        xsr.close();
+      } catch ( XMLStreamException e ) {
+        logger.warn( "Failed to close XMLStreamReader", e );
+      }
+    }
+  }
+
+  private static class InvalidXmlPayloadException extends Exception {
+    InvalidXmlPayloadException( Throwable cause ) {
+      super( cause );
     }
   }
 

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
@@ -76,6 +76,7 @@ import java.util.List;
 
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1068,7 +1069,7 @@ public class FileResourceTest {
     doCallRealMethod().when( fileResource ).doSetMetadata( anyString(), any( StreamSource.class ) );
     doCallRealMethod().when( fileResource ).getUnmarshaller( any() );
     doCallRealMethod().when( fileResource ).getSecureXmlStreamReader( any( StreamSource.class ) );
-    assertEquals( INTERNAL_SERVER_ERROR.getStatusCode(),
+    assertEquals( UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
       fileResource.doSetMetadata( PATH_ID, new StreamSource( new ByteArrayInputStream( xmlDocWithExternalEntitiesLol.getBytes() ) ) ).getStatus() );
   }
 


### PR DESCRIPTION
@pentaho/tatooine_dev 