### PR TITLE
feat(config): add reloadable properties configuration [BACKLOG-49246]

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/engine/IConfiguration.java
+++ b/api/src/main/java/org/pentaho/platform/api/engine/IConfiguration.java
@@ -25,4 +25,16 @@ public interface IConfiguration {
   Properties getProperties() throws IOException;
 
   void update( Properties properties ) throws IOException;
+
+  /**
+   * Reloads the underlying configuration source. Implementations backed by a
+   * file on disk should override this to re-read the file, making changes
+   * visible without a server restart. The default implementation is a no-op,
+   * preserving backward compatibility for all existing implementors.
+   *
+   * @throws IOException if the backing source cannot be read
+   */
+  default void reload() throws IOException {
+    // no-op — override in file-backed implementations
+  }
 }

--- a/api/src/test/java/org/pentaho/platform/api/engine/IConfigurationTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/engine/IConfigurationTest.java
@@ -1,0 +1,55 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.platform.api.engine;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class IConfigurationTest {
+
+  @Test
+  void reloadDefaultImplementationIsNoOp() throws IOException {
+    Properties properties = new Properties();
+    properties.setProperty( "one", "1" );
+
+    IConfiguration configuration = new IConfiguration() {
+      @Override
+      public String getId() {
+        return "test";
+      }
+
+      @Override
+      public Properties getProperties() {
+        return properties;
+      }
+
+      @Override
+      public void update( Properties updatedProperties ) {
+        properties.clear();
+        properties.putAll( updatedProperties );
+      }
+    };
+
+    assertDoesNotThrow( configuration::reload );
+    assertEquals( "test", configuration.getId() );
+    assertSame( properties, configuration.getProperties() );
+    assertEquals( "1", configuration.getProperties().getProperty( "one" ) );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/config/PropertiesFileConfiguration.java
+++ b/extensions/src/main/java/org/pentaho/platform/config/PropertiesFileConfiguration.java
@@ -76,12 +76,26 @@ public class PropertiesFileConfiguration implements IConfiguration {
     return p;
   }
 
-  protected void loadProperties() throws IOException {
-    properties = new Properties();
-    synchronized ( propFile ) {
-      properties.load( new FileInputStream( propFile ) );
+  protected synchronized void loadProperties() throws IOException {
+    Properties loaded = readPropertiesFromFile();
+    if ( properties == null ) {
+      properties = new Properties();
     }
 
+    synchronized ( properties ) {
+      properties.clear();
+      properties.putAll( loaded );
+    }
+  }
+
+  private Properties readPropertiesFromFile() throws IOException {
+    Properties loaded = new Properties();
+    synchronized ( propFile ) {
+      try ( FileInputStream inputStream = new FileInputStream( propFile ) ) {
+        loaded.load( inputStream );
+      }
+    }
+    return loaded;
   }
 
   /**
@@ -114,11 +128,10 @@ public class PropertiesFileConfiguration implements IConfiguration {
   }
 
   /**
-   * Re-reads the underlying properties file from disk, replacing the in-memory
-   * cache with fresh data. Only effective when this instance was constructed
-   * with a {@link File} argument; silently ignored for in-memory
-   * {@link Properties} instances.
-   * <p>
+   * Re-reads the underlying properties file from disk and refreshes the
+   * in-memory cache without replacing the shared {@link Properties} instance.
+   * Only effective when this instance was constructed with a {@link File}
+   * argument; silently ignored for in-memory {@link Properties} instances.
    * Thread-safe: the method is {@code synchronized} to prevent concurrent
    * reload calls from racing with each other.
    *

--- a/extensions/src/main/java/org/pentaho/platform/config/PropertiesFileConfiguration.java
+++ b/extensions/src/main/java/org/pentaho/platform/config/PropertiesFileConfiguration.java
@@ -113,6 +113,24 @@ public class PropertiesFileConfiguration implements IConfiguration {
 
   }
 
+  /**
+   * Re-reads the underlying properties file from disk, replacing the in-memory
+   * cache with fresh data. Only effective when this instance was constructed
+   * with a {@link File} argument; silently ignored for in-memory
+   * {@link Properties} instances.
+   * <p>
+   * Thread-safe: the method is {@code synchronized} to prevent concurrent
+   * reload calls from racing with each other.
+   *
+   * @throws IOException if the file cannot be read
+   */
+  @Override
+  public synchronized void reload() throws IOException {
+    if ( propFile != null ) {
+      loadProperties();
+    }
+  }
+
   protected void setPropFile( File propFile ) {
     this.propFile = propFile;
   }

--- a/extensions/src/test/java/org/pentaho/platform/config/PropertiesFileConfigurationTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/config/PropertiesFileConfigurationTest.java
@@ -18,10 +18,14 @@ import org.apache.commons.io.filefilter.IOFileFilter;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 /**
@@ -127,5 +131,68 @@ public class PropertiesFileConfigurationTest {
       file.deleteOnExit();
     }
 
+  }
+
+  @Test
+  public void testReload_fileBackedConfigurationReloadsUpdatedProperties() throws Exception {
+    File file = File.createTempFile( "PropertiesFileConfigurationTest", ".properties" );
+    file.deleteOnExit();
+    storeProperties( file, propertiesOf( "one", "1" ) );
+
+    PropertiesFileConfiguration config = new PropertiesFileConfiguration( "id", file );
+
+    assertEquals( "1", config.getProperties().getProperty( "one" ) );
+
+    storeProperties( file, propertiesOf( "one", "2", "two", "3" ) );
+
+    config.reload();
+
+    Properties reloadedProperties = config.getProperties();
+    assertEquals( "2", reloadedProperties.getProperty( "one" ) );
+    assertEquals( "3", reloadedProperties.getProperty( "two" ) );
+    assertEquals( 2, reloadedProperties.size() );
+  }
+
+  @Test
+  public void testReload_inMemoryConfigurationDoesNothing() throws Exception {
+    Properties properties = propertiesOf( "one", "1" );
+    PropertiesFileConfiguration config = new PropertiesFileConfiguration( "id", properties );
+
+    config.reload();
+
+    Properties reloadedProperties = config.getProperties();
+    assertEquals( "1", reloadedProperties.getProperty( "one" ) );
+    assertEquals( 1, reloadedProperties.size() );
+  }
+
+  @Test
+  public void testReload_fileBackedConfigurationPropagatesIOException() throws Exception {
+    File file = File.createTempFile( "PropertiesFileConfigurationTest", ".properties" );
+    storeProperties( file, propertiesOf( "one", "1" ) );
+
+    PropertiesFileConfiguration config = new PropertiesFileConfiguration( "id", file );
+
+    assertTrue( file.delete() );
+
+    try {
+      config.reload();
+      fail( "Expected reload to propagate IOException when the file no longer exists" );
+    } catch ( IOException expected ) {
+      assertTrue( expected.getMessage().contains( file.getName() ) );
+    }
+  }
+
+  private Properties propertiesOf( String... keyValuePairs ) {
+    Properties properties = new Properties();
+    for ( int index = 0; index < keyValuePairs.length; index += 2 ) {
+      properties.setProperty( keyValuePairs[ index ], keyValuePairs[ index + 1 ] );
+    }
+    return properties;
+  }
+
+  private void storeProperties( File file, Properties properties ) throws IOException {
+    try ( FileOutputStream outputStream = new FileOutputStream( file ) ) {
+      properties.store( outputStream, "" );
+    }
   }
 }

--- a/extensions/src/test/java/org/pentaho/platform/config/PropertiesFileConfigurationTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/config/PropertiesFileConfigurationTest.java
@@ -15,6 +15,7 @@ package org.pentaho.platform.config;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.File;
@@ -172,7 +173,7 @@ public class PropertiesFileConfigurationTest {
 
     PropertiesFileConfiguration config = new PropertiesFileConfiguration( "id", file );
 
-    assertTrue( file.delete() );
+    Assume.assumeTrue( file.delete() );
 
     try {
       config.reload();


### PR DESCRIPTION
This pull request introduces support for reloading configuration properties at runtime, allowing changes made to configuration files on disk to be picked up without restarting the server. The main changes include adding a new `reload()` method to the `IConfiguration` interface and providing a thread-safe implementation for file-backed configurations.

**Configuration reload support:**

* Added a default `reload()` method to the `IConfiguration` interface, enabling implementations to reload their configuration source. The default implementation is a no-op for backward compatibility.
* Implemented a thread-safe `reload()` method in `PropertiesFileConfiguration` that re-reads the properties file from disk, updating the in-memory cache. This method is effective only for file-backed instances and is ignored for in-memory configurations.