### PR TITLE
fix[SP-7346]: update doSetMetadata endpoint to accept XML

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -2156,7 +2156,7 @@ public class FileResource extends AbstractJaxRSResource {
    *
    * @param pathId   The path from the root folder to the root node of the tree to return using colon characters in place of /
    *                 or \ characters. To clarify /path/to/file, the encoded pathId would be :path:to:file.
-   * @param metadata A list of StringKeyStringValueDto objects.
+   * @param metadataXml A list of StringKeyStringValueDto objects.
    * @return A jax-rs Response object with the appropriate status code, header, and body.
    *
    * <p><b>Example Response:</b></p>
@@ -2167,12 +2167,47 @@ public class FileResource extends AbstractJaxRSResource {
   @PUT
   @Path( "{pathId : .+}/metadata" )
   @Produces( {MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON} )
+  @Consumes( {MediaType.APPLICATION_XML} )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully retrieved metadata." ),
+    @ResponseCode( code = 403, condition = "Invalid path." ),
+    @ResponseCode( code = 400, condition = "Invalid payload." ),
+    @ResponseCode( code = 500, condition = "Server Error." )} )
+  public Response doSetMetadata( @PathParam( "pathId" ) String pathId, StreamSource metadataXml ) {
+    XMLStreamReader xsr = null;
+    try {
+      Unmarshaller unmarshaller = getUnmarshaller( StringKeyStringValueDtoWrapper.class );
+      xsr = getSecureXmlStreamReader( metadataXml );
+      StringKeyStringValueDtoWrapper metadata = (StringKeyStringValueDtoWrapper) unmarshaller.unmarshal( xsr );
+      if ( metadata == null || metadata.getStringKeyStringValueDtoes() == null ) {
+        return Response.status( Response.Status.BAD_REQUEST ).entity( "Invalid payload." ).build();
+      }
+      fileService.doSetMetadata( pathId, metadata.getStringKeyStringValueDtoes() );
+      return buildOkResponse();
+    } catch ( GeneralSecurityException e ) {
+      return buildStatusResponse( Response.Status.UNAUTHORIZED );
+    } catch ( Throwable t ) {
+      return buildServerErrorResponse( t.getMessage() );
+    } finally {
+      if ( xsr != null ) {
+        try {
+          xsr.close();
+        } catch ( XMLStreamException e ) {
+          logger.warn( "Failed to close XMLStreamReader", e );
+        }
+      }
+    }
+  }
+
+  @PUT
+  @Path( "{pathId : .+}/metadata" )
+  @Produces( {MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON} )
   @Consumes( {MediaType.APPLICATION_JSON} )
   @StatusCodes( {
-      @ResponseCode( code = 200, condition = "Successfully retrieved metadata." ),
-      @ResponseCode( code = 403, condition = "Invalid path." ),
-      @ResponseCode( code = 400, condition = "Invalid payload." ),
-      @ResponseCode( code = 500, condition = "Server Error." )} )
+    @ResponseCode( code = 200, condition = "Successfully retrieved metadata." ),
+    @ResponseCode( code = 403, condition = "Invalid path." ),
+    @ResponseCode( code = 400, condition = "Invalid payload." ),
+    @ResponseCode( code = 500, condition = "Server Error." )} )
   public Response doSetMetadata( @PathParam( "pathId" ) String pathId, StringKeyStringValueDtoWrapper  metadata ) {
     try {
       if ( metadata == null || metadata.getStringKeyStringValueDtoes() == null ) {
@@ -2186,6 +2221,7 @@ public class FileResource extends AbstractJaxRSResource {
       return buildServerErrorResponse( t.getMessage() );
     }
   }
+
 
   /**
    * Creates a new folder with the specified name.

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -2169,16 +2169,22 @@ public class FileResource extends AbstractJaxRSResource {
   @Produces( {MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON} )
   @Consumes( {MediaType.APPLICATION_XML} )
   @StatusCodes( {
-    @ResponseCode( code = 200, condition = "Successfully retrieved metadata." ),
+    @ResponseCode( code = 200, condition = "Successfully stored metadata." ),
     @ResponseCode( code = 403, condition = "Invalid path." ),
     @ResponseCode( code = 400, condition = "Invalid payload." ),
+    @ResponseCode( code = 415, condition = "Invalid, missing or unparseable XML payload." ),
     @ResponseCode( code = 500, condition = "Server Error." )} )
   public Response doSetMetadata( @PathParam( "pathId" ) String pathId, StreamSource metadataXml ) {
+    if ( metadataXml == null ) {
+      return Response.status( Response.Status.UNSUPPORTED_MEDIA_TYPE ).entity( "Missing XML payload." ).build();
+    }
     XMLStreamReader xsr = null;
     try {
-      Unmarshaller unmarshaller = getUnmarshaller( StringKeyStringValueDtoWrapper.class );
       xsr = getSecureXmlStreamReader( metadataXml );
-      StringKeyStringValueDtoWrapper metadata = (StringKeyStringValueDtoWrapper) unmarshaller.unmarshal( xsr );
+      if ( xsr == null ) {
+        return Response.status( Response.Status.UNSUPPORTED_MEDIA_TYPE ).entity( "Invalid XML payload." ).build();
+      }
+      StringKeyStringValueDtoWrapper metadata = unmarshalMetadata( xsr );
       if ( metadata == null || metadata.getStringKeyStringValueDtoes() == null ) {
         return Response.status( Response.Status.BAD_REQUEST ).entity( "Invalid payload." ).build();
       }
@@ -2186,16 +2192,40 @@ public class FileResource extends AbstractJaxRSResource {
       return buildOkResponse();
     } catch ( GeneralSecurityException e ) {
       return buildStatusResponse( Response.Status.UNAUTHORIZED );
+    } catch ( InvalidXmlPayloadException | JAXBException | XMLStreamException e ) {
+      return Response.status( Response.Status.UNSUPPORTED_MEDIA_TYPE ).entity( "Invalid or unparseable XML payload." ).build();
     } catch ( Throwable t ) {
       return buildServerErrorResponse( t.getMessage() );
     } finally {
-      if ( xsr != null ) {
-        try {
-          xsr.close();
-        } catch ( XMLStreamException e ) {
-          logger.warn( "Failed to close XMLStreamReader", e );
-        }
+      closeXmlStreamReader( xsr );
+    }
+  }
+
+  private StringKeyStringValueDtoWrapper unmarshalMetadata( XMLStreamReader xsr ) throws JAXBException, InvalidXmlPayloadException {
+    try {
+      Unmarshaller unmarshaller = getUnmarshaller( StringKeyStringValueDtoWrapper.class );
+      return (StringKeyStringValueDtoWrapper) unmarshaller.unmarshal( xsr );
+    } catch ( RuntimeException e ) {
+      if ( e.getCause() instanceof XMLStreamException ) {
+        throw new InvalidXmlPayloadException( e );
       }
+      throw e;
+    }
+  }
+
+  private void closeXmlStreamReader( XMLStreamReader xsr ) {
+    if ( xsr != null ) {
+      try {
+        xsr.close();
+      } catch ( XMLStreamException e ) {
+        logger.warn( "Failed to close XMLStreamReader", e );
+      }
+    }
+  }
+
+  private static class InvalidXmlPayloadException extends Exception {
+    InvalidXmlPayloadException( Throwable cause ) {
+      super( cause );
     }
   }
 

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
@@ -1048,64 +1048,46 @@ public class FileResourceTest {
       fileResource.setFileAcls( PATH_ID, new StreamSource( new ByteArrayInputStream( xmlDocWithExternalEntitiesLol.getBytes() ) ) ).getStatus() );
   }
 
-  /* Note: tests commented out because we removed the Accepts: XML decorator from this method; should only
-   * accept JSON now.
-   * [PPP-5021] Ensure external entities cannot be inserted into XML payloads
-   */
-//  @Test
-//  public void testDoSetMetadataXxeError() throws JAXBException, XMLStreamException {
-//    String xmlDocWithExternalEntitiesLol =
-//      "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
-//        + "<!DOCTYPE lolz ["
-//        + "<!ENTITY lol \"lol\">"
-//        + "<!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">"
-//        + "<!ENTITY lol2 \"&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;\">"
-//        + "<!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">"
-//        + "<!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">"
-//        + "]>"
-//        + "\n"
-//        + "<stringKeyStringValueDto><key>fooKey</key><value>barValue&lol4;</value></stringKeyStringValueDto>";
-//
-//    doCallRealMethod().when( fileResource ).doSetMetadata( anyString(), any( StreamSource.class ) );
-//    doCallRealMethod().when( fileResource ).getUnmarshaller( any() );
-//    doCallRealMethod().when( fileResource ).getSecureXmlStreamReader( any( StreamSource.class ) );
-//    assertEquals( INTERNAL_SERVER_ERROR.getStatusCode(),
-//      fileResource.doSetMetadata( PATH_ID, new StreamSource( new ByteArrayInputStream( xmlDocWithExternalEntitiesLol.getBytes() ) ) ).getStatus() );
-//  }
+  @Test
+  public void testDoSetMetadataXxeError() throws JAXBException, XMLStreamException {
+    String xmlDocWithExternalEntitiesLol =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+        + "<!DOCTYPE lolz ["
+        + "<!ENTITY lol \"lol\">"
+        + "<!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">"
+        + "<!ENTITY lol2 \"&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;\">"
+        + "<!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">"
+        + "<!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">"
+        + "]>"
+        + "\n"
+        + "<stringKeyStringValueDtoes>"
+        + "<stringKeyStringValueDto><key>fooKey</key><value>barValue&lol4;</value></stringKeyStringValueDto>"
+        + "<stringKeyStringValueDto><key>fooKey1</key><value>barValue1</value></stringKeyStringValueDto>"
+        + "</stringKeyStringValueDtoes>";
+
+    doCallRealMethod().when( fileResource ).doSetMetadata( anyString(), any( StreamSource.class ) );
+    doCallRealMethod().when( fileResource ).getUnmarshaller( any() );
+    doCallRealMethod().when( fileResource ).getSecureXmlStreamReader( any( StreamSource.class ) );
+    assertEquals( INTERNAL_SERVER_ERROR.getStatusCode(),
+      fileResource.doSetMetadata( PATH_ID, new StreamSource( new ByteArrayInputStream( xmlDocWithExternalEntitiesLol.getBytes() ) ) ).getStatus() );
+  }
 
   /*
    * [PPP-5021] Ensure external entities cannot be inserted into XML payloads
    */
-//  @Test
-//  public void testDoSetMetadataXxeErrorClean() throws JAXBException, XMLStreamException {
-//    String xmlDocWithExternalEntitiesLol =
-//      "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
-//        + "<stringKeyStringValueDtoes><stringKeyStringValueDto><key>fooKey</key><value>barValue</value></stringKeyStringValueDto>"
-//        + "<stringKeyStringValueDto><key>fooKey1</key><value>barValue1</value></stringKeyStringValueDto></stringKeyStringValueDtoes>";
-//
-//    doCallRealMethod().when( fileResource ).doSetMetadata( anyString(), any( StreamSource.class ) );
-//    doCallRealMethod().when( fileResource ).getUnmarshaller( any() );
-//    doCallRealMethod().when( fileResource ).getSecureXmlStreamReader( any( StreamSource.class ) );
-//    assertEquals( OK.getStatusCode(),
-//      fileResource.doSetMetadata( PATH_ID, new StreamSource( new ByteArrayInputStream( xmlDocWithExternalEntitiesLol.getBytes() ) ) ).getStatus() );
-//  }
+  @Test
+  public void testDoSetMetadataXxeErrorClean() throws JAXBException, XMLStreamException {
+    String xmlDocWithExternalEntitiesLol =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+        + "<stringKeyStringValueDtoes><stringKeyStringValueDto><key>fooKey</key><value>barValue</value></stringKeyStringValueDto>"
+        + "<stringKeyStringValueDto><key>fooKey1</key><value>barValue1</value></stringKeyStringValueDto></stringKeyStringValueDtoes>";
 
-//  public void generateStringKeyAndValueXml() throws JAXBException {
-//    // save this in case someone needs to rebuild the XML
-//    StringKeyStringValueDto stringKeyStringValueDto1 = new StringKeyStringValueDto();
-//    stringKeyStringValueDto1.setKey( "fooKey" );
-//    stringKeyStringValueDto1.setValue( "barValue" );
-//    StringKeyStringValueDto stringKeyStringValueDto2 = new StringKeyStringValueDto();
-//    stringKeyStringValueDto2.setKey( "fooKey" );
-//    stringKeyStringValueDto2.setValue( "barValue" );
-//    List<StringKeyStringValueDto> stringKeyStringValueDtoList = new ArrayList<>();
-//    stringKeyStringValueDtoList.add( stringKeyStringValueDto1 );
-//    stringKeyStringValueDtoList.add( stringKeyStringValueDto2 );
-//    JAXBContext jaxbContext = JAXBContext.newInstance( StringKeyStringValueDto.class, ArrayList.class );
-//    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-//    jaxbContext.createMarshaller().marshal( stringKeyStringValueDtoList, bos );
-//    System.out.println( bos.toString() );
-//  }
+    doCallRealMethod().when( fileResource ).doSetMetadata( anyString(), any( StreamSource.class ) );
+    doCallRealMethod().when( fileResource ).getUnmarshaller( any() );
+    doCallRealMethod().when( fileResource ).getSecureXmlStreamReader( any( StreamSource.class ) );
+    assertEquals( OK.getStatusCode(),
+      fileResource.doSetMetadata( PATH_ID, new StreamSource( new ByteArrayInputStream( xmlDocWithExternalEntitiesLol.getBytes() ) ) ).getStatus() );
+  }
 
   /*
    * [PPP-5021] Ensure external entities cannot be inserted into XML payloads
@@ -1800,7 +1782,7 @@ public class FileResourceTest {
   }
 
   @Test
-  public void testDoSetMetadata() throws Exception {
+  public void testDoSetMetadataJson() throws Exception {
     List<StringKeyStringValueDto> metadata = mock( List.class );
 
     StringKeyStringValueDtoWrapper metadataWrapper = new StringKeyStringValueDtoWrapper();
@@ -1818,7 +1800,7 @@ public class FileResourceTest {
   }
 
   @Test
-  public void testDoSetMetadataError() throws Exception {
+  public void testDoSetMetadataJsonError() throws Exception {
     List<StringKeyStringValueDto> metadata =  mock( List.class );
 
     StringKeyStringValueDtoWrapper metadataWrapper = new StringKeyStringValueDtoWrapper();
@@ -1854,7 +1836,75 @@ public class FileResourceTest {
     verify( fileResource, times( 1 ) ).buildServerErrorResponse( errMsg );
   }
 
+  @Test
+  public void testDoSetMetadataXML() throws Exception {
+    List<StringKeyStringValueDto> metadata = mock( List.class );
 
+    StringKeyStringValueDtoWrapper metadataWrapper = new StringKeyStringValueDtoWrapper();
+    metadataWrapper.setStringKeyStringValueDtoes( metadata );
+    doNothing().when( fileResource.fileService ).doSetMetadata( PATH_ID, metadata );
+
+    Unmarshaller mockUnmarshaller = mock( Unmarshaller.class );
+    XMLStreamReader mockXsr = mock( XMLStreamReader.class );
+    doReturn( mockUnmarshaller ).when( fileResource ).getUnmarshaller( StringKeyStringValueDtoWrapper.class );
+    doReturn( mockXsr ).when( fileResource ).getSecureXmlStreamReader( any( StreamSource.class ) );
+    doReturn( metadataWrapper ).when( mockUnmarshaller ).unmarshal( mockXsr );
+
+    Response mockResponse = mock( Response.class );
+    doReturn( mockResponse ).when( fileResource ).buildOkResponse();
+
+    StreamSource mockStreamSource = mock( StreamSource.class );
+    Response testResponse = fileResource.doSetMetadata( PATH_ID, mockStreamSource );
+    assertEquals( mockResponse, testResponse );
+
+    verify( fileResource.fileService, times( 1 ) ).doSetMetadata( PATH_ID, metadata );
+    verify( fileResource, times( 1 ) ).buildOkResponse();
+  }
+
+  @Test
+  public void testDoSetMetadataXMLError() throws Exception {
+    List<StringKeyStringValueDto> metadata =  mock( List.class );
+
+    StringKeyStringValueDtoWrapper metadataWrapper = new StringKeyStringValueDtoWrapper();
+    metadataWrapper.setStringKeyStringValueDtoes( metadata );
+
+    Unmarshaller mockUnmarshaller = mock( Unmarshaller.class );
+    XMLStreamReader mockXsr = mock( XMLStreamReader.class );
+    doReturn( mockUnmarshaller ).when( fileResource ).getUnmarshaller( StringKeyStringValueDtoWrapper.class );
+    doReturn( mockXsr ).when( fileResource ).getSecureXmlStreamReader( any( StreamSource.class ) );
+    doReturn( metadataWrapper ).when( mockUnmarshaller ).unmarshal( mockXsr );
+
+    Response mockUnauthorizedResponse = mock( Response.class );
+    doReturn( mockUnauthorizedResponse ).when( fileResource ).buildStatusResponse( Response.Status.UNAUTHORIZED );
+
+    Throwable mockThrowable = mock( RuntimeException.class );
+
+    String errMsg = "errMsg";
+    doReturn( errMsg ).when( mockThrowable ).getMessage();
+
+    Response mockThrowableResponse = mock( Response.class );
+    doReturn( mockThrowableResponse ).when( fileResource ).buildServerErrorResponse( errMsg );
+
+    StreamSource mockStreamSource = mock( StreamSource.class );
+
+    // Test 1
+    Exception mockGeneralSecurityException = mock( GeneralSecurityException.class );
+    doThrow( mockGeneralSecurityException ).when( fileResource.fileService ).doSetMetadata( PATH_ID, metadataWrapper.getStringKeyStringValueDtoes() );
+
+    Response testResponse = fileResource.doSetMetadata( PATH_ID, mockStreamSource );
+    assertEquals( mockUnauthorizedResponse, testResponse );
+
+    // Test 2
+    doThrow( mockThrowable ).when( fileResource.fileService ).doSetMetadata( PATH_ID, metadata );
+
+    testResponse = fileResource.doSetMetadata( PATH_ID, mockStreamSource );
+    assertEquals( mockThrowableResponse, testResponse );
+
+    verify( fileResource.fileService, times( 2 ) ).doSetMetadata( PATH_ID, metadata );
+    verify( fileResource, times( 1 ) ).buildStatusResponse( Response.Status.UNAUTHORIZED );
+    verify( mockThrowable, times( 1 ) ).getMessage();
+    verify( fileResource, times( 1 ) ).buildServerErrorResponse( errMsg );
+  }
   @Test
   public void testCustomMime() {
     FileResource fileResource = new FileResource();

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/FileResourceTest.java
@@ -76,6 +76,7 @@ import java.util.List;
 
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1068,7 +1069,7 @@ public class FileResourceTest {
     doCallRealMethod().when( fileResource ).doSetMetadata( anyString(), any( StreamSource.class ) );
     doCallRealMethod().when( fileResource ).getUnmarshaller( any() );
     doCallRealMethod().when( fileResource ).getSecureXmlStreamReader( any( StreamSource.class ) );
-    assertEquals( INTERNAL_SERVER_ERROR.getStatusCode(),
+    assertEquals( UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
       fileResource.doSetMetadata( PATH_ID, new StreamSource( new ByteArrayInputStream( xmlDocWithExternalEntitiesLol.getBytes() ) ) ).getStatus() );
   }
 


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7346 - Backport of BISERVER-15545 - (11.0 Suite) PUT /repo/files/.../metadata endpoint returns 415 for XML in Pentaho 10.2](https://hv-eng.atlassian.net/browse/SP-7346)
- **Base Case:** [BISERVER-15545 - Backport of BISERVER-15545 - (11.0 Suite) PUT /repo/files/.../metadata endpoint returns 415 for XML in Pentaho 10.2](https://hv-eng.atlassian.net/browse/BISERVER-15545)
- **Original Master PRs:**
  - https://github.com/pentaho/pentaho-platform/pull/6201
  - https://github.com/pentaho/pentaho-platform/pull/6251

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-platform/pull/6201
- Cherry-picked from https://github.com/pentaho/pentaho-platform/pull/6251
- Commit: d782d53fe16bed2b3b2ebf5370cd99977c7ca8ee
- Commit: e95364b7d1ef434d0795a0db00e6f1d55e8c00cf

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
