### PR TITLE
fix: remove additional languages menu [BISERVER-14508]

### DIFF
--- a/user-console/src/main/java/org/pentaho/mantle/client/ui/xul/MantleController.java
+++ b/user-console/src/main/java/org/pentaho/mantle/client/ui/xul/MantleController.java
@@ -232,7 +232,6 @@ public class MantleController extends AbstractXulEventHandler {
       String currentLanguage = resourceBundle.getLanguage();
 
       MenuBar langMenu = (MenuBar) languageMenu.getManagedObject();
-      langMenu.insertSeparator( 0 );
       for ( String lang : supportedLanguages.keySet() ) {
         CheckBoxMenuItem langMenuItem = new CheckBoxMenuItem( supportedLanguages.get( lang ), new SwitchLocaleCommand( lang ) );
         langMenuItem.getElement().setId( supportedLanguages.get( lang ) + "_menu_item" );

--- a/user-console/src/main/resources/org/pentaho/mantle/public/xul/mantle.xul
+++ b/user-console/src/main/resources/org/pentaho/mantle/public/xul/mantle.xul
@@ -29,8 +29,6 @@
                 command="mantleXulHandler.showHiddenFilesClicked()" type="checkbox" checked="false"/>
       <menubarseparator id="descriptionsSeparator"/>
       <menubar id="languagemenu" label="${languages}" layout="vertical">
-           <menuitem id="additionalLanguagesMenuItem" label="${additionalLanguages}"
-                js-command="window.open('http://community.pentaho.com/marketplace/language-packs/', 'moreLang', '')" />
       </menubar>
       <menubar id="themesmenu" label="${themes}" layout="vertical">
       </menubar>


### PR DESCRIPTION
https://hv-eng.atlassian.net/browse/BISERVER-14508

To be merged with:
1. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1084
2. https://github.com/pentaho/pentaho-scheduler-plugin/pull/394
3. https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/647