### PR TITLE
FUSE-562 Integrate CMS with pentaho-server's connection repository

### DIFF
--- a/repository/src/main/java/org/pentaho/platform/repository/DatabaseHelper.java
+++ b/repository/src/main/java/org/pentaho/platform/repository/DatabaseHelper.java
@@ -45,6 +45,8 @@ public class DatabaseHelper {
 
   private static final String PROP_PASSWORD = "PASSWORD"; //$NON-NLS-1$
 
+  private static final String PROP_CONNECTION_ID = "CONNECTION_ID"; //$NON-NLS-1$LS-1$
+
   private static final String PROP_USERNAME = "USERNAME"; //$NON-NLS-1$
 
   private static final String PROP_PORT = "PORT"; //$NON-NLS-1$
@@ -104,6 +106,7 @@ public class DatabaseHelper {
     rootNode.setProperty( PROP_HOST_NAME, setNull( databaseConnection.getHostname() ) );
     rootNode.setProperty( PROP_DATABASE_NAME, setNull( databaseConnection.getDatabaseName() ) );
     rootNode.setProperty( PROP_PORT, Long.parseLong( port ) );
+    rootNode.setProperty( PROP_CONNECTION_ID, setNull( databaseConnection.getConnectionId() ) );
     rootNode.setProperty( PROP_USERNAME, setNull( databaseConnection.getUsername() ) );
     rootNode.setProperty( PROP_PASSWORD, encryptPassword( databaseConnection.getPassword() ) );
     rootNode.setProperty( PROP_SERVERNAME, setNull( databaseConnection.getInformixServername() ) );
@@ -188,6 +191,7 @@ public class DatabaseHelper {
     databaseConnection.setAccessType( accessType != null
       ? DatabaseAccessType.getAccessTypeByName( accessType ) : null );
     databaseConnection.setHostname( databaseMeta.environmentSubstitute( databaseMeta.getHostname() ) );
+    databaseConnection.setConnectionId( databaseMeta.environmentSubstitute( databaseMeta.getConnectionId() ) );
     databaseConnection.setDatabaseName( databaseMeta.environmentSubstitute( databaseMeta.getDatabaseName() ) );
     databaseConnection.setDatabasePort( databaseMeta.environmentSubstitute( databaseMeta.getDatabasePortNumberString() ) );
     databaseConnection.setUsername( databaseMeta.environmentSubstitute( databaseMeta.getUsername() ) );
@@ -251,6 +255,7 @@ public class DatabaseHelper {
     databaseConnection.setAccessType( accessType != null
       ? DatabaseAccessType.getAccessTypeByName( accessType ) : null );
     databaseConnection.setHostname( getString( rootNode, PROP_HOST_NAME ) );
+    databaseConnection.setConnectionId( getString( rootNode, PROP_CONNECTION_ID ) );
     databaseConnection.setDatabaseName( getString( rootNode, PROP_DATABASE_NAME ) );
     databaseConnection.setDatabasePort( getString( rootNode, PROP_PORT ) );
     databaseConnection.setUsername( getString( rootNode, PROP_USERNAME ) );

--- a/repository/src/test/java/org/pentaho/platform/repository/DatabaseHelperTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository/DatabaseHelperTest.java
@@ -42,6 +42,8 @@ public class DatabaseHelperTest {
 
   public static final String PROP_DATA_TBS = "DATA_TBS"; //$NON-NLS-1$
 
+  public static final String PROP_CONNECTION_ID = "CONNECTION_ID"; //$NON-NLS-1$
+
   public static final String PROP_SERVERNAME = "SERVERNAME"; //$NON-NLS-1$
 
   public static final String PROP_PASSWORD = "PASSWORD"; //$NON-NLS-1$
@@ -87,6 +89,7 @@ public class DatabaseHelperTest {
   public static final String ATTRIBUTE_PORT_NUMBER = "PORT_NUMBER";
 
   final String DB_CONN_NAME = "DB_CONN_NAME";
+  final String DB_CONN_ID = "DB_CONN_ID";
   final String DB_NAME = "DB_NAME";
   final String DB_HOST = "DB_HOST";
   final String DB_PORT = "DB_PORT";
@@ -160,6 +163,7 @@ public class DatabaseHelperTest {
   @Test
   public void testDatabaseMetaToDatabaseConnectionWithVars() throws KettleException {
     final String DB_CONN_NAME_VAR = "DB_CONN_NAME_VAR";
+    final String CONNECTION_ID_VAR = "CONNECTION_ID_VAR";
     final String DB_NAME_VAR = "DB_NAME_VAR";
     final String DB_HOST_VAR = "DB_HOST_VAR";
     final String DB_PORT_VAR = "DB_PORT_VAR";
@@ -185,6 +189,7 @@ public class DatabaseHelperTest {
     DatabaseMeta dbMeta = new DatabaseMeta( DB_CONN_NAME, "GENERIC", "Native", DB_HOST, DB_NAME, DB_PORT, DB_USERNAME, DB_PASSWORD );
     Variables vars = new Variables();
     vars.setVariable( DB_CONN_NAME_VAR, DB_CONN_NAME );
+    vars.setVariable( CONNECTION_ID_VAR, DB_CONN_ID );
     vars.setVariable( DB_NAME_VAR, DB_NAME );
     vars.setVariable( DB_HOST_VAR, DB_HOST );
     vars.setVariable( DB_PORT_VAR, DB_PORT );
@@ -200,6 +205,7 @@ public class DatabaseHelperTest {
 
     dbMeta.shareVariablesWith( vars );
 
+    dbMeta.setConnectionId( wrapVar( CONNECTION_ID_VAR ) );
     dbMeta.setName( wrapVar( DB_CONN_NAME_VAR ) );
     dbMeta.setHostname( wrapVar( DB_HOST_VAR ) );
     dbMeta.setDBPort( wrapVar( DB_PORT_VAR ) );
@@ -222,6 +228,7 @@ public class DatabaseHelperTest {
 
     IDatabaseConnection testConnection = databaseHelper.databaseMetaToDatabaseConnection( dbMeta );
     assertEquals( "Conn name incorrect", DB_CONN_NAME, testConnection.getName() );
+    assertEquals( "DB connection Id incorrect", DB_CONN_ID, testConnection.getConnectionId() );
     assertEquals( "DB name incorrect", DB_NAME, testConnection.getDatabaseName() );
     assertEquals( "Host name incorrect", DB_HOST, testConnection.getHostname() );
     assertEquals( "Port incorrect", DB_PORT, testConnection.getDatabasePort() );
@@ -261,6 +268,7 @@ public class DatabaseHelperTest {
 
     DatabaseMeta dbMeta = new DatabaseMeta( DB_CONN_NAME, "GENERIC", "Native", DB_HOST, DB_NAME, DB_PORT, DB_USERNAME, DB_PASSWORD );
 
+    dbMeta.setConnectionId( DB_CONN_ID );
     dbMeta.setName( DB_CONN_NAME );
     dbMeta.setHostname( DB_HOST );
     dbMeta.setDBPort( DB_PORT );
@@ -284,6 +292,7 @@ public class DatabaseHelperTest {
     IDatabaseConnection testConnection = databaseHelper.databaseMetaToDatabaseConnection( dbMeta );
     assertEquals( "Conn name incorrect", DB_CONN_NAME, testConnection.getName() );
     assertEquals( "DB name incorrect", DB_NAME, testConnection.getDatabaseName() );
+    assertEquals( "Connection ID incorrect", DB_CONN_ID, testConnection.getConnectionId() );
     assertEquals( "Host name incorrect", DB_HOST, testConnection.getHostname() );
     assertEquals( "Port incorrect", DB_PORT, testConnection.getDatabasePort() );
     assertEquals( "User name incorrect", DB_USERNAME, testConnection.getUsername() );
@@ -312,6 +321,7 @@ public class DatabaseHelperTest {
     databaseConnection.setId( "id" );
     databaseConnection.setAccessType( DatabaseAccessType.CUSTOM );
 
+    databaseConnection.setConnectionId( "connectionId" );
     databaseConnection.setHostname( "hostName" );
     databaseConnection.setDatabaseName( "databaseName" );
     databaseConnection.setDatabasePort( "8080" );
@@ -353,6 +363,7 @@ public class DatabaseHelperTest {
 
     rootNode.setProperty( PROP_TYPE, "portType" );
     rootNode.setProperty( PROP_CONTYPE, "contype" );
+    rootNode.setProperty( PROP_CONNECTION_ID, "connectionId" );
     rootNode.setProperty( PROP_HOST_NAME, "portType" );
     rootNode.setProperty( PROP_DATABASE_NAME, "databaseName" );
     rootNode.setProperty( PROP_PORT, 8080 );


### PR DESCRIPTION
### [FUSE-562](https://hv-eng.atlassian.net/browse/FUSE-562)

In order to add support of the [connection-management-service](https://github.com/pentaho/connection-management-service)'s connections to the data-access service, we need to add a new field to the request payload which will specify the connection Id from the connection-management-service. This Id will later be used to retrieve actual connection metadata and perform requested operations.

### What was changed?
Added new field processing to the DatabaseHelper class which helps to map connections from Nodes to Objects and vice versa.

[FUSE-562]: https://hv-eng.atlassian.net/browse/FUSE-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ