### PR TITLE
Revert "[PPP-6529] - Remove JFace and other desktop UI dependency from platform"

### DIFF
--- a/assemblies/pentaho-war/pom.xml
+++ b/assemblies/pentaho-war/pom.xml
@@ -112,24 +112,6 @@
           <artifactId>hsqldb</artifactId>
           <groupId>org.hsqldb</groupId>
         </exclusion>
-        <!-- Exclude Eclipse/JFace UI libraries - not needed for server -->
-        <exclusion>
-          <artifactId>org.eclipse.jface</artifactId>
-          <groupId>org.eclipse.platform</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jface</artifactId>
-          <groupId>org.eclipse</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>org.eclipse.swt</artifactId>
-          <groupId>org.eclipse.platform</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>commons-xul-swt</artifactId>
-          <groupId>org.pentaho</groupId>
-        </exclusion>
-
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
Reverts pentaho/pentaho-platform#6262

Apparently. we try to get RunConfiguration using Spoon.getInstance when running on the server. For this reason we need jface library on the server which spoon needs to initialize