### PR TITLE
cleanup[PPP-6449][PPP-6447][PPP-6448]: Remove Apache Neethi

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -1997,18 +1997,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.ws.commons.neethi</groupId>
-      <artifactId>neethi</artifactId>
-      <version>${neethi.version}</version>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>woodstox</groupId>
       <artifactId>wstx-asl</artifactId>
       <version>${wstx-asl.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,6 @@
     <hamcrest-library.version>1.3</hamcrest-library.version>
     <xmlenc.version>0.52</xmlenc.version>
     <jsendnsca.version>2.0.1</jsendnsca.version>
-    <neethi.version>2.0.1</neethi.version>
     <barbecue.version>1.5-beta1</barbecue.version>
     <antlr-complete.version>3.5.2</antlr-complete.version>
     <license.inception.year>2002</license.inception.year>


### PR DESCRIPTION
Apache Neethi is a WS-Policy framework primarily used by Apache SOAP frameworks such as CXF and Axis2.
Axis2 was removed from the project prior to 11.0, eliminating one of the primary consumers. While CXF is still present in the OSGi environment, I found no evidence that the remaining CXF components require it. There is also no entry in `custom.properties` to make the library available to OSGi bundles, suggesting it is not required by the current OSGi runtime.
 
This pull request removes the `neethi` dependency from the project. The change eliminates both the dependency declaration in `extensions/pom.xml` and the corresponding version property from the root `pom.xml`.

Dependency cleanup:

* Removed the `neethi` dependency from `extensions/pom.xml`, including its version, scope, and exclusions.
* Deleted the `neethi.version` property from the root `pom.xml` to reflect the removal of the dependency.