### PR TITLE
PPP-6575: bump commons-jxpath to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <jaybird.version>2.1.6</jaybird.version>
     <resolver.version>20050927</resolver.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-jxpath.version>1.2</commons-jxpath.version>
+    <commons-jxpath.version>1.4.0</commons-jxpath.version>
     <maven-surefire-plugin.reuseForks>false</maven-surefire-plugin.reuseForks>
     <sapdbc.version>7.4.4</sapdbc.version>
     <jcr.version>2.0</jcr.version>


### PR DESCRIPTION
Automated vulnerability remediation.

- Ticket: PPP-6575
- Library: commons-jxpath
- Target version: 1.4.0
- CVE(s): CVE-2022-40159

Branch was built successfully in Docker (java-builder) with JDK 21 before this PR was raised.