### PR TITLE
[PPP-6549] CVE fix: CVE-2016-3093 in ognl:ognl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <barcode4j.version>2.0</barcode4j.version>
     <commons-validator.version>1.3.1</commons-validator.version>
     <jmockit.version>1.8</jmockit.version>
-    <!-- [PPP-6549] ognl.version removed: now inherited from pentaho-ce-jar-parent-pom (CVE-2016-3093 fix, 3.0.21) -->
+    <!-- [PPP-6549] ognl.version removed: now inherited from pentaho-ce-jar-parent-pom (CVE-2016-3093 fix) -->
     <oro.version>2.0.8</oro.version>
     <mockrunner-servlet.version>0.3.7</mockrunner-servlet.version>
     <feed4j.version>1.0</feed4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <barcode4j.version>2.0</barcode4j.version>
     <commons-validator.version>1.3.1</commons-validator.version>
     <jmockit.version>1.8</jmockit.version>
-    <ognl.version>2.6.9</ognl.version>
+    <!-- [PPP-6549] ognl.version removed: now inherited from pentaho-ce-jar-parent-pom (CVE-2016-3093 fix, 3.0.21) -->
     <oro.version>2.0.8</oro.version>
     <mockrunner-servlet.version>0.3.7</mockrunner-servlet.version>
     <feed4j.version>1.0</feed4j.version>


### PR DESCRIPTION
## CVE fix: CVE-2016-3093 in ognl:ognl

Advisory: CVE-2016-3093 -- OGNL < 3.0.12 DoS (CWE-20), CVSS 5.3 MEDIUM. Fixed upstream in OGNL 3.0.12.

Change: removes the local `<ognl.version>2.6.9</ognl.version>` property override in the root `pom.xml` so it now inherits the centralized fix (`3.0.21`) from `pentaho-ce-jar-parent-pom` (see pentaho/maven-parent-poms#899).

No direct OGNL API usage in this repo (`ognl` is only a transitive/convergence pin consumed by `assemblies/pentaho-war`, which depends on kettle artifacts). Companion fix in pentaho/pentaho-kettle (the one repo with real OGNL code usage).

### Proof
`mvn help:evaluate -Dexpression=ognl.version` on `assemblies/pentaho-war` now returns `3.0.21` (was `2.6.9` before this change).

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.