### PR TITLE
feat: scoped logger levels for execution appenders [PDI-20391]

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/util/LogUtil.java
+++ b/api/src/main/java/org/pentaho/platform/api/util/LogUtil.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -35,6 +36,8 @@ import java.util.Map;
  *
  */
 public class LogUtil {
+
+  private static final Map<LoggerConfigKey, ManagedLoggerConfig> MANAGED_LOGGER_CONFIGS = new HashMap<>();
 
   /**
    * Adds an appender to a logger creating a LoggerConfig if necessary so that the appender only listens to the
@@ -81,6 +84,190 @@ public class LogUtil {
     loggerConfig.removeAppender( appender.getName() );
     ctx.updateLoggers();
     appender.stop();
+  }
+
+  /**
+   * Adds an appender to a logger and temporarily enables the supplied log level. Closing the returned registration
+   * removes the appender and restores the logger's previous configuration.
+   *
+   * @param appender
+   * @param logger
+   * @param level
+   * @param filter
+   * @return a registration that must be closed when the appender is no longer needed
+   */
+  public static AppenderRegistration addAppenderWithLevel( Appender appender, Logger logger, Level level,
+                                                            Filter filter ) {
+    LoggerContext ctx = (LoggerContext) LogManager.getContext( false );
+    Configuration config = ctx.getConfiguration();
+    LoggerConfigKey key = new LoggerConfigKey( ctx, logger.getName() );
+
+    synchronized ( MANAGED_LOGGER_CONFIGS ) {
+      ManagedLoggerConfig managedLoggerConfig = MANAGED_LOGGER_CONFIGS.get( key );
+      boolean newManagedLoggerConfig = managedLoggerConfig == null;
+      if ( managedLoggerConfig == null ) {
+        LoggerConfig loggerConfig = config.getLoggers().get( logger.getName() );
+        boolean created = loggerConfig == null;
+        Level previousLevel = null;
+        boolean previousAdditivity = false;
+        if ( created ) {
+          LoggerConfig parentConfig = config.getLoggerConfig( logger.getName() );
+          loggerConfig = new LoggerConfig( logger.getName(), level, false );
+          loggerConfig.setParent( parentConfig );
+          config.addLogger( logger.getName(), loggerConfig );
+        } else {
+          previousLevel = loggerConfig.getLevel();
+          previousAdditivity = loggerConfig.isAdditive();
+        }
+        managedLoggerConfig = new ManagedLoggerConfig( config, loggerConfig, created, previousLevel,
+          previousAdditivity );
+      }
+
+      try {
+        managedLoggerConfig.addAppender( appender, level, filter );
+        ctx.updateLoggers();
+        if ( newManagedLoggerConfig ) {
+          MANAGED_LOGGER_CONFIGS.put( key, managedLoggerConfig );
+        }
+      } catch ( RuntimeException e ) {
+        managedLoggerConfig.removeAppender( appender );
+        if ( newManagedLoggerConfig ) {
+          managedLoggerConfig.restore( key.loggerName );
+        }
+        ctx.updateLoggers();
+        throw e;
+      }
+    }
+    return new AppenderRegistration( key, appender );
+  }
+
+  public static final class AppenderRegistration implements AutoCloseable {
+    private final LoggerConfigKey key;
+    private final Appender appender;
+    private boolean closed;
+
+    private AppenderRegistration( LoggerConfigKey key, Appender appender ) {
+      this.key = key;
+      this.appender = appender;
+    }
+
+    @Override
+    public void close() {
+      synchronized ( MANAGED_LOGGER_CONFIGS ) {
+        if ( closed ) {
+          return;
+        }
+        closed = true;
+
+        ManagedLoggerConfig managedLoggerConfig = MANAGED_LOGGER_CONFIGS.get( key );
+        if ( managedLoggerConfig != null ) {
+          managedLoggerConfig.removeAppender( appender );
+          if ( managedLoggerConfig.isEmpty() ) {
+            managedLoggerConfig.restore( key.loggerName );
+            MANAGED_LOGGER_CONFIGS.remove( key );
+          }
+          key.context.updateLoggers();
+        }
+      }
+    }
+  }
+
+  private static final class ManagedLoggerConfig {
+    private final Configuration configuration;
+    private final LoggerConfig loggerConfig;
+    private final boolean created;
+    private final Level previousLevel;
+    private final boolean previousAdditivity;
+    private final Map<String, Appender> appenders = new HashMap<>();
+    private final Map<String, Level> appenderLevels = new HashMap<>();
+
+    private ManagedLoggerConfig( Configuration configuration, LoggerConfig loggerConfig, boolean created,
+                                 Level previousLevel, boolean previousAdditivity ) {
+      this.configuration = configuration;
+      this.loggerConfig = loggerConfig;
+      this.created = created;
+      this.previousLevel = previousLevel;
+      this.previousAdditivity = previousAdditivity;
+    }
+
+    private void addAppender( Appender appender, Level level, Filter filter ) {
+      appender.start();
+      configuration.addAppender( appender );
+      loggerConfig.setAdditive( false );
+      loggerConfig.addAppender( appender, level, filter );
+      appenders.put( appender.getName(), appender );
+      appenderLevels.put( appender.getName(), level );
+      loggerConfig.setLevel( getEffectiveLevel() );
+    }
+
+    private void removeAppender( Appender appender ) {
+      loggerConfig.removeAppender( appender.getName() );
+      configuration.getAppenders().remove( appender.getName() );
+      appenders.remove( appender.getName() );
+      appenderLevels.remove( appender.getName() );
+      if ( !appenders.isEmpty() ) {
+        loggerConfig.setLevel( getEffectiveLevel() );
+      }
+      appender.stop();
+    }
+
+    private Level getEffectiveLevel() {
+      Level effectiveLevel = created ? null : previousLevel;
+      for ( Level appenderLevel : appenderLevels.values() ) {
+        effectiveLevel = getMostVerboseLevel( effectiveLevel, appenderLevel );
+      }
+      return effectiveLevel;
+    }
+
+    private Level getMostVerboseLevel( Level first, Level second ) {
+      if ( first == null ) {
+        return second;
+      }
+      if ( second == null ) {
+        return first;
+      }
+      return first.intLevel() >= second.intLevel() ? first : second;
+    }
+
+    private boolean isEmpty() {
+      return appenders.isEmpty();
+    }
+
+    private void restore( String loggerName ) {
+      if ( created ) {
+        configuration.removeLogger( loggerName );
+      } else {
+        loggerConfig.setLevel( previousLevel );
+        loggerConfig.setAdditive( previousAdditivity );
+      }
+    }
+  }
+
+  private static final class LoggerConfigKey {
+    private final LoggerContext context;
+    private final String loggerName;
+
+    private LoggerConfigKey( LoggerContext context, String loggerName ) {
+      this.context = context;
+      this.loggerName = loggerName;
+    }
+
+    @Override
+    public boolean equals( Object object ) {
+      if ( this == object ) {
+        return true;
+      }
+      if ( !( object instanceof LoggerConfigKey ) ) {
+        return false;
+      }
+      LoggerConfigKey other = (LoggerConfigKey) object;
+      return context == other.context && loggerName.equals( other.loggerName );
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * System.identityHashCode( context ) + loggerName.hashCode();
+    }
   }
 
   public static Appender makeAppender( String name, StringWriter sw, String layout ) {

--- a/api/src/test/java/org/pentaho/platform/api/util/LogUtilTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/util/LogUtilTest.java
@@ -1,0 +1,149 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.api.util;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LogUtilTest {
+
+  @Test
+  void addAppenderWithLevelCapturesInfoAndRestoresThePreviousConfiguration() {
+    String loggerName = "org.pentaho.test.dynamic." + UUID.randomUUID();
+    Logger logger = LogManager.getLogger( loggerName );
+    LoggerContext context = (LoggerContext) LogManager.getContext( false );
+    Configuration configuration = context.getConfiguration();
+    StringWriter output = new StringWriter();
+    Appender appender = LogUtil.makeAppender( loggerName + ".appender", output, "%m" );
+
+    try ( LogUtil.AppenderRegistration ignored =
+            LogUtil.addAppenderWithLevel( appender, logger, Level.INFO, null ) ) {
+      logger.info( "application_123456789_0001" );
+
+      assertEquals( "application_123456789_0001", output.toString() );
+      assertEquals( Level.INFO, configuration.getLoggers().get( loggerName ).getLevel() );
+    }
+
+    assertFalse( configuration.getLoggers().containsKey( loggerName ) );
+  }
+
+  @Test
+  void addAppenderWithLevelRestoresAnExistingLoggerLevel() {
+    String loggerName = "org.pentaho.test.existing." + UUID.randomUUID();
+    LoggerContext context = (LoggerContext) LogManager.getContext( false );
+    Configuration configuration = context.getConfiguration();
+    LoggerConfig loggerConfig = new LoggerConfig( loggerName, Level.ERROR, true );
+    configuration.addLogger( loggerName, loggerConfig );
+    context.updateLoggers();
+
+    Appender appender = LogUtil.makeAppender( loggerName + ".appender", new StringWriter(), "%m" );
+    try ( LogUtil.AppenderRegistration ignored =
+            LogUtil.addAppenderWithLevel( appender, LogManager.getLogger( loggerName ), Level.INFO, null ) ) {
+      assertEquals( Level.INFO, loggerConfig.getLevel() );
+      assertFalse( loggerConfig.isAdditive() );
+    }
+
+    try {
+      assertEquals( Level.ERROR, loggerConfig.getLevel() );
+      assertTrue( loggerConfig.isAdditive() );
+    } finally {
+      configuration.removeLogger( loggerName );
+      context.updateLoggers();
+    }
+  }
+
+  @Test
+  void addAppenderWithLevelRestoresAnExistingLoggerOnlyAfterTheLastRegistrationCloses() {
+    String loggerName = "org.pentaho.test.overlapping." + UUID.randomUUID();
+    LoggerContext context = (LoggerContext) LogManager.getContext( false );
+    Configuration configuration = context.getConfiguration();
+    LoggerConfig loggerConfig = new LoggerConfig( loggerName, Level.ERROR, true );
+    configuration.addLogger( loggerName, loggerConfig );
+    context.updateLoggers();
+
+    Appender firstAppender = LogUtil.makeAppender( loggerName + ".first", new StringWriter(), "%m" );
+    Appender secondAppender = LogUtil.makeAppender( loggerName + ".second", new StringWriter(), "%m" );
+    LogUtil.AppenderRegistration firstRegistration =
+      LogUtil.addAppenderWithLevel( firstAppender, LogManager.getLogger( loggerName ), Level.DEBUG, null );
+    LogUtil.AppenderRegistration secondRegistration =
+      LogUtil.addAppenderWithLevel( secondAppender, LogManager.getLogger( loggerName ), Level.INFO, null );
+
+    try {
+      assertEquals( Level.DEBUG, loggerConfig.getLevel() );
+
+      firstRegistration.close();
+
+      assertEquals( Level.INFO, loggerConfig.getLevel() );
+      assertFalse( loggerConfig.isAdditive() );
+
+      secondRegistration.close();
+
+      assertEquals( Level.ERROR, loggerConfig.getLevel() );
+      assertTrue( loggerConfig.isAdditive() );
+    } finally {
+      firstRegistration.close();
+      secondRegistration.close();
+      configuration.removeLogger( loggerName );
+      context.updateLoggers();
+    }
+  }
+
+  @Test
+  void addAppenderWithLevelDoesNotPropagateToParentAppenders() {
+    String parentLoggerName = "org.pentaho.test.parent." + UUID.randomUUID();
+    String loggerName = parentLoggerName + ".child";
+    LoggerContext context = (LoggerContext) LogManager.getContext( false );
+    Configuration configuration = context.getConfiguration();
+    LoggerConfig parentLoggerConfig = new LoggerConfig( parentLoggerName, Level.INFO, true );
+    StringWriter parentOutput = new StringWriter();
+    Appender parentAppender = LogUtil.makeAppender( parentLoggerName + ".appender", parentOutput, "%m" );
+    parentAppender.start();
+    configuration.addAppender( parentAppender );
+    parentLoggerConfig.addAppender( parentAppender, Level.INFO, null );
+    configuration.addLogger( parentLoggerName, parentLoggerConfig );
+    context.updateLoggers();
+
+    StringWriter childOutput = new StringWriter();
+    Appender childAppender = LogUtil.makeAppender( loggerName + ".appender", childOutput, "%m" );
+    Logger logger = LogManager.getLogger( loggerName );
+
+    try ( LogUtil.AppenderRegistration ignored =
+            LogUtil.addAppenderWithLevel( childAppender, logger, Level.INFO, null ) ) {
+      logger.info( "application_123456789_0002" );
+
+      assertEquals( "application_123456789_0002", childOutput.toString() );
+      assertEquals( "", parentOutput.toString() );
+      assertFalse( configuration.getLoggers().get( loggerName ).isAdditive() );
+    } finally {
+      configuration.removeLogger( parentLoggerName );
+      configuration.getAppenders().remove( parentAppender.getName() );
+      parentAppender.stop();
+      context.updateLoggers();
+    }
+
+    assertTrue( parentLoggerConfig.isAdditive() );
+  }
+}


### PR DESCRIPTION
Enable temporary filtered appenders with different log level, restoring the previous logger configuration after the final registration closes.