### PR TITLE
chore[SP-7434]: Reallow XAction Parameters

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
@@ -92,3 +92,9 @@ cors-requests-allow-credentials=true
 
 # Exposed response HTTP headers for all cross-origin requests:
 cors-requests-exposed-headers=
+
+# XAction Parameters requires the use of Saxon extension functions used by XSL stylesheets.
+# These capabilities are disabled by default in order to avoid potential security vulnerabilities.
+# Set this to true only if you have a specific need for XAction Parameters and understand
+# the security implications.
+allowXActionParameters=false

--- a/assemblies/pentaho-war/src/main/webapp/js/parameters.js
+++ b/assemblies/pentaho-war/src/main/webapp/js/parameters.js
@@ -288,7 +288,6 @@ function doRun( id, baseUrl, target, background ) {
 	// change this URL to point to another machine if required...
 	// ----------------------------------------------------------
 	var submitUrl = baseUrl;
-	// delete line? var action = submitUrl;
 	var formCheck = false;
 	try {
 		formCheck = doFormCheck( id );
@@ -305,12 +304,8 @@ function doRun( id, baseUrl, target, background ) {
 		
 		var params = window.getParams();
 		var json = {};
-		json.inputFile = params['path']; // createPath(params['solution'], params['path'], params['action']);
-		
-		// delete params['solution'];
-		// delete params['path'];
-		// delete params['action'];
-		
+		json.inputFile = params['path'];
+
 		json.outputFile = null;
 		json.simpleJobTrigger = {repeatInterval:0, repeatCount:0, startTime:null, endTime:null};
 		json.jobParameters = getParamEntries(params);
@@ -478,7 +473,6 @@ function getParameters( id ) {
       return params;
     }
 }
-
 
 function closeMantleTab(){
   try{

--- a/assemblies/pentaho-war/src/main/webapp/js/parameters.js
+++ b/assemblies/pentaho-war/src/main/webapp/js/parameters.js
@@ -280,8 +280,6 @@ function doPost( url, query, func) {
   // submit the request
   http_request.open('POST', url, true);
   http_request.setRequestHeader("Content-type", "application/json");
-  http_request.setRequestHeader("Content-length", query.length);
-  http_request.setRequestHeader("Connection", "close");
   http_request.send(query);
 }
 
@@ -329,7 +327,7 @@ function doRun( id, baseUrl, target, background ) {
 		return false;
 	}
 	// this is set in the xsl file
-	if (!USEPOSTFORFORMS) {
+	if (typeof USEPOSTFORFORMS === "undefined" || !USEPOSTFORFORMS) {
 		submitUrl += params;
 		return executeAction(target, submitUrl);
 	} else {

--- a/assemblies/pentaho-war/src/main/webapp/js/subscription.js
+++ b/assemblies/pentaho-war/src/main/webapp/js/subscription.js
@@ -77,7 +77,6 @@ function doParameterFormDisplay( id ) {
 					}
 				}
 				alert(destMsg);
-				// subsMsgObj.value = '';
 			}
 		} catch (ignored) {
 		}
@@ -300,8 +299,6 @@ function doSave( id, url, createNew ) {
 		form.elements['_PENTAHO_ADDITIONAL_PARAMS_'].value = submitUrl;
 
 		form.elements['subscribe'].value = 'save';
-		// document.location.href=submitUrl;
-		// return false;
 		form.target = '';
 		form.action = url;
 		form.submit();
@@ -430,7 +427,6 @@ function doSubscribedArchive( id, actionUrl ) {
 	
 		var name= document.getElementById('subscription-archive'+id).value;
 		form.elements['subscribe-name'].value = name;
-		// submitUrl += '&subscribe-name='+escape(name);
 		form.action = formAction;
 		form.target = target;
 		form.submit();

--- a/assemblies/pentaho-war/src/main/webapp/js/subscription.js
+++ b/assemblies/pentaho-war/src/main/webapp/js/subscription.js
@@ -130,7 +130,7 @@ function doCancelScheduling( id, cancelEditing) {
 		var form = document.forms['form_'+id];
 		var form2 = document.forms['save_form_'+id];
 		doClearEditingFields(form, form2);
-		if (USEPOSTFORFORMS) {
+		if (typeof USEPOSTFORFORMS !== "undefined" && USEPOSTFORFORMS) {
 			if (cancelEditing) {
 				form2.target = '';
 				form2.submit();
@@ -201,7 +201,7 @@ function modifyURL(url, appendStr) {
 function doSave( id, url, createNew ) {
 	var submitUrl = null;
 
-	if (!USEPOSTFORFORMS) {
+	if (typeof USEPOSTFORFORMS === "undefined" || !USEPOSTFORFORMS) {
 		submitUrl = modifyURL(url, 'subscribe=save');
 	} else {
 		submitUrl = url;
@@ -235,7 +235,7 @@ function doSave( id, url, createNew ) {
 		var element = form.elements[ n ];
 		if( (element.type == 'checkbox') && (element.id.indexOf( 'schedule-' ) == 0 ) && (element.checked == true) ) {
 			hasSchedules = true;
-			if (!USEPOSTFORFORMS) {
+			if (typeof USEPOSTFORFORMS === "undefined" || !USEPOSTFORFORMS) {
 				submitUrl += '&'+element.id+'=true';
 			} else {
 				break;
@@ -284,7 +284,7 @@ function doSave( id, url, createNew ) {
 		}
 	}
 
-	if (!USEPOSTFORFORMS) {
+	if (typeof USEPOSTFORFORMS === "undefined" || !USEPOSTFORFORMS) {
 		submitUrl += '&subscribe-name='+escape(name);		
 		submitUrl += '&destination='+escape(destination);
 		document.location.href=submitUrl;
@@ -318,7 +318,7 @@ function doSubscribed(id, actionUrl, displayUrl ) {
 	var target='REPORTWINDOW';
 	var options = '';
 	var form = document.forms['save_form_'+id];
-	if (!USEPOSTFORFORMS) {
+	if (typeof USEPOSTFORFORMS === "undefined" || !USEPOSTFORFORMS) {
 
 		if( action == 'run' ) {
 			submitUrl += actionUrl + 'subscribe=run';
@@ -379,12 +379,11 @@ function doSubscribed(id, actionUrl, displayUrl ) {
 			eval(mthName);
 		} catch (ignored) {
 		}
-
-	}	
+	}
 }
 
 function doSubscribedArchive( id, actionUrl ) {
-	if (!USEPOSTFORFORMS) {
+	if (typeof USEPOSTFORFORMS === "undefined" || !USEPOSTFORFORMS) {
  		var submitUrl = '';
 		var action= document.getElementById('subscription-archive-action'+id).value;
 		var target='REPORTWINDOW';

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -639,6 +639,10 @@
       <version>${mockito-core.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>net.sf.saxon</groupId>
+      <artifactId>Saxon-HE</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/core/src/main/java/org/pentaho/platform/util/xml/XMLParserFactoryProducer.java
+++ b/core/src/main/java/org/pentaho/platform/util/xml/XMLParserFactoryProducer.java
@@ -37,9 +37,9 @@ public class XMLParserFactoryProducer {
   private static Configuration saxonConfig = new Configuration();
 
   /**
-   * Creates an instance of {@link DocumentBuilderFactory} class
-   * with enabled {@link XMLConstants#FEATURE_SECURE_PROCESSING} property.
-   * Enabling this feature prevents from some XXE attacks (e.g. XML bomb)
+   * Creates an instance of {@link DocumentBuilderFactory} class with enabled
+   * {@link XMLConstants#FEATURE_SECURE_PROCESSING} property.
+   * Enabling this feature prevents from some XXE attacks (e.g. XML bomb).
    * See PPP-3506 for more details.
    *
    * @throws ParserConfigurationException if feature can't be enabled
@@ -54,21 +54,17 @@ public class XMLParserFactoryProducer {
   }
 
   /**
-   * Creates an instance of {@link SAXParserFactory} class with enabled {@link XMLConstants#FEATURE_SECURE_PROCESSING} property.
-   * Enabling this feature prevents from some XXE attacks (e.g. XML bomb)
+   * Creates an instance of {@link SAXParserFactory} class with enabled
+   * {@link XMLConstants#FEATURE_SECURE_PROCESSING} property.
+   * Enabling this feature prevents from some XXE attacks (e.g. XML bomb).
    *
-   * @throws ParserConfigurationException if a parser cannot
-   *     be created which satisfies the requested configuration.
-   *
-   * @throws SAXNotRecognizedException When the underlying XMLReader does
-   *            not recognize the property name.
-   *
-   * @throws SAXNotSupportedException When the underlying XMLReader
-   *            recognizes the property name but doesn't support the
-   *            property.
+   * @throws ParserConfigurationException if a parser cannot be created which satisfies the requested configuration.
+   * @throws SAXNotRecognizedException    When the underlying XMLReader does not recognize the property name.
+   * @throws SAXNotSupportedException     When the underlying XMLReader recognizes the property name but doesn't
+   *                                      support the property.
    */
   public static SAXParserFactory createSecureSAXParserFactory()
-          throws SAXNotSupportedException, SAXNotRecognizedException, ParserConfigurationException {
+    throws SAXNotSupportedException, SAXNotRecognizedException, ParserConfigurationException {
     SAXParserFactory factory = SAXParserFactory.newInstance();
     factory.setFeature( XMLConstants.FEATURE_SECURE_PROCESSING, true );
     factory.setFeature( "http://xml.org/sax/features/external-general-entities", false );
@@ -106,7 +102,7 @@ public class XMLParserFactoryProducer {
 
   /**
    * Sets the Saxon configuration object to be used by this class to create instances of {@link TransformerFactory}.
-   * a {@code null} value will reset the configuration to a new instance of {@link Configuration}
+   * A {@code null} value will reset the configuration to a new instance of {@link Configuration}
    */
   public static void setSaxonConfig( Configuration config ) {
     saxonConfig = Objects.requireNonNullElseGet( config, Configuration::new );

--- a/core/src/main/java/org/pentaho/platform/util/xml/XMLParserFactoryProducer.java
+++ b/core/src/main/java/org/pentaho/platform/util/xml/XMLParserFactoryProducer.java
@@ -13,6 +13,7 @@
 
 package org.pentaho.platform.util.xml;
 
+import net.sf.saxon.Configuration;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dom4j.io.SAXReader;
@@ -25,10 +26,16 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import java.util.Objects;
 
 public class XMLParserFactoryProducer {
 
   private static final Log logger = LogFactory.getLog( XMLParserFactoryProducer.class );
+
+  private static Configuration saxonConfig = new Configuration();
+
   /**
    * Creates an instance of {@link DocumentBuilderFactory} class
    * with enabled {@link XMLConstants#FEATURE_SECURE_PROCESSING} property.
@@ -86,5 +93,70 @@ public class XMLParserFactoryProducer {
     reader.setIncludeExternalDTDDeclarations( false );
     reader.setIncludeInternalDTDDeclarations( false );
     return reader;
+  }
+
+  /**
+   * Returns the Saxon configuration object being used by this class to create instances of {@link TransformerFactory}
+   *
+   * @return Saxon configuration object being used by this class to create instances of {@link TransformerFactory}
+   */
+  public static Configuration getSaxonConfig() {
+    return saxonConfig;
+  }
+
+  /**
+   * Sets the Saxon configuration object to be used by this class to create instances of {@link TransformerFactory}.
+   * a {@code null} value will reset the configuration to a new instance of {@link Configuration}
+   */
+  public static void setSaxonConfig( Configuration config ) {
+    saxonConfig = Objects.requireNonNullElseGet( config, Configuration::new );
+  }
+
+  /**
+   * Creates an instance of {@link TransformerFactory} class with enabled
+   * {@link XMLConstants#FEATURE_SECURE_PROCESSING} property.
+   *
+   * @throws TransformerConfigurationException if a TransformerFactory cannot be created which satisfies the
+   *                                           requested configuration
+   */
+  public static TransformerFactory createSecureTransformerFactory()
+    throws TransformerConfigurationException {
+    return createSecureTransformerFactory( false );
+  }
+
+  /**
+   * Creates an instance of {@link TransformerFactory} class with enabled
+   * {@link XMLConstants#FEATURE_SECURE_PROCESSING} property. Depending on {@code useConfiguration} parameter value,
+   * it may use the class' Saxon configuration object for creation
+   *
+   * @param useConfiguration if this class' Saxon configuration object is to be used when creating the factory
+   * @throws TransformerConfigurationException if a TransformerFactory cannot be created which satisfies the
+   *                                           requested configuration
+   */
+  public static TransformerFactory createSecureTransformerFactory( boolean useConfiguration )
+    throws TransformerConfigurationException {
+    return createSecureTransformerFactory( useConfiguration ? saxonConfig : null );
+  }
+
+  /**
+   * Creates an instance of {@link TransformerFactory} class with enabled
+   * {@link XMLConstants#FEATURE_SECURE_PROCESSING} property or using this class' Saxon configuration object
+   *
+   * @param config Saxon configuration to use, or null to use default TransformerFactory implementation
+   * @throws TransformerConfigurationException if a TransformerFactory cannot be created which satisfies the
+   *                                           requested configuration
+   */
+  public static TransformerFactory createSecureTransformerFactory( Configuration config )
+    throws TransformerConfigurationException {
+    TransformerFactory transformerFactory = null;
+
+    if ( config == null ) {
+      transformerFactory = TransformerFactory.newInstance();
+      transformerFactory.setFeature( XMLConstants.FEATURE_SECURE_PROCESSING, true );
+    } else {
+      transformerFactory = new net.sf.saxon.jaxp.SaxonTransformerFactory( config );
+    }
+
+    return transformerFactory;
   }
 }

--- a/core/src/main/java/org/pentaho/platform/util/xml/XmlHelper.java
+++ b/core/src/main/java/org/pentaho/platform/util/xml/XmlHelper.java
@@ -151,13 +151,12 @@ public class XmlHelper {
       throw new UnsupportedOperationException( Messages.getInstance().getErrorString( "XMLUTL.ERROR_0012_DATA_TYPE", obj //$NON-NLS-1$
           .getClass().getName() ) );
     }
-
   }
 
   public static void decode( final String[] strings ) {
     if ( strings != null ) {
       for ( int i = 0; i < strings.length; ++i ) {
-        strings[i] = XmlHelper.decode( strings[i] );
+        strings[ i ] = XmlHelper.decode( strings[ i ] );
       }
     }
   }
@@ -165,11 +164,11 @@ public class XmlHelper {
   public static String decode( String string ) {
     // TODO replace this is a more robust encoder
     if ( string != null ) {
-      string = string.replaceAll( "&lt;", "<" ) //$NON-NLS-1$ //$NON-NLS-2$
-          .replaceAll( "&gt;", ">" ) //$NON-NLS-1$ //$NON-NLS-2$
-          .replaceAll( "&apos;", "'" ) //$NON-NLS-1$ //$NON-NLS-2$
-          .replaceAll( "&quot;", "\"" ) //$NON-NLS-1$ //$NON-NLS-2$
-          .replaceAll( "&amp;", "&" ); //$NON-NLS-1$ //$NON-NLS-2$ // DO THE & LAST!!!!
+      string = string.replace( "&lt;", "<" )
+          .replace( "&gt;", ">" )
+          .replace( "&apos;", "'" )
+          .replace( "&quot;", "\"" )
+          .replace( "&amp;", "&" ); // DO THE & LAST!!!!
     }
     return string;
   }
@@ -183,30 +182,23 @@ public class XmlHelper {
   }
 
   public static String encode( final String string ) {
-
     return StringEscapeUtils.escapeXml( string );
   }
 
   private static final int BUFF_SIZE = 512;
 
   public static String getEncoding( final File f ) throws IOException {
-    char[] cbuf = new char[XmlHelper.BUFF_SIZE];
-    Reader rdr = null;
-    try {
-      rdr = new FileReader( f );
-      rdr.read( cbuf );
-    } finally {
-      if ( rdr != null ) {
-        rdr.close();
-      }
+    char[] cBuff = new char[XmlHelper.BUFF_SIZE];
+
+    try ( Reader rdr = new FileReader( f ) ) {
+      rdr.read( cBuff );
     }
-    String strEnc = String.valueOf( cbuf );
-    return XmlHelper.getEncoding( strEnc );
+
+    return XmlHelper.getEncoding( String.valueOf( cBuff ) );
   }
 
   public static String getEncoding( final InputStream inStream ) throws IOException {
-    String encodingPI = XmlHelper.readEncodingProcessingInstruction( inStream );
-    return XmlHelper.getEncoding( encodingPI );
+    return XmlHelper.getEncoding( XmlHelper.readEncodingProcessingInstruction( inStream ) );
   }
 
   /**
@@ -214,8 +206,8 @@ public class XmlHelper {
    * Otherwise, return null.
    * 
    * @param xml
-   *          String containing the xml
-   * @return String containing the character encoding in the xml processing instruction if it exists, else null.
+   *          String containing the XML
+   * @return String containing the character encoding in the XML processing instruction if it exists, else null.
    */
   public static String getEncoding( final String xml ) {
     Matcher m = XmlHelper.RE_ENCODING.matcher( xml );
@@ -228,15 +220,15 @@ public class XmlHelper {
   }
 
   /**
-   * Find the character encoding specification in the xml String. If it exists, return the character encoding.
+   * Find the character encoding specification in the XML String. If it exists, return the character encoding.
    * Otherwise, return the system encoding.
    * 
    * @param xml
-   *          String containing the xml
+   *          String containing the XML
    * @param defaultEncoding
-   *          Encoding to use if there is no encoding in the xml document
-   * @return String containing the character encoding in the xml processing instruction, or defaultEncoding if there is
-   *         no encoding in the xml document. If defaultEncoding is also null, then it returns the value in
+   *          Encoding to use if there is no encoding in the XML document
+   * @return String containing the character encoding in the XML processing instruction, or defaultEncoding if there is
+   *         no encoding in the XML document. If defaultEncoding is also null, then it returns the value in
    *         LocaleHelper.getSystemEncoding(). if it exists, else the system encoding.
    */
   public static String getEncoding( final String xml, final String defaultEncoding ) {
@@ -282,9 +274,9 @@ public class XmlHelper {
    * document.
    * 
    * @param xslName
-   *          String containing the name of a file in the repository containing the xsl transform
+   *          String containing the name of a file in the repository containing the XSL transform
    * @param xslPath
-   *          String containing the path to the file identifyied by <code>xslName</code>
+   *          String containing the path to the file identified by <code>xslName</code>
    * @param uri
    *          String containing the URI of a resource containing the document to be transformed
    * @param params
@@ -296,7 +288,7 @@ public class XmlHelper {
    * @throws TransformerException
    *           If attempt to transform the document fails.
    */
-  public static final StringBuffer transformXml( final String xslName, final String xslPath, final String strDocument,
+  public static StringBuffer transformXml( final String xslName, final String xslPath, final String strDocument,
       final Map params, final IDocumentResourceLoader loader ) throws TransformerException {
     InputStream inStrm = null;
     try {
@@ -318,10 +310,10 @@ public class XmlHelper {
    * Use the transform specified by xslPath and xslName and transform the document specified by docInStrm, and return
    * the resulting document.
    * 
-   * @param xslSrc
-   *          StreamSrc containing the xsl transform
-   * @param docSrc
-   *          StreamSrc containing the document to be transformed
+   * @param xslName
+   *          String containing the name of a file in the repository containing the XSL transform
+   * @param xslPath
+   *          String containing the path to the file identified by <code>xslName</code>
    * @param params
    *          Map of properties to set on the transform
    * @param session
@@ -332,7 +324,7 @@ public class XmlHelper {
    *           If attempt to transform the document fails.
    */
   @SuppressWarnings( { "unchecked" } )
-  public static final StringBuffer transformXml( final String xslName, final String xslPath,
+  public static StringBuffer transformXml( final String xslName, final String xslPath,
       final InputStream docInStrm, Map params, final IDocumentResourceLoader loader ) throws TransformerException {
     StringBuffer result = null;
 
@@ -344,7 +336,6 @@ public class XmlHelper {
       Logger.error( XmlHelper.class.getName(), Messages.getInstance().getErrorString(
           "XmlHelper.ERROR_0004_NULL_DOCUMENT" ) ); //$NON-NLS-1$
     } else {
-
       // at this point, we have both of our InputStreams
 
       // Add encoding for any xsl that may set/use it
@@ -371,7 +362,7 @@ public class XmlHelper {
    * document.
    * 
    * @param xslInStream
-   *          InputStream containing the xsl transform
+   *          InputStream containing the XSL transform
    * @param docInStrm
    *          InputStream containing the document to be transformed
    * @param params
@@ -385,7 +376,7 @@ public class XmlHelper {
    * @throws TransformerException
    *           if actual transform fails.
    */
-  public static final StringBuffer transformXml( final InputStream xslInStream, final InputStream docInStrm,
+  public static StringBuffer transformXml( final InputStream xslInStream, final InputStream docInStrm,
       final Map params, final URIResolver resolver ) throws TransformerConfigurationException, TransformerException {
 
     StreamSource xslSrc = new StreamSource( xslInStream );
@@ -398,7 +389,7 @@ public class XmlHelper {
    * document.
    * 
    * @param xslSrc
-   *          StreamSrc containing the xsl transform
+   *          StreamSrc containing the XSL transform
    * @param docSrc
    *          StreamSrc containing the document to be transformed
    * @param params
@@ -412,21 +403,16 @@ public class XmlHelper {
    * @throws TransformerException
    *           if actual transform fails.
    */
-  protected static final StringBuffer transformXml( final StreamSource xslSrc, final StreamSource docSrc,
+  protected static StringBuffer transformXml( final StreamSource xslSrc, final StreamSource docSrc,
       final Map params, final URIResolver resolver ) throws TransformerConfigurationException, TransformerException {
 
-    StringBuffer sb = null;
-    StringWriter writer = new StringWriter();
-
-    TransformerFactory tf = TransformerFactory.newInstance();
-    tf.setAttribute( XMLConstants.ACCESS_EXTERNAL_DTD, "" );
+    TransformerFactory tf = XMLParserFactoryProducer.createSecureTransformerFactory( true );
     tf.setAttribute( XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "" );
     if ( null != resolver ) {
       tf.setURIResolver( resolver );
     }
     // TODO need to look into compiling the XSLs...
-    Transformer t = tf.newTransformer( xslSrc ); // can throw
-    // TransformerConfigurationException
+    Transformer t = tf.newTransformer( xslSrc ); // can throw TransformerConfigurationException
     // Start the transformation
     if ( params != null ) {
       for ( Map.Entry<String, String> entry : (Iterable<Map.Entry<String, String>>) params.entrySet() ) {
@@ -435,11 +421,12 @@ public class XmlHelper {
         }
       }
     }
-    t.transform( docSrc, new StreamResult( writer ) ); // can throw
-    // TransformerException
-    sb = writer.getBuffer();
 
-    return sb;
+    StringWriter writer = new StringWriter();
+
+    t.transform( docSrc, new StreamResult( writer ) ); // can throw TransformerException
+
+    return writer.getBuffer();
   }
 
   /**
@@ -484,27 +471,26 @@ public class XmlHelper {
     String fileName = fullPath;
     int dotIndex = fileName.indexOf( '.' );
     String baseName = dotIndex == -1 ? fileName : fileName.substring( 0, dotIndex ); // These two lines fix an
-                                                                                     // index out
-                                                                                     // of bounds
-    String extension = dotIndex == -1 ? "" : fileName.substring( dotIndex ); // Exception that occurs when //$NON-NLS-1$
+                                                                                     // index out of bounds
+    String extension = dotIndex == -1 ? "" : fileName.substring( dotIndex ); // Exception that occurs when
                                                                              // a filename has no extension
 
     InputStream in = null;
     try {
-      if ( !variant.equals( "" ) ) { //$NON-NLS-1$
-        in = loader.loadXsl( baseName + "_" + language + "_" + country + "_" + variant + extension ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+      if ( !variant.equals( "" ) ) {
+        in = loader.loadXsl( baseName + "_" + language + "_" + country + "_" + variant + extension );
       }
       if ( in == null ) {
-        in = loader.loadXsl( baseName + "_" + language + "_" + country + extension ); //$NON-NLS-1$//$NON-NLS-2$
+        in = loader.loadXsl( baseName + "_" + language + "_" + country + extension );
       }
       if ( in == null ) {
-        in = loader.loadXsl( baseName + "_" + language + extension ); //$NON-NLS-1$
+        in = loader.loadXsl( baseName + "_" + language + extension );
       }
       if ( in == null ) {
         in = loader.loadXsl( baseName + extension );
       }
     } catch ( Exception e ) {
-      Logger.error( XmlHelper.class.getName(), "Error loading localized file: " + fullPath ); //$NON-NLS-1$
+      Logger.error( XmlHelper.class.getName(), "Error loading localized file: " + fullPath );
     }
     return in;
   }
@@ -519,5 +505,4 @@ public class XmlHelper {
   public static String createXmlProcessingInstruction( final String version, final String encoding ) {
     return "<?xml version=\"" + version + "\" encoding = \"" + encoding + "\" ?>"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
   }
-
 }

--- a/core/src/main/java/org/pentaho/platform/util/xml/dom4j/XmlDom4JHelper.java
+++ b/core/src/main/java/org/pentaho/platform/util/xml/dom4j/XmlDom4JHelper.java
@@ -54,10 +54,10 @@ import java.util.Map;
  * text
  * 
  * Design notes: This class should never have any dependencies (i.e. imports) on anything on org.pentaho or
- * com.pentaho or their decendant packages. In general, methods in the class should not attempt to handle
- * exceptions, but should let the exceptions propogate to the caller to be handled there. Please do not use
+ * com.pentaho or their descendant packages. In general, methods in the class should not attempt to handle
+ * exceptions, but should let the exceptions propagate to the caller to be handled there. Please do not use
  * european-reuse in this class. One of the primary design goals for this class was to construct it in a way that
- * it could be used without change outside of the Pentaho platform. Related XML-helper type code that is dependant
+ * it could be used without change outside the Pentaho platform. Related XML-helper type code that is dependent
  * on the platform should be moved "up" to XmlHelper.
  */
 public class XmlDom4JHelper {
@@ -65,14 +65,14 @@ public class XmlDom4JHelper {
   private static final Log logger = LogFactory.getLog( XmlDom4JHelper.class );
 
   /**
-   * Create a <code>Document</code> from <code>str</code>.
+   * Create a {@link Document} from <code>strXml</code>.
    * 
-   * @param str
+   * @param strXml
    *          String containing the XML that will be used to create the Document
    * @param resolver
-   *          EntityResolver an instance of an EntityResolver that will resolve any external URIs. See the docs on
-   *          EntityResolver. null is an acceptable value.
-   * @return <code>Document</code> initialized with the xml in <code>strXml</code>.
+   *          an {@link EntityResolver} instance that will resolve any external URIs. See the docs on
+   *          {@link EntityResolver}. <code>null</code> is an acceptable value.
+   * @return a {@link Document} initialized with the XML in <code>strXml</code>.
    * @throws XmlParseException
    */
   public static Document getDocFromString( final String strXml, final EntityResolver resolver )
@@ -91,14 +91,14 @@ public class XmlDom4JHelper {
   }
 
   /**
-   * Create a <code>Document</code> from the contents of a file.
+   * Create a {@link Document} from the contents of a file.
    * 
-   * @param path
-   *          String containing the path to the file containing XML that will be used to create the Document.
+   * @param file
+   *          File containing XML that will be used to create the Document.
    * @param resolver
-   *          EntityResolver an instance of an EntityResolver that will resolve any external URIs. See the docs on
-   *          EntityResolver. null is an acceptable value.
-   * @return <code>Document</code> initialized with the xml in <code>strXml</code>.
+   *          an {@link EntityResolver} instance that will resolve any external URIs. See the docs on
+   *          {@link EntityResolver}. <code>null</code> is an acceptable value.
+   * @return a {@link Document} initialized with the XML in <code>strXml</code>.
    * @throws DocumentException
    *           if the document isn't valid
    * @throws IOException
@@ -111,13 +111,18 @@ public class XmlDom4JHelper {
   }
 
   /**
-   * Create a <code>Document</code> from the contents of an input stream, where the input stream contains valid
-   * XML.
-   * 
+   * Create a {@link Document} from the contents of an input stream, where the input stream contains valid XML.
+   *
    * @param inStream
-   * @return
+   *          the XML that will be used to create the Document.
+   * @param resolver
+   *          an {@link EntityResolver} instance that will resolve any external URIs. See the docs on
+   *          {@link EntityResolver}. <code>null</code> is an acceptable value.
+   * @return a {@link Document} initialized with the XML in <code>inStream</code>.
    * @throws DocumentException
+   *           if the document isn't valid
    * @throws IOException
+   *           if the file doesn't exist
    */
   public static Document getDocFromStream( final InputStream inStream, final EntityResolver resolver )
     throws DocumentException, IOException {
@@ -127,13 +132,15 @@ public class XmlDom4JHelper {
   }
 
   /**
-   * Create a <code>Document</code> from the contents of an input stream, where the input stream contains valid
-   * XML.
+   * Create a {@link Document} from the contents of an input stream, where the input stream contains valid XML.
    * 
    * @param inStream
-   * @return
+   *          the XML that will be used to create the Document.
+   * @return a {@link Document} initialized with the XML in <code>inStream</code>.
    * @throws DocumentException
+   *           if the document isn't valid
    * @throws IOException
+   *           if the file doesn't exist
    */
   public static Document getDocFromStream( final InputStream inStream ) throws DocumentException, IOException {
 
@@ -141,11 +148,11 @@ public class XmlDom4JHelper {
   }
 
   /**
-   * Use the transform specified by xslSrc and transform the document specified by docSrc, and return the resulting
-   * document.
+   * Use the transform specified by <code>xslSrc</code> and transform the document specified by <code>docSrc</code>,
+   * and return the resulting document.
    * 
    * @param xslSrc
-   *          StreamSrc containing the xsl transform
+   *          StreamSrc containing the XSL transform
    * @param docSrc
    *          StreamSrc containing the document to be transformed
    * @param params
@@ -159,22 +166,17 @@ public class XmlDom4JHelper {
    * @throws TransformerException
    *           if actual transform fails.
    */
-  protected static final StringBuffer transformXml( final StreamSource xslSrc, final StreamSource docSrc,
+  protected static StringBuffer transformXml( final StreamSource xslSrc, final StreamSource docSrc,
       final Map params, final URIResolver resolver ) throws TransformerConfigurationException, TransformerException {
 
-    StringBuffer sb = null;
-    StringWriter writer = new StringWriter();
-
-    TransformerFactory tf = TransformerFactory.newInstance();
-    tf.setFeature( XMLConstants.FEATURE_SECURE_PROCESSING, true );
+    TransformerFactory tf = XMLParserFactoryProducer.createSecureTransformerFactory( );
     tf.setAttribute( XMLConstants.ACCESS_EXTERNAL_DTD, "" );
     tf.setAttribute( XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "" );
     if ( null != resolver ) {
       tf.setURIResolver( resolver );
     }
     // TODO need to look into compiling the XSLs...
-    Transformer t = tf.newTransformer( xslSrc ); // can throw
-    // TransformerConfigurationException
+    Transformer t = tf.newTransformer( xslSrc ); // can throw TransformerConfigurationException
     // Start the transformation
     if ( params != null ) {
       for ( Map.Entry<String, String> entry : (Iterable<Map.Entry<String, String>>) params.entrySet() ) {
@@ -183,11 +185,8 @@ public class XmlDom4JHelper {
         }
       }
     }
-    t.transform( docSrc, new StreamResult( writer ) ); // can throw
-    // TransformerException
-    sb = writer.getBuffer();
 
-    return sb;
+    return transformSource( t, docSrc );
   }
 
   /**
@@ -204,25 +203,34 @@ public class XmlDom4JHelper {
    * @throws TransformerException
    *           If the attempt to transform the document fails.
    */
-  public static final StringBuffer docToString( final org.w3c.dom.Document doc )
+  public static StringBuffer docToString( final org.w3c.dom.Document doc )
     throws TransformerConfigurationException, TransformerException {
 
-    StringBuffer sb = null;
-    StringWriter writer = new StringWriter();
-
-    TransformerFactory tf = TransformerFactory.newInstance();
-    tf.setFeature( XMLConstants.FEATURE_SECURE_PROCESSING, true );
+    TransformerFactory tf = XMLParserFactoryProducer.createSecureTransformerFactory( );
     tf.setAttribute( XMLConstants.ACCESS_EXTERNAL_DTD, "" );
     tf.setAttribute( XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "" );
-    Transformer t = tf.newTransformer(); // can throw
-    // TransformerConfigurationException
+    Transformer t = tf.newTransformer(); // can throw TransformerConfigurationException
 
-    Source docSrc = new DOMSource( doc );
-    t.transform( docSrc, new StreamResult( writer ) ); // can throw
-    // TransformerException
-    sb = writer.getBuffer();
+    return transformSource( t, new DOMSource( doc ) );
+  }
 
-    return sb;
+  /**
+   * Transform the XML {@link Source} using the given {@link Transformer} instance, returning the result as a
+   * {@link StringBuffer}.
+   *
+   * @param t
+   *          the {@link Transformer} instance to use to transform the
+   * @param docSrc
+   *          the XML input to transform.
+   * @return a {@link StringBuffer} containing the XML results of the transform.
+   * @throws TransformerException if an unrecoverable error occurs during the course of the transformation.
+   */
+  private static StringBuffer transformSource( Transformer t, Source docSrc ) throws TransformerException {
+    StringWriter writer = new StringWriter();
+
+    t.transform( docSrc, new StreamResult( writer ) ); // can throw TransformerException
+
+    return writer.getBuffer();
   }
 
   // TODO sbarkdull, this code is duplicated in LocaleHelper
@@ -240,9 +248,9 @@ public class XmlDom4JHelper {
     for ( int n = 0; n < rawValue.length(); n++ ) {
       int charValue = rawValue.charAt( n );
       if ( charValue >= 0x80 ) {
-        value.append( "&#x" ); //$NON-NLS-1$
+        value.append( "&#x" );
         value.append( Integer.toString( charValue, 0x10 ) );
-        value.append( ";" ); //$NON-NLS-1$
+        value.append( ';' );
       } else {
         value.append( (char) charValue );
       }
@@ -348,8 +356,7 @@ public class XmlDom4JHelper {
     DocumentException {
     DOMSource source = new DOMSource( doc );
     StreamResult result = new StreamResult( new StringWriter() );
-    TransformerFactory tf = TransformerFactory.newInstance();
-    tf.setFeature( XMLConstants.FEATURE_SECURE_PROCESSING, true );
+    TransformerFactory tf = XMLParserFactoryProducer.createSecureTransformerFactory( );
     tf.setAttribute( XMLConstants.ACCESS_EXTERNAL_DTD, "" );
     tf.setAttribute( XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "" );
     tf.newTransformer().transform( source, result );

--- a/core/src/test/java/org/pentaho/platform/util/BogusXactionSaxonExtensions.java
+++ b/core/src/test/java/org/pentaho/platform/util/BogusXactionSaxonExtensions.java
@@ -1,0 +1,166 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2028-08-13
+ ******************************************************************************/
+
+package org.pentaho.platform.util;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.lib.ExtensionFunctionCall;
+import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.Sequence;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.trans.XPathException;
+import net.sf.saxon.value.SequenceType;
+import net.sf.saxon.value.StringValue;
+
+/**
+ * Bogus version of XactionSaxonExtensions for unit testing.
+ * <p>
+ * This class provides the same 3 Saxon extension functions as XactionSaxonExtensions
+ * but with no external dependencies. It returns hardcoded/dummy values suitable for
+ * testing XSL transformations without requiring actual message bundles or locale helpers.
+ * <p>
+ * This is useful when testing in modules that don't depend on the full extensions module
+ * or when the actual message bundles are not available.
+ */
+public class BogusXactionSaxonExtensions {
+  private static final String MSG_NAMESPACE = "org.pentaho.platform.util.messages.Messages";
+  private static final String LOC_NAMESPACE = "org.pentaho.platform.util.messages.LocaleHelper";
+
+  /**
+   * BOGUS VERSION for:
+   * <b>msg:getInstance()</b><br>
+   * Namespace: org.pentaho.platform.util.messages.Messages<br>
+   * XSL usage: <code>&lt;xsl:variable name="messages" select="msg:getInstance()" /&gt;</code>
+   */
+  public static class MsgGetInstance extends ExtensionFunctionDefinition {
+    @Override public StructuredQName getFunctionQName() {
+      return new StructuredQName( "msg", MSG_NAMESPACE, "getInstance" );
+    }
+
+    @Override public SequenceType[] getArgumentTypes() {
+      return new SequenceType[ 0 ];
+    }
+
+    @Override public SequenceType getResultType( SequenceType[] suppliedArgumentTypes ) {
+      return SequenceType.SINGLE_STRING;
+    }
+
+    @Override public ExtensionFunctionCall makeCallExpression() {
+      return new ExtensionFunctionCall() {
+        @Override public Sequence call( XPathContext context, Sequence[] arguments ) throws XPathException {
+          // Sentinel value — the actual Messages instance is resolved inside getXslString below
+          return StringValue.makeStringValue( "__MSG_INSTANCE__" );
+        }
+      };
+    }
+  }
+
+  /**
+   * BOGUS VERSION for:
+   * <b>msg:getXslString(messages, key)</b><br>
+   * Namespace: org.pentaho.platform.util.messages.Messages<br>
+   * XSL usage: <code>msg:getXslString($messages, 'UI.SOME_KEY')</code>
+   */
+  public static class MsgGetXslString extends ExtensionFunctionDefinition {
+    @Override public StructuredQName getFunctionQName() {
+      return new StructuredQName( "msg", MSG_NAMESPACE, "getXslString" );
+    }
+
+    @Override public SequenceType[] getArgumentTypes() {
+      return new SequenceType[] { SequenceType.SINGLE_STRING, SequenceType.SINGLE_STRING };
+    }
+
+    @Override public SequenceType getResultType( SequenceType[] suppliedArgumentTypes ) {
+      return SequenceType.SINGLE_STRING;
+    }
+
+    @Override public ExtensionFunctionCall makeCallExpression() {
+      return new ExtensionFunctionCall() {
+        @Override public Sequence call( XPathContext context, Sequence[] arguments ) throws XPathException {
+          String key = arguments[ 1 ].head().getStringValue();
+          return StringValue.makeStringValue( "[msg:getXslString(_, " + key + ")]" );
+        }
+      };
+    }
+  }
+
+  /**
+   * BOGUS VERSION for:
+   * <b>msg:getString(messages, key)</b><br>
+   * Namespace: org.pentaho.platform.util.messages.Messages<br>
+   * XSL usage: <code>msg:getString($messages, 'UI.USER_UPDATE')</code>
+   */
+  public static class MsgGetString extends ExtensionFunctionDefinition {
+    @Override public StructuredQName getFunctionQName() {
+      return new StructuredQName( "msg", MSG_NAMESPACE, "getString" );
+    }
+
+    @Override public SequenceType[] getArgumentTypes() {
+      return new SequenceType[] { SequenceType.SINGLE_STRING, SequenceType.SINGLE_STRING };
+    }
+
+    @Override public SequenceType getResultType( SequenceType[] suppliedArgumentTypes ) {
+      return SequenceType.SINGLE_STRING;
+    }
+
+    @Override public ExtensionFunctionCall makeCallExpression() {
+      return new ExtensionFunctionCall() {
+        @Override public Sequence call( XPathContext context, Sequence[] arguments ) throws XPathException {
+          String key = arguments[ 1 ].head().getStringValue();
+          return StringValue.makeStringValue( "[msg:getString(_, " + key + ")]" );
+        }
+      };
+    }
+  }
+
+  /**
+   * BOGUS VERSION for:
+   * <b>loc:getTextDirection()</b><br>
+   * Namespace: org.pentaho.platform.util.messages.LocaleHelper<br>
+   * XSL usage: <code>&lt;xsl:value-of select="loc:getTextDirection()"/&gt;</code>
+   */
+  public static class LocGetTextDirection extends ExtensionFunctionDefinition {
+    @Override public StructuredQName getFunctionQName() {
+      return new StructuredQName( "loc", LOC_NAMESPACE, "getTextDirection" );
+    }
+
+    @Override public SequenceType[] getArgumentTypes() {
+      return new SequenceType[ 0 ];
+    }
+
+    @Override public SequenceType getResultType( SequenceType[] suppliedArgumentTypes ) {
+      return SequenceType.SINGLE_STRING;
+    }
+
+    @Override public ExtensionFunctionCall makeCallExpression() {
+      return new ExtensionFunctionCall() {
+        @Override public Sequence call( XPathContext context, Sequence[] arguments ) throws XPathException {
+          return StringValue.makeStringValue( "[loc:getTextDirection()]" );
+        }
+      };
+    }
+  }
+
+  /**
+   * Register all 3 bogus extension functions into a Saxon Configuration.
+   *
+   * @param config the Saxon Configuration to register the functions with
+   */
+  public static void registerAll( Configuration config ) {
+    config.registerExtensionFunction( new MsgGetInstance() );
+    config.registerExtensionFunction( new MsgGetXslString() );
+    config.registerExtensionFunction( new MsgGetString() );
+    config.registerExtensionFunction( new LocGetTextDirection() );
+  }
+}
+

--- a/core/src/test/java/org/pentaho/platform/util/BogusXactionSaxonExtensions.java
+++ b/core/src/test/java/org/pentaho/platform/util/BogusXactionSaxonExtensions.java
@@ -163,4 +163,3 @@ public class BogusXactionSaxonExtensions {
     config.registerExtensionFunction( new LocGetTextDirection() );
   }
 }
-

--- a/core/src/test/java/org/pentaho/platform/util/TestAll.java
+++ b/core/src/test/java/org/pentaho/platform/util/TestAll.java
@@ -39,7 +39,6 @@ public class TestAll {
     suite.addTestSuite( PasswordServiceTest.class );
     suite.addTestSuite( PentahoSystemExceptionTest.class );
     suite.addTestSuite( VersionHelperTest.class );
-    suite.addTestSuite( XmlHelperTest.class );
 
     return suite;
   }

--- a/core/src/test/java/org/pentaho/platform/util/XmlHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/XmlHelperTest.java
@@ -13,71 +13,88 @@
 
 package org.pentaho.platform.util;
 
+import net.sf.saxon.Configuration;
+import org.apache.commons.lang.StringUtils;
+import org.dom4j.Document;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.tree.DefaultElement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.pentaho.platform.api.util.XmlParseException;
+import org.pentaho.platform.util.messages.LocaleHelper;
+import org.pentaho.platform.util.xml.XMLParserFactoryProducer;
+import org.pentaho.platform.util.xml.XmlHelper;
+import org.pentaho.platform.util.xml.dom4j.XmlDom4JHelper;
+import org.pentaho.platform.util.xml.w3c.XmlW3CHelper;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.apache.commons.lang.StringUtils;
-import org.dom4j.Document;
-import org.dom4j.DocumentHelper;
-import org.dom4j.Element;
-import org.dom4j.tree.DefaultElement;
-import org.junit.Assert;
-import org.pentaho.platform.util.messages.LocaleHelper;
-import org.pentaho.platform.util.xml.XmlHelper;
-import org.pentaho.platform.util.xml.dom4j.XmlDom4JHelper;
-import org.pentaho.platform.util.xml.w3c.XmlW3CHelper;
+@RunWith( JUnit4.class )
+public class XmlHelperTest {
 
-import junit.framework.TestCase;
+  private static final String TEST_ACTION_URL = "http://localhost:8080/pentaho/ViewAction?";
+  private static final String TEST_BASE_URL = "http://localhost:8080/pentaho";
+  private static final String TEST_DISPLAY_URL = "http://localhost:8080/pentaho";
 
-@SuppressWarnings( { "all" } )
-public class XmlHelperTest extends TestCase {
+  @BeforeClass
+  public static void setupSaxonExtensions() {
+    Configuration config = XMLParserFactoryProducer.getSaxonConfig();
+    BogusXactionSaxonExtensions.registerAll( config );
+  }
 
+  @Test
   public void testGetEncoding_Valid() {
     // these should succeed, and cause the specified (windows-1252) encoding to be returned
-    String[] winXmls = { "<?xml version=\"1.0\" encoding=\"windows-1252\"?><root></root>", //$NON-NLS-1$
-      "<?xml encoding=\"windows-1252\" version=\"1.0\"?><root></root>", //$NON-NLS-1$
-      "<?xml encoding=\"windows-1252\" version='1.0'?><root></root>", //$NON-NLS-1$
-      "<?xml encoding='windows-1252' version=\"1.0\"?><root></root>", //$NON-NLS-1$
-      "<?xml encoding='windows-1252' version='1.0'?><root></root>" //$NON-NLS-1$
+    String[] winXmls = { "<?xml version=\"1.0\" encoding=\"windows-1252\"?><root></root>",
+      "<?xml encoding=\"windows-1252\" version=\"1.0\"?><root></root>",
+      "<?xml encoding=\"windows-1252\" version='1.0'?><root></root>",
+      "<?xml encoding='windows-1252' version=\"1.0\"?><root></root>",
+      "<?xml encoding='windows-1252' version='1.0'?><root></root>"
     };
 
     for ( String element : winXmls ) {
-      String enc = XmlHelper.getEncoding( element );
-      assertTrue( enc.equals( "windows-1252" ) ); //$NON-NLS-1$
+      assertEquals( "windows-1252", XmlHelper.getEncoding( element ) );
     }
   }
 
+  @Test
   public void testGetEncoding_DefaultInsteadOfInvalid() {
     // these should fail, and cause the default system encoding to be returned
-    String[] defaultXmls = { "<?xml encoding='UTF-8' version='1.0'?><root></root>", //$NON-NLS-1$
-      "<?xml encoding='UTF-8' version='1.0'?><root></root>", "<?xml encoding='UTF-8' version=\"1.0\"?><root></root>",
-      // $NON-NLS-1$ //$NON-NLS-2$
-      "<?xml encoding='UTF-8' version='1.0'?><root>encoding=bad</root>" //$NON-NLS-1$
+    String[] defaultXmls = { "<?xml encoding='UTF-8' version='1.0'?><root></root>",
+      "<?xml encoding='UTF-8' version='1.0'?><root></root>",
+      "<?xml encoding='UTF-8' version=\"1.0\"?><root></root>",
+      "<?xml encoding='UTF-8' version='1.0'?><root>encoding=bad</root>"
     };
 
+    String systemEncoding = LocaleHelper.getSystemEncoding();
     for ( String element : defaultXmls ) {
-      String enc = XmlHelper.getEncoding( element );
-      assertTrue( enc.equals( LocaleHelper.getSystemEncoding() ) );
+      assertEquals( systemEncoding, XmlHelper.getEncoding( element ) );
     }
   }
 
   /**
    * Load an XML file into a dom4j.Document, convert that document to a string, load that string into a w3c.Document,
    * and turn it back into a string.
-   * 
-   * @throws FileNotFoundException
-   * @throws TransformerConfigurationException
-   * @throws TransformerException
    */
+  @Test
   public void testGetXMLFromDocument() throws Exception {
     InputStream in = prepareSampleXmlStream();
     org.dom4j.Document doc = XmlDom4JHelper.getDocFromStream( in );
@@ -87,154 +104,137 @@ public class XmlHelperTest extends TestCase {
     assertFalse( StringUtils.isEmpty( converted ) );
   }
 
+  @Test
   public void testEncode_NullStringIsEncodedToNull() {
     assertNull( XmlHelper.encode( (String) null ) );
   }
 
+  @Test
   public void testEncode_NullArrayIsIgnored() {
     XmlHelper.encode( (String[]) null );
   }
 
+  @Test
   public void testDecode_NullStringIsDecodedToNull() {
     assertNull( XmlHelper.decode( (String) null ) );
   }
 
+  @Test
   public void testDecode_NullArrayIsIgnored() {
     XmlHelper.decode( (String[]) null );
   }
 
+  @Test
   public void testEncodeDecode() {
     String encodedXml =
-        " ABC 123 abc &amp;amp;=&amp; &amp;lt;=&lt; &amp;gt;=&gt; &amp;apos;=&apos; &amp;quot;=&quot; ABC123abc &amp;"
-            + "quot = &quot; &amp;apos; = &apos; &amp;gt; = &gt; &amp;lt; = &lt; &amp;amp; = &amp; ABC123abc "; //$NON-NLS-1$
+      " ABC 123 abc &amp;amp;=&amp; &amp;lt;=&lt; &amp;gt;=&gt; &amp;apos;=&apos; &amp;quot;=&quot; ABC123abc &amp;"
+        + "quot = &quot; &amp;apos; = &apos; &amp;gt; = &gt; &amp;lt; = &lt; &amp;amp; = &amp; ABC123abc ";
     String decodedXml =
-        " ABC 123 abc &amp;=& &lt;=< &gt;=> &apos;=' &quot;=\" ABC123abc &quot = \" &apos; = ' &gt; = > &lt; = < &amp; "
-            + "= & ABC123abc "; //$NON-NLS-1$
-    assertEquals( "Error in decode", decodedXml, XmlHelper.decode( encodedXml ) ); //$NON-NLS-1$
-    assertEquals( "Error in encode", encodedXml, XmlHelper.encode( decodedXml ) ); //$NON-NLS-1$
-    assertEquals( "Error encoding after decoding", encodedXml, XmlHelper.encode( XmlHelper.decode( encodedXml ) ) ); // $NON-NLS-1$
-    assertEquals( "Error decoding after encoding", decodedXml, XmlHelper.decode( XmlHelper.encode( decodedXml ) ) ); // $NON-NLS-1$
+      " ABC 123 abc &amp;=& &lt;=< &gt;=> &apos;=' &quot;=\" ABC123abc &quot = \" &apos; = ' &gt; = > &lt; = < &amp; "
+        + "= & ABC123abc ";
+    assertEquals( "Error in decode", decodedXml, XmlHelper.decode( encodedXml ) );
+    assertEquals( "Error in encode", encodedXml, XmlHelper.encode( decodedXml ) );
+    assertEquals( "Error encoding after decoding", encodedXml, XmlHelper.encode( XmlHelper.decode( encodedXml ) ) );
+    assertEquals( "Error decoding after encoding", decodedXml, XmlHelper.decode( XmlHelper.encode( decodedXml ) ) );
   }
 
-  public void testXForm() throws TransformerException {
-    try {
-      InputStream inStrm = new FileInputStream( "src/test/resources/solution/test/xml/XmlHelperTest1.xml" ); //$NON-NLS-1$
-      String xslName = "CustomReportParametersForPortlet.xsl"; //$NON-NLS-1$
-      String xslPath = "src/test/resources/solution/system/custom/xsl"; //$NON-NLS-1$
+  @Test
+  public void testXForm() throws Exception {
+    try (
+      InputStream inStrm = new FileInputStream( "src/test/resources/solution/test/xml/XmlHelperTest1.xml" ) ) {
+      String xslName = "CustomReportParametersForPortlet.xsl";
+      String xslPath = "src/test/resources/solution/system/custom/xsl";
 
       StringBuffer b = XmlHelper.transformXml( xslName, xslPath, inStrm, null, new TestEntityResolver() );
-      Assert.assertTrue( StringUtils.isNotEmpty( b.toString() ) );
-    } catch ( Throwable e ) {
-      System.out.println( "Exception thrown " + e.getMessage() ); //$NON-NLS-1$
-      Assert.assertTrue( "Exception thrown " + e.getMessage(), false ); //$NON-NLS-1$
+      assertTrue( StringUtils.isNotEmpty( b.toString() ) );
     }
   }
 
-  public void testFailureGetDocFromString() {
-    try {
-      Document doc = XmlDom4JHelper.getDocFromString( "1231231231231", null ); //$NON-NLS-1$
-      fail( "Unexpected XML parsing success" );
-    } catch ( Exception e ) {
-      assertTrue( "Exception thrown " + e.getMessage(), true ); //$NON-NLS-1$
-    }
+  @Test( expected = XmlParseException.class )
+  public void testFailureGetDocFromString() throws Exception {
+    Document doc = XmlDom4JHelper.getDocFromString( "1231231231231", null );
+    fail( "Unexpected XML parsing success" );
   }
 
+  @Test
   public void testSuccessGetDocFromString() throws Exception {
     Document doc =
-        XmlDom4JHelper.getDocFromString( "<root><contents><value>One</value><value>Two</value></contents></root>", //$NON-NLS-1$
-            null );
+      XmlDom4JHelper.getDocFromString( "<root><contents><value>One</value><value>Two</value></contents></root>",
+        null );
     assertNotNull( "Unexpected XML parsing failure", doc );
   }
 
+  @Test
   public void testGetDocFromStream() throws Exception {
     InputStream in = prepareSampleXmlStream();
     Document doc = XmlDom4JHelper.getDocFromStream( in );
     assertNotNull( doc );
   }
 
+  @Test
   public void testFailureTransformXML() throws Exception {
-    String parameterXsl = "DefaultParameterForm.xsl"; //$NON-NLS-1$
+    String parameterXsl = "DefaultParameterForm.xsl";
     String xslPath = "system/custom/xsl";
-
-    Map<String, String> parameters = new HashMap<String, String>();
-    String actionUrl = "http://localhost:8080/pentaho/ViewAction?"; //$NON-NLS-1$
-    String baseUrl = "http://localhost:8080/pentaho"; //$NON-NLS-1$
-    String displayUrl = "http://localhost:8080/pentaho"; //$NON-NLS-1$
-    parameters.put( "baseUrl", baseUrl ); //$NON-NLS-1$
-    parameters.put( "actionUrl", actionUrl ); //$NON-NLS-1$
-    parameters.put( "displayUrl", displayUrl ); // $NON-NLS-1$
 
     Document document =
-        XmlDom4JHelper.getDocFromString( "<?xml version=\"1.0\" encoding=\"windows-1252\"?><root></root>", null ); //$NON-NLS-1$
-    assertEquals( document.getRootElement().getName(), "root" ); //$NON-NLS-1$
+      XmlDom4JHelper.getDocFromString( "<?xml version=\"1.0\" encoding=\"windows-1252\"?><root></root>", null );
+    assertEquals( "root", document.getRootElement().getName() );
 
-    XmlHelper.transformXml( parameterXsl, xslPath, document.asXML(), parameters, new JarEntityResolver() );
+    XmlHelper.transformXml( parameterXsl, xslPath, document.asXML(), getURLParameters(), new JarEntityResolver() );
   }
 
+  @Test
   public void testFailureTransformXML2() throws Exception {
-    String parameterXsl = "DefaultParameterForm.xsl"; //$NON-NLS-1$
+    String parameterXsl = "DefaultParameterForm.xsl";
     String xslPath = "system/custom/xsl";
 
-    Map parameters = new HashMap();
-    String actionUrl = "http://localhost:8080/pentaho/ViewAction?"; //$NON-NLS-1$
-    String baseUrl = "http://localhost:8080/pentaho"; //$NON-NLS-1$
-    String displayUrl = "http://localhost:8080/pentaho"; //$NON-NLS-1$
-    parameters.put( "baseUrl", baseUrl ); //$NON-NLS-1$
-    parameters.put( "actionUrl", actionUrl ); //$NON-NLS-1$
-    parameters.put( "displayUrl", displayUrl ); //$NON-NLS-1$
-
     String xmlString =
-        "<?xml version=\"1.0\" encoding=\"" + "UTF-8" + "\" ?><filters xmlns:xf=\"http://www.w3.org/2002/xforms\">" + // $NON-NLS-1$
-                                                                                                                      // //$NON-NLS-2$
-                                                                                                                      // //$NON-NLS-3$
-            "<Header/>" + "<id><![CDATA[" + //$NON-NLS-1$ //$NON-NLS-2$
-            "]]></id><description><![CDATA[" + //$NON-NLS-1$
-            "MyDescription" + "]]></description><icon><![CDATA[" + //$NON-NLS-1$ //$NON-NLS-2$
-            "GetIcon" + "]]></icon><help><![CDATA[" + //$NON-NLS-1$ //$NON-NLS-2$
-            "GetHelp" + "]]></help>" + //$NON-NLS-1$ //$NON-NLS-2$
-            "<action><![CDATA[" + actionUrl + "]]></action>" + //$NON-NLS-1$ //$NON-NLS-2$
-            "<display><![CDATA[" + displayUrl + "]]></display>" + //$NON-NLS-1$ //$NON-NLS-2$
-            "<Body/>" + "</filters>"; //$NON-NLS-1$ //$NON-NLS-2$
+      "<?xml version=\"1.0\" encoding=\"" + StandardCharsets.UTF_8.name()
+        + "\" ?><filters xmlns:xf=\"http://www.w3.org/2002/xforms\">" +
+        "<Header/>" + "<id><![CDATA[" +
+        "]]></id><description><![CDATA[" +
+        "MyDescription" + "]]></description><icon><![CDATA[" +
+        "GetIcon" + "]]></icon><help><![CDATA[" +
+        "GetHelp" + "]]></help>" +
+        "<action><![CDATA[" + TEST_ACTION_URL + "]]></action>" +
+        "<display><![CDATA[" + TEST_DISPLAY_URL + "]]></display>" +
+        "<Body/>" + "</filters>";
 
     Document document = XmlDom4JHelper.getDocFromString( xmlString, null );
 
-    XmlHelper.transformXml( parameterXsl, xslPath, document.asXML(), parameters, new JarEntityResolver() );
+    XmlHelper.transformXml( parameterXsl, xslPath, document.asXML(), getURLParameters(), new JarEntityResolver() );
   }
 
+  @Test
   public void testFailureTransformXML3() throws Exception {
-    String parameterXsl = "DefaultParameterForm.xsl"; //$NON-NLS-1$
+    String parameterXsl = "DefaultParameterForm.xsl";
     String xslPath = "system/custom/xsl";
 
-    Map parameters = new HashMap();
-    String actionUrl = "http://localhost:8080/pentaho/ViewAction?"; //$NON-NLS-1$
-    String baseUrl = "http://localhost:8080/pentaho"; //$NON-NLS-1$
-    String displayUrl = "http://localhost:8080/pentaho"; //$NON-NLS-1$
-    parameters.put( "baseUrl", baseUrl ); //$NON-NLS-1$
-    parameters.put( "actionUrl", actionUrl ); //$NON-NLS-1$
-    parameters.put( "displayUrl", displayUrl ); //$NON-NLS-1$
 
     Document document =
-        XmlDom4JHelper.getDocFromString( "<?xml version=\"1.0\" encoding=\"" + "UTF-8"
-            + "\" ?><filters xmlns:xf=\"http://www.w3.org/2002/xforms\">" + // $NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            "<Header/>" + "<id><![CDATA[" + //$NON-NLS-1$ //$NON-NLS-2$
-            "]]></id><description><![CDATA[" + //$NON-NLS-1$
-            "MyDescription" + "]]></description><icon><![CDATA[" + //$NON-NLS-1$ //$NON-NLS-2$
-            "GetIcon" + "]]></icon><help><![CDATA[" + //$NON-NLS-1$ //$NON-NLS-2$
-            "GetHelp" + "]]></help>" + //$NON-NLS-1$ //$NON-NLS-2$
-            "<action><![CDATA[" + actionUrl + "]]></action>" + //$NON-NLS-1$ //$NON-NLS-2$
-            "<display><![CDATA[" + displayUrl + "]]></display>" + //$NON-NLS-1$ //$NON-NLS-2$
-            "<Body/>" + "</filters>", null ); //$NON-NLS-1$ //$NON-NLS-2$
+      XmlDom4JHelper.getDocFromString( "<?xml version=\"1.0\" encoding=\"" + StandardCharsets.UTF_8.name()
+        + "\" ?><filters xmlns:xf=\"http://www.w3.org/2002/xforms\">" +
+        "<Header/>" + "<id><![CDATA[" +
+        "]]></id><description><![CDATA[" +
+        "MyDescription" + "]]></description><icon><![CDATA[" +
+        "GetIcon" + "]]></icon><help><![CDATA[" +
+        "GetHelp" + "]]></help>" +
+        "<action><![CDATA[" + TEST_ACTION_URL + "]]></action>" +
+        "<display><![CDATA[" + TEST_DISPLAY_URL + "]]></display>" +
+        "<Body/>" + "</filters>", null );
 
-    XmlHelper.transformXml( parameterXsl, xslPath, new ByteArrayInputStream( document.asXML().getBytes() ), parameters,
-        new JarEntityResolver() );
+    XmlHelper.transformXml( parameterXsl, xslPath, new ByteArrayInputStream( document.asXML().getBytes() ),
+      getURLParameters(),
+      new JarEntityResolver() );
   }
 
+  @Test
   public void testEncoding() throws Exception {
-    doEncodingTest( "rootElement", "hello", "UTF-8" );
-    doEncodingTest( "rootElement", "hello", "UTF-16" );
+    doEncodingTest( "rootElement", "hello", StandardCharsets.UTF_8.name() );
+    doEncodingTest( "rootElement", "hello", StandardCharsets.UTF_16.name() );
     String unicodeElementText = new String( new char[] { '\uAA93', '\uAA94', '\uAA95' } );
-    doEncodingTest( "rootElement", unicodeElementText, "UTF-8" );
-    doEncodingTest( "rootElement", unicodeElementText, "UTF-16" );
+    doEncodingTest( "rootElement", unicodeElementText, StandardCharsets.UTF_8.name() );
+    doEncodingTest( "rootElement", unicodeElementText, StandardCharsets.UTF_16.name() );
   }
 
   public void doEncodingTest( String rootElementName, String rootElementText, String encoding ) throws Exception {
@@ -272,12 +272,18 @@ public class XmlHelperTest extends TestCase {
   }
 
   private static InputStream prepareSampleXmlStream() {
-    String sampleXml =
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-            + "<report name=\"Quadrant For Region\" orientation=\"portrait\" topmargin=\"0pt\" leftmargin=\"5pt\" "
-            + "bottommargin=\"0pt\" rightmargin=\"5pt\" />";
+    String sampleXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      + "<report name=\"Quadrant For Region\" orientation=\"portrait\" topmargin=\"0pt\" leftmargin=\"5pt\" "
+      + "bottommargin=\"0pt\" rightmargin=\"5pt\" />";
 
     return new ByteArrayInputStream( sampleXml.getBytes() );
   }
 
+  private static Map<String, String> getURLParameters() {
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put( "baseUrl", TEST_BASE_URL );
+    parameters.put( "actionUrl", TEST_ACTION_URL );
+    parameters.put( "displayUrl", TEST_DISPLAY_URL );
+    return parameters;
+  }
 }

--- a/core/src/test/java/org/pentaho/platform/util/xml/dom4j/XmlDom4JHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/util/xml/dom4j/XmlDom4JHelperTest.java
@@ -18,12 +18,15 @@ import org.junit.Test;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class XmlDom4JHelperTest {
 
   @Test ( expected = TransformerFactoryConfigurationError.class )
   public void testConvertToDom4JDocTrowTransformerFactoryConfigurationErrorException() throws Exception {
+    // Create a mock with proper DOM node structure (DOCUMENT_NODE = 9)
     final org.w3c.dom.Document doc = mock( org.w3c.dom.Document.class );
+    when( doc.getNodeType() ).thenReturn( org.w3c.dom.Document.DOCUMENT_NODE );  // nodeType = 9
     XmlDom4JHelper.convertToDom4JDoc( doc );
   }
 }

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -517,12 +517,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.validation</groupId>
-      <artifactId>jakarta.validation-api</artifactId>
-      <version>${jakarta.validation.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
       <version>${jersey.version}</version>
@@ -2145,10 +2139,6 @@
           <groupId>*</groupId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
     </dependency>
     <dependency>
       <groupId>net.javacrumbs.json-unit</groupId>

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
@@ -15,6 +15,17 @@ package org.pentaho.platform.web.http.api.resources;
 
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import net.sf.saxon.Configuration;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -23,13 +34,14 @@ import org.apache.commons.logging.LogFactory;
 import org.codehaus.enunciate.Facet;
 import org.codehaus.enunciate.jaxrs.ResponseCode;
 import org.codehaus.enunciate.jaxrs.StatusCodes;
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.IContentGenerator;
 import org.pentaho.platform.api.engine.IContentInfo;
 import org.pentaho.platform.api.engine.IPluginManager;
 import org.pentaho.platform.api.engine.IPluginOperation;
-import org.pentaho.platform.api.engine.PluginBeanException;
+import org.pentaho.platform.api.engine.ISystemConfig;
 import org.pentaho.platform.api.engine.ObjectFactoryException;
-import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.engine.PluginBeanException;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.UnifiedRepositoryException;
@@ -45,19 +57,6 @@ import org.pentaho.platform.web.http.api.resources.utils.XactionSaxonExtensions;
 import org.pentaho.platform.web.http.messages.Messages;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
-import jakarta.servlet.http.HttpServletRequest;
-
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.GenericEntity;
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -71,10 +70,10 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static jakarta.ws.rs.core.MediaType.WILDCARD;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
-import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.WILDCARD;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 
 /**
@@ -102,8 +101,14 @@ public class RepositoryResource extends AbstractJaxRSResource {
   protected RepositoryDownloadWhitelist whitelist;
 
   static {
-    Configuration config = org.pentaho.platform.util.xml.XMLParserFactoryProducer.getSaxonConfig();
-    XactionSaxonExtensions.registerAll( config );
+    ISystemConfig settings = PentahoSystem.get( ISystemConfig.class );
+    if ( settings != null && "true".equals( settings.getProperty( "system.allowXActionParameters" ) ) ) {
+      logger.info( "System allowXActionParameters is set; if this is not intended, check the configuration." );
+      Configuration config = org.pentaho.platform.util.xml.XMLParserFactoryProducer.getSaxonConfig();
+      if ( config != null ) {
+        XactionSaxonExtensions.registerAll( config );
+      }
+    }
   }
 
   @GET

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java
@@ -15,6 +15,7 @@ package org.pentaho.platform.web.http.api.resources;
 
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import net.sf.saxon.Configuration;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -40,6 +41,7 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.repository.RepositoryDownloadWhitelist;
 import org.pentaho.platform.repository.RepositoryFilenameUtils;
 import org.pentaho.platform.util.RepositoryPathEncoder;
+import org.pentaho.platform.web.http.api.resources.utils.XactionSaxonExtensions;
 import org.pentaho.platform.web.http.messages.Messages;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
@@ -76,7 +78,7 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 
 /**
- * The RepositoryResource service retrieves the repository files through various methods.  Allows you to execute repository content.
+ * The RepositoryResource service retrieves the repository files through various methods. Allows you to execute repository content.
  */
 @Path ( "/repos" )
 public class RepositoryResource extends AbstractJaxRSResource {
@@ -98,6 +100,11 @@ public class RepositoryResource extends AbstractJaxRSResource {
   protected IUnifiedRepository repository = PentahoSystem.get( IUnifiedRepository.class );
 
   protected RepositoryDownloadWhitelist whitelist;
+
+  static {
+    Configuration config = org.pentaho.platform.util.xml.XMLParserFactoryProducer.getSaxonConfig();
+    XactionSaxonExtensions.registerAll( config );
+  }
 
   @GET
   @Path ( "{pathId : .+}/content" )
@@ -135,8 +142,6 @@ public class RepositoryResource extends AbstractJaxRSResource {
   public Response doExecuteDefault( @PathParam ( "pathId" ) String pathId ) throws FileNotFoundException,
       MalformedURLException, URISyntaxException {
     String perspective = null;
-    StringBuffer buffer = null;
-    String url = null;
     String path = FileResource.idToPath( pathId );
 
     if ( FileResource.getRepository().getFile( path ) == null ) {
@@ -147,7 +152,7 @@ public class RepositoryResource extends AbstractJaxRSResource {
     IPluginManager pluginManager = PentahoSystem.get( IPluginManager.class, PentahoSessionHolder.getSession() );
     IContentInfo info = pluginManager.getContentTypeInfo( extension );
     for ( IPluginOperation operation : info.getOperations() ) {
-      if ( operation.getId().equalsIgnoreCase( "RUN" ) ) { //$NON-NLS-1$
+      if ( operation.getId().equalsIgnoreCase( "RUN" ) ) {
         perspective = operation.getPerspective();
         break;
       }
@@ -156,9 +161,9 @@ public class RepositoryResource extends AbstractJaxRSResource {
       perspective = GENERATED_CONTENT_PERSPECTIVE;
     }
 
-    buffer = httpServletRequest.getRequestURL();
+    StringBuffer buffer = httpServletRequest.getRequestURL();
     String queryString = httpServletRequest.getQueryString();
-    url = buffer.substring( 0, buffer.lastIndexOf( "/" ) + 1 ) + perspective + //$NON-NLS-1$
+    String url = buffer.substring( 0, buffer.lastIndexOf( "/" ) + 1 ) + perspective +
         ( ( queryString != null && queryString.length() > 0 ) ? "?" + httpServletRequest.getQueryString() : "" );
     return Response.seeOther( ( new URL( url ) ).toURI() ).build();
   }
@@ -178,7 +183,7 @@ public class RepositoryResource extends AbstractJaxRSResource {
    * @param resourceId Identifies a resource to be retrieved. This value may be a static file residing in a publicly visible plugin folder, repository file ID or content generator ID
    * @param formParams Any arguments needed to render the resource
    *
-   * @return A jax-rs Response object with the appropriate status code, header, and body. In many cases this will trigger a streaming operation after it it is returned to the caller..
+   * @return A jax-rs Response object with the appropriate status code, header, and body. In many cases this will trigger a streaming operation after it is returned to the caller.
    *
    * <p><b>Example Response:</b></p>
    *  <pre function="syntax.xml">
@@ -195,14 +200,13 @@ public class RepositoryResource extends AbstractJaxRSResource {
   } )
   public Response doFormPost( @PathParam ( "contextId" ) String contextId, @PathParam ( "resourceId" ) String resourceId,
                               final MultivaluedMap<String, String> formParams )
-    throws ObjectFactoryException, PluginBeanException,
-      IOException, URISyntaxException {
+    throws ObjectFactoryException, PluginBeanException, IOException, URISyntaxException {
 
     httpServletRequest = JerseyUtil.correctPostRequest( formParams, httpServletRequest );
 
     if ( logger.isDebugEnabled() ) {
       for ( Object key : httpServletRequest.getParameterMap().keySet() ) {
-        logger.debug( "param [" + key + "]" ); //$NON-NLS-1$ //$NON-NLS-2$
+        logger.debug( "param [" + key + "]" );
       }
     }
 
@@ -614,7 +618,7 @@ public class RepositoryResource extends AbstractJaxRSResource {
 
     if ( logger.isDebugEnabled() ) {
       for ( Object key : httpServletRequest.getParameterMap().keySet() ) {
-        logger.debug( "param [" + key + "]" ); //$NON-NLS-1$ //$NON-NLS-2$
+        logger.debug( "param [" + key + "]" );
       }
     }
 
@@ -631,7 +635,7 @@ public class RepositoryResource extends AbstractJaxRSResource {
   @Produces ( { APPLICATION_XML, APPLICATION_JSON } )
   @Facet ( name = "Unsupported" )
   public ExecutableFileTypeDtoWrapper getExecutableTypes() {
-    ArrayList<ExecutableFileTypeDto> executableTypes = new ArrayList<ExecutableFileTypeDto>();
+    ArrayList<ExecutableFileTypeDto> executableTypes = new ArrayList<>();
     for ( String contentType : pluginManager.getContentTypes() ) {
       IContentInfo contentInfo = pluginManager.getContentTypeInfo( contentType );
       ExecutableFileTypeDto executableFileType = new ExecutableFileTypeDto();
@@ -643,7 +647,7 @@ public class RepositoryResource extends AbstractJaxRSResource {
       executableTypes.add( executableFileType );
     }
 
-    final GenericEntity<List<ExecutableFileTypeDto>> entity = new GenericEntity<List<ExecutableFileTypeDto>>( executableTypes ) { };
+    final GenericEntity<List<ExecutableFileTypeDto>> entity = new GenericEntity<>( executableTypes ) { };
     return new ExecutableFileTypeDtoWrapper( executableTypes );
   }
 
@@ -1014,9 +1018,8 @@ public class RepositoryResource extends AbstractJaxRSResource {
     }
     Response response = checkPermissionIfUserIsEditingContent( fac.getContentGeneratorId() );
     if ( response == null ) {
-      rsc(
-              "Yep, [{0}] is a content generator ID. Executing (where command path is {1})..", fac.getContentGeneratorId(),
-              fac.getCommand() ); //$NON-NLS-1$
+      rsc( "Yep, [{0}] is a content generator ID. Executing (where command path is {1})..", fac.getContentGeneratorId(),
+        fac.getCommand() );
       GeneratorStreamingOutput gso = fac.getStreamingOutput( contentGenerator );
       response = Response.ok( gso ).build();
     }
@@ -1134,12 +1137,10 @@ public class RepositoryResource extends AbstractJaxRSResource {
         if ( "URL".equalsIgnoreCase( propname ) ) { //$NON-NLS-1$
           return value;
         }
-
       }
     }
     // No URL found
-    return ""; //$NON-NLS-1$
-
+    return "";
   }
 
   public RepositoryDownloadWhitelist getWhitelist() {
@@ -1153,7 +1154,7 @@ public class RepositoryResource extends AbstractJaxRSResource {
   private Response checkPermissionIfUserIsEditingContent( String resourceId ) {
     // Check if we are editing a content
     String perspectiveId = resourceId;
-    if ( perspectiveId != null && perspectiveId.indexOf( "." ) >= 0 ) {
+    if ( perspectiveId != null && perspectiveId.indexOf( '.' ) >= 0 ) {
       String[] parts = perspectiveId.split( "\\." );
       if ( parts != null && parts.length > 0 ) {
         perspectiveId = parts[1];

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensions.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensions.java
@@ -1,0 +1,136 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2028-08-13
+ ******************************************************************************/
+
+package org.pentaho.platform.web.http.api.resources.utils;
+
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.lib.ExtensionFunctionCall;
+import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.Sequence;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.trans.XPathException;
+import net.sf.saxon.value.SequenceType;
+import net.sf.saxon.value.StringValue;
+import org.pentaho.platform.util.messages.LocaleHelper;
+import org.pentaho.platform.web.xsl.messages.Messages;
+
+/**
+ * This class registers and provides Pentaho Saxon extension functions used by XSL stylesheets (namely Xaction
+ * parameter forms).
+ */
+public class XactionSaxonExtensions {
+
+  /**
+   * <b>msg:getInstance()</b><br>
+   * Namespace: org.pentaho.platform.web.xsl.messages.Messages<br>
+   * XSL usage: <code>&lt;xsl:variable name="messages" select="msg:getInstance()" /&gt;</code>
+   */
+  public static class MsgGetInstance extends ExtensionFunctionDefinition {
+
+    private static final String NAMESPACE = "org.pentaho.platform.web.xsl.messages.Messages";
+
+    @Override public StructuredQName getFunctionQName() {
+      return new StructuredQName( "msg", NAMESPACE, "getInstance" );
+    }
+
+    @Override public SequenceType[] getArgumentTypes() {
+      return new SequenceType[ 0 ];
+    }
+
+    @Override public SequenceType getResultType( SequenceType[] suppliedArgumentTypes ) {
+      return SequenceType.SINGLE_STRING;
+    }
+
+    @Override public ExtensionFunctionCall makeCallExpression() {
+      return new ExtensionFunctionCall() {
+        @Override public Sequence call( XPathContext context, Sequence[] arguments ) throws XPathException {
+          // Sentinel value — the actual Messages instance is resolved inside getXslString below
+          return StringValue.makeStringValue( "__MSG_INSTANCE__" );
+        }
+      };
+    }
+  }
+
+  /**
+   * <b>msg:getXslString(messages, key)</b><br>
+   * Namespace: org.pentaho.platform.web.xsl.messages.Messages<br>
+   * XSL usage: <code>msg:getXslString($messages, 'UI.SOME_KEY')</code>
+   */
+  public static class MsgGetXslString extends ExtensionFunctionDefinition {
+
+    private static final String NAMESPACE = "org.pentaho.platform.web.xsl.messages.Messages";
+
+    @Override public StructuredQName getFunctionQName() {
+      return new StructuredQName( "msg", NAMESPACE, "getXslString" );
+    }
+
+    @Override public SequenceType[] getArgumentTypes() {
+      return new SequenceType[] { SequenceType.SINGLE_STRING, // messages instance (sentinel)
+        SequenceType.SINGLE_STRING  // key
+      };
+    }
+
+    @Override public SequenceType getResultType( SequenceType[] suppliedArgumentTypes ) {
+      return SequenceType.SINGLE_STRING;
+    }
+
+    @Override public ExtensionFunctionCall makeCallExpression() {
+      return new ExtensionFunctionCall() {
+        @Override public Sequence call( XPathContext context, Sequence[] arguments ) throws XPathException {
+          String key = arguments[ 1 ].head().getStringValue(); Messages messages = Messages.getInstance();
+          return StringValue.makeStringValue( messages.getXslString( key ) );
+        }
+      };
+    }
+  }
+
+  /**
+   * <b>loc:getTextDirection()</b><br>
+   * Namespace: org.pentaho.platform.util.messages.LocaleHelper<br>
+   * XSL usage: <code>&lt;xsl:value-of select="loc:getTextDirection()"/&gt;</code>
+   */
+  public static class LocGetTextDirection extends ExtensionFunctionDefinition {
+
+    private static final String NAMESPACE = "org.pentaho.platform.util.messages.LocaleHelper";
+
+    @Override public StructuredQName getFunctionQName() {
+      return new StructuredQName( "loc", NAMESPACE, "getTextDirection" );
+    }
+
+    @Override public SequenceType[] getArgumentTypes() {
+      return new SequenceType[ 0 ];
+    }
+
+    @Override public SequenceType getResultType( SequenceType[] suppliedArgumentTypes ) {
+      return SequenceType.SINGLE_STRING;
+    }
+
+    @Override public ExtensionFunctionCall makeCallExpression() {
+      return new ExtensionFunctionCall() {
+        @Override public Sequence call( XPathContext context, Sequence[] arguments ) throws XPathException {
+          return StringValue.makeStringValue( LocaleHelper.getTextDirection() );
+        }
+      };
+    }
+  }
+
+  /**
+   * Register all 3 extensions into a Saxon Configuration.
+   */
+  public static void registerAll( Configuration config ) {
+    config.registerExtensionFunction( new MsgGetInstance() );
+    config.registerExtensionFunction( new MsgGetXslString() );
+    config.registerExtensionFunction( new LocGetTextDirection() );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensions.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensions.java
@@ -129,8 +129,10 @@ public class XactionSaxonExtensions {
    * Register all 3 extensions into a Saxon Configuration.
    */
   public static void registerAll( Configuration config ) {
-    config.registerExtensionFunction( new MsgGetInstance() );
-    config.registerExtensionFunction( new MsgGetXslString() );
-    config.registerExtensionFunction( new LocGetTextDirection() );
+    if ( config != null ) {
+      config.registerExtensionFunction( new MsgGetInstance() );
+      config.registerExtensionFunction( new MsgGetXslString() );
+      config.registerExtensionFunction( new LocGetTextDirection() );
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,11 @@
         <artifactId>jackson-databind</artifactId>
         <version>${fasterxml-jackson.non-osgi.version}</version>
       </dependency>
+      <dependency>
+        <groupId>net.sf.saxon</groupId>
+        <artifactId>Saxon-HE</artifactId>
+        <version>${saxon-he.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7434 - Backport of BISERVER-15586 - (11.0 Suite) Form-Based Xactions fail in Pentaho v10.2.0.7.](https://pentaho-eng.atlassian.net/browse/SP-7434)
- **Base Case:** [BISERVER-15586 - Backport of BISERVER-15586 - (11.0 Suite) Form-Based Xactions fail in Pentaho v10.2.0.7.](https://pentaho-eng.atlassian.net/browse/BISERVER-15586)
- **Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6240

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-platform/pull/6240
- Commit: c35c55e5864f851d95c8f0b32bad09b401c375b5
- Commit: a26a84798c42b370369c57503e90b2a8962b4784
- Commit: 0b6474189258e33a0d92af0c7618fc50c206d27b
- Commit: 484eb5b8b82fe02d73d6434183dea26cc73b2360
- Commit: 327171813fa8a0f40849157858d086ecd31d03d5

## Conflict Resolution
- Conflict at `a26a84798c42` (Make this functionality configurable): resolved in `extensions/src/main/java/org/pentaho/platform/web/http/api/resources/RepositoryResource.java`

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
