### PR TITLE
fix[BISERVER-15741]: skip datasources with invalid database types

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -16,6 +16,7 @@ package org.pentaho.platform.plugin.services.importer;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.metadata.repository.DomainAlreadyExistsException;
@@ -384,8 +385,10 @@ public class SolutionImportHandler implements IPlatformImportHandler {
       }
       IDatasourceMgmtService datasourceMgmtSvc = PentahoSystem.get( IDatasourceMgmtService.class );
       for ( DatabaseConnection databaseConnection : datasourceList ) {
-        if ( databaseConnection.getDatabaseType() == null ) {
-          // don't try to import the connection if there is no type it will cause an error
+        if ( databaseConnection.getDatabaseType() == null
+          || StringUtils.isBlank( databaseConnection.getDatabaseType().getShortName() ) ) {
+          // don't try to import the connection if there is no database type
+          // or its shortName is not valid (BISERVER-15741)
           // However, if this is the DI Server, and the connection is defined in a ktr, it will import automatically
           String connectionName = getConnectionNameForLog( databaseConnection );
           getLogger().error( Messages.getInstance()

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandler.java
@@ -16,7 +16,7 @@ package org.pentaho.platform.plugin.services.importer;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.pentaho.database.model.IDatabaseConnection;
 import org.pentaho.metadata.repository.DomainAlreadyExistsException;

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
@@ -102,20 +102,24 @@ public class SolutionImportHandlerTest {
   @Test
   public void givenLegacyDatasourceWithoutDatabaseTypeShortNameWhenRestoringThenItIsSkipped() {
     // Given
+    String connectionName = "AIM SQL Dev";
     IDatasourceMgmtService datasourceMgmtService = mockToPentahoSystem( IDatasourceMgmtService.class );
     DatabaseConnection databaseConnection = new DatabaseConnection();
-    databaseConnection.setName( "AIM SQL Dev" );
+    databaseConnection.setName( connectionName );
     databaseConnection.setDatabaseType( new DatabaseType() );
     ExportManifest manifest = new ExportManifest();
     manifest.getDatasourceList().add( databaseConnection );
 
     // When
-    importHandler.importJDBCDataSource( manifest, new SolutionImportHandler.ImportState() );
+    SolutionImportHandler.ImportState importState = new SolutionImportHandler.ImportState();
+    importState.isPerformingRestore = true;
+    importHandler.importJDBCDataSource( manifest, importState );
 
     // Then
-    verify( datasourceMgmtService, never() ).getDatasourceByName( "AIM SQL Dev" );
+    verify( datasourceMgmtService, never() ).getDatasourceByName( connectionName );
     verify( datasourceMgmtService, never() ).createDatasource( ArgumentMatchers.any() );
-    verify( logger ).error( ArgumentMatchers.anyString() );
+    verify( logger ).error( Messages.getInstance().getString( "SolutionImportHandler.ConnectionWithoutDatabaseType",
+      connectionName ) );
   }
 
   @Test

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
@@ -100,7 +100,7 @@ public class SolutionImportHandlerTest {
   }
 
   @Test
-  public void givenLegacyDatasourceWithoutDatabaseTypeShortNameWhenRestoringThenItIsSkipped() {
+  public void givenLegacyDatasourceWithoutDatabaseTypeShortNameWhenRestoringThenItIsSkipped() throws Exception {
     // Given
     String connectionName = "AIM SQL Dev";
     IDatasourceMgmtService datasourceMgmtService = mockToPentahoSystem( IDatasourceMgmtService.class );

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerTest.java
@@ -48,6 +48,7 @@ import org.pentaho.platform.plugin.services.importexport.RoleExport;
 import org.pentaho.platform.plugin.services.importexport.UserExport;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.ExportManifest;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseConnection;
+import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.DatabaseType;
 import org.pentaho.platform.plugin.services.importexport.exportManifest.bindings.ExportManifestMetaStore;
 import org.pentaho.platform.plugin.services.messages.Messages;
 import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRoleBindingDao;
@@ -96,6 +97,25 @@ public class SolutionImportHandlerTest {
     T t = mock( cl );
     PentahoSystem.registerObject( t );
     return t;
+  }
+
+  @Test
+  public void givenLegacyDatasourceWithoutDatabaseTypeShortNameWhenRestoringThenItIsSkipped() {
+    // Given
+    IDatasourceMgmtService datasourceMgmtService = mockToPentahoSystem( IDatasourceMgmtService.class );
+    DatabaseConnection databaseConnection = new DatabaseConnection();
+    databaseConnection.setName( "AIM SQL Dev" );
+    databaseConnection.setDatabaseType( new DatabaseType() );
+    ExportManifest manifest = new ExportManifest();
+    manifest.getDatasourceList().add( databaseConnection );
+
+    // When
+    importHandler.importJDBCDataSource( manifest, new SolutionImportHandler.ImportState() );
+
+    // Then
+    verify( datasourceMgmtService, never() ).getDatasourceByName( "AIM SQL Dev" );
+    verify( datasourceMgmtService, never() ).createDatasource( ArgumentMatchers.any() );
+    verify( logger ).error( ArgumentMatchers.anyString() );
   }
 
   @Test


### PR DESCRIPTION
## Summary
- skip datasource restore records whose database type is absent or has a blank `shortName`
- add a regression test for an empty database type

## Validation
- `mvn -pl extensions -Dtest=SolutionImportHandlerTest test` did not reach compilation or test execution because Maven stalled while resolving the 11.1 dependency graph from the internal repository.
- `git diff --check` passed.