### PR TITLE
fix[SP-7477]: upgrade commons-jxpath to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <jaybird.version>2.1.6</jaybird.version>
     <resolver.version>20050927</resolver.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-jxpath.version>1.2</commons-jxpath.version>
+    <commons-jxpath.version>1.4.0</commons-jxpath.version>
     <maven-surefire-plugin.reuseForks>false</maven-surefire-plugin.reuseForks>
     <mysql-connector-java.version>5.1.17</mysql-connector-java.version>
     <sapdbc.version>7.4.4</sapdbc.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7477 - Backport of PPP-6575 - (10.2 Suite) CVE-2022-40159 | pdia-master has a security violation in gav://commons-jxpath:commons-jxpath:1.2](https://pentaho-eng.atlassian.net/browse/SP-7477)
- **Base Case:** [PPP-6575 - Backport of PPP-6575 - (10.2 Suite) CVE-2022-40159 | pdia-master has a security violation in gav://commons-jxpath:commons-jxpath:1.2](https://pentaho-eng.atlassian.net/browse/PPP-6575)
- **Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6301

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-platform/pull/6301
- Commit: fa57bc8ab855da680989abe1426b5958b0621452

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
