### PR TITLE
fix[SP-7476]: upgrade commons-jxpath to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <jaybird.version>2.1.6</jaybird.version>
     <resolver.version>20050927</resolver.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-jxpath.version>1.2</commons-jxpath.version>
+    <commons-jxpath.version>1.4.0</commons-jxpath.version>
     <maven-surefire-plugin.reuseForks>false</maven-surefire-plugin.reuseForks>
     <sapdbc.version>7.4.4</sapdbc.version>
     <jcr.version>2.0</jcr.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7476 - Backport of PPP-6575 - (11.0 Suite) CVE-2022-40159 | pdia-master has a security violation in gav://commons-jxpath:commons-jxpath:1.2](https://pentaho-eng.atlassian.net/browse/SP-7476)
- **Base Case:** [PPP-6575 - Backport of PPP-6575 - (11.0 Suite) CVE-2022-40159 | pdia-master has a security violation in gav://commons-jxpath:commons-jxpath:1.2](https://pentaho-eng.atlassian.net/browse/PPP-6575)
- **Original Master PR:** https://github.com/pentaho/pentaho-platform/pull/6301

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-platform/pull/6301
- Commit: fa57bc8ab855da680989abe1426b5958b0621452

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
