### PR TITLE
feat: add feature flag for the ServiceAction chart component "query" parameter [PPP-6784]

### DIFF
--- a/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
+++ b/assemblies/pentaho-solutions/src/main/resources/pentaho-solutions/system/system.properties
@@ -98,3 +98,28 @@ cors-requests-exposed-headers=
 # Set this to true only if you have a specific need for XAction Parameters and understand
 # the security implications.
 allowXActionParameters=false
+
+## Deprecated chart "query" request parameter ##
+
+# Enables the undocumented and deprecated `query` request parameter of the chart component of the
+# `/ServiceAction` endpoint (e.g. `/pentaho/ServiceAction?component=chart&connection=...&query=...`).
+#
+# Default value: false (disabled).
+#
+# When disabled (the default), the `query` parameter of any such request is ignored: an error is logged,
+# no connection is opened for it and the supplied SQL is not executed. Chart generation carries on
+# without it, so charts that source their data from an action sequence, from a chart definition or
+# through the `data-process` parameter are unaffected.
+#
+# The `org.pentaho.platform.uifoundation.chart.ChartHelper` class that implements this capability has
+# been deprecated since 6.1 GA (BISERVER-12899), and the `query` parameter is documented in that class
+# itself as "an atypical way to access data for the chart... undocumented, and only left in here to
+# support older solutions that may be using them".
+#
+# *ATTENTION*:
+# Setting this option to true allows callers to supply the SQL statement that the server executes,
+# which is a known SQL injection vector: the supplied statement is passed to the data source as is,
+# without validation. It also allows resource exhaustion via deliberately expensive queries. Set this
+# to true only if you have a specific legacy solution that depends on it, and only if you accept the
+# security implications.
+chart-query-parameter-enabled=false

--- a/core/src/main/java/org/pentaho/platform/uifoundation/chart/ChartHelper.java
+++ b/core/src/main/java/org/pentaho/platform/uifoundation/chart/ChartHelper.java
@@ -25,6 +25,7 @@ import org.pentaho.platform.api.engine.IMessageFormatter;
 import org.pentaho.platform.api.engine.IParameterProvider;
 import org.pentaho.platform.api.engine.IPentahoRequestContext;
 import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.ISystemConfig;
 import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.engine.core.system.PentahoRequestContextHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
@@ -40,12 +41,26 @@ import org.pentaho.platform.util.web.SimpleUrlFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.StringTokenizer;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class provides wrapper functions to make it easier to execute action sequences and generate a widget.
  */
 @Deprecated // BISERVER-12899
 public class ChartHelper {
+
+  /**
+   * Property that enables the deprecated <code>query</code> request parameter of the chart component. Disabled by
+   * default. The <code>system.</code> prefix identifies the <code>system.properties</code> configuration, so the
+   * property is declared there as <code>chart-query-parameter-enabled</code>.
+   */
+  static final String CHART_QUERY_PARAMETER_ENABLED_PROPERTY = "system.chart-query-parameter-enabled"; //$NON-NLS-1$
+
+  /**
+   * Guards the one-time warning emitted when the deprecated <code>query</code> request parameter is found enabled.
+   * Package private so that tests can reset it, since the latch is held for the lifetime of the JVM.
+   */
+  static final AtomicBoolean QUERY_PARAMETER_ENABLED_WARNING_LOGGED = new AtomicBoolean( false );
 
   private static void deprecateWarning() {
     String key = "PentahoSystem.WARN_DEPRECATED_CLASS"; //$NON-NLS-1$
@@ -248,6 +263,11 @@ public class ChartHelper {
           String query = parameterProvider.getStringParameter( "query", null ); //$NON-NLS-1$
           String dataAction = parameterProvider.getStringParameter( "data-process", null ); //$NON-NLS-1$
 
+          // The query is dropped rather than executed while the capability is disabled, so the supplied SQL
+          // never reaches a data source. Chart generation carries on with whatever other data source it was
+          // given, if any.
+          query = resolveChartQueryParameter( query, logger );
+
           IPentahoConnection connection = null;
           try {
             chartComponent.setParamName( innerParam );
@@ -313,6 +333,61 @@ public class ChartHelper {
       }
     }
     return result;
+  }
+
+  /**
+   * Resolves the deprecated <code>query</code> request parameter of the chart component against the capability
+   * flag.
+   * <p/>
+   * When the capability is disabled, which is the default, the supplied query is discarded and an error is logged,
+   * so that it never reaches a data source. Chart generation carries on without it: charts that source their data
+   * from an action sequence, from a chart definition or through the <code>data-process</code> parameter are
+   * unaffected.
+   * <p/>
+   * When the capability is enabled, the query is returned unchanged and, the first time this happens, a warning is
+   * logged so that the deviation from the secure default is visible in the server log.
+   *
+   * @param query  the SQL supplied through the <code>query</code> request parameter, possibly <code>null</code>
+   * @param logger the logger that records the discarded query
+   * @return the supplied query when the capability is enabled, <code>null</code> otherwise
+   */
+  static String resolveChartQueryParameter( final String query, final ILogger logger ) {
+    if ( query == null ) {
+      return null;
+    }
+
+    if ( isChartQueryParameterEnabled() ) {
+      if ( QUERY_PARAMETER_ENABLED_WARNING_LOGGED.compareAndSet( false, true ) ) {
+        Logger.warn( ChartHelper.class,
+          Messages.getInstance().getString( "ChartHelper.WARN_0001_QUERY_PARAMETER_ENABLED" ) ); //$NON-NLS-1$
+      }
+
+      return query;
+    }
+
+    // Do not echo the ignored statement back to the caller, only record the fact server side.
+    logger.error(
+      Messages.getInstance().getErrorString( "ChartHelper.ERROR_0004_QUERY_PARAMETER_IGNORED" ) ); //$NON-NLS-1$
+
+    return null;
+  }
+
+  /**
+   * Indicates whether the deprecated <code>query</code> request parameter of the chart component is enabled.
+   * <p/>
+   * The value is read from the <code>chart-query-parameter-enabled</code> property of
+   * <code>system.properties</code> on every call, and defaults to <code>false</code> when the property is absent
+   * or when the system configuration is unavailable, so that the capability always fails closed.
+   *
+   * @return <code>true</code> when the <code>query</code> request parameter may be used, <code>false</code>
+   *         otherwise
+   */
+  static boolean isChartQueryParameterEnabled() {
+    final ISystemConfig systemConfig = PentahoSystem.get( ISystemConfig.class );
+    final String value = ( systemConfig == null ) ? null
+      : systemConfig.getProperty( CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ); //$NON-NLS-1$
+
+    return "true".equalsIgnoreCase( value ); //$NON-NLS-1$
   }
 
   /**

--- a/core/src/main/resources/org/pentaho/platform/uifoundation/messages/messages.properties
+++ b/core/src/main/resources/org/pentaho/platform/uifoundation/messages/messages.properties
@@ -68,6 +68,8 @@ Widget.ERROR_0002_INVALID_RESOURCE=Could not load resource: {0}
 ChartHelper.ERROR_0001_IO_PROBLEM_GETTING_CHART_TYPE=Could not retrieve chart type from xml definition - I/O error.
 ChartHelper.ERROR_0002_COULD_NOT_DETERMINE_CHART_TYPE=Chart type not found in xml definition nor as a parameter. Can not generate chart without a chart type.
 ChartHelper.ERROR_0003_INVALID_CHART_TYPE=Invalid chart type: {0}, {1}
+ChartHelper.ERROR_0004_QUERY_PARAMETER_IGNORED=The deprecated "query" request parameter of the chart component is disabled and was ignored; the supplied SQL will not be executed. Chart generation continues without it and may fail if the chart has no other data source. To enable the parameter, set "chart-query-parameter-enabled=true" in system.properties and restart the server.
+ChartHelper.WARN_0001_QUERY_PARAMETER_ENABLED=The deprecated "query" request parameter of the chart component is enabled via the "chart-query-parameter-enabled" property in system.properties. This lets callers supply the SQL statement executed by the server, which is a known SQL injection vector. If this is not intended, check the configuration.
 
 WidgetGrid.ERROR_0001_NO_RESULTS_FROM_ACTION=Could not get any results from the specified action
 WidgetGrid.ERROR_0002_NO_VALUE_ITEM=The value item has not been defined

--- a/core/src/test/java/org/pentaho/platform/engine/services/MessageFormatterTest.java
+++ b/core/src/test/java/org/pentaho/platform/engine/services/MessageFormatterTest.java
@@ -42,11 +42,13 @@ import org.pentaho.platform.util.UUIDUtil;
 import org.pentaho.platform.util.web.SimpleUrlFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.anyString;
@@ -59,6 +61,9 @@ import static org.mockito.Mockito.when;
  * @author Andrei Abramov
  */
 public class MessageFormatterTest {
+
+  /** Matches the license header comment the build prepends to the test template resource. */
+  private static final Pattern LICENSE_HEADER_PATTERN = Pattern.compile( "^\\s*<!--.*?-->\\s*", Pattern.DOTALL );
 
   IRuntimeRepository mockedRuntimeRepository;
   ISolutionEngine mockedSolutionEngine;
@@ -122,12 +127,7 @@ public class MessageFormatterTest {
       MessageFormatter mf = new MessageFormatter() {
         @Override
         String getTemplate( StringBuffer messageBuffer ) {
-          try {
-            return IOUtils.toString( this.getClass()
-              .getResourceAsStream( "viewActionErrorTestTemplate.html" ), "UTF-8" );
-          } catch ( IOException e ) {
-            return null;
-          }
+          return loadTestTemplate();
         }
 
         @Override
@@ -164,12 +164,7 @@ public class MessageFormatterTest {
       MessageFormatter mf = new MessageFormatter() {
         @Override
         String getTemplate( StringBuffer messageBuffer ) {
-          try {
-            return IOUtils.toString( this.getClass()
-              .getResourceAsStream( "viewActionErrorTestTemplate.html" ), "UTF-8" );
-          } catch ( IOException e ) {
-            return null;
-          }
+          return loadTestTemplate();
         }
       };
       StringBuffer messageBuffer = new StringBuffer();
@@ -186,6 +181,20 @@ public class MessageFormatterTest {
           + "<div id=\"details\" class=\"details\"><span class=\"label\">%STACK_TRACE_LABEL%</span><pre "
           + "class=\"stackTrace\">%STACK_TRACE%<pre></div>",
         messageBuffer.toString() );
+    }
+  }
+
+  /**
+   * Loads the error template used by the tests. The build stamps a license header onto every source file, including
+   * this test resource, so the header is stripped here: it is not part of the template under test.
+   */
+  private String loadTestTemplate() {
+    try {
+      final String template = IOUtils.toString(
+        this.getClass().getResourceAsStream( "viewActionErrorTestTemplate.html" ), StandardCharsets.UTF_8 );
+      return LICENSE_HEADER_PATTERN.matcher( template ).replaceFirst( "" ).trim();
+    } catch ( IOException e ) {
+      return null;
     }
   }
 

--- a/core/src/test/java/org/pentaho/platform/uifoundation/chart/ChartHelperTest.java
+++ b/core/src/test/java/org/pentaho/platform/uifoundation/chart/ChartHelperTest.java
@@ -22,18 +22,31 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.platform.api.engine.ILogger;
 import org.pentaho.platform.api.engine.IParameterProvider;
+import org.pentaho.platform.api.engine.ISystemConfig;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.platform.util.logging.Logger;
 import org.pentaho.platform.util.logging.SimpleLogger;
 
 import java.util.ArrayList;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
+/**
+ * Tests for {@link ChartHelper}.
+ * <p>
+ * The class under test is deprecated (BISERVER-12899), so referencing it here is intentional and
+ * unavoidable: deprecated code still has to be covered for as long as it ships.
+ */
+@SuppressWarnings( { "deprecation", "java:S1874" } )
 @RunWith( MockitoJUnitRunner.class )
 public class ChartHelperTest {
 
@@ -44,6 +57,8 @@ public class ChartHelperTest {
   @Before
   public void setUp() {
     logger = new SimpleLogger( ChartHelperTest.class );
+    // the latch lives for the whole JVM, so it has to be cleared to keep the warning tests deterministic
+    ChartHelper.QUERY_PARAMETER_ENABLED_WARNING_LOGGED.set( false );
     when( parameterProvider.getStringParameter( anyString(), any() ) )
       .thenThrow( new RuntimeException( "Failing on purpose, only testing deprecate warning" ) );
   }
@@ -91,6 +106,180 @@ public class ChartHelperTest {
       //Verify chartHelper.deprecateWarning was called by confirming the deprecation warning log was logged
       staticLogger.verify( () -> Logger.warn( eq( ChartHelper.class ), anyString() ),
         times( 1 ) );
+    }
+  }
+
+  @Test
+  public void isChartQueryParameterEnabledReturnsFalseByDefault() {
+    final ISystemConfig systemConfig = Mockito.mock( ISystemConfig.class );
+    when( systemConfig.getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ) )
+      .thenReturn( "false" );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( systemConfig );
+
+      assertFalse( ChartHelper.isChartQueryParameterEnabled() );
+    }
+  }
+
+  @Test
+  public void isChartQueryParameterEnabledFailsClosedWithoutSystemConfig() {
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( null );
+
+      assertFalse( ChartHelper.isChartQueryParameterEnabled() );
+    }
+  }
+
+  @Test
+  public void isChartQueryParameterEnabledReturnsTrueWhenExplicitlyEnabled() {
+    final ISystemConfig systemConfig = Mockito.mock( ISystemConfig.class );
+    when( systemConfig.getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ) )
+      .thenReturn( "true" );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( systemConfig );
+
+      assertTrue( ChartHelper.isChartQueryParameterEnabled() );
+    }
+  }
+
+  @Test
+  public void isChartQueryParameterEnabledIsCaseInsensitive() {
+    final ISystemConfig systemConfig = Mockito.mock( ISystemConfig.class );
+    when( systemConfig.getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ) )
+      .thenReturn( "TRUE" );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( systemConfig );
+
+      assertTrue( ChartHelper.isChartQueryParameterEnabled() );
+    }
+  }
+
+  @Test
+  public void isChartQueryParameterEnabledIsReadOnEveryCall() {
+    final ISystemConfig systemConfig = Mockito.mock( ISystemConfig.class );
+    when( systemConfig.getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ) )
+      .thenReturn( "false" );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( systemConfig );
+
+      ChartHelper.isChartQueryParameterEnabled();
+      ChartHelper.isChartQueryParameterEnabled();
+
+      // the property is not cached, so a configuration change is picked up without a class reload
+      Mockito.verify( systemConfig, times( 2 ) )
+        .getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" );
+    }
+  }
+
+  @Test
+  public void chartQueryParameterIsIgnoredWhenDisabled() {
+    final ILogger mockedLogger = Mockito.mock( ILogger.class );
+    final ISystemConfig systemConfig = Mockito.mock( ISystemConfig.class );
+    when( systemConfig.getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ) )
+      .thenReturn( "false" );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( systemConfig );
+
+      final String resolved =
+        ChartHelper.resolveChartQueryParameter( "select department, actual from QUADRANT_ACTUALS", mockedLogger );
+
+      // the query is dropped, so the supplied statement will never be executed
+      assertNull( resolved );
+      Mockito.verify( mockedLogger ).error( anyString() );
+    }
+  }
+
+  @Test
+  public void chartQueryParameterIsKeptWhenEnabled() {
+    final ILogger mockedLogger = Mockito.mock( ILogger.class );
+    final ISystemConfig systemConfig = Mockito.mock( ISystemConfig.class );
+    when( systemConfig.getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ) )
+      .thenReturn( "true" );
+
+    final String query = "select department, actual from QUADRANT_ACTUALS";
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( systemConfig );
+
+      // the query is kept exactly as supplied
+      assertEquals( query, ChartHelper.resolveChartQueryParameter( query, mockedLogger ) );
+      Mockito.verifyNoInteractions( mockedLogger );
+    }
+  }
+
+  @Test
+  public void isChartQueryParameterEnabledDoesNotLog() {
+    final ISystemConfig systemConfig = Mockito.mock( ISystemConfig.class );
+    when( systemConfig.getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ) )
+      .thenReturn( "true" );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class );
+          MockedStatic<Logger> staticLogger = Mockito.mockStatic( Logger.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( systemConfig );
+
+      assertTrue( ChartHelper.isChartQueryParameterEnabled() );
+
+      // reporting the flag state is the caller's concern, this method only answers the question
+      staticLogger.verifyNoInteractions();
+      assertFalse( ChartHelper.QUERY_PARAMETER_ENABLED_WARNING_LOGGED.get() );
+    }
+  }
+
+  @Test
+  public void chartQueryParameterResolutionWarnsOnlyOnceWhenEnabled() {
+    final ILogger mockedLogger = Mockito.mock( ILogger.class );
+    final ISystemConfig systemConfig = Mockito.mock( ISystemConfig.class );
+    when( systemConfig.getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ) )
+      .thenReturn( "true" );
+
+    final String query = "select department, actual from QUADRANT_ACTUALS";
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class );
+          MockedStatic<Logger> staticLogger = Mockito.mockStatic( Logger.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( systemConfig );
+
+      ChartHelper.resolveChartQueryParameter( query, mockedLogger );
+      ChartHelper.resolveChartQueryParameter( query, mockedLogger );
+
+      // the latch keeps the deviation from the secure default visible without flooding the log
+      staticLogger.verify( () -> Logger.warn( eq( ChartHelper.class ), anyString() ), times( 1 ) );
+    }
+  }
+
+  @Test
+  public void chartQueryParameterResolutionDoesNotWarnWhenDisabled() {
+    final ILogger mockedLogger = Mockito.mock( ILogger.class );
+    final ISystemConfig systemConfig = Mockito.mock( ISystemConfig.class );
+    when( systemConfig.getProperty( ChartHelper.CHART_QUERY_PARAMETER_ENABLED_PROPERTY, "false" ) )
+      .thenReturn( "false" );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class );
+          MockedStatic<Logger> staticLogger = Mockito.mockStatic( Logger.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( systemConfig );
+
+      ChartHelper.resolveChartQueryParameter( "select department, actual from QUADRANT_ACTUALS", mockedLogger );
+
+      // the secure default is not a deviation, so only the ignored query is reported
+      staticLogger.verifyNoInteractions();
+      Mockito.verify( mockedLogger ).error( anyString() );
+    }
+  }
+
+  @Test
+  public void chartQueryParameterResolutionIgnoresTheFlagWhenNoQueryIsSupplied() {
+    final ILogger mockedLogger = Mockito.mock( ILogger.class );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = Mockito.mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( ISystemConfig.class ) ).thenReturn( null );
+
+      // no query was supplied, so the flag is never consulted and nothing is logged
+      assertNull( ChartHelper.resolveChartQueryParameter( null, mockedLogger ) );
+      Mockito.verifyNoInteractions( mockedLogger );
     }
   }
 }


### PR DESCRIPTION
This pull request strengthens the security of the chart component by disabling the deprecated and undocumented `query` request parameter by default. This parameter previously allowed callers to supply arbitrary SQL queries, posing a significant SQL injection risk. The change introduces a configuration property to explicitly enable this legacy capability if needed, and ensures that, by default, any supplied `query` parameter is ignored and an error is logged. The update also adds comprehensive tests and clear documentation for this behavior.

**Security improvements:**
* The deprecated `query` request parameter in the chart component is now disabled by default. When disabled, any supplied `query` is ignored, no SQL is executed, and an error is logged. This prevents SQL injection and resource exhaustion attacks via this vector. [[1]](diffhunk://#diff-1d2f85fc40158b984717941059bdb6bc9ca2c4e06bcb2a3d0f758d4b5b7eddb2R265-R268) [[2]](diffhunk://#diff-1d2f85fc40158b984717941059bdb6bc9ca2c4e06bcb2a3d0f758d4b5b7eddb2R336-R386)
* A new configuration property, `chart-query-parameter-enabled`, is added to `system.properties` to allow explicit enabling of this legacy feature for backward compatibility, with clear warnings about the security risks.
* New error and warning messages are added to clarify when the deprecated parameter is ignored or enabled.

**Code and test improvements:**
* The logic for handling the `query` parameter is refactored into dedicated methods (`resolveChartQueryParameter` and `isChartQueryParameterEnabled`) for clarity and testability.
* Extensive unit tests are added to verify the new behavior, including default disabling, case insensitivity, dynamic property reading, and correct logging.

**Test utility improvements:**
* In `MessageFormatterTest`, the template loading logic is improved to strip out build-stamped license headers, making the tests more robust. [[1]](diffhunk://#diff-8433fe552f7576bb964182478fb91e283fe0eb66ef57684d198504d5720897dbR45-R51) [[2]](diffhunk://#diff-8433fe552f7576bb964182478fb91e283fe0eb66ef57684d198504d5720897dbR65-R67) [[3]](diffhunk://#diff-8433fe552f7576bb964182478fb91e283fe0eb66ef57684d198504d5720897dbL125-R130) [[4]](diffhunk://#diff-8433fe552f7576bb964182478fb91e283fe0eb66ef57684d198504d5720897dbL167-R167) [[5]](diffhunk://#diff-8433fe552f7576bb964182478fb91e283fe0eb66ef57684d198504d5720897dbR187-R200)

These changes collectively improve the security posture of the chart component while maintaining backward compatibility for legacy solutions that require the deprecated feature.

@pentaho/millenniumfalcon please review