### PR TITLE
Backport of BISERVER-15566 - fix import response is invalid html [SP-7487]

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/util/LogUtil.java
+++ b/api/src/main/java/org/pentaho/platform/api/util/LogUtil.java
@@ -79,8 +79,20 @@ public class LogUtil {
     Configuration config = ctx.getConfiguration();
     LoggerConfig loggerConfig = config.getLoggerConfig( logger.getName() );
     loggerConfig.removeAppender( appender.getName() );
+    if ( !isAppenderAttached( config, appender.getName() ) ) {
+      config.getAppenders().remove( appender.getName() );
+      appender.stop();
+    }
     ctx.updateLoggers();
-    appender.stop();
+  }
+
+  private static boolean isAppenderAttached( Configuration config, String appenderName ) {
+    for ( LoggerConfig loggerConfig : config.getLoggers().values() ) {
+      if ( loggerConfig.getAppenders().containsKey( appenderName ) ) {
+        return true;
+      }
+    }
+    return config.getRootLogger().getAppenders().containsKey( appenderName );
   }
 
   public static Appender makeAppender( String name, StringWriter sw, String layout ) {

--- a/api/src/test/java/org/pentaho/platform/api/util/LogUtilTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/util/LogUtilTest.java
@@ -1,0 +1,69 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.platform.api.util;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LogUtilTest {
+
+  @Test
+  void removeAppenderUnregistersAppenderFromConfiguration() {
+    String loggerName = "org.pentaho.test.remove." + UUID.randomUUID();
+    Logger logger = LogManager.getLogger( loggerName );
+    LoggerContext context = (LoggerContext) LogManager.getContext( false );
+    Configuration configuration = context.getConfiguration();
+    Appender appender = LogUtil.makeAppender( loggerName + ".appender", new StringWriter(), "%m" );
+
+    LogUtil.addAppender( appender, logger, Level.INFO );
+    assertTrue( configuration.getAppenders().containsKey( appender.getName() ) );
+
+    LogUtil.removeAppender( appender, logger );
+
+    assertFalse( configuration.getAppenders().containsKey( appender.getName() ) );
+  }
+
+  @Test
+  void removeAppenderStopsOnlyAfterLastLoggerDetaches() {
+    String loggerName = "org.pentaho.test.remove.shared." + UUID.randomUUID();
+    Logger firstLogger = LogManager.getLogger( loggerName + ".first" );
+    Logger secondLogger = LogManager.getLogger( loggerName + ".second" );
+    LoggerContext context = (LoggerContext) LogManager.getContext( false );
+    Configuration configuration = context.getConfiguration();
+    Appender appender = LogUtil.makeAppender( loggerName + ".appender", new StringWriter(), "%m" );
+
+    LogUtil.addAppender( appender, firstLogger, Level.INFO );
+    LogUtil.addAppender( appender, secondLogger, Level.INFO );
+
+    LogUtil.removeAppender( appender, firstLogger );
+
+    assertTrue( configuration.getAppenders().containsKey( appender.getName() ) );
+    assertTrue( configuration.getLoggerConfig( secondLogger.getName() ).getAppenders()
+      .containsKey( appender.getName() ) );
+
+    LogUtil.removeAppender( appender, secondLogger );
+
+    assertFalse( configuration.getAppenders().containsKey( appender.getName() ) );
+  }
+}

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessor.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessor.java
@@ -656,6 +656,7 @@ public class CommandLineProcessor {
     } else {
       String charSet = getOptionValue( INFO_OPTION_CHARSET_NAME, false, true );
       String logFile = getOptionValue( INFO_OPTION_LOGFILE_NAME, false, true );
+      String logLevel = getOptionValue( INFO_OPTION_LOGLEVEL_NAME, false, true );
       String path = getOptionValue( INFO_OPTION_PATH_NAME, true, false );
 
       String importURL = contextURL + API_REPO_FILES_IMPORT;
@@ -683,6 +684,7 @@ public class CommandLineProcessor {
         part.field( MULTIPART_FIELD_CHAR_SET, charSet == null ? StandardCharsets.UTF_8.name() : charSet );
         part.field( MULTIPART_FIELD_APPLY_ACL_PERMISSIONS, "true".equals( permission ) ? "true" : "false",
             MediaType.MULTIPART_FORM_DATA_TYPE );
+        part.field( MULTIVALUE_FIELD_LOG_LEVEL, StringUtils.isEmpty( logLevel ) ? DEFAULT_LOG_LEVEL : logLevel );
         part.field( MULTIPART_FIELD_FILE_UPLOAD, in, MediaType.MULTIPART_FORM_DATA_TYPE );
 
         // If the import service needs the file name do the following.
@@ -716,7 +718,8 @@ public class CommandLineProcessor {
     }
   }
 
-  private void logResponseMessage( String logFile, String path, ClientResponse response, RequestType requestType ) {
+  @VisibleForTesting
+  void logResponseMessage( String logFile, String path, ClientResponse response, RequestType requestType ) {
     boolean badLogFilePath = false;
     if ( response.getStatus() == ClientResponse.Status.OK.getStatusCode() ) {
       errorMessage = Messages.getInstance().getString( "CommandLineProcessor.INFO_" + requestType.toString() + "_SUCCESSFUL" );
@@ -739,7 +742,7 @@ public class CommandLineProcessor {
       }
       System.out.println( message );
       if ( StringUtils.isNotBlank( logFile ) ) {
-        writeToFile( message.toString(), logFile );
+        writeToFile( message.append( System.lineSeparator() ).toString(), logFile );
       }
     } else {
       System.out.println( message );

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/Log4JRepositoryImportLog.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/importexport/Log4JRepositoryImportLog.java
@@ -13,8 +13,10 @@
 
 package org.pentaho.platform.plugin.services.importexport;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.Level;
@@ -36,6 +38,7 @@ public class Log4JRepositoryImportLog {
   private Level logLevel;
   private Appender appender;
   private StringLayout layout;
+  private Writer writer;
 
   /**
    * Constructs an object that keeps track of additional fields for Log4j logging and writes/formats an html file to the
@@ -71,8 +74,8 @@ public class Log4JRepositoryImportLog {
     logName = "RepositoryImportLog." + getThreadName();
     logger = LogManager.getLogger( logName );
     LogUtil.setLevel( logger, logLevel );
-    appender =
-        LogUtil.makeAppender( logName, new OutputStreamWriter( outputStream, StandardCharsets.UTF_8 ), this.layout );
+    writer = new OutputStreamWriter( outputStream, StandardCharsets.UTF_8 );
+    appender = LogUtil.makeAppender( logName, writer, this.layout );
     LogUtil.addAppender( appender, logger, logLevel );
   }
 
@@ -103,13 +106,12 @@ public class Log4JRepositoryImportLog {
   }
 
   protected void endJob() {
-    try {
-      outputStream.write( appender.getLayout().getFooter() );
-    } catch ( Exception e ) {
-      System.out.println( e );
-      // Don't try logging a log error.
-    }
     LogUtil.removeAppender( appender, logger );
+    try {
+      writer.flush();
+    } catch ( IOException e ) {
+      System.out.println( e );
+    }
   }
 
   private String getThreadName() {

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorDatasourceImportTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorDatasourceImportTest.java
@@ -1,0 +1,98 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.platform.plugin.services.importexport;
+
+import com.sun.jersey.api.client.ClientResponse;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.platform.engine.core.output.MultiOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Unit tests for CommandLineProcessor datasource import response message parsing functionality
+ */
+public class CommandLineProcessorDatasourceImportTest extends Assert {
+
+  private static final PrintStream CONSOLE_OUT = System.out;
+  private static final ByteArrayOutputStream CONSOLE_BUFFER = new ByteArrayOutputStream();
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    Locale.setDefault( Locale.US );
+    OutputStream multiOut = new MultiOutputStream( new OutputStream[] { CONSOLE_BUFFER, CONSOLE_OUT } );
+    PrintStream ps = new PrintStream( multiOut );
+    System.setOut( ps );
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    System.setOut( CONSOLE_OUT );
+  }
+
+
+  @Before
+  public void before() {
+    CONSOLE_BUFFER.reset();
+  }
+
+  @Test
+  public void testLogResponseMessageSeparatesAppendedResponses() throws Exception {
+    File logFile = File.createTempFile( "CommandLineProcessorDatasourceImportTest", ".log" );
+    ClientResponse firstResponse = mock( ClientResponse.class );
+    ClientResponse secondResponse = mock( ClientResponse.class );
+    when( firstResponse.getStatus() ).thenReturn( 200 );
+    when( firstResponse.hasEntity() ).thenReturn( true );
+    when( firstResponse.getEntity( String.class ) ).thenReturn( "<html>first</html>" );
+    when( secondResponse.getStatus() ).thenReturn( 200 );
+    when( secondResponse.hasEntity() ).thenReturn( true );
+    when( secondResponse.getEntity( String.class ) ).thenReturn( "<html>second</html>" );
+
+    try {
+      invokeLogResponseMessage( logFile.getAbsolutePath(), "/test/path", firstResponse,
+        CommandLineProcessor.RequestType.IMPORT );
+      invokeLogResponseMessage( logFile.getAbsolutePath(), "/test/path", secondResponse,
+        CommandLineProcessor.RequestType.IMPORT );
+
+      String contents = FileUtils.readFileToString( logFile, StandardCharsets.UTF_8 );
+      assertTrue( contents.contains( "</html>" + System.lineSeparator() + "Import was successful" ) );
+      assertTrue( contents.endsWith( System.lineSeparator() ) );
+    } finally {
+      logFile.delete();
+    }
+  }
+
+
+  /**
+   * Invokes package-private logResponseMessage method
+   */
+  private void invokeLogResponseMessage( String logFile, String path, ClientResponse response,
+                                         CommandLineProcessor.RequestType requestType ) throws Exception {
+    CommandLineProcessor clp = new CommandLineProcessor( new String[] { "--help" } );
+    clp.logResponseMessage( logFile, path, response, requestType );
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/CommandLineProcessorTest.java
@@ -18,9 +18,13 @@ import java.io.File;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.config.ClientConfig;
 import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.multipart.FormDataMultiPart;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -39,10 +43,13 @@ import org.pentaho.platform.engine.core.output.MultiOutputStream;
 import org.pentaho.platform.plugin.services.importexport.CommandLineProcessor.RequestType;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.nullable;
 import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.MediaType;
 
 
 @FixMethodOrder( MethodSorters.NAME_ASCENDING )
@@ -164,7 +171,7 @@ public class CommandLineProcessorTest extends Assert {
       WebResource mockWebResource = mock( WebResource.class );
       when( mockWebResource.type( nullable( String.class ) ) ).thenThrow( new RuntimeException( exception ) );
       when( mockClient.resource( nullable( String.class ) ) ).thenReturn( mockWebResource );
-      clientMock.when( () -> Client.create( any() ) ).thenReturn( mockClient );
+      clientMock.when( () -> Client.create( any( ClientConfig.class ) ) ).thenReturn( mockClient );
 
       File file = File.createTempFile( "CommandLineProcessorTest", ".log" );
 
@@ -185,6 +192,44 @@ public class CommandLineProcessorTest extends Assert {
         file.delete();
       }
       assertTrue( CONSOLE_BUFFER.toString().contains( exception ) );
+    }
+  }
+
+  @Test
+  public void importSendsConfiguredLogLevel() throws Exception {
+    try ( MockedStatic<Client> clientMock = mockStatic( Client.class ) ) {
+      Client mockClient = mock( Client.class );
+      WebResource mockWebResource = mock( WebResource.class );
+      WebResource.Builder mockRequest = mock( WebResource.Builder.class );
+      ClientResponse mockResponse = mock( ClientResponse.class );
+      AtomicReference<String> requestLogLevel = new AtomicReference<>();
+      when( mockClient.resource( nullable( String.class ) ) ).thenReturn( mockWebResource );
+      when( mockWebResource.type( eq( MediaType.MULTIPART_FORM_DATA ) ) ).thenReturn( mockRequest );
+      when( mockRequest.post( eq( ClientResponse.class ), any( FormDataMultiPart.class ) ) ).thenAnswer( invocation -> {
+        FormDataMultiPart multipart = invocation.getArgument( 1 );
+        requestLogLevel.set( multipart.getField( "logLevel" ).getValue() );
+        return mockResponse;
+      } );
+      when( mockResponse.getStatus() ).thenReturn( ClientResponse.Status.OK.getStatusCode() );
+      when( mockResponse.hasEntity() ).thenReturn( false );
+      clientMock.when( () -> Client.create( any( ClientConfig.class ) ) ).thenReturn( mockClient );
+
+      File file = File.createTempFile( "CommandLineProcessorTest", ".zip" );
+      try {
+        CommandLineProcessor.main( new String[] {
+          "--import",
+          "--url=http://test/pentaho",
+          "--username=admin",
+          "--password=password",
+          "--path=/test",
+          "--file-path=" + file.getAbsolutePath(),
+          "--logLevel=DEBUG"
+        } );
+
+        assertEquals( "DEBUG", requestLogLevel.get() );
+      } finally {
+        file.delete();
+      }
     }
   }
 

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/RepositoryImportLogTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/importexport/RepositoryImportLogTest.java
@@ -17,6 +17,7 @@ import junit.framework.TestCase;
 import org.apache.logging.log4j.Level;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This test creates two mock import logs in two threads to test thread safety. Html output is sent to a
@@ -48,6 +49,22 @@ public class RepositoryImportLogTest extends TestCase {
     if ( r2.getTestException() != null ) {
       fail( "Thread 2 Failed with " + r2.getTestException().getMessage() );
     }
+  }
+
+  public void testErrorLevelLogWithoutEventsIncludesHeaderAndFooter() {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    Log4JRepositoryImportLog importLog = new Log4JRepositoryImportLog( output, "/dir", Level.ERROR );
+
+    importLog.endJob();
+
+    String logText = new String( output.toByteArray(), StandardCharsets.UTF_8 );
+    assertTrue( logText.startsWith( "<!DOCTYPE HTML" ) );
+    assertTrue( logText.endsWith( "</body></html>" ) );
+    assertEquals( 1, occurrences( logText, "</table>" ) );
+  }
+
+  private int occurrences( String text, String value ) {
+    return ( text.length() - text.replace( value, "" ).length() ) / value.length();
   }
 
   public static class TestRun implements Runnable {


### PR DESCRIPTION
- Adapted the original 11.x tests due to 10.2 using Jersey 1 (WebResource/ClientResponse)

Original PR: https://github.com/pentaho/pentaho-platform/pull/6298