### PR TITLE
test[BACKLOG-50636]: fix file download authorization scenario

### DIFF
--- a/extensions/src/it/java/org/pentaho/platform/web/http/api/resources/services/FileServiceIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/web/http/api/resources/services/FileServiceIT.java
@@ -1135,6 +1135,7 @@ public class FileServiceIT {
     IAuthorizationPolicy mockAuthPolicy = mock( IAuthorizationPolicy.class );
     doReturn( false ).when( mockAuthPolicy ).isAllowed( nullable( String.class ) );
     doReturn( mockAuthPolicy ).when( fileService ).getPolicy();
+    doReturn( mock( RepositoryFile.class ) ).when( fileService.repository ).getFile( nullable( String.class ) );
 
     /* register  mockAuthPolicy with PentahoSystem so SystemUtils can use it */
     PentahoSystem.registerObject( mockAuthPolicy );


### PR DESCRIPTION
**FileServiceIT**: Updated the authorization setup because `b720ced294e` (`BISERVER-15515`) now returns `FileNotFoundException` for missing files before authorization, so the denied-access case must supply an existing file.