### PR TITLE
fix[BISERVER-14405]: prevent JCR session cache log growth

### DIFF
--- a/extensions/src/it/java/org/pentaho/test/platform/security/userroledao/jackrabbit/UserRoleDaoIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/security/userroledao/jackrabbit/UserRoleDaoIT.java
@@ -59,6 +59,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.extensions.jcr.JcrCallback;
 import org.springframework.extensions.jcr.JcrTemplate;
 import org.springframework.extensions.jcr.SessionFactory;
+import org.pentaho.platform.repository2.unified.jcr.sejcr.PentahoJcrTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -98,6 +99,8 @@ import static org.junit.Assert.fail;
 @Ignore
 // Test commented out until BISERVER-14405 is fixed.
 public class UserRoleDaoIT implements ApplicationContextAware {
+
+  private static final File REPOSITORY_HOME = new File( "/tmp/repository-future/jackrabbit-test-TRUNK" );
 
   public static final String MAIN_TENANT_1 = "maintenant1";
   public static final String SUB_TENANT1_1 = "subtenant11";
@@ -238,9 +241,7 @@ public class UserRoleDaoIT implements ApplicationContextAware {
 
   @BeforeClass
   public static void setUpClass() throws Exception {
-    // folder cannot be deleted at teardown shutdown hooks have not yet necessarily completed
-    // parent folder must match jcrRepository.homeDir bean property in repository-test-override.spring.xml
-    FileUtils.deleteDirectory( new File( "/tmp/jackrabbit-test-TRUNK" ) );
+    FileUtils.deleteDirectory( REPOSITORY_HOME );
     PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_GLOBAL );
   }
 
@@ -307,7 +308,6 @@ public class UserRoleDaoIT implements ApplicationContextAware {
     testJcrTemplate = null;
     roleBindingDaoTarget = null;
     authorizationPolicy = null;
-    mp = null;
     repositoryFileDao = null;
     tenantedRoleNameUtils = null;
     tenantedUserNameUtils = null;
@@ -326,9 +326,18 @@ public class UserRoleDaoIT implements ApplicationContextAware {
     subTenant2_1_2 = null;
     subTenant2_2_1 = null;
     subTenant2_2_2 = null;
-    if ( startupCalled ) {
-      manager.shutdown();
+    try {
+      if ( startupCalled ) {
+        manager.shutdown();
+      }
+    } finally {
+      if ( mp != null ) {
+        mp.stop();
+      }
+      PentahoSessionHolder.removeSession();
+      SecurityContextHolder.clearContext();
     }
+    mp = null;
     tenantManager = null;
   }
 
@@ -390,7 +399,7 @@ public class UserRoleDaoIT implements ApplicationContextAware {
   public void setApplicationContext( final ApplicationContext applicationContext ) throws BeansException {
     manager = (IBackingRepositoryLifecycleManager) applicationContext.getBean( "backingRepositoryLifecycleManager" );
     SessionFactory jcrSessionFactory = (SessionFactory) applicationContext.getBean( "jcrSessionFactory" );
-    testJcrTemplate = new JcrTemplate( jcrSessionFactory );
+    testJcrTemplate = new PentahoJcrTemplate( jcrSessionFactory );
     testJcrTemplate.setAllowCreate( true );
     testJcrTemplate.setExposeNativeSession( true );
     repositoryAdminUsername = (String) applicationContext.getBean( "repositoryAdminUsername" );

--- a/extensions/src/it/java/org/pentaho/test/platform/security/userroledao/jackrabbit/UserRoleDaoIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/security/userroledao/jackrabbit/UserRoleDaoIT.java
@@ -24,7 +24,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
@@ -97,8 +96,6 @@ import static org.junit.Assert.fail;
 @ContextConfiguration ( locations = { "classpath:/repository.spring.xml",
     "classpath:/repository-test-override.spring.xml" } )
 @SuppressWarnings ( "nls" )
-@Ignore
-// Test commented out until BISERVER-14405 is fixed.
 public class UserRoleDaoIT implements ApplicationContextAware {
 
   private static final File REPOSITORY_HOME = new File( "/tmp/repository-future/jackrabbit-test-TRUNK" );

--- a/extensions/src/it/java/org/pentaho/test/platform/security/userroledao/jackrabbit/UserRoleDaoIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/security/userroledao/jackrabbit/UserRoleDaoIT.java
@@ -65,6 +65,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ContextConfiguration;
@@ -236,9 +237,14 @@ public class UserRoleDaoIT implements ApplicationContextAware {
   private ITenant subTenant2_1_2;
   private ITenant subTenant2_2_1;
   private ITenant subTenant2_2_2;
+  private static SecurityContextHolderStrategy previousSecurityContextHolderStrategy;
+  private static String previousPentahoSessionHolderStrategy;
 
   @BeforeClass
   public static void setUpClass() throws Exception {
+    previousSecurityContextHolderStrategy = SecurityContextHolder.getContextHolderStrategy();
+    previousPentahoSessionHolderStrategy = System.getProperty( PentahoSessionHolder.SYSTEM_PROPERTY,
+      PentahoSessionHolder.MODE_INHERITABLETHREADLOCAL );
     FileUtils.deleteDirectory( REPOSITORY_HOME );
     PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_GLOBAL );
     SecurityContextHolder.setStrategyName( SecurityContextHolder.MODE_GLOBAL );
@@ -246,7 +252,8 @@ public class UserRoleDaoIT implements ApplicationContextAware {
 
   @AfterClass
   public static void tearDownClass() throws Exception {
-    PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_INHERITABLETHREADLOCAL );
+    PentahoSessionHolder.setStrategyName( previousPentahoSessionHolderStrategy );
+    SecurityContextHolder.setContextHolderStrategy( previousSecurityContextHolderStrategy );
   }
 
   @Before

--- a/extensions/src/it/java/org/pentaho/test/platform/security/userroledao/jackrabbit/UserRoleDaoIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/security/userroledao/jackrabbit/UserRoleDaoIT.java
@@ -53,6 +53,7 @@ import org.pentaho.platform.security.userroledao.DefaultTenantedPrincipleNameRes
 import org.pentaho.platform.security.userroledao.PentahoRole;
 import org.pentaho.platform.security.userroledao.PentahoUser;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
+import org.pentaho.test.platform.utils.TestResourceLocation;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -243,6 +244,7 @@ public class UserRoleDaoIT implements ApplicationContextAware {
   public static void setUpClass() throws Exception {
     FileUtils.deleteDirectory( REPOSITORY_HOME );
     PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_GLOBAL );
+    SecurityContextHolder.setStrategyName( SecurityContextHolder.MODE_GLOBAL );
   }
 
   @AfterClass
@@ -252,7 +254,7 @@ public class UserRoleDaoIT implements ApplicationContextAware {
 
   @Before
   public void setUp() throws Exception {
-    mp = new MicroPlatform();
+    mp = new MicroPlatform( TestResourceLocation.TEST_RESOURCES + "/solution" );
     // used by DefaultPentahoJackrabbitAccessControlHelper
     mp.defineInstance( IPluginManager.class, pluginManager );
     mp.defineInstance( IAuthorizationPolicy.class, authorizationPolicy );
@@ -266,6 +268,7 @@ public class UserRoleDaoIT implements ApplicationContextAware {
     mp.defineInstance( "useMultiByteEncoding", new Boolean( false ) );
     // Start the micro-platform
     mp.start();
+    SecurityContextHolder.setStrategyName( SecurityContextHolder.MODE_GLOBAL );
     loginAsRepositoryAdmin();
     setAclManagement();
     logout();
@@ -274,59 +277,28 @@ public class UserRoleDaoIT implements ApplicationContextAware {
 
   @After
   public void tearDown() throws Exception {
-    cleanupTenant( subTenant2_2_2 );
-    cleanupTenant( subTenant2_2_1 );
-    cleanupTenant( subTenant2_2 );
-    cleanupTenant( subTenant2_1_2 );
-    cleanupTenant( subTenant2_1_1 );
-    cleanupTenant( subTenant2_1 );
-    cleanupTenant( subTenant1_2_2 );
-    cleanupTenant( subTenant1_2_1 );
-    cleanupTenant( subTenant1_2 );
-    cleanupTenant( subTenant1_1_2 );
-    cleanupTenant( subTenant1_1_1 );
-    cleanupTenant( subTenant1_1 );
-    cleanupTenant( mainTenant_2 );
-    cleanupTenant( mainTenant_1 );
-    cleanupTenant( systemTenant );
-
-    // null out fields to get back memory
-    pluginManager = null;
-    authorizationPolicy = null;
-    loginAsRepositoryAdmin();
-    logout();
-
-    pPrincipalName = null;
-    userRoleDaoProxy = null;
-    userRoleDaoTestProxy = null;
-    tenantManager = null;
-    repositoryAdminUsername = null;
-    adminRoleName = null;
-    authenticatedRoleName = null;
-    sysAdminRoleName = null;
-    sysAdminUserName = null;
-    testJcrTemplate = null;
-    roleBindingDaoTarget = null;
-    authorizationPolicy = null;
-    repositoryFileDao = null;
-    tenantedRoleNameUtils = null;
-    tenantedUserNameUtils = null;
-    systemTenant = null;
-    mainTenant_1 = null;
-    mainTenant_2 = null;
-    subTenant1_1 = null;
-    subTenant1_2 = null;
-    subTenant1_1_1 = null;
-    subTenant1_1_2 = null;
-    subTenant1_2_1 = null;
-    subTenant1_2_2 = null;
-    subTenant2_1 = null;
-    subTenant2_2 = null;
-    subTenant2_1_1 = null;
-    subTenant2_1_2 = null;
-    subTenant2_2_1 = null;
-    subTenant2_2_2 = null;
     try {
+      cleanupTenant( subTenant2_2_2 );
+      cleanupTenant( subTenant2_2_1 );
+      cleanupTenant( subTenant2_2 );
+      cleanupTenant( subTenant2_1_2 );
+      cleanupTenant( subTenant2_1_1 );
+      cleanupTenant( subTenant2_1 );
+      cleanupTenant( subTenant1_2_2 );
+      cleanupTenant( subTenant1_2_1 );
+      cleanupTenant( subTenant1_2 );
+      cleanupTenant( subTenant1_1_2 );
+      cleanupTenant( subTenant1_1_1 );
+      cleanupTenant( subTenant1_1 );
+      cleanupTenant( mainTenant_2 );
+      cleanupTenant( mainTenant_1 );
+      cleanupTenant( systemTenant );
+
+      pluginManager = null;
+      authorizationPolicy = null;
+      loginAsRepositoryAdmin();
+      logout();
+
       if ( startupCalled ) {
         manager.shutdown();
       }
@@ -399,7 +371,8 @@ public class UserRoleDaoIT implements ApplicationContextAware {
   public void setApplicationContext( final ApplicationContext applicationContext ) throws BeansException {
     manager = (IBackingRepositoryLifecycleManager) applicationContext.getBean( "backingRepositoryLifecycleManager" );
     SessionFactory jcrSessionFactory = (SessionFactory) applicationContext.getBean( "jcrSessionFactory" );
-    testJcrTemplate = new PentahoJcrTemplate( jcrSessionFactory );
+    testJcrTemplate = new PentahoJcrTemplate();
+    testJcrTemplate.setSessionFactory( jcrSessionFactory );
     testJcrTemplate.setAllowCreate( true );
     testJcrTemplate.setExposeNativeSession( true );
     repositoryAdminUsername = (String) applicationContext.getBean( "repositoryAdminUsername" );

--- a/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
@@ -76,6 +76,7 @@ import org.pentaho.platform.security.policy.rolebased.RoleAuthorizationPolicy;
 import org.pentaho.platform.security.userroledao.service.UserRoleDaoUserDetailsService;
 import org.pentaho.platform.security.userroledao.service.UserRoleDaoUserRoleListService;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
+import org.pentaho.test.platform.utils.TestResourceLocation;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -119,7 +120,7 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
   private static final File REPOSITORY_HOME = new File( "/tmp/repository-future/jackrabbit-test-TRUNK" );
 
-  private static MicroPlatform mp = new MicroPlatform();
+  private static MicroPlatform mp = new MicroPlatform( TestResourceLocation.TEST_RESOURCES + "/solution" );
 
   private static ResourceConfig config = new ResourceConfig().packages( "org.pentaho.platform.web.http.api.resources" );
   private static ServletDeploymentContext servletDeploymentContext = ServletDeploymentContext.forServlet( new ServletContainer( config ) )
@@ -197,9 +198,10 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     }
   }
 
+  @Override
   @Before
-  public void beforeTest() throws PlatformInitializationException {
-    mp = new MicroPlatform();
+  public void setUp() throws Exception {
+    mp = new MicroPlatform( TestResourceLocation.TEST_RESOURCES + "/solution" );
     // used by DefaultPentahoJackrabbitAccessControlHelper
     mp.defineInstance( IPluginManager.class, pluginManager );
     mp.defineInstance( IAuthorizationPolicy.class, authorizationPolicy );
@@ -236,34 +238,38 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     logout();
     startupCalled = true;
     SecurityContextHolder.setStrategyName( SecurityContextHolder.MODE_GLOBAL );
+    super.setUp();
   }
 
+  @Override
   @After
-  public void afterTest() throws Exception {
-    clearRoleBindings();
-    // null out fields to get back memory
-    pluginManager = null;
-    authorizationPolicy = null;
-    loginAsRepositoryAdmin();
-    SimpleJcrTestUtils.deleteItem( testJcrTemplate, ServerRepositoryPaths.getPentahoRootFolderPath() );
-    logout();
-    repositoryAdminUsername = null;
-    adminAuthorityName = null;
-    authenticatedAuthorityName = null;
-    authorizationPolicy = null;
-    testJcrTemplate = null;
+  public void tearDown() throws Exception {
     try {
+      clearRoleBindings();
+      pluginManager = null;
+      authorizationPolicy = null;
+      loginAsRepositoryAdmin();
+      SimpleJcrTestUtils.deleteItem( testJcrTemplate, ServerRepositoryPaths.getPentahoRootFolderPath() );
+      logout();
+      repositoryAdminUsername = null;
+      adminAuthorityName = null;
+      authenticatedAuthorityName = null;
+      authorizationPolicy = null;
+      testJcrTemplate = null;
       if ( startupCalled ) {
         manager.shutdown();
       }
     } finally {
-      if ( mp != null ) {
-        mp.stop();
+      try {
+        super.tearDown();
+      } finally {
+        if ( mp != null ) {
+          mp.stop();
+        }
+        PentahoSessionHolder.removeSession();
+        SecurityContextHolder.clearContext();
       }
-      PentahoSessionHolder.removeSession();
-      SecurityContextHolder.clearContext();
     }
-    // null out fields to get back memory
     repo = null;
   }
 
@@ -676,7 +682,8 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   public void setApplicationContext( final ApplicationContext applicationContext ) throws BeansException {
     manager = (IBackingRepositoryLifecycleManager) applicationContext.getBean( "backingRepositoryLifecycleManager" );
     SessionFactory jcrSessionFactory = (SessionFactory) applicationContext.getBean( "jcrSessionFactory" );
-    testJcrTemplate = new PentahoJcrTemplate( jcrSessionFactory );
+    testJcrTemplate = new PentahoJcrTemplate();
+    testJcrTemplate.setSessionFactory( jcrSessionFactory );
     testJcrTemplate.setAllowCreate( true );
     testJcrTemplate.setExposeNativeSession( true );
     repositoryAdminUsername = (String) applicationContext.getBean( "repositoryAdminUsername" );

--- a/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
@@ -266,7 +266,6 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
       repositoryAdminUsername = null;
       adminAuthorityName = null;
       authenticatedAuthorityName = null;
-      authorizationPolicy = null;
       testJcrTemplate = null;
       if ( startupCalled ) {
         manager.shutdown();

--- a/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
@@ -92,6 +92,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ContextConfiguration;
@@ -131,6 +132,9 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
   private static final String API_CONTEXT_PATH = "api";
   public static final String MAIN_TENANT_1 = "maintenant1";
+  private static String previousSpringSecurityStrategy;
+  private static SecurityContextHolderStrategy previousSecurityContextHolderStrategy;
+  private static String previousPentahoSessionHolderStrategy;
 
   private IUnifiedRepository repo;
 
@@ -183,6 +187,10 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    previousSpringSecurityStrategy = System.getProperty( SYSTEM_PROPERTY );
+    previousSecurityContextHolderStrategy = SecurityContextHolder.getContextHolderStrategy();
+    previousPentahoSessionHolderStrategy = System.getProperty( PentahoSessionHolder.SYSTEM_PROPERTY,
+      PentahoSessionHolder.MODE_INHERITABLETHREADLOCAL );
     System.setProperty( SYSTEM_PROPERTY, "MODE_GLOBAL" );
     PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_GLOBAL );
 
@@ -194,8 +202,13 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   public static void afterClass() {
     PentahoSessionHolder.removeSession();
     SecurityContextHolder.clearContext();
-    PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_GLOBAL );
-    SecurityContextHolder.setStrategyName( SecurityContextHolder.MODE_GLOBAL );
+    PentahoSessionHolder.setStrategyName( previousPentahoSessionHolderStrategy );
+    SecurityContextHolder.setContextHolderStrategy( previousSecurityContextHolderStrategy );
+    if ( previousSpringSecurityStrategy == null ) {
+      System.clearProperty( SYSTEM_PROPERTY );
+    } else {
+      System.setProperty( SYSTEM_PROPERTY, previousSpringSecurityStrategy );
+    }
   }
 
   private void cleanupUserAndRoles( final ITenant tenant ) {
@@ -212,6 +225,7 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   @Before
   public void setUp() throws Exception {
     mp = new MicroPlatform( TestResourceLocation.TEST_RESOURCES + "/solution" );
+    mp.setFullyQualifiedServerUrl( getBaseUri() + API_CONTEXT_PATH + "/" );
     // used by DefaultPentahoJackrabbitAccessControlHelper
     mp.defineInstance( IPluginManager.class, pluginManager );
     mp.defineInstance( IAuthorizationPolicy.class, authorizationPolicy );

--- a/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
@@ -81,6 +81,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.extensions.jcr.JcrTemplate;
 import org.springframework.extensions.jcr.SessionFactory;
+import org.pentaho.platform.repository2.unified.jcr.sejcr.PentahoJcrTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -115,6 +116,8 @@ import static org.pentaho.test.platform.web.http.api.JerseyTestUtil.assertRespon
 @Ignore
 // Test commented out until BISERVER-14405 is fixed.
 public class FileResourceIT extends JerseyTest implements ApplicationContextAware {
+
+  private static final File REPOSITORY_HOME = new File( "/tmp/repository-future/jackrabbit-test-TRUNK" );
 
   private static MicroPlatform mp = new MicroPlatform();
 
@@ -172,12 +175,14 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     System.setProperty( SYSTEM_PROPERTY, "MODE_GLOBAL" );
     PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_GLOBAL );
 
-    FileUtils.deleteDirectory( new File( "/tmp/jackrabbit-test-TRUNK" ) );
+    FileUtils.deleteDirectory( REPOSITORY_HOME );
     SecurityContextHolder.setStrategyName( SecurityContextHolder.MODE_GLOBAL );
   }
 
   @AfterClass
   public static void afterClass() {
+    PentahoSessionHolder.removeSession();
+    SecurityContextHolder.clearContext();
     PentahoSessionHolder.setStrategyName( PentahoSessionHolder.MODE_GLOBAL );
     SecurityContextHolder.setStrategyName( SecurityContextHolder.MODE_GLOBAL );
   }
@@ -247,10 +252,17 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
     authenticatedAuthorityName = null;
     authorizationPolicy = null;
     testJcrTemplate = null;
-    if ( startupCalled ) {
-      manager.shutdown();
+    try {
+      if ( startupCalled ) {
+        manager.shutdown();
+      }
+    } finally {
+      if ( mp != null ) {
+        mp.stop();
+      }
+      PentahoSessionHolder.removeSession();
+      SecurityContextHolder.clearContext();
     }
-    mp.stop();
     // null out fields to get back memory
     repo = null;
   }
@@ -664,7 +676,7 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
   public void setApplicationContext( final ApplicationContext applicationContext ) throws BeansException {
     manager = (IBackingRepositoryLifecycleManager) applicationContext.getBean( "backingRepositoryLifecycleManager" );
     SessionFactory jcrSessionFactory = (SessionFactory) applicationContext.getBean( "jcrSessionFactory" );
-    testJcrTemplate = new JcrTemplate( jcrSessionFactory );
+    testJcrTemplate = new PentahoJcrTemplate( jcrSessionFactory );
     testJcrTemplate.setAllowCreate( true );
     testJcrTemplate.setExposeNativeSession( true );
     repositoryAdminUsername = (String) applicationContext.getBean( "repositoryAdminUsername" );

--- a/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/http/api/FileResourceIT.java
@@ -21,6 +21,8 @@ import jakarta.ws.rs.core.Response;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 import org.apache.commons.io.FileUtils;
+import org.apache.jackrabbit.api.JackrabbitWorkspace;
+import org.apache.jackrabbit.api.security.authorization.PrivilegeManager;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;
@@ -32,7 +34,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
@@ -67,6 +68,7 @@ import org.pentaho.platform.repository2.mt.RepositoryTenantManager;
 import org.pentaho.platform.repository2.unified.DefaultRepositoryVersionManager;
 import org.pentaho.platform.repository2.unified.IRepositoryFileDao;
 import org.pentaho.platform.repository2.unified.ServerRepositoryPaths;
+import org.pentaho.platform.repository2.unified.jcr.PentahoJcrConstants;
 import org.pentaho.platform.repository2.unified.jcr.RepositoryFileProxyFactory;
 import org.pentaho.platform.repository2.unified.jcr.SimpleJcrTestUtils;
 import org.pentaho.platform.repository2.unified.jcr.jackrabbit.security.TestPrincipalProvider;
@@ -75,11 +77,13 @@ import org.pentaho.platform.security.policy.rolebased.IRoleAuthorizationPolicyRo
 import org.pentaho.platform.security.policy.rolebased.RoleAuthorizationPolicy;
 import org.pentaho.platform.security.userroledao.service.UserRoleDaoUserDetailsService;
 import org.pentaho.platform.security.userroledao.service.UserRoleDaoUserRoleListService;
+import org.pentaho.platform.web.http.filters.PentahoRequestContextFilter;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 import org.pentaho.test.platform.utils.TestResourceLocation;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.extensions.jcr.JcrCallback;
 import org.springframework.extensions.jcr.JcrTemplate;
 import org.springframework.extensions.jcr.SessionFactory;
 import org.pentaho.platform.repository2.unified.jcr.sejcr.PentahoJcrTemplate;
@@ -94,7 +98,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.security.AccessControlException;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -114,18 +123,13 @@ import static org.pentaho.test.platform.web.http.api.JerseyTestUtil.assertRespon
 @ContextConfiguration ( locations = { "classpath:/repository.spring.xml",
     "classpath:/repository-test-override.spring.xml" } )
 @SuppressWarnings ( "nls" )
-@Ignore
-// Test commented out until BISERVER-14405 is fixed.
 public class FileResourceIT extends JerseyTest implements ApplicationContextAware {
 
   private static final File REPOSITORY_HOME = new File( "/tmp/repository-future/jackrabbit-test-TRUNK" );
 
   private static MicroPlatform mp = new MicroPlatform( TestResourceLocation.TEST_RESOURCES + "/solution" );
 
-  private static ResourceConfig config = new ResourceConfig().packages( "org.pentaho.platform.web.http.api.resources" );
-  private static ServletDeploymentContext servletDeploymentContext = ServletDeploymentContext.forServlet( new ServletContainer( config ) )
-    .contextPath( "api" )
-    .build();
+  private static final String API_CONTEXT_PATH = "api";
   public static final String MAIN_TENANT_1 = "maintenant1";
 
   private IUnifiedRepository repo;
@@ -160,13 +164,19 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
   public FileResourceIT() throws Exception {
     super();
-    mp.setFullyQualifiedServerUrl( getBaseUri() + servletDeploymentContext.getContextPath() + "/" );
+    mp.setFullyQualifiedServerUrl( getBaseUri() + API_CONTEXT_PATH + "/" );
   }
 
+  @Override
   protected DeploymentContext configureDeployment() {
-    return servletDeploymentContext;
+    ResourceConfig config = new ResourceConfig().packages( "org.pentaho.platform.web.http.api.resources" );
+    return ServletDeploymentContext.forServlet( new ServletContainer( config ) )
+      .addFilter( PentahoRequestContextFilter.class, "pentahoRequestContextFilter" )
+      .contextPath( API_CONTEXT_PATH )
+      .build();
   }
 
+  @Override
   protected TestContainerFactory getTestContainerFactory() {
     return new GrizzlyWebTestContainerFactory();
   }
@@ -235,6 +245,8 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
     mp.defineInstance( IUserRoleListService.class, userRoleListService );
     mp.start();
+    loginAsRepositoryAdmin();
+    setAclManagement();
     logout();
     startupCalled = true;
     SecurityContextHolder.setStrategyName( SecurityContextHolder.MODE_GLOBAL );
@@ -275,6 +287,25 @@ public class FileResourceIT extends JerseyTest implements ApplicationContextAwar
 
   protected void clearRoleBindings() throws Exception {
     loginAsRepositoryAdmin();
+  }
+
+  private void setAclManagement() {
+    testJcrTemplate.execute( new JcrCallback() {
+      @Override
+      public Object doInJcr( Session session ) throws IOException, RepositoryException {
+        PentahoJcrConstants pentahoJcrConstants = new PentahoJcrConstants( session );
+        Workspace workspace = session.getWorkspace();
+        PrivilegeManager privilegeManager = ( (JackrabbitWorkspace) workspace ).getPrivilegeManager();
+        try {
+          privilegeManager.getPrivilege( pentahoJcrConstants.getPHO_ACLMANAGEMENT_PRIVILEGE() );
+        } catch ( AccessControlException ace ) {
+          privilegeManager.registerPrivilege( pentahoJcrConstants.getPHO_ACLMANAGEMENT_PRIVILEGE(), false,
+              new String[0] );
+        }
+        session.save();
+        return null;
+      }
+    } );
   }
 
   protected void createTestFile( String pathId, String text ) {

--- a/extensions/src/it/resources/repository.spring.xml
+++ b/extensions/src/it/resources/repository.spring.xml
@@ -682,7 +682,7 @@
   </bean>
 
 
-  <bean id="adminJcrTemplate" class="org.springframework.extensions.jcr.JcrTemplate">
+  <bean id="adminJcrTemplate" class="org.pentaho.platform.repository2.unified.jcr.sejcr.PentahoJcrTemplate">
     <property name="sessionFactory" ref="jcrAdminSessionFactory"/>
     <property name="allowCreate" value="false"/>
     <property name="exposeNativeSession" value="true"/>

--- a/extensions/src/test/resources/repository.spring.xml
+++ b/extensions/src/test/resources/repository.spring.xml
@@ -681,7 +681,7 @@
   </bean>
 
 
-  <bean id="adminJcrTemplate" class="org.springframework.extensions.jcr.JcrTemplate">
+  <bean id="adminJcrTemplate" class="org.pentaho.platform.repository2.unified.jcr.sejcr.PentahoJcrTemplate">
     <property name="sessionFactory" ref="jcrAdminSessionFactory"/>
     <property name="allowCreate" value="false"/>
     <property name="exposeNativeSession" value="true"/>

--- a/repository/src/main/java/org/pentaho/platform/repository2/mt/RepositoryTenantManager.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/mt/RepositoryTenantManager.java
@@ -236,7 +236,7 @@ public class RepositoryTenantManager extends AbstractRepositoryTenantManager {
         }
         repositoryFileAclDao.updateAcl( aclBuilder.build() );
       } catch ( Throwable th ) {
-        th.printStackTrace();
+        logger.error( "Unable to grant parent tenant administrators access to the new tenant", th );
       } finally {
         PentahoSessionHolder.setSession( origPentahoSession );
         SecurityContextHolder.getContext().setAuthentication( origAuthentication );
@@ -286,7 +286,7 @@ public class RepositoryTenantManager extends AbstractRepositoryTenantManager {
         try {
           deleteTenants( session, tenants );
         } catch ( RepositoryException e ) {
-          e.printStackTrace();
+          logger.error( "Unable to delete tenants", e );
         }
         return null;
       }
@@ -301,7 +301,7 @@ public class RepositoryTenantManager extends AbstractRepositoryTenantManager {
         try {
           deleteTenant( session, tenant );
         } catch ( RepositoryException e ) {
-          e.printStackTrace();
+          logger.error( "Unable to delete tenant", e );
         }
         return null;
       }
@@ -321,7 +321,7 @@ public class RepositoryTenantManager extends AbstractRepositoryTenantManager {
         try {
           enableTenant( session, tenant, enable );
         } catch ( RepositoryException e ) {
-          e.printStackTrace();
+          logger.error( "Unable to update tenant enabled state", e );
         }
         return null;
       }
@@ -354,7 +354,7 @@ public class RepositoryTenantManager extends AbstractRepositoryTenantManager {
         try {
           enableTenants( session, tenants, enable );
         } catch ( RepositoryException e ) {
-          e.printStackTrace();
+          logger.error( "Unable to update tenants enabled state", e );
         }
         return null;
       }
@@ -371,7 +371,7 @@ public class RepositoryTenantManager extends AbstractRepositoryTenantManager {
           childTenants = getChildTenants( session, parentTenant, includeDisabledTenants );
         } catch ( RepositoryException e ) {
           childTenants = new ArrayList<ITenant>();
-          e.printStackTrace();
+          logger.error( "Unable to get child tenants", e );
         }
         return childTenants;
       }
@@ -388,7 +388,7 @@ public class RepositoryTenantManager extends AbstractRepositoryTenantManager {
           childTenants = getChildTenants( session, parentTenant );
         } catch ( RepositoryException e ) {
           childTenants = new ArrayList<ITenant>();
-          e.printStackTrace();
+          logger.error( "Unable to get child tenants", e );
         }
         return childTenants;
       }

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/sejcr/GuavaCachePoolPentahoJcrSessionFactory.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/sejcr/GuavaCachePoolPentahoJcrSessionFactory.java
@@ -94,10 +94,11 @@ class GuavaCachePoolPentahoJcrSessionFactory extends NoCachePentahoJcrSessionFac
       .maximumSize( cacheSize )
       .removalListener( (RemovalListener<CacheKey, Session>) objectObjectRemovalNotification -> {
         Session session = objectObjectRemovalNotification.getValue();
-        if ( sessionIsUnused( session ) && session.isLive() ) {
+        boolean sessionIsLive = session.isLive();
+        if ( sessionIsLive && sessionIsUnused( session ) ) {
           logger.debug( "Logging out cached session after eviction " + session );
           session.logout();
-        } else if ( session.isLive() ) {
+        } else if ( sessionIsLive ) {
           logger.warn( "Session has expired from cache, but still marked as in use.  May be orphaned.  " + session );
         }
       } ).recordStats()

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/sejcr/GuavaCachePoolPentahoJcrSessionFactory.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/sejcr/GuavaCachePoolPentahoJcrSessionFactory.java
@@ -94,10 +94,10 @@ class GuavaCachePoolPentahoJcrSessionFactory extends NoCachePentahoJcrSessionFac
       .maximumSize( cacheSize )
       .removalListener( (RemovalListener<CacheKey, Session>) objectObjectRemovalNotification -> {
         Session session = objectObjectRemovalNotification.getValue();
-        if ( sessionIsUnused( session ) ) {
+        if ( sessionIsUnused( session ) && session.isLive() ) {
           logger.debug( "Logging out cached session after eviction " + session );
           session.logout();
-        } else {
+        } else if ( session.isLive() ) {
           logger.warn( "Session has expired from cache, but still marked as in use.  May be orphaned.  " + session );
         }
       } ).recordStats()

--- a/repository/src/main/resources/repository.spring.xml
+++ b/repository/src/main/resources/repository.spring.xml
@@ -678,7 +678,7 @@
   </bean>
 
 
-  <bean id="adminJcrTemplate" class="org.springframework.extensions.jcr.JcrTemplate">
+  <bean id="adminJcrTemplate" class="org.pentaho.platform.repository2.unified.jcr.sejcr.PentahoJcrTemplate">
     <property name="sessionFactory" ref="jcrAdminSessionFactory"/>
     <property name="allowCreate" value="false"/>
     <property name="exposeNativeSession" value="true"/>

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/sejcr/GuavaCachePoolPentahoJcrRaceConditionTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/sejcr/GuavaCachePoolPentahoJcrRaceConditionTest.java
@@ -13,6 +13,7 @@
 
 package org.pentaho.platform.repository2.unified.jcr.sejcr;
 
+import com.google.common.cache.Cache;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,8 +23,11 @@ import org.springframework.extensions.jcr.JcrCallback;
 import org.springframework.extensions.jcr.SessionFactory;
 
 import javax.jcr.RepositoryException;
+import javax.jcr.Repository;
 import javax.jcr.Session;
+import javax.jcr.SimpleCredentials;
 
+import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -31,6 +35,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pentaho.platform.repository2.unified.jcr.sejcr.GuavaCachePoolPentahoJcrSessionFactory.USAGE_COUNT;
 
@@ -199,5 +208,33 @@ public class GuavaCachePoolPentahoJcrRaceConditionTest {
       throw new AssertionError( "Worker thread failed", workerFailure.get() );
     }
     assertEquals( "All balanced factory + template operations return the count to 0", 0, usageCount.get() );
+  }
+
+  @Test
+  public void evictingDeadSessionDoesNotReadUsageCountOrLogOut() throws Exception {
+    Repository repository = org.mockito.Mockito.mock( Repository.class );
+    Session cachedSession = org.mockito.Mockito.mock( Session.class );
+    SimpleCredentials credentials = new SimpleCredentials( "user", "password".toCharArray() );
+    when( repository.login( any( SimpleCredentials.class ), eq( "workspace" ) ) ).thenReturn( cachedSession );
+    when( cachedSession.isLive() ).thenReturn( true );
+    when( cachedSession.getAttribute( USAGE_COUNT ) ).thenReturn( usageCount );
+
+    GuavaCachePoolPentahoJcrSessionFactory factory =
+      new GuavaCachePoolPentahoJcrSessionFactory( repository, "workspace" );
+    factory.getSession( credentials );
+
+    clearInvocations( cachedSession );
+    when( cachedSession.isLive() ).thenReturn( false );
+    getSessionCache( factory ).invalidateAll();
+
+    verify( cachedSession, never() ).getAttribute( USAGE_COUNT );
+    verify( cachedSession, never() ).logout();
+  }
+
+  @SuppressWarnings( "unchecked" )
+  private Cache<?, ?> getSessionCache( GuavaCachePoolPentahoJcrSessionFactory factory ) throws Exception {
+    Field cacheField = GuavaCachePoolPentahoJcrSessionFactory.class.getDeclaredField( "sessionCache" );
+    cacheField.setAccessible( true );
+    return (Cache<?, ?>) cacheField.get( factory );
   }
 }


### PR DESCRIPTION
## Summary

Prevents excessive log and disk growth when the JCR session cache evicts sessions, restores cache-aware JCR template wiring, and re-enables the two integration suites originally suppressed for this issue.

## Changes

- Guard cache eviction so only live, unused JCR sessions are logged out; a dead cached session is not queried for `USAGE_COUNT` or logged out.
- Restore `adminJcrTemplate` to `PentahoJcrTemplate` in production and test/IT Spring shadows, preserving the template/factory cache-protection contract.
- Replace direct tenant-manager stack-trace output with contextual logging.
- Repair the `FileResourceIT` Jersey and MicroPlatform lifecycle: create a fresh deployment per test, register the request-context filter and ACL privilege, preserve the active Grizzly server URL, and restore JVM-wide security holder state after the class.
- Repair and enable `UserRoleDaoIT`: use the intended MicroPlatform solution path, clean up reliably, and restore its prior Spring Security and Pentaho session-holder strategies after the class.

## Validation

- Cache eviction/race test: `6/6` passed, including the non-live cached-session eviction regression.
- `FileResourceIT`: enabled and passed `11/11` with no failures, errors, or skips.
- `UserRoleDaoIT`: enabled and passed `16/16` with no failures, errors, or skips.
- Each integration suite ran through direct Failsafe compilation and execution using the integration-test source lifecycle.

## Scope

The original `BISERVER-14405` suppression commit ignored exactly `FileResourceIT` and `UserRoleDaoIT`; both are intentionally enabled by this PR. Test cases and assertions remain unchanged.