### PR TITLE
fix[BACKLOG-50639] [SP-7540]: Restore legacy PUC JSON writer precedence

### DIFF
--- a/extensions/src/it/java/org/pentaho/platform/web/servlet/JAXRSServletTest.java
+++ b/extensions/src/it/java/org/pentaho/platform/web/servlet/JAXRSServletTest.java
@@ -14,6 +14,9 @@
 package org.pentaho.platform.web.servlet;
 
 import com.sun.jersey.api.core.ResourceConfig;
+import com.sun.jersey.json.impl.provider.entity.JSONJAXBElementProvider;
+import com.sun.jersey.json.impl.provider.entity.JSONListElementProvider;
+import com.sun.jersey.json.impl.provider.entity.JSONRootElementProvider;
 import com.sun.jersey.spi.MessageBodyWorkers;
 import com.sun.jersey.spi.container.WebApplication;
 import com.sun.jersey.spi.container.servlet.ServletContainer;
@@ -164,6 +167,7 @@ public class JAXRSServletTest {
     ConfigurableApplicationContext context = mock( ConfigurableApplicationContext.class );
     String[] beans = {};
     HashSet<Class> classes = new HashSet<>();
+    HashSet<Class<?>> providerClasses = new HashSet<>();
     classes.add( ResourseClass.class );
 
     when( request.getMethod() ).thenReturn( "POST" );
@@ -180,10 +184,14 @@ public class JAXRSServletTest {
     doReturn( servletContext ).when( webServletConfig ).getServletContext();
     doReturn( resourceConfig ).when( webServletConfig ).getDefaultResourceConfig( any() );
     doReturn( classes ).when( resourceConfig ).getRootResourceClasses();
+    doReturn( providerClasses ).when( resourceConfig ).getClasses();
     doReturn( context ).when( jaxrsServlet ).getAppContext();
     doReturn( Collections.emptyEnumeration() ).when( request ).getHeaderNames();
     try {
       jaxrsServlet.init();
+      assertTrue( providerClasses.contains( JSONRootElementProvider.App.class ) );
+      assertTrue( providerClasses.contains( JSONListElementProvider.App.class ) );
+      assertTrue( providerClasses.contains( JSONJAXBElementProvider.App.class ) );
       jaxrsServlet.service( request, response );
       verify( (SpringServlet) jaxrsServlet ).service( eq( request ), eq( response ) );
       verify( response ).setStatus( 404, "Not Found" );

--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/JAXRSServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/JAXRSServlet.java
@@ -17,6 +17,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.sun.jersey.api.container.ContainerException;
 import com.sun.jersey.api.container.MappableContainerException;
 import com.sun.jersey.api.core.ResourceConfig;
+import com.sun.jersey.json.impl.provider.entity.JSONJAXBElementProvider;
+import com.sun.jersey.json.impl.provider.entity.JSONListElementProvider;
+import com.sun.jersey.json.impl.provider.entity.JSONRootElementProvider;
 import com.sun.jersey.server.impl.ThreadLocalInvoker;
 import com.sun.jersey.server.probes.UriRuleProbeProvider;
 import com.sun.jersey.spi.MessageBodyWorkers;
@@ -219,6 +222,12 @@ public class JAXRSServlet extends SpringServlet {
     @Override
     protected void configure( WebConfig wc, ResourceConfig rc, WebApplication wa ) {
       super.configure( wc, rc, wa );
+
+      // BACKLOG-50639: 10.2 PUC requires its legacy JAXB JSON contract. Register the legacy writers as
+      // application providers so Jersey evaluates them before the service-discovered JacksonJsonProvider.
+      rc.getClasses().add( JSONRootElementProvider.App.class );
+      rc.getClasses().add( JSONListElementProvider.App.class );
+      rc.getClasses().add( JSONJAXBElementProvider.App.class );
 
       JAXRSServlet.this.configure( wc, rc, wa );
     }


### PR DESCRIPTION
Fixes BACKLOG-50639 by restoring the legacy Jersey JAXB JSON writers required by PUC 10.2.

Jersey was selecting the service-discovered `JacksonJsonProvider` before the legacy JAXB JSON writers on Windows. This changed PUC response contracts from legacy JAXB JSON to standard Jackson JSON, including bare list responses and typed Boolean/numeric values that the legacy GWT client cannot parse.

The fix explicitly registers the `application/json` JAXB writers as application providers during servlet configuration. Jersey evaluates application providers before service-discovered providers, preserving the historic PUC JSON contract while retaining Jackson as the fallback for non-JAXB entities.