### PR TITLE
fix[BACKLOG-50636]: Add Saxon compatibility for legacy XSL functions

### DIFF
--- a/extensions/src/it/java/org/pentaho/platform/plugin/services/connections/xquery/XQueryIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/plugin/services/connections/xquery/XQueryIT.java
@@ -43,7 +43,8 @@ public class XQueryIT extends BaseTest {
   private static final String ALT_SOLUTION_PATH = TestResourceLocation.TEST_RESOURCES + "/connections-solution";
   private static final String PENTAHO_XML_PATH = "/system/pentaho.xml";
 
-  private static final String TEST_QUERY = "doc(\"" + SOLUTION_PATH + "/xquery/books.xml\")/bookstore/book";
+  private static final String TEST_QUERY = "doc(\"" + new File( SOLUTION_PATH, "xquery/books.xml" ).toURI()
+    + "\")/bookstore/book";
 
   public String getSolutionPath() {
     File file = new File( SOLUTION_PATH + PENTAHO_XML_PATH );

--- a/extensions/src/it/java/org/pentaho/test/platform/plugin/JFreeReportIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/plugin/JFreeReportIT.java
@@ -25,7 +25,9 @@ import org.pentaho.platform.engine.core.system.PentahoRequestContextHolder;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.platform.plugin.services.messages.Messages;
 import org.pentaho.platform.uifoundation.component.ActionComponent;
+import org.pentaho.platform.util.xml.XMLParserFactoryProducer;
 import org.pentaho.platform.util.web.SimpleUrlFactory;
+import org.pentaho.platform.web.http.api.resources.utils.XactionSaxonExtensions;
 import org.pentaho.test.platform.engine.core.BaseTest;
 import org.pentaho.test.platform.utils.TestResourceLocation;
 
@@ -36,6 +38,10 @@ import java.util.Map;
 @SuppressWarnings( "nls" )
 public class JFreeReportIT extends BaseTest {
   private static final String SOLUTION_PATH = TestResourceLocation.TEST_RESOURCES + "/solution";
+
+  static {
+    XactionSaxonExtensions.registerAll( XMLParserFactoryProducer.getSaxonConfig() );
+  }
 
   public String getSolutionPath() {
     return SOLUTION_PATH;

--- a/extensions/src/it/java/org/pentaho/test/platform/plugin/RuntimeIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/plugin/RuntimeIT.java
@@ -22,6 +22,8 @@ import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.platform.plugin.services.messages.Messages;
+import org.pentaho.platform.util.xml.XMLParserFactoryProducer;
+import org.pentaho.platform.web.http.api.resources.utils.XactionSaxonExtensions;
 import org.pentaho.test.platform.engine.core.BaseTest;
 import org.pentaho.test.platform.utils.TestResourceLocation;
 
@@ -31,6 +33,10 @@ import java.io.OutputStream;
 public class RuntimeIT extends BaseTest {
 
   private static final String SOLUTION_PATH = TestResourceLocation.TEST_RESOURCES + "/solution";
+
+  static {
+    XactionSaxonExtensions.registerAll( XMLParserFactoryProducer.getSaxonConfig() );
+  }
 
   public String getSolutionPath() {
     return SOLUTION_PATH;

--- a/extensions/src/it/java/org/pentaho/test/platform/plugin/XQConnectionIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/plugin/XQConnectionIT.java
@@ -19,6 +19,8 @@ import org.pentaho.platform.engine.core.output.SimpleOutputHandler;
 import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.platform.plugin.services.messages.Messages;
+import org.pentaho.platform.util.xml.XMLParserFactoryProducer;
+import org.pentaho.platform.web.http.api.resources.utils.XactionSaxonExtensions;
 import org.pentaho.test.platform.engine.core.BaseTest;
 import org.pentaho.test.platform.utils.TestResourceLocation;
 
@@ -32,6 +34,10 @@ import java.util.Map;
 public class XQConnectionIT extends BaseTest {
   private static final String SOLUTION_PATH = TestResourceLocation.TEST_RESOURCES + "/solution";
   private static final String ALT_SOLUTION_PATH = TestResourceLocation.TEST_RESOURCES + "/solution";
+
+  static {
+    XactionSaxonExtensions.registerAll( XMLParserFactoryProducer.getSaxonConfig() );
+  }
 
   // private static final String PENTAHO_XML_PATH = "/system/pentaho.xml";
 

--- a/extensions/src/main/java/org/pentaho/platform/plugin/action/xml/xquery/XQueryBaseComponent.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/action/xml/xquery/XQueryBaseComponent.java
@@ -15,7 +15,6 @@
 package org.pentaho.platform.plugin.action.xml.xquery;
 
 import net.sf.saxon.trans.XPathException;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.logging.Log;
 import org.dom4j.Document;
 import org.dom4j.Node;
@@ -277,8 +276,7 @@ public abstract class XQueryBaseComponent extends ComponentBase implements IPrep
           }
           out.close();
           inputStream.close();
-          documentPath = temp.getAbsolutePath();
-          documentPath = FilenameUtils.separatorsToUnix( documentPath );
+          documentPath = temp.toURI().toString();
 
           rawQuery = "doc(\"" + documentPath + "\")" + rawQuery; //$NON-NLS-1$ //$NON-NLS-2$
         }

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensions.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensions.java
@@ -32,17 +32,29 @@ import org.pentaho.platform.web.xsl.messages.Messages;
  */
 public class XactionSaxonExtensions {
 
+  private static final String CURRENT_MESSAGE_NAMESPACE = "org.pentaho.platform.web.xsl.messages.Messages";
+  private static final String LEGACY_MESSAGE_NAMESPACE = "org.pentaho.platform.plugin.action.messages.Messages";
+
   /**
    * <b>msg:getInstance()</b><br>
-   * Namespace: org.pentaho.platform.web.xsl.messages.Messages<br>
+   * Namespaces: org.pentaho.platform.web.xsl.messages.Messages and
+   * org.pentaho.platform.plugin.action.messages.Messages<br>
    * XSL usage: <code>&lt;xsl:variable name="messages" select="msg:getInstance()" /&gt;</code>
    */
   public static class MsgGetInstance extends ExtensionFunctionDefinition {
 
-    private static final String NAMESPACE = "org.pentaho.platform.web.xsl.messages.Messages";
+    private final String namespace;
+
+    public MsgGetInstance() {
+      this( CURRENT_MESSAGE_NAMESPACE );
+    }
+
+    public MsgGetInstance( String namespace ) {
+      this.namespace = namespace;
+    }
 
     @Override public StructuredQName getFunctionQName() {
-      return new StructuredQName( "msg", NAMESPACE, "getInstance" );
+      return new StructuredQName( "msg", namespace, "getInstance" );
     }
 
     @Override public SequenceType[] getArgumentTypes() {
@@ -65,15 +77,24 @@ public class XactionSaxonExtensions {
 
   /**
    * <b>msg:getXslString(messages, key)</b><br>
-   * Namespace: org.pentaho.platform.web.xsl.messages.Messages<br>
+    * Namespaces: org.pentaho.platform.web.xsl.messages.Messages and
+    * org.pentaho.platform.plugin.action.messages.Messages<br>
    * XSL usage: <code>msg:getXslString($messages, 'UI.SOME_KEY')</code>
    */
   public static class MsgGetXslString extends ExtensionFunctionDefinition {
 
-    private static final String NAMESPACE = "org.pentaho.platform.web.xsl.messages.Messages";
+    private final String namespace;
+
+    public MsgGetXslString() {
+      this( CURRENT_MESSAGE_NAMESPACE );
+    }
+
+    public MsgGetXslString( String namespace ) {
+      this.namespace = namespace;
+    }
 
     @Override public StructuredQName getFunctionQName() {
-      return new StructuredQName( "msg", NAMESPACE, "getXslString" );
+      return new StructuredQName( "msg", namespace, "getXslString" );
     }
 
     @Override public SequenceType[] getArgumentTypes() {
@@ -99,15 +120,24 @@ public class XactionSaxonExtensions {
 
   /**
    * <b>msg:getString(messages, key)</b><br>
-   * Namespace: org.pentaho.platform.web.xsl.messages.Messages<br>
+    * Namespaces: org.pentaho.platform.web.xsl.messages.Messages and
+    * org.pentaho.platform.plugin.action.messages.Messages<br>
    * XSL usage: <code>msg:getString($messages, 'UI.SOME_KEY')</code>
    */
   public static class MsgGetString extends ExtensionFunctionDefinition {
 
-    private static final String NAMESPACE = "org.pentaho.platform.web.xsl.messages.Messages";
+    private final String namespace;
+
+    public MsgGetString() {
+      this( CURRENT_MESSAGE_NAMESPACE );
+    }
+
+    public MsgGetString( String namespace ) {
+      this.namespace = namespace;
+    }
 
     @Override public StructuredQName getFunctionQName() {
-      return new StructuredQName( "msg", NAMESPACE, "getString" );
+      return new StructuredQName( "msg", namespace, "getString" );
     }
 
     @Override public SequenceType[] getArgumentTypes() {
@@ -159,13 +189,16 @@ public class XactionSaxonExtensions {
   }
 
   /**
-  * Register all extensions into a Saxon Configuration.
+   * Register all extensions into a Saxon Configuration.
    */
   public static void registerAll( Configuration config ) {
     if ( config != null ) {
       config.registerExtensionFunction( new MsgGetInstance() );
       config.registerExtensionFunction( new MsgGetXslString() );
       config.registerExtensionFunction( new MsgGetString() );
+      config.registerExtensionFunction( new MsgGetInstance( LEGACY_MESSAGE_NAMESPACE ) );
+      config.registerExtensionFunction( new MsgGetXslString( LEGACY_MESSAGE_NAMESPACE ) );
+      config.registerExtensionFunction( new MsgGetString( LEGACY_MESSAGE_NAMESPACE ) );
       config.registerExtensionFunction( new LocGetTextDirection() );
     }
   }

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensions.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensions.java
@@ -89,8 +89,40 @@ public class XactionSaxonExtensions {
     @Override public ExtensionFunctionCall makeCallExpression() {
       return new ExtensionFunctionCall() {
         @Override public Sequence call( XPathContext context, Sequence[] arguments ) throws XPathException {
-          String key = arguments[ 1 ].head().getStringValue(); Messages messages = Messages.getInstance();
+          String key = arguments[ 1 ].head().getStringValue();
+          Messages messages = Messages.getInstance();
           return StringValue.makeStringValue( messages.getXslString( key ) );
+        }
+      };
+    }
+  }
+
+  /**
+   * <b>msg:getString(messages, key)</b><br>
+   * Namespace: org.pentaho.platform.web.xsl.messages.Messages<br>
+   * XSL usage: <code>msg:getString($messages, 'UI.SOME_KEY')</code>
+   */
+  public static class MsgGetString extends ExtensionFunctionDefinition {
+
+    private static final String NAMESPACE = "org.pentaho.platform.web.xsl.messages.Messages";
+
+    @Override public StructuredQName getFunctionQName() {
+      return new StructuredQName( "msg", NAMESPACE, "getString" );
+    }
+
+    @Override public SequenceType[] getArgumentTypes() {
+      return new SequenceType[] { SequenceType.SINGLE_STRING, SequenceType.SINGLE_STRING };
+    }
+
+    @Override public SequenceType getResultType( SequenceType[] suppliedArgumentTypes ) {
+      return SequenceType.SINGLE_STRING;
+    }
+
+    @Override public ExtensionFunctionCall makeCallExpression() {
+      return new ExtensionFunctionCall() {
+        @Override public Sequence call( XPathContext context, Sequence[] arguments ) throws XPathException {
+          String key = arguments[ 1 ].head().getStringValue();
+          return StringValue.makeStringValue( Messages.getInstance().getString( key ) );
         }
       };
     }
@@ -127,12 +159,13 @@ public class XactionSaxonExtensions {
   }
 
   /**
-   * Register all 3 extensions into a Saxon Configuration.
+  * Register all extensions into a Saxon Configuration.
    */
   public static void registerAll( Configuration config ) {
     if ( config != null ) {
       config.registerExtensionFunction( new MsgGetInstance() );
       config.registerExtensionFunction( new MsgGetXslString() );
+      config.registerExtensionFunction( new MsgGetString() );
       config.registerExtensionFunction( new LocGetTextDirection() );
     }
   }

--- a/extensions/src/test/java/org/pentaho/platform/plugin/action/xml/xquery/XQueryBaseComponentTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/action/xml/xquery/XQueryBaseComponentTest.java
@@ -1,0 +1,95 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+package org.pentaho.platform.plugin.action.xml.xquery;
+
+import org.apache.commons.logging.Log;
+import org.junit.Test;
+import org.pentaho.actionsequence.dom.IActionInput;
+import org.pentaho.actionsequence.dom.IActionOutput;
+import org.pentaho.actionsequence.dom.IActionResource;
+import org.pentaho.actionsequence.dom.actions.XQueryAction;
+import org.pentaho.commons.connection.IPentahoConnection;
+import org.pentaho.platform.api.engine.IActionSequenceResource;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class XQueryBaseComponentTest {
+
+  @Test
+  public void testPrepareQueryUsesFileUriForXmlResource() throws Exception {
+    XQueryAction action = mock( XQueryAction.class );
+    IActionInput sourceXml = mock( IActionInput.class );
+    IActionResource xmlResource = mock( IActionResource.class );
+    IActionSequenceResource resource = mock( IActionSequenceResource.class );
+    IActionOutput preparedStatement = mock( IActionOutput.class );
+
+    when( action.getSourceXml() ).thenReturn( sourceXml );
+    when( sourceXml.getStringValue() ).thenReturn( null );
+    when( action.getXmlDocument() ).thenReturn( xmlResource );
+    when( xmlResource.getName() ).thenReturn( "test.xml" );
+    when( action.getOutputPreparedStatement() ).thenReturn( preparedStatement );
+    when( resource.getSourceType() ).thenReturn( IActionSequenceResource.SOLUTION_FILE_RESOURCE );
+    when( resource.getInputStream( RepositoryFilePermission.READ ) ).thenAnswer( invocation -> xml() );
+
+    TestXQueryBaseComponent component = new TestXQueryBaseComponent( resource );
+    component.setActionDefinition( action );
+
+    assertTrue( component.runQuery( mock( IPentahoConnection.class ), "/result-set" ) );
+    assertTrue( component.preparedQuery.startsWith( "doc(\"file:" ) );
+  }
+
+  private InputStream xml() {
+    return new ByteArrayInputStream( "<result-set/>".getBytes( StandardCharsets.UTF_8 ) );
+  }
+
+  private static class TestXQueryBaseComponent extends XQueryBaseComponent {
+    private final IActionSequenceResource resource;
+
+    private TestXQueryBaseComponent( IActionSequenceResource resource ) {
+      this.resource = resource;
+    }
+
+    @Override
+    public boolean validateSystemSettings() {
+      return true;
+    }
+
+    @Override
+    public Log getLogger() {
+      return mock( Log.class );
+    }
+
+    @Override
+    protected IActionSequenceResource getResource( String resourceName ) {
+      return resource;
+    }
+
+    @Override
+    protected boolean retrieveColumnTypes() {
+      return false;
+    }
+
+    @Override
+    protected boolean prepareFinalQuery( String rawQuery, String[] columnTypes ) {
+      preparedQuery = rawQuery;
+      return true;
+    }
+  }
+}

--- a/extensions/src/test/java/org/pentaho/platform/plugin/action/xml/xquery/XQueryBaseComponentTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/action/xml/xquery/XQueryBaseComponentTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 public class XQueryBaseComponentTest {
 
   @Test
-  public void testPrepareQueryUsesFileUriForXmlResource() throws Exception {
+  public void testPrepareQueryUsesFileUriForXmlResource() {
     XQueryAction action = mock( XQueryAction.class );
     IActionInput sourceXml = mock( IActionInput.class );
     IActionResource xmlResource = mock( IActionResource.class );

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensionsTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/utils/XactionSaxonExtensionsTest.java
@@ -1,0 +1,59 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+package org.pentaho.platform.web.http.api.resources.utils;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.StructuredQName;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class XactionSaxonExtensionsTest {
+  private static final String CURRENT_NAMESPACE = "org.pentaho.platform.web.xsl.messages.Messages";
+  private static final String LEGACY_NAMESPACE = "org.pentaho.platform.plugin.action.messages.Messages";
+
+  @Test
+  public void testRegistersMessageFunctionsForCurrentAndLegacyNamespaces() {
+    RecordingConfiguration configuration = new RecordingConfiguration();
+
+    XactionSaxonExtensions.registerAll( configuration );
+
+    assertEquals( Set.of(
+      function( CURRENT_NAMESPACE, "getInstance" ),
+      function( CURRENT_NAMESPACE, "getXslString" ),
+      function( CURRENT_NAMESPACE, "getString" ),
+      function( LEGACY_NAMESPACE, "getInstance" ),
+      function( LEGACY_NAMESPACE, "getXslString" ),
+      function( LEGACY_NAMESPACE, "getString" ) ), configuration.messageFunctions );
+  }
+
+  private static String function( String namespace, String localPart ) {
+    return namespace + ':' + localPart;
+  }
+
+  private static class RecordingConfiguration extends Configuration {
+    private final Set<String> messageFunctions = new HashSet<>();
+
+    @Override
+    public void registerExtensionFunction( ExtensionFunctionDefinition function ) {
+      StructuredQName name = function.getFunctionQName();
+      if ( CURRENT_NAMESPACE.equals( name.getURI() ) || LEGACY_NAMESPACE.equals( name.getURI() ) ) {
+        messageFunctions.add( function( name.getURI(), name.getLocalPart() ) );
+      }
+    }
+  }
+}

--- a/extensions/src/test/resources/solution/system/custom/xsl/CustomReportParameters.xsl
+++ b/extensions/src/test/resources/solution/system/custom/xsl/CustomReportParameters.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	version="2.0" 
 	xmlns:html="http://www.w3.org/TR/REC-html40"
-	xmlns:msg="org.pentaho.platform.plugin.action.messages.Messages"
+	xmlns:msg="org.pentaho.platform.web.xsl.messages.Messages"
     xmlns:loc="org.pentaho.platform.util.messages.LocaleHelper"
 	exclude-result-prefixes="html msg loc">
 	

--- a/extensions/src/test/resources/solution/system/custom/xsl/ParameterFormUtil.xsl
+++ b/extensions/src/test/resources/solution/system/custom/xsl/ParameterFormUtil.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	version="2.0" 
 	xmlns:html="http://www.w3.org/TR/REC-html40"
-	xmlns:msg="org.pentaho.platform.plugin.action.messages.Messages"
+	xmlns:msg="org.pentaho.platform.web.xsl.messages.Messages"
 	exclude-result-prefixes="html msg">
 
     <xsl:include href="system/custom/xsl/html4.xsl"/>

--- a/extensions/src/test/resources/solution/system/custom/xsl/SubscriptionUtil.xsl
+++ b/extensions/src/test/resources/solution/system/custom/xsl/SubscriptionUtil.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	version="2.0" 
 	xmlns:html="http://www.w3.org/TR/REC-html40"
-    xmlns:msg="org.pentaho.platform.plugin.action.messages.Messages"
+	xmlns:msg="org.pentaho.platform.web.xsl.messages.Messages"
 	exclude-result-prefixes="html msg">
         
 	<xsl:output method="html" encoding="UTF-8" />

--- a/extensions/src/test/resources/solution/system/custom/xsl/html-form-controls.xsl
+++ b/extensions/src/test/resources/solution/system/custom/xsl/html-form-controls.xsl
@@ -3,7 +3,7 @@
 	xmlns:xforms="http://www.w3.org/2002/xforms"
 	xmlns:chiba="http://chiba.sourceforge.net/xforms"
 	xmlns:xlink="http://www.w3.org/1999/xlink"
-	xmlns:msg="org.pentaho.platform.plugin.action.messages.Messages"
+	xmlns:msg="org.pentaho.platform.web.xsl.messages.Messages"
 	exclude-result-prefixes="chiba xforms xlink msg">
 	<!-- Copyright 2005 Chibacon -->
 


### PR DESCRIPTION
## Summary
- Register the missing Saxon message extension used by legacy XSL transforms.
- Use file URIs for XQuery document inputs and register the extensions in affected integration tests.

## Testing
- Not run locally; CI should validate the affected integration tests.