### PR TITLE
test[BACKLOG-50636]: Isolate HSQL integration test fixtures

### DIFF
--- a/extensions/src/test/resources/cache-solution/system/hibernate/hibernate-settings.xml
+++ b/extensions/src/test/resources/cache-solution/system/hibernate/hibernate-settings.xml
@@ -12,7 +12,7 @@
   *
   -->
   <!-- DEV TESTING ONLY -->
-  <config-file>system/hibernate/postgresql.hibernate.cfg.xml</config-file>
+  <config-file>system/hibernate/hsql.hibernate.cfg.xml</config-file>
 
   <!--
   *

--- a/extensions/src/test/resources/cache-solution/system/hibernate/hsql.hibernate.cfg.xml
+++ b/extensions/src/test/resources/cache-solution/system/hibernate/hsql.hibernate.cfg.xml
@@ -13,7 +13,7 @@
     <property name="hibernate.cache.use_query_cache">true</property>
       
     <property name="connection.driver_class">org.hsqldb.jdbcDriver</property>
-    <property name="connection.url">jdbc:hsqldb:mem:hibernate</property>
+    <property name="connection.url">jdbc:hsqldb:mem:cache</property>
     <property name="connection.username">sa</property>
     <property name="connection.password"></property>
     <property name="dialect">org.hibernate.dialect.HSQLDialect</property>

--- a/extensions/src/test/resources/metadata-solution/system/hibernate/hsql.hibernate.cfg.xml
+++ b/extensions/src/test/resources/metadata-solution/system/hibernate/hsql.hibernate.cfg.xml
@@ -13,7 +13,7 @@
     <property name="hibernate.cache.use_query_cache">true</property>
 
     <property name="connection.driver_class">org.hsqldb.jdbcDriver</property>
-    <property name="connection.url">jdbc:hsqldb:mem:hibernate</property>
+    <property name="connection.url">jdbc:hsqldb:mem:metadata</property>
     <property name="connection.username">sa</property>
     <property name="connection.password"></property>
     <property name="dialect">org.hibernate.dialect.HSQLDialect</property>

--- a/extensions/src/test/resources/metadata-solution/system/hibernate/hsql.hibernate.cfg.xml
+++ b/extensions/src/test/resources/metadata-solution/system/hibernate/hsql.hibernate.cfg.xml
@@ -11,7 +11,7 @@
 
     <property name="hibernate.generate_statistics">true</property>
     <property name="hibernate.cache.use_query_cache">true</property>
-      
+
     <property name="connection.driver_class">org.hsqldb.jdbcDriver</property>
     <property name="connection.url">jdbc:hsqldb:mem:hibernate</property>
     <property name="connection.username">sa</property>
@@ -23,5 +23,6 @@
     <property name="hibernate.hbm2ddl.auto">update</property>
     <property name="hibernate.id.db_structure_naming_strategy">legacy</property>
     <mapping resource="hibernate/hsql.hbm.xml" />
+
   </session-factory>
 </hibernate-configuration>

--- a/extensions/src/test/resources/metadata-solution/system/pentahoObjects.spring.xml
+++ b/extensions/src/test/resources/metadata-solution/system/pentahoObjects.spring.xml
@@ -15,6 +15,7 @@ PentahoSystem which is initialized after Spring
   <bean id="IAuditEntry" class="org.pentaho.platform.engine.services.audit.AuditFileEntry" scope="singleton" />
   <bean id="IVersionHelper" class="org.pentaho.platform.util.VersionHelper" scope="singleton" />
   <bean id="ICacheManager" class="org.pentaho.platform.plugin.services.cache.CacheManager" scope="singleton" />
+  <bean id="ICacheExpirationRegistry" class="org.pentaho.platform.plugin.services.cache.CacheExpirationRegistry" scope="singleton" />
     <bean id="IDatasourceMgmtService" class="org.pentaho.platform.repository2.unified.JcrBackedDatasourceMgmtService" scope="prototype" />
   <bean id="IDBDatasourceService" class="org.pentaho.platform.engine.services.connection.datasource.dbcp.PooledDatasourceService" scope="prototype" />
   <bean id="IPasswordService" class="org.pentaho.platform.util.KettlePasswordService" scope="singleton" />

--- a/extensions/src/test/resources/solution/system/data/sampledata.properties
+++ b/extensions/src/test/resources/solution/system/data/sampledata.properties
@@ -1,4 +1,4 @@
-#HSQL Database Engine 1.8.0.5
+#HSQL Database Engine 2.7.4
 #Fri Jun 05 23:27:19 EDT 2015
 hsqldb.script_format=0
 runtime.gc_interval=0
@@ -7,11 +7,11 @@ hsqldb.cache_size_scale=8
 readonly=false
 hsqldb.nio_data_file=true
 hsqldb.cache_scale=14
-version=1.8.0
-hsqldb.default_table_type=memory
+version=2.7.4
+hsqldb.default_table_type=cached
 hsqldb.cache_file_scale=1
 hsqldb.log_size=200
 modified=yes
-hsqldb.cache_version=1.7.0
-hsqldb.original_version=1.8.0
-hsqldb.compatible_version=1.8.0
+hsqldb.cache_version=2.7.4
+hsqldb.original_version=2.7.4
+hsqldb.compatible_version=2.7.4

--- a/extensions/src/test/resources/solution/system/hibernate/hsql.hibernate.cfg.xml
+++ b/extensions/src/test/resources/solution/system/hibernate/hsql.hibernate.cfg.xml
@@ -13,7 +13,7 @@
     <property name="hibernate.cache.use_query_cache">true</property>
       
     <property name="connection.driver_class">org.hsqldb.jdbcDriver</property>
-    <property name="connection.url">jdbc:hsqldb:mem:hibernate</property>
+    <property name="connection.url">jdbc:hsqldb:mem:solution</property>
     <property name="connection.username">sa</property>
     <property name="connection.password"></property>
     <property name="dialect">org.hibernate.dialect.HSQLDialect</property>

--- a/extensions/src/test/resources/web-servlet-solution/system/data/sampledata.properties
+++ b/extensions/src/test/resources/web-servlet-solution/system/data/sampledata.properties
@@ -1,4 +1,4 @@
-#HSQL Database Engine 1.8.0.5
+#HSQL Database Engine 2.7.4
 #Tue Sep 09 14:00:04 EDT 2008
 hsqldb.script_format=0
 runtime.gc_interval=0
@@ -7,11 +7,11 @@ hsqldb.cache_size_scale=8
 readonly=false
 hsqldb.nio_data_file=true
 hsqldb.cache_scale=14
-version=1.8.0
-hsqldb.default_table_type=memory
+version=2.7.4
+hsqldb.default_table_type=cached
 hsqldb.cache_file_scale=1
 hsqldb.log_size=200
 modified=yes
-hsqldb.cache_version=1.7.0
-hsqldb.original_version=1.8.0
-hsqldb.compatible_version=1.8.0
+hsqldb.cache_version=2.7.4
+hsqldb.original_version=2.7.4
+hsqldb.compatible_version=2.7.4

--- a/extensions/src/test/resources/web-solution/system/data/sampledata.properties
+++ b/extensions/src/test/resources/web-solution/system/data/sampledata.properties
@@ -1,4 +1,4 @@
-#HSQL Database Engine 1.8.0.5
+#HSQL Database Engine 2.7.4
 #Tue Sep 09 14:00:04 EDT 2008
 hsqldb.script_format=0
 runtime.gc_interval=0
@@ -7,11 +7,11 @@ hsqldb.cache_size_scale=8
 readonly=false
 hsqldb.nio_data_file=true
 hsqldb.cache_scale=14
-version=1.8.0
-hsqldb.default_table_type=memory
+version=2.7.4
+hsqldb.default_table_type=cached
 hsqldb.cache_file_scale=1
 hsqldb.log_size=200
 modified=yes
-hsqldb.cache_version=1.7.0
-hsqldb.original_version=1.8.0
-hsqldb.compatible_version=1.8.0
+hsqldb.cache_version=2.7.4
+hsqldb.original_version=2.7.4
+hsqldb.compatible_version=2.7.4

--- a/extensions/src/test/resources/web-solution/system/pentahoObjects.spring.xml
+++ b/extensions/src/test/resources/web-solution/system/pentahoObjects.spring.xml
@@ -27,6 +27,7 @@ PentahoSystem which is initialized after Spring
   <bean id="IAclPublisher" class="org.pentaho.platform.engine.security.acls.AclPublisher" scope="singleton" />
   <bean id="IAclVoter" class="org.pentaho.platform.engine.security.acls.voter.PentahoBasicAclVoter" scope="singleton" />
   <bean id="IVersionHelper" class="org.pentaho.platform.util.VersionHelper" scope="singleton" />
+  <bean id="ISystemConfig" class="org.pentaho.platform.config.SystemConfig" scope="singleton" />
   <bean id="ICacheManager" class="org.pentaho.platform.plugin.services.cache.CacheManager" scope="singleton" />
   <bean id="IScheduler" class="org.pentaho.platform.scheduler.QuartzScheduler" scope="session" />
   <bean id="IConditionalExecution" class="org.pentaho.platform.plugin.condition.javascript.ConditionalExecution" scope="prototype" />

--- a/repository/src/test/resources/solution/system/data/sampledata.properties
+++ b/repository/src/test/resources/solution/system/data/sampledata.properties
@@ -1,4 +1,4 @@
-#HSQL Database Engine 1.8.0.5
+#HSQL Database Engine 2.7.4
 #Tue Sep 09 10:46:55 EDT 2008
 hsqldb.script_format=0
 runtime.gc_interval=0
@@ -7,11 +7,11 @@ hsqldb.cache_size_scale=8
 readonly=false
 hsqldb.nio_data_file=true
 hsqldb.cache_scale=14
-version=1.8.0
-hsqldb.default_table_type=memory
+version=2.7.4
+hsqldb.default_table_type=cached
 hsqldb.cache_file_scale=1
 hsqldb.log_size=200
 modified=yes
-hsqldb.cache_version=1.7.0
-hsqldb.original_version=1.8.0
-hsqldb.compatible_version=1.8.0
+hsqldb.cache_version=2.7.4
+hsqldb.original_version=2.7.4
+hsqldb.compatible_version=2.7.4


### PR DESCRIPTION
## Summary
- Move cache and metadata test fixtures to isolated in-memory HSQL configuration.
- Update committed HSQL fixture metadata for the current HSQL version.

## Testing
- Not run locally; CI should validate the affected integration tests.