### PR TITLE
test[BACKLOG-50636]: Update web integration test fixtures

### DIFF
--- a/extensions/src/it/java/org/pentaho/test/platform/web/GetResourceIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/GetResourceIT.java
@@ -157,6 +157,7 @@ public class GetResourceIT {
     final int repoFileLength = 100;
 
     final RepositoryFile repositoryFile = mock( RepositoryFile.class );
+    when( repositoryFile.getId() ).thenReturn( repoFileName );
 
     final InputStream inputStream = mock( InputStream.class );
     when( inputStream.read( any( byte[].class ) ) ).thenReturn( repoFileLength, -1 );

--- a/extensions/src/it/java/org/pentaho/test/platform/web/ProxyServletIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/ProxyServletIT.java
@@ -175,7 +175,7 @@ public class ProxyServletIT extends BaseTestCase {
 
     URIBuilder uriBuilder = new URIBuilder( "http://foo.bar/pentaho" );
     uriBuilder.addParameter( "_TRUST_USER_", "system" );
-    uriBuilder.addParameter( "_TRUST_LOCALE_OVERRIDE_", "en_PT" );
+    uriBuilder.addParameter( "_TRUST_LOCALE_OVERRIDE_", LocaleHelper.getLocale().toString() );
 
     TestProxyServlet servlet = spy( new TestProxyServlet() );
     servlet.init( config );

--- a/extensions/src/it/java/org/pentaho/test/platform/web/ProxyServletIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/ProxyServletIT.java
@@ -162,6 +162,7 @@ public class ProxyServletIT extends BaseTestCase {
   public void testServiceTrustUserQueryParameter() throws ServletException, IOException, URISyntaxException {
 
     MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod( "GET" );
     MockHttpServletResponse response = new MockHttpServletResponse();
 
     request.setServletPath( "/pentaho" );
@@ -187,6 +188,7 @@ public class ProxyServletIT extends BaseTestCase {
   public void testServiceTrustLocaleOverrideQueryParameter() throws ServletException, IOException, URISyntaxException {
 
     MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod( "GET" );
     MockHttpServletResponse response = new MockHttpServletResponse();
 
     request.setServletPath( "/pentaho" );
@@ -215,6 +217,7 @@ public class ProxyServletIT extends BaseTestCase {
   public void testServiceNoUserSessionQueryParameter() throws ServletException, IOException, URISyntaxException {
 
     MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod( "GET" );
     MockHttpServletResponse response = new MockHttpServletResponse();
 
     request.setServletPath( "/pentaho" );

--- a/extensions/src/it/java/org/pentaho/test/platform/web/http/api/RepositoryPublishResourceIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/http/api/RepositoryPublishResourceIT.java
@@ -27,7 +27,9 @@ import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
 import jakarta.ws.rs.core.Application;
 import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -98,6 +100,11 @@ public class RepositoryPublishResourceIT extends JerseyTest implements Applicati
       .addFilter( PentahoRequestContextFilter.class, "pentahoRequestContextFilter" )
       .contextPath( "api" )
       .build();
+  }
+
+  @Override
+  protected TestContainerFactory getTestContainerFactory() {
+    return new GrizzlyWebTestContainerFactory();
   }
 
   private IPlatformImporter importer;

--- a/extensions/src/it/java/org/pentaho/test/platform/web/ui/ThemeManagerIT.java
+++ b/extensions/src/it/java/org/pentaho/test/platform/web/ui/ThemeManagerIT.java
@@ -27,8 +27,10 @@ import org.pentaho.test.platform.engine.core.BaseTest;
 import org.pentaho.test.platform.utils.TestResourceLocation;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileInputStream;
-import java.util.Arrays;
+import java.io.InputStream;
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -50,12 +52,25 @@ public class ThemeManagerIT extends BaseTest {
   @Test
   public void testThemes() throws Exception {
     // setup mock context
-    MockServletContext context = new MockServletContext();
-    context.addInitParameter( "/", Arrays.asList( "test-module/" ).toString() );
-    context.addInitParameter( "/test-module/", Arrays.asList( "themes.xml" ).toString());
-    File themesDotXML = new File( getSolutionPath() + "/system/themeplugin/themes.xml" );
-    context.setAttribute( "/test-module/themes.xml", themesDotXML.toURI().toURL() );
-    context.setAttribute( "/test-module/themes.xml", new FileInputStream( themesDotXML ) );
+    final File themesDotXML = new File( getSolutionPath() + "/system/themeplugin/themes.xml" );
+    MockServletContext context = new MockServletContext() {
+      @Override
+      public Set<String> getResourcePaths( String path ) {
+        return "/".equals( path ) ? Collections.singleton( "/test-module/" ) : Collections.emptySet();
+      }
+
+      @Override
+      public InputStream getResourceAsStream( String path ) {
+        if ( "/test-module/themes.xml".equals( path ) ) {
+          try {
+            return new FileInputStream( themesDotXML );
+          } catch ( FileNotFoundException e ) {
+            return null;
+          }
+        }
+        return null;
+      }
+    };
     PentahoSystem.getApplicationContext().setContext( context );
 
     StandaloneSession session = new StandaloneSession();

--- a/extensions/src/test/resources/web-servlet-solution/system/pentahoObjects.spring.xml
+++ b/extensions/src/test/resources/web-servlet-solution/system/pentahoObjects.spring.xml
@@ -11,5 +11,5 @@ PentahoSystem which is initialized after Spring
   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd"
   default-lazy-init="false">
   
-  
+  <bean id="ISystemConfig" class="org.pentaho.platform.config.SystemConfig" scope="singleton" />
 </beans>

--- a/extensions/src/test/resources/web-solution/system/pentahoObjects.spring.xml
+++ b/extensions/src/test/resources/web-solution/system/pentahoObjects.spring.xml
@@ -41,6 +41,7 @@ PentahoSystem which is initialized after Spring
   <bean id="IPluginResourceLoader" class="org.pentaho.platform.plugin.services.pluginmgr.PluginResourceLoader" scope="singleton" />
   <bean id="IChartBeansGenerator" class="org.pentaho.platform.plugin.action.chartbeans.DefaultChartBeansGenerator" scope="singleton" />
   <bean id="IThemeManager" class="org.pentaho.platform.web.html.themes.DefaultThemeManager" scope="singleton"/>
+  <bean id="ISystemConfig" class="org.pentaho.platform.config.SystemConfig" scope="singleton" />
     
     <!-- Data connections.  Connections objects should be accessed through PentahoConnectionFactory, 
        not directly from the PentahoObjectFactory. -->


### PR DESCRIPTION
## Summary
- Update servlet, Jersey, repository mock, and theme-resource test fixtures for current runtime behavior.
- Provide the required system configuration beans in legacy web test solutions.

## Testing
- Not run locally; CI should validate the affected integration tests.