### PR TITLE
fix[BACKLOG-50639] [SP-7540]: Restore legacy JSON writer precedence for plugins

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/servlet/JAXRSPluginServlet.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/servlet/JAXRSPluginServlet.java
@@ -15,6 +15,9 @@ package org.pentaho.platform.web.servlet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.sun.jersey.api.core.ResourceConfig;
+import com.sun.jersey.json.impl.provider.entity.JSONJAXBElementProvider;
+import com.sun.jersey.json.impl.provider.entity.JSONListElementProvider;
+import com.sun.jersey.json.impl.provider.entity.JSONRootElementProvider;
 import com.sun.jersey.spi.container.WebApplication;
 import com.sun.jersey.spi.container.servlet.WebConfig;
 import com.sun.jersey.spi.spring.container.servlet.SpringServlet;
@@ -147,11 +150,20 @@ public class JAXRSPluginServlet extends SpringServlet implements ApplicationCont
 
   @Override
   protected void initiate( ResourceConfig rc, WebApplication wa ) {
+    registerLegacyJaxbJsonWriters( rc );
     if ( logger.isDebugEnabled() ) {
       rc.getFeatures().put( ResourceConfig.FEATURE_TRACE, true );
       rc.getFeatures().put( ResourceConfig.FEATURE_TRACE_PER_REQUEST, true );
     }
     super.initiate( rc, wa );
+  }
+
+  @VisibleForTesting
+  void registerLegacyJaxbJsonWriters( ResourceConfig rc ) {
+    // Register application providers before Jersey discovers Jackson so plugin resources retain their legacy JAXB JSON contract.
+    rc.getClasses().add( JSONRootElementProvider.App.class );
+    rc.getClasses().add( JSONListElementProvider.App.class );
+    rc.getClasses().add( JSONJAXBElementProvider.App.class );
   }
 
   protected ResourceConfig getDefaultResourceConfig( Map<String, Object> props, WebConfig webConfig ) throws ServletException {

--- a/extensions/src/test/java/org/pentaho/platform/web/servlet/JAXRSPluginServletTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/servlet/JAXRSPluginServletTest.java
@@ -13,6 +13,11 @@
 
 package org.pentaho.platform.web.servlet;
 
+import com.sun.jersey.api.core.ResourceConfig;
+import com.sun.jersey.json.impl.provider.entity.JSONJAXBElementProvider;
+import com.sun.jersey.json.impl.provider.entity.JSONListElementProvider;
+import com.sun.jersey.json.impl.provider.entity.JSONRootElementProvider;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -21,8 +26,11 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
-import static org.mockito.Mockito.any;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -33,6 +41,20 @@ import static org.mockito.Mockito.when;
 
 @RunWith( MockitoJUnitRunner.class )
 public class JAXRSPluginServletTest {
+
+  @Test
+  public void registerLegacyJaxbJsonWriters_registersApplicationProviders_test() {
+    JAXRSPluginServlet servlet = new JAXRSPluginServlet();
+    ResourceConfig resourceConfig = mock( ResourceConfig.class );
+    Set<Class<?>> providerClasses = new HashSet<>();
+    when( resourceConfig.getClasses() ).thenReturn( providerClasses );
+
+    servlet.registerLegacyJaxbJsonWriters( resourceConfig );
+
+    assertTrue( providerClasses.contains( JSONRootElementProvider.App.class ) );
+    assertTrue( providerClasses.contains( JSONListElementProvider.App.class ) );
+    assertTrue( providerClasses.contains( JSONJAXBElementProvider.App.class ) );
+  }
 
   private void validateSendErrorForStatus( JAXRSPluginServlet servlet, int httpStatusCode, boolean shouldCallSendError )
       throws ServletException, IOException {


### PR DESCRIPTION
Follow up of https://github.com/pentaho/pentaho-platform/pull/6330. Missing the same configuration for the Plugin Servlet