### PR TITLE
feat: add tree filter [BACKLOG-42484]

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/repository2/unified/RepositoryRequest.java
+++ b/api/src/main/java/org/pentaho/platform/api/repository2/unified/RepositoryRequest.java
@@ -27,18 +27,18 @@ public class RepositoryRequest {
 
   private static final Pattern FILES_MEMBERS_INCLUDE_PATTERN = Pattern.compile( "includeMembers=(.+)" );
   private static final Pattern FILES_MEMBERS_EXCLUDE_PATTERN = Pattern.compile( "excludeMembers=(.+)" );
-  public static final String PATH_SEPARATOR = "/"; //$NON-NLS-1$
+  public static final String PATH_SEPARATOR = "/";
 
   /**
    * separates the parts of the legacy filter, e.g. <code>*.ktr|FILES_FOLDERS</code>, and the terms of a child node
    * filter disjunction
    */
-  public static final String FILTER_SEPARATOR = "|"; //$NON-NLS-1$
+  public static final String FILTER_SEPARATOR = "|";
 
   /**
    * the wildcard accepted inside a node name filter; a filter made of this single character means "everything"
    */
-  public static final String FILTER_WILDCARD = "*"; //$NON-NLS-1$
+  public static final String FILTER_WILDCARD = "*";
 
   private static final Pattern FILTER_SEPARATOR_PATTERN = Pattern.compile( Pattern.quote( FILTER_SEPARATOR ) );
 

--- a/api/src/main/java/org/pentaho/platform/api/repository2/unified/RepositoryRequest.java
+++ b/api/src/main/java/org/pentaho/platform/api/repository2/unified/RepositoryRequest.java
@@ -29,6 +29,19 @@ public class RepositoryRequest {
   private static final Pattern FILES_MEMBERS_EXCLUDE_PATTERN = Pattern.compile( "excludeMembers=(.+)" );
   public static final String PATH_SEPARATOR = "/"; //$NON-NLS-1$
 
+  /**
+   * separates the parts of the legacy filter, e.g. <code>*.ktr|FILES_FOLDERS</code>, and the terms of a child node
+   * filter disjunction
+   */
+  public static final String FILTER_SEPARATOR = "|"; //$NON-NLS-1$
+
+  /**
+   * the wildcard accepted inside a node name filter; a filter made of this single character means "everything"
+   */
+  public static final String FILTER_WILDCARD = "*"; //$NON-NLS-1$
+
+  private static final Pattern FILTER_SEPARATOR_PATTERN = Pattern.compile( Pattern.quote( FILTER_SEPARATOR ) );
+
   private String path;
   private boolean showHidden = false;
   private boolean includeAcls = false;
@@ -63,7 +76,7 @@ public class RepositoryRequest {
     types = FILES_TYPE_FILTER.FILES_FOLDERS;
     StringBuilder strippedFilter = new StringBuilder();
     if ( !workingFilter.isEmpty() ) {
-      String[] parts = workingFilter.split( "\\|" );
+      String[] parts = FILTER_SEPARATOR_PATTERN.split( workingFilter );
       for ( String part : parts ) {
         Matcher m = FILES_TYPES_PATTERN.matcher( part );
         if ( m.matches() ) {
@@ -85,7 +98,7 @@ public class RepositoryRequest {
 
   private void appendFilter( StringBuilder strippedFilter, String part ) {
     if ( strippedFilter.length() != 0 ) {
-      strippedFilter.append( "|" );
+      strippedFilter.append( FILTER_SEPARATOR );
     }
     strippedFilter.append( part );
   }
@@ -104,7 +117,7 @@ public class RepositoryRequest {
 
   private Set<String> parseOutPattern( Pattern pattern ) {
     StringBuilder strippedFilter = new StringBuilder();
-    String[] parts = workingFilter.split( "\\|" );
+    String[] parts = FILTER_SEPARATOR_PATTERN.split( workingFilter );
     Set<String> memberSet = null;
 
     for ( String part : parts ) {
@@ -134,7 +147,8 @@ public class RepositoryRequest {
   }
 
   private void setLegacyFilter( String legacyFilter ) {
-    this.workingFilter = ( legacyFilter == null || StringUtils.isEmpty( legacyFilter ) ) ? "*" : legacyFilter;
+    this.workingFilter =
+      ( legacyFilter == null || StringUtils.isEmpty( legacyFilter ) ) ? FILTER_WILDCARD : legacyFilter;
     parseOutFileTypes();
     parseOutIncludeExclude();
     childNodeFilter = workingFilter.isEmpty() ? null : workingFilter;
@@ -217,8 +231,10 @@ public class RepositoryRequest {
 
   /**
    * @param childNodefilter
-   *          filter may be a full name or a partial name with one or more wildcard characters ("*"), or a disjunction
-   *          (using the "|" character to represent logical OR) of these; filter does not apply to root node.
+   *          filter may be a full name or a partial name with one or more wildcard characters
+   *          ("{@value #FILTER_WILDCARD}"), or a disjunction
+   *          (using the "{@value #FILTER_SEPARATOR}" character to represent logical OR) of these; filter does not
+   *          apply to root node.
    */
   public void setChildNodeFilter( String childNodeFilter ) {
     this.childNodeFilter = childNodeFilter;
@@ -241,7 +257,7 @@ public class RepositoryRequest {
   }
 
   /**
-   * 
+   *
    * @param includeAcls
    *     Set to true to return ACL permission information with the output.  Default is false.
    */

--- a/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryRequestTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/repository2/unified/RepositoryRequestTest.java
@@ -32,7 +32,9 @@ public class RepositoryRequestTest {
   private static final boolean SHOW_HIDE = true;
   private static final boolean INCLUDE_SYSTEM_FOLDERS = false;
   private static final Integer DEPTH = 2;
-  private static final String LEGACY_FILTER = "FILES||ODD_FILTER";
+  private static final String LEGACY_FILTER =
+    RepositoryRequest.FILES_TYPE_FILTER.FILES + RepositoryRequest.FILTER_SEPARATOR
+      + RepositoryRequest.FILTER_SEPARATOR + "ODD_FILTER";
   private static final String INLCUDE_ONE = "includeOne";
   private static final String INCLUDE_TWO = "includeTwo";
   private static final Set<String> INCLUDE_SET = new HashSet<String>( Arrays.asList( INLCUDE_ONE, INCLUDE_TWO ) );
@@ -99,7 +101,8 @@ public class RepositoryRequestTest {
     assertEquals( newPath, request.getPath() );
 
     // Test absence of include/exclude member sets
-    String legacyFilter = "includeMembers=(include)|excludeMembers=(exclude)";
+    String legacyFilter =
+      "includeMembers=(include)" + RepositoryRequest.FILTER_SEPARATOR + "excludeMembers=(exclude)";
     try {
       new RepositoryRequest( PATH, SHOW_HIDE, DEPTH, legacyFilter );
       fail( "RuntimeException should of been thrown" );

--- a/extensions/src/it/java/org/pentaho/platform/web/http/api/resources/services/FileServiceIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/web/http/api/resources/services/FileServiceIT.java
@@ -1944,7 +1944,8 @@ public class FileServiceIT {
   public void testDoGetTree() {
     String pathId = ":path:to:file:file1.ext";
     int depth = 1;
-    String filter = "*|FOLDERS";
+    String filter = RepositoryRequest.FILTER_WILDCARD + RepositoryRequest.FILTER_SEPARATOR
+      + RepositoryRequest.FILES_TYPE_FILTER.FOLDERS;
     boolean showHidden = true;
     boolean includeAcls = true;
 

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -1744,19 +1744,20 @@ public class FileResource extends AbstractJaxRSResource {
    * </p>
    *
    * @param depth      How many level should the search go.
-   * @param filter     Filter to be applied for search. The filter can be broken down into 3 parts; File types, Child Node
-   *                   Filter, and Member Filters. Each part is separated with a pipe (|) character.
+   * @param filter     Filter to be applied for search. The filter can be broken down into 3 parts; File types, Child
+   *                   Node Filter, and Member Filters. Each part is separated with a pipe (|) character.
    *                   <p/>
-   *                   File Types are represented by a word phrase. This phrase is recognized as a file type phrase and processed
-   *                   accordingly. Valid File Type word phrases include "FILES", "FOLDERS", and "FILES_FOLDERS" and denote
-   *                   whether to return files, folders, or both files and folders, respectively.
+   *                   File Types are represented by a word phrase. This phrase is recognized as a file type phrase
+   *                   and processed accordingly. Valid File Type word phrases include "FILES", "FOLDERS", and
+   *                   "FILES_FOLDERS" and denote whether to return files, folders, or both files and folders,
+   *                   respectively.
    *                   <p/>
-   *                   The Child Node Filter is a list of allowed names of files separated by the pipe (|) character. Each file
-   *                   name in the filter may be a full name or a partial name with one or more wildcard characters ("*"). The
-   *                   filter does not apply to root node.
+   *                   The Child Node Filter is a list of allowed names of files separated by the pipe (|) character.
+   *                   Each file name in the filter may be a full name or a partial name with one or more wildcard
+   *                   characters ("*"). The filter does not apply to root node.
    *                   <p/>
-   *                   The Child Node Filter also accepts a structured form, which filters files and folders independently
-   *                   instead of applying the same expression to both:
+   *                   The Child Node Filter also accepts a structured form, which filters files and folders
+   *                   independently instead of applying the same expression to both:
    *                   "{@value TreeNodeFilterSpec#FILE_FILTER_TOKEN}&lt;patterns&gt;" and/or
    *                   "{@value TreeNodeFilterSpec#FOLDER_FILTER_TOKEN}&lt;patterns&gt;", where patterns is a comma
    *                   separated list of names with optional wildcards ("*"). Both clauses are combined with
@@ -1764,17 +1765,20 @@ public class FileResource extends AbstractJaxRSResource {
    *                   the filter parameter itself. A missing clause means "all", so
    *                   "{@value TreeNodeFilterSpec#FILE_FILTER_TOKEN}*.ktr{@value TreeNodeFilterSpec#INSIDE_FILTER_TOKEN_SEPARATOR}*.kjb"
    *                   returns the complete folder structure containing only ktr and kjb files. This form is only
-   *                   supported by
-   *                   repository providers backed by JCR; other providers ignore it.
+   *                   supported by repository providers backed by JCR; other providers may ignore it if they did not
+   *                   implement the filtering logic.
    *                   <p/>
-   *                   The Member Filter portion of the filter parameter allows the caller to specify which properties of the
-   *                   metadata to return. Member Filters start with "includeMembers=" or "excludeMembers=" followed by a list of
-   *                   comma separated field names that are to be included in, or, excluded from, the list. Valid field names can
-   *                   be found in org.pentaho.platform.repository2.unified.webservices#RepositoryFileAdapter.
-   *                   Omission of a member filter will return all members. It is invalid to both and includeMembers= and an
-   *                   excludeMembers= clause in the same service call.
+   *                   The Member Filter portion of the filter parameter allows the caller to specify which
+   *                   properties of the metadata to return. Member Filters start with "includeMembers=" or
+   *                   "excludeMembers=" followed by a list of comma separated field names that are to be included
+   *                   in, or, excluded from, the
+   *                   list. Valid field names can be found in org.pentaho.platform.repository2.unified
+   *                   .webservices#RepositoryFileAdapter.
+   *                   Omission of a member filter will return all members. It is invalid to both and includeMembers=
+   *                   and an excludeMembers= clause in the same service call.
    * @param showHidden Include or exclude hidden files from the file list.
-   * @return A RepositoryFileTreeDto object containing the files at the root of the repository. Will return files but not folders under the "/" folder. The fields returned will include the name, filesize, description, id and title.
+   * @return A RepositoryFileTreeDto object containing the files at the root of the repository. Will return files but
+   * not folders under the "/" folder. The fields returned will include the name, filesize, description, id and title.
    *
    * <p><b>Example Response:</b></p>
    * <pre function="syntax.xml">
@@ -1881,22 +1885,24 @@ public class FileResource extends AbstractJaxRSResource {
    * GET pentaho/api/repo/files/:public/tree?showHidden=false&filter=*|FILES&_=1389042244670
    * </p>
    *
-   * @param pathId      The path from the root folder to the root node of the tree to return using colon characters in place of /
-   *                    or \ characters. To clarify /path/to/file, the encoded pathId would be :path:to:file.
+   * @param pathId      The path from the root folder to the root node of the tree to return using colon characters
+   *                    in place of / or \ characters. To clarify /path/to/file, the encoded pathId would be
+   *                    :path:to:file.
    * @param depth       How many level should the search go.
-   * @param filter      Filter to be applied for search. The filter can be broken down into 3 parts; File types, Child Node
-   *                    Filter, and Member Filters. Each part is separated with a pipe (|) character.
+   * @param filter      Filter to be applied for search. The filter can be broken down into 3 parts; File types,
+   *                    Child Node Filter, and Member Filters. Each part is separated with a pipe (|) character.
    *                    <p/>
-   *                    File Types are represented by a word phrase. This phrase is recognized as a file type phrase and processed
-   *                    accordingly. Valid File Type word phrases include "FILES", "FOLDERS", and "FILES_FOLDERS" and denote
-   *                    whether to return files, folders, or both files and folders, respectively.
+   *                    File Types are represented by a word phrase. This phrase is recognized as a file type phrase
+   *                    and processed accordingly. Valid File Type word phrases include "FILES", "FOLDERS", and
+   *                    "FILES_FOLDERS" and denote whether to return files, folders, or both files and folders,
+   *                    respectively.
    *                    <p/>
-   *                    The Child Node Filter is a list of allowed names of files separated by the pipe (|) character. Each file
-   *                    name in the filter may be a full name or a partial name with one or more wildcard characters ("*"). The
-   *                    filter does not apply to root node.
+   *                    The Child Node Filter is a list of allowed names of files separated by the pipe (|) character
+   *                    . Each file name in the filter may be a full name or a partial name with one or more wildcard
+   *                    characters ("*"). The filter does not apply to root node.
    *                    <p/>
-   *                    The Child Node Filter also accepts a structured form, which filters files and folders independently
-   *                    instead of applying the same expression to both:
+   *                    The Child Node Filter also accepts a structured form, which filters files and folders
+   *                    independently instead of applying the same expression to both:
    *                    "{@value TreeNodeFilterSpec#FILE_FILTER_TOKEN}&lt;patterns&gt;" and/or
    *                    "{@value TreeNodeFilterSpec#FOLDER_FILTER_TOKEN}&lt;patterns&gt;", where patterns is a comma
    *                    separated list of names with optional wildcards ("*"). Both clauses are combined with
@@ -1904,18 +1910,20 @@ public class FileResource extends AbstractJaxRSResource {
    *                    the filter parameter itself. A missing clause means "all", so
    *                    "{@value TreeNodeFilterSpec#FILE_FILTER_TOKEN}*.ktr{@value TreeNodeFilterSpec#INSIDE_FILTER_TOKEN_SEPARATOR}*.kjb"
    *                    returns the complete folder structure containing only ktr and kjb files. This form is only
-   *                    supported by
-   *                    repository providers backed by JCR; other providers ignore it.
+   *                    supported by repository providers backed by JCR; other providers may ignore it if they did not
+   *                    implement the filtering logic.
    *                    <p/>
-   *                    The Member Filter portion of the filter parameter allows the caller to specify which properties of the
-   *                    metadata to return. Member Filters start with "includeMembers=" or "excludeMembers=" followed by a list of
-   *                    comma separated field names that are to be included in, or, excluded from, the list. Valid field names can
-   *                    be found in  org.pentaho.platform.repository2.unified.webservices#RepositoryFileAdapter.
-   *                    Omission of a member filter will return all members. It is invalid to both and includeMembers= and an
-   *                    excludeMembers= clause in the same service call.
+   *                    The Member Filter portion of the filter parameter allows the caller to specify which
+   *                    properties of the metadata to return. Member Filters start with "includeMembers=" or
+   *                    "excludeMembers=" followed by a list of comma separated field names that are to be included
+   *                    in, or, excluded from, the list. Valid field names can be found in  org.pentaho.platform
+   *                    .repository2.unified.webservices#RepositoryFileAdapter.
+   *                    Omission of a member filter will return all members. It is invalid to both and
+   *                    includeMembers= and an excludeMembers= clause in the same service call.
    * @param showHidden  Include or exclude hidden files from the file list.
    * @param includeAcls Include permission information about the file in the output.
-   * @return A RepositoryFileTreeDto object containing the files at the root of the repository. Will return files but not folders under the "/" folder. The fields returned will include the name, filesize, description, id and title.
+   * @return A RepositoryFileTreeDto object containing the files at the root of the repository. Will return files but
+   * not folders under the "/" folder. The fields returned will include the name, filesize, description, id and title.
    *
    * <p><b>Example Response:</b></p>
    * <pre function="syntax.xml">

--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/FileResource.java
@@ -51,6 +51,7 @@ import org.pentaho.platform.plugin.services.importexport.Exporter;
 import org.pentaho.platform.repository.RepositoryDownloadWhitelist;
 import org.pentaho.platform.repository.RepositoryFilenameUtils;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
+import org.pentaho.platform.repository2.unified.TreeNodeFilterSpec;
 import org.pentaho.platform.repository2.unified.jcr.JcrRepositoryFileUtils;
 import org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService;
 import org.pentaho.platform.repository2.unified.webservices.FileVersioningConfiguration;
@@ -1754,6 +1755,18 @@ public class FileResource extends AbstractJaxRSResource {
    *                   name in the filter may be a full name or a partial name with one or more wildcard characters ("*"). The
    *                   filter does not apply to root node.
    *                   <p/>
+   *                   The Child Node Filter also accepts a structured form, which filters files and folders independently
+   *                   instead of applying the same expression to both:
+   *                   "{@value TreeNodeFilterSpec#FILE_FILTER_TOKEN}&lt;patterns&gt;" and/or
+   *                   "{@value TreeNodeFilterSpec#FOLDER_FILTER_TOKEN}&lt;patterns&gt;", where patterns is a comma
+   *                   separated list of names with optional wildcards ("*"). Both clauses are combined with
+   *                   "{@value TreeNodeFilterSpec#FILTER_TOKEN_SEPARATOR}" because the pipe (|) is the separator of
+   *                   the filter parameter itself. A missing clause means "all", so
+   *                   "{@value TreeNodeFilterSpec#FILE_FILTER_TOKEN}*.ktr{@value TreeNodeFilterSpec#INSIDE_FILTER_TOKEN_SEPARATOR}*.kjb"
+   *                   returns the complete folder structure containing only ktr and kjb files. This form is only
+   *                   supported by
+   *                   repository providers backed by JCR; other providers ignore it.
+   *                   <p/>
    *                   The Member Filter portion of the filter parameter allows the caller to specify which properties of the
    *                   metadata to return. Member Filters start with "includeMembers=" or "excludeMembers=" followed by a list of
    *                   comma separated field names that are to be included in, or, excluded from, the list. Valid field names can
@@ -1881,6 +1894,18 @@ public class FileResource extends AbstractJaxRSResource {
    *                    The Child Node Filter is a list of allowed names of files separated by the pipe (|) character. Each file
    *                    name in the filter may be a full name or a partial name with one or more wildcard characters ("*"). The
    *                    filter does not apply to root node.
+   *                    <p/>
+   *                    The Child Node Filter also accepts a structured form, which filters files and folders independently
+   *                    instead of applying the same expression to both:
+   *                    "{@value TreeNodeFilterSpec#FILE_FILTER_TOKEN}&lt;patterns&gt;" and/or
+   *                    "{@value TreeNodeFilterSpec#FOLDER_FILTER_TOKEN}&lt;patterns&gt;", where patterns is a comma
+   *                    separated list of names with optional wildcards ("*"). Both clauses are combined with
+   *                    "{@value TreeNodeFilterSpec#FILTER_TOKEN_SEPARATOR}" because the pipe (|) is the separator of
+   *                    the filter parameter itself. A missing clause means "all", so
+   *                    "{@value TreeNodeFilterSpec#FILE_FILTER_TOKEN}*.ktr{@value TreeNodeFilterSpec#INSIDE_FILTER_TOKEN_SEPARATOR}*.kjb"
+   *                    returns the complete folder structure containing only ktr and kjb files. This form is only
+   *                    supported by
+   *                    repository providers backed by JCR; other providers ignore it.
    *                    <p/>
    *                    The Member Filter portion of the filter parameter allows the caller to specify which properties of the
    *                    metadata to return. Member Filters start with "includeMembers=" or "excludeMembers=" followed by a list of

--- a/repository/src/it/java/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryContentIT.java
+++ b/repository/src/it/java/org/pentaho/platform/repository2/unified/DefaultUnifiedRepositoryContentIT.java
@@ -1829,20 +1829,27 @@ public class DefaultUnifiedRepositoryContentIT extends DefaultUnifiedRepositoryB
         repo.createFolder( publicFolder.getId(), new RepositoryFile.Builder( "testFolder" ).versioned( false ).hidden(
             false ).folder( true ).build(), null, null );
 
-    root = repo.getTree( new RepositoryRequest( publicFolder.getPath(), true, 1, "*|FILES" ) );
+    root = repo.getTree( new RepositoryRequest( publicFolder.getPath(), true, 1,
+      RepositoryRequest.FILTER_WILDCARD + RepositoryRequest.FILTER_SEPARATOR
+        + RepositoryRequest.FILES_TYPE_FILTER.FILES ) );
     assertFalse( root.getChildren().isEmpty() );
     assertEquals( 1, root.getChildren().size() );
     assertEquals( "helloworld.xaction", root.getChildren().get( 0 ).getFile().getName() );
 
-    root = repo.getTree( new RepositoryRequest( publicFolder.getPath(), true, 1, "*" ) );
+    root = repo.getTree(
+      new RepositoryRequest( publicFolder.getPath(), true, 1, RepositoryRequest.FILTER_WILDCARD ) );
     assertFalse( root.getChildren().isEmpty() );
     assertEquals( 2, root.getChildren().size() );
 
-    root = repo.getTree( new RepositoryRequest( publicFolder.getPath(), true, 1, "*|FILES_FOLDERS" ) );
+    root = repo.getTree( new RepositoryRequest( publicFolder.getPath(), true, 1,
+      RepositoryRequest.FILTER_WILDCARD + RepositoryRequest.FILTER_SEPARATOR
+        + RepositoryRequest.FILES_TYPE_FILTER.FILES_FOLDERS ) );
     assertFalse( root.getChildren().isEmpty() );
     assertEquals( 2, root.getChildren().size() );
 
-    root = repo.getTree( new RepositoryRequest( publicFolder.getPath(), true, 1, "*|FOLDERS" ) );
+    root = repo.getTree( new RepositoryRequest( publicFolder.getPath(), true, 1,
+      RepositoryRequest.FILTER_WILDCARD + RepositoryRequest.FILTER_SEPARATOR
+        + RepositoryRequest.FILES_TYPE_FILTER.FOLDERS ) );
     assertFalse( root.getChildren().isEmpty() );
     assertEquals( 1, root.getChildren().size() );
     assertEquals( "testFolder", root.getChildren().get( 0 ).getFile().getName() );

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/TreeNodeFilterSpec.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/TreeNodeFilterSpec.java
@@ -1,0 +1,204 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+package org.pentaho.platform.repository2.unified;
+
+import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+
+import java.util.regex.Pattern;
+
+/**
+ * Parses the <i>structured</i> form of the legacy child node filter, which allows a caller to filter files and folders
+ * independently instead of applying a single node name filter to both:
+ *
+ * <pre>
+ *   {@value #FILE_FILTER_TOKEN}&lt;patterns&gt;[{@value #FILTER_TOKEN_SEPARATOR}{@value #FOLDER_FILTER_TOKEN}&lt;patterns&gt;]
+ *   {@value #FOLDER_FILTER_TOKEN}&lt;patterns&gt;[{@value #FILTER_TOKEN_SEPARATOR}{@value #FILE_FILTER_TOKEN}&lt;patterns&gt;]
+ * </pre>
+ * <p>
+ * where <code>patterns</code> is a comma separated list of node names, each one accepting the
+ * <code>{@value RepositoryRequest#FILTER_WILDCARD}</code> wildcard.
+ * The pipe ( {@value RepositoryRequest#FILTER_SEPARATOR} ) character cannot be used because it is the separator of the
+ * legacy filter itself. Examples of the complete <code>filter</code> parameter:
+ *
+ * <pre>
+ *   {@value #FILE_FILTER_TOKEN}*.ktr{@value #INSIDE_FILTER_TOKEN_SEPARATOR}*.kjb{@value
+ *   RepositoryRequest#FILTER_SEPARATOR}FILES_FOLDERS
+ *                                              the whole folder structure plus the ktr and kjb files
+ *   {@value #FOLDER_FILTER_TOKEN}sales*{@value RepositoryRequest#FILTER_SEPARATOR}FILES_FOLDERS
+ *                                              only folders named sales*, empty ones included, plus the files they
+ *                                              carry
+ *   {@value #FILE_FILTER_TOKEN}*.prpt{@value #FILTER_TOKEN_SEPARATOR}{@value #FOLDER_FILTER_TOKEN}2026*
+ *                                              both filters combined
+ *   *.ktr{@value RepositoryRequest#FILTER_SEPARATOR}FILES        legacy filter, untouched
+ * </pre>
+ * <p>
+ * Each filter narrows its own kind of node and nothing else: the folder filter alone decides which folders the
+ * result carries, empty ones included, and the file filter alone decides which files it carries. A file whose folder
+ * the folder filter rejected goes with it, for the result carries no folder to hold it, and the folders between a
+ * matching folder and the requested path belong to the result so that it stays reachable.
+ * <p>
+ * A filter that carries none of the tokens is a plain legacy glob and {@link #isStructured()} returns
+ * <code>false</code>,
+ * meaning the caller must keep using the regular tree traversal.
+ */
+public class TreeNodeFilterSpec {
+  public static final String FILE_FILTER_TOKEN = "fileFilter=";
+  public static final String FOLDER_FILTER_TOKEN = "folderFilter=";
+
+  /**
+   * separates the {@link #FILE_FILTER_TOKEN} clause from the {@link #FOLDER_FILTER_TOKEN} one
+   */
+  public static final String FILTER_TOKEN_SEPARATOR = ";";
+
+  /**
+   * separates the individual node name patterns inside a single clause
+   */
+  public static final String INSIDE_FILTER_TOKEN_SEPARATOR = ",";
+
+  /**
+   * the filter a request degrades to when the provider cannot honor the structured form: "everything"
+   */
+  public static final String DEFAULT_CHILD_NODE_FILTER = RepositoryRequest.FILTER_WILDCARD;
+
+  /**
+   * characters that are never valid inside a node name filter, including the legacy filter separator, which is
+   * quoted because it is injected into a regular expression
+   */
+  private static final Pattern ILLEGAL_CHARS =
+    Pattern.compile( ".*[/\\\\\\[\\]'\"" + Pattern.quote( RepositoryRequest.FILTER_SEPARATOR ) + "\t\r\n"
+      + "]+.*" );
+
+  private static final TreeNodeFilterSpec LEGACY = new TreeNodeFilterSpec( null, null );
+
+  private final String fileFilter;
+  private final String folderFilter;
+
+  private TreeNodeFilterSpec( final String fileFilter, final String folderFilter ) {
+    this.fileFilter = fileFilter;
+    this.folderFilter = folderFilter;
+  }
+
+  /**
+   * Parses the given child node filter.
+   *
+   * @param childNodeFilter the value of
+   *                        {@link org.pentaho.platform.api.repository2.unified.RepositoryRequest#getChildNodeFilter()}
+   * @return the parsed specification; never <code>null</code>
+   * @throws IllegalArgumentException when the structured syntax is malformed
+   */
+  public static TreeNodeFilterSpec parse( final String childNodeFilter ) {
+    if ( !hasStructuredTokens( childNodeFilter ) ) {
+      // plain legacy glob; nothing to do here
+      return LEGACY;
+    }
+
+    String fileFilter = null;
+    String folderFilter = null;
+
+    for ( String clause : childNodeFilter.split( FILTER_TOKEN_SEPARATOR ) ) {
+      String trimmed = clause.trim();
+
+      if ( trimmed.isEmpty() ) {
+        continue;
+      }
+
+      if ( trimmed.startsWith( FILE_FILTER_TOKEN ) ) {
+        fileFilter = validate( trimmed.substring( FILE_FILTER_TOKEN.length() ), FILE_FILTER_TOKEN, childNodeFilter );
+      } else if ( trimmed.startsWith( FOLDER_FILTER_TOKEN ) ) {
+        folderFilter =
+          validate( trimmed.substring( FOLDER_FILTER_TOKEN.length() ), FOLDER_FILTER_TOKEN, childNodeFilter );
+      } else {
+        throw new IllegalArgumentException(
+          "Unknown clause '" + trimmed + "' in filter '" + childNodeFilter + "'. Expected '" + FILE_FILTER_TOKEN
+            + "' or '" + FOLDER_FILTER_TOKEN + "'" );
+      }
+    }
+
+    return new TreeNodeFilterSpec( fileFilter, folderFilter );
+  }
+
+  private static String validate( final String value, final String token, final String childNodeFilter ) {
+    StringBuilder normalized = new StringBuilder();
+
+    for ( String pattern : value.split( INSIDE_FILTER_TOKEN_SEPARATOR, -1 ) ) {
+      String trimmed = pattern.trim();
+
+      if ( trimmed.isEmpty() || ILLEGAL_CHARS.matcher( trimmed ).matches() ) {
+        throw new IllegalArgumentException( "Invalid '" + token + "' value in filter '" + childNodeFilter + "'" );
+      }
+
+      if ( !normalized.isEmpty() ) {
+        normalized.append( INSIDE_FILTER_TOKEN_SEPARATOR );
+      }
+
+      normalized.append( trimmed );
+    }
+
+    if ( normalized.isEmpty() ) {
+      throw new IllegalArgumentException( "Empty '" + token + "' value in filter '" + childNodeFilter + "'" );
+    }
+
+    return normalized.toString();
+  }
+
+  /**
+   * Cheap syntax detection, without validating the clauses.
+   *
+   * @param childNodeFilter the child node filter to inspect
+   * @return <code>true</code> when the filter carries at least one structured token
+   */
+  public static boolean hasStructuredTokens( final String childNodeFilter ) {
+    return childNodeFilter != null
+      && ( childNodeFilter.contains( FILE_FILTER_TOKEN ) || childNodeFilter.contains( FOLDER_FILTER_TOKEN ) );
+  }
+
+  /**
+   * Degrades a structured child node filter to {@link #DEFAULT_CHILD_NODE_FILTER}, for call paths that cannot honor
+   * it ( e.g. a children request, where no provider applies the file/folder distinction ). A plain legacy filter is
+   * left untouched.
+   *
+   * @param repositoryRequest the request about to be handed to the provider
+   * @return <code>true</code> when the filter was degraded
+   */
+  public static boolean applyFallback( final RepositoryRequest repositoryRequest ) {
+    if ( repositoryRequest == null || !hasStructuredTokens( repositoryRequest.getChildNodeFilter() ) ) {
+      return false;
+    }
+
+    repositoryRequest.setChildNodeFilter( DEFAULT_CHILD_NODE_FILTER );
+
+    return true;
+  }
+
+  /**
+   * @return <code>true</code> when the caller asked for independent file and folder filtering, which requires the
+   * query based tree implementation.
+   */
+  public boolean isStructured() {
+    return fileFilter != null || folderFilter != null;
+  }
+
+  /**
+   * @return comma separated file name patterns, or <code>null</code> meaning "every file"
+   */
+  public String getFileFilter() {
+    return fileFilter;
+  }
+
+  /**
+   * @return comma separated folder name patterns, or <code>null</code> meaning "every folder", empty ones included
+   */
+  public String getFolderFilter() {
+    return folderFilter;
+  }
+}

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDao.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/fs/FileSystemRepositoryFileDao.java
@@ -53,6 +53,7 @@ import org.pentaho.platform.api.repository2.unified.data.node.NodeRepositoryFile
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
 import org.pentaho.platform.repository.RepositoryFilenameUtils;
 import org.pentaho.platform.repository2.unified.IRepositoryFileDao;
+import org.pentaho.platform.repository2.unified.TreeNodeFilterSpec;
 import org.pentaho.platform.util.RepositoryPathEncoder;
 
 @SuppressWarnings( "nls" )
@@ -288,10 +289,13 @@ public class FileSystemRepositoryFileDao implements IRepositoryFileDao {
 
   @Override
   public RepositoryFileTree getTree( RepositoryRequest repositoryRequest ) {
+    // this provider does not implement the structured child node filter; degrade it to "everything" so the request
+    // does not silently return an empty tree
+    TreeNodeFilterSpec.applyFallback( repositoryRequest );
 
     File root = new File( getPhysicalFileLocation( repositoryRequest.getPath() ) );
 
-    //TODO ACL     
+    //TODO ACL
     return getTree( root, repositoryRequest.getDepth().intValue(),
         repositoryRequest.getChildNodeFilter(), repositoryRequest.getTypes() );
   }
@@ -301,7 +305,7 @@ public class FileSystemRepositoryFileDao implements IRepositoryFileDao {
 
     File root = new File( getPhysicalFileLocation( relPath ) );
 
-    //TODO ACL     
+    //TODO ACL
     return getTree( root, depth, filter, RepositoryRequest.FILES_TYPE_FILTER.FILES_FOLDERS );
   }
 

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileDao.java
@@ -59,6 +59,7 @@ import org.pentaho.platform.repository2.messages.Messages;
 import org.pentaho.platform.repository2.unified.IRepositoryFileAclDao;
 import org.pentaho.platform.repository2.unified.IRepositoryFileDao;
 import org.pentaho.platform.repository2.unified.ServerRepositoryPaths;
+import org.pentaho.platform.repository2.unified.TreeNodeFilterSpec;
 import org.springframework.extensions.jcr.JcrCallback;
 import org.springframework.extensions.jcr.JcrTemplate;
 import org.springframework.util.Assert;
@@ -66,7 +67,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * CRUD operations against JCR. Note that there is no access control in this class (implicit or explicit).
- * 
+ *
  * @author mlowery
  */
 public class JcrRepositoryFileDao implements IRepositoryFileDao {
@@ -510,6 +511,9 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
   @SuppressWarnings( "unchecked" )
   public List<RepositoryFile> getChildren( final RepositoryRequest repositoryRequest ) {
     Assert.notNull( repositoryRequest.getPath(), "Repository request path must not be null" );
+    // the structured filter only applies to tree requests; a children request degrades it to "everything"
+    TreeNodeFilterSpec.applyFallback( repositoryRequest );
+
     return (List<RepositoryFile>) jcrTemplate.execute( new JcrCallback() {
       @Override
       public Object doInJcr( final Session session ) throws RepositoryException, IOException {
@@ -1049,11 +1053,22 @@ public class JcrRepositoryFileDao implements IRepositoryFileDao {
   @Override
   public RepositoryFileTree getTree( final RepositoryRequest repositoryRequest ) {
     Assert.hasText( repositoryRequest.getPath(), "Repository request path must not be null or empty" );
+
+    // the structured child node filter filters files and folders independently, which the node traversal below
+    // cannot do; it is served by a JCR-SQL2 query instead
+    final TreeNodeFilterSpec filterSpec = TreeNodeFilterSpec.parse( repositoryRequest.getChildNodeFilter() );
+
     return (RepositoryFileTree) jcrTemplate.execute( new JcrCallback() {
       @Override
       public Object doInJcr( final Session session ) throws RepositoryException, IOException {
         PentahoJcrConstants pentahoJcrConstants = new PentahoJcrConstants( session );
         String absPath = pathConversionHelper.relToAbs( repositoryRequest.getPath() );
+
+        if ( filterSpec.isStructured() ) {
+          return JcrTreeQueryUtils.getTreeByQuery( session, pentahoJcrConstants, pathConversionHelper, lockHelper,
+              absPath, repositoryRequest, accessVoterManager );
+        }
+
         return JcrRepositoryFileUtils.getTree( session, pentahoJcrConstants, pathConversionHelper, lockHelper, absPath,
             repositoryRequest, accessVoterManager );
       }

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrRepositoryFileUtils.java
@@ -78,7 +78,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Class of static methods where the real JCR work takes place.
- * 
+ *
  * @author mlowery
  */
 public class JcrRepositoryFileUtils {
@@ -506,7 +506,7 @@ public class JcrRepositoryFileUtils {
   /**
    * Getting base version of the node. In the case of getting NullPointerException from Jackrabbit Content Repository
    * (see https://issues.apache.org/jira/browse/JCR-2382), catching it, logging the error and returning null
-   * 
+   *
    * @param node
    * @return version of the node or null
    * @throws UnsupportedRepositoryOperationException
@@ -1062,7 +1062,7 @@ public class JcrRepositoryFileUtils {
 
   /**
    * Returns the node as it was at the given version.
-   * 
+   *
    * @param version
    *          version to get
    * @return node at version
@@ -1157,7 +1157,7 @@ public class JcrRepositoryFileUtils {
    * first find a file that satisfies the criteria of the <code>childNodeFilter</code> mask. A file meeting the criteria
    * may be any number of folders down the repository structure, so the <code>foundFiltered</code> MutableBoolean tells
    * the caller if a file was found, at any level, meeting that criteria.
-   * 
+   *
    * @param session
    *          The current session in progress
    * @param pentahoJcrConstants
@@ -1203,7 +1203,8 @@ public class JcrRepositoryFileUtils {
     // to go)
     if ( depth != 0 ) {
       children = new ArrayList<RepositoryFileTree>();
-      int numberOfPasses = childNodeFilter != null && !childNodeFilter.equals( "*" ) ? 2 : 1;
+      int numberOfPasses =
+        childNodeFilter != null && !childNodeFilter.equals( RepositoryRequest.FILTER_WILDCARD ) ? 2 : 1;
 
       // get Filtered Children set
       HashSet<Node> filteredChildrenSet;
@@ -1442,7 +1443,7 @@ public class JcrRepositoryFileUtils {
 
   /**
    * Use override list from PentahoSystem if it exists
-   * 
+   *
    * @return
    */
   public static List<Character> getReservedChars() {

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtils.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtils.java
@@ -72,12 +72,12 @@ import java.util.regex.Pattern;
 public class JcrTreeQueryUtils {
   private static final Log logger = LogFactory.getLog( JcrTreeQueryUtils.class );
 
-  private static final String PATH_SEPARATOR = "/"; //$NON-NLS-1$
+  private static final String PATH_SEPARATOR = "/";
 
   /**
    * the name of the internal folder <code>DefaultDeleteHelper</code> moves the deleted files to
    */
-  private static final String TRASH_FOLDER_NAME = ".trash"; //$NON-NLS-1$
+  private static final String TRASH_FOLDER_NAME = ".trash";
 
   /**
    * The trash folder as a path segment.
@@ -91,7 +91,7 @@ public class JcrTreeQueryUtils {
   /**
    * the JCR-SQL2 <code>LIKE</code> wildcards, which the node name filter wildcard is translated to
    */
-  private static final String SQL_LIKE_WILDCARD = "%"; //$NON-NLS-1$
+  private static final String SQL_LIKE_WILDCARD = "%";
 
   /**
    * the node name filter wildcard, as a regular expression, so that a pattern can be split on it

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtils.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtils.java
@@ -1,0 +1,613 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.repository2.unified.IRepositoryAccessVoterManager;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileTree;
+import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.repository2.unified.TreeNodeFilterSpec;
+import org.springframework.util.Assert;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.Item;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * JCR-SQL2 based implementation of the repository tree retrieval.
+ * <p>
+ * Unlike {@link JcrRepositoryFileUtils#getTree(Session, PentahoJcrConstants, IPathConversionHelper, ILockHelper,
+ * String, RepositoryRequest, IRepositoryAccessVoterManager)}, which walks the node hierarchy and applies a single node
+ * name filter to both files and folders, this implementation honors the structured child node filter parsed by
+ * {@link TreeNodeFilterSpec} by issuing two queries:
+ * <ul>
+ * <li>one returning the <code>pentahoFolder</code> nodes matching <code>folderFilter</code>, or every folder below the
+ * requested path when no folder filter was given;</li>
+ * <li>one returning the <code>pentahoFile</code> nodes matching <code>fileFilter</code>.</li>
+ * </ul>
+ * The nodes those queries return are the <i>matches</i> of the request, and the tree is assembled around them:
+ * <ul>
+ * <li>every folder the folder filter selects belongs to the tree, empty ones included, and every file the file
+ * filter selects does too: a filter only ever narrows its own kind of node;</li>
+ * <li>the folders between a matching folder and the root are materialized, because a query returns a flat result set
+ * while the node traversal walks through them, so that a matching folder deeper than a direct child of the requested
+ * path stays reachable;</li>
+ * <li>a file living in a folder the folder filter rejected is left out, for the tree carries no folder to hold
+ * it;</li>
+ * <li>{@link RepositoryRequest.FILES_TYPE_FILTER#FOLDERS} leaves the files out of the tree altogether, while the
+ * folders always answer to the folder filter alone;</li>
+ * <li>the deleted files, which keep their node type below the trash folder of a user home folder, are left out, as
+ * the traversal leaves them out by refusing to descend into that internal folder.</li>
+ * </ul>
+ * This class is JCR specific and must only be used by the JCR repository provider.
+ */
+public class JcrTreeQueryUtils {
+  private static final Log logger = LogFactory.getLog( JcrTreeQueryUtils.class );
+
+  private static final String PATH_SEPARATOR = "/"; //$NON-NLS-1$
+
+  /**
+   * the name of the internal folder <code>DefaultDeleteHelper</code> moves the deleted files to
+   */
+  private static final String TRASH_FOLDER_NAME = ".trash"; //$NON-NLS-1$
+
+  /**
+   * The trash folder as a path segment.
+   * <p>
+   * Its node type is <code>pentahoInternalFolder</code>, which the node traversal refuses to descend into, so the
+   * files below it never belong to a tree. A query, on the other hand, returns them, because they keep their
+   * <code>pentahoFile</code> type once deleted, hence this check.
+   */
+  private static final String TRASH_FOLDER_PATH_SEGMENT = PATH_SEPARATOR + TRASH_FOLDER_NAME + PATH_SEPARATOR;
+
+  /**
+   * the JCR-SQL2 <code>LIKE</code> wildcards, which the node name filter wildcard is translated to
+   */
+  private static final String SQL_LIKE_WILDCARD = "%"; //$NON-NLS-1$
+
+  /**
+   * the node name filter wildcard, as a regular expression, so that a pattern can be split on it
+   */
+  private static final String WILDCARD_SPLITTER = Pattern.quote( RepositoryRequest.FILTER_WILDCARD );
+
+  private JcrTreeQueryUtils() {
+    // static utility class
+  }
+
+  /**
+   * Builds the repository tree of the given request with two JCR-SQL2 queries, so that files and folders are filtered
+   * independently.
+   *
+   * @param session              the JCR session
+   * @param pentahoJcrConstants  the constants of the session workspace
+   * @param pathConversionHelper the relative / absolute path converter
+   * @param lockHelper           the lock helper
+   * @param absPath              the absolute path of the root of the tree
+   * @param repositoryRequest    the request, whose child node filter must carry the structured syntax
+   * @param accessVoterManager   the access voter manager; must not be <code>null</code>, exactly as required by
+   *                             {@link JcrRepositoryFileUtils#getTree(Session, PentahoJcrConstants,
+   *                             IPathConversionHelper, ILockHelper, String, RepositoryRequest,
+   *                             IRepositoryAccessVoterManager)}
+   * @return the tree, or <code>null</code> when the root is hidden, is an ACL node, or is not readable
+   * @throws RepositoryException when the queries cannot be executed
+   */
+  public static RepositoryFileTree getTreeByQuery( final Session session,
+                                                   final PentahoJcrConstants pentahoJcrConstants,
+                                                   final IPathConversionHelper pathConversionHelper,
+                                                   final ILockHelper lockHelper, final String absPath,
+                                                   final RepositoryRequest repositoryRequest,
+                                                   final IRepositoryAccessVoterManager accessVoterManager )
+    throws RepositoryException {
+    String encodedRootPath = JcrStringHelper.pathEncode( absPath );
+    Item rootItem = session.getItem( encodedRootPath );
+
+    // items are nodes or properties; this must be a node
+    Assert.isTrue( rootItem.isNode(),
+      "The specified item must be a node. Ensure the provided path corresponds to a valid node in the repository." );
+
+    Node rootNode = (Node) rootItem;
+    RepositoryFile rootFile =
+      JcrRepositoryFileUtils.nodeToFile( session, pentahoJcrConstants, pathConversionHelper, lockHelper, rootNode );
+
+    // the very same root rejection as the node traversal: hidden, ACL node or unreadable yields no tree at all. The
+    // ACL is read without guarding against AccessDeniedException on purpose, so that it propagates just as it does
+    // there
+    if ( ( !repositoryRequest.isShowHidden() && rootFile.isHidden() ) || rootFile.isAclNode()
+      || !accessVoterManager.hasAccess( rootFile, RepositoryFilePermission.READ,
+      JcrRepositoryFileAclUtils.getAcl( session, pentahoJcrConstants, rootFile.getId() ),
+      PentahoSessionHolder.getSession() ) ) {
+      return null;
+    }
+
+    // if depth is neither negative ( indicating unlimited depth ) nor positive ( indicating at least one more level to
+    // go ), the root carries no children at all
+    if ( repositoryRequest.getDepth() == 0 ) {
+      return new RepositoryFileTree( rootFile, null );
+    }
+
+    TreeQueryContext context =
+      new TreeQueryContext( session, pentahoJcrConstants, pathConversionHelper, lockHelper, accessVoterManager,
+        repositoryRequest );
+    // the path of the node itself, rather than the encoded request path, so that it compares equal to the paths of
+    // the nodes the queries return, whatever the encoding did
+    context.setRoot( rootNode.getPath(), rootFile );
+
+    // the folders are what the tree is made of, so they are always collected, and only the folder filter narrows
+    // them; the folders between a matching folder and the root are materialized along with it
+    collectNodes( context, buildFolderQuery( pentahoJcrConstants, encodedRootPath, context.filterSpec ), true );
+
+    // a file, on the other hand, is only attached to a folder the tree already carries: the folder filter is what
+    // decides which folders those are
+    if ( repositoryRequest.getTypes() != RepositoryRequest.FILES_TYPE_FILTER.FOLDERS ) {
+      collectNodes( context, buildFileQuery( pentahoJcrConstants, encodedRootPath, context.filterSpec ), false );
+    }
+
+    return toRepositoryFileTree( context.nodesByPath.get( context.rootPath ) );
+  }
+
+  // region Query building
+  private static String buildFolderQuery( final PentahoJcrConstants pentahoJcrConstants, final String encodedRootPath,
+                                          final TreeNodeFilterSpec filterSpec ) {
+    return "SELECT * FROM [" + pentahoJcrConstants.getPHO_NT_PENTAHOFOLDER() + "]"
+      + " WHERE ISDESCENDANTNODE(" + toPathLiteral( encodedRootPath ) + ")"
+      + nameConstraint( filterSpec.getFolderFilter() );
+  }
+
+  private static String buildFileQuery( final PentahoJcrConstants pentahoJcrConstants, final String encodedRootPath,
+                                        final TreeNodeFilterSpec filterSpec ) {
+    return "SELECT * FROM [" + pentahoJcrConstants.getPHO_NT_PENTAHOFILE() + "]"
+      + " WHERE ISDESCENDANTNODE(" + toPathLiteral( encodedRootPath ) + ")"
+      + nameConstraint( filterSpec.getFileFilter() );
+  }
+
+  /**
+   * Translates <code>"*.ktr,*.kjb"</code> into
+   * <code>" AND ( LOWER(LOCALNAME()) LIKE '%.ktr' OR LOWER(LOCALNAME()) LIKE '%.kjb' )"</code>. A <code>null</code>
+   * filter means "every node of this type".
+   * <p>
+   * Two limitations of the JCR-SQL2 implementation shape this constraint:
+   * <ul>
+   * <li>the SQL <code>ESCAPE</code> clause is not supported, so the <code>LIKE</code> wildcards of a node name cannot
+   * be escaped;</li>
+   * <li><code>NAME()</code> only supports an equality comparison without transformation, so a <code>LIKE</code> on it
+   * is rejected as soon as it appears in a boolean constraint, whereas <code>LOCALNAME()</code> supports both.</li>
+   * </ul>
+   * The constraint is therefore a widening one, matching at least every node the filter selects, and the exact
+   * matching is done in memory by {@link #matchesNodeFilter(String, String)}.
+   */
+  private static String nameConstraint( final String nodeFilter ) {
+    if ( nodeFilter == null || TreeNodeFilterSpec.DEFAULT_CHILD_NODE_FILTER.equals( nodeFilter )
+      // LOCALNAME() drops the namespace prefix, so a pattern carrying its separator is left to the in-memory
+      // matching alone rather than risking a false negative. Repository file names cannot contain it anyway
+      || nodeFilter.indexOf( ':' ) >= 0 ) {
+      return "";
+    }
+
+    StringBuilder constraint = new StringBuilder( " AND (" );
+    boolean first = true;
+
+    for ( String pattern : nodeFilter.split( TreeNodeFilterSpec.INSIDE_FILTER_TOKEN_SEPARATOR ) ) {
+      if ( !first ) {
+        constraint.append( " OR " );
+      }
+
+      constraint.append( "LOWER(LOCALNAME()) LIKE '" ).append( toLikeLiteral( pattern ) ).append( "'" );
+      first = false;
+    }
+
+    return constraint.append( ")" ).toString();
+  }
+
+  private static String toLikeLiteral( final String pattern ) {
+    return pattern.toLowerCase( Locale.ROOT )
+      .replace( "'", "''" )
+      .replace( RepositoryRequest.FILTER_WILDCARD, SQL_LIKE_WILDCARD );
+  }
+
+  /**
+   * Turns the given path into the quoted path literal of a JCR-SQL2 statement.
+   * <p>
+   * The bracketed form, <code>[/a/b]</code>, is a node name and the engine silently matches nothing when a segment
+   * of the path carries a space, which repository folder and file names commonly do; the quoted form is parsed as a
+   * path and behaves.
+   */
+  private static String toPathLiteral( final String path ) {
+    return "'" + path.replace( "'", "''" ) + "'";
+  }
+  // endregion Query building
+
+  // region Query execution
+  private static void collectNodes( final TreeQueryContext context, final String statement,
+                                    final boolean materializeAncestors ) throws RepositoryException {
+    Query query = context.session.getWorkspace().getQueryManager().createQuery( statement, Query.JCR_SQL2 );
+    NodeIterator nodeIterator = query.execute().getNodes();
+
+    while ( nodeIterator.hasNext() ) {
+      Node node = nodeIterator.nextNode();
+      RepositoryFile file = accept( context, node );
+
+      if ( file != null ) {
+        add( context, node, file, materializeAncestors );
+      }
+    }
+  }
+
+  /**
+   * Adds the given match to the tree, below its parent folder.
+   * <p>
+   * A query returns a flat result set, so the parent may not be there yet: when the caller asks for it, it is
+   * materialized, and so on up to the root, exactly as the node traversal walks through the folders a matching
+   * folder lives in. Otherwise, and whenever an ancestor must be skipped ( unsupported, hidden, ACL node, system
+   * folder or unreadable ), the node is left unlinked, which drops it, and everything below it, from the tree being
+   * returned: a file whose folder the folder filter rejected is dropped that way.
+   *
+   * @return the node added to the tree
+   */
+  private static TreeNode add( final TreeQueryContext context, final Node node, final RepositoryFile file,
+                               final boolean materializeAncestors ) throws RepositoryException {
+    String path = normalizePath( file.getPath() );
+    TreeNode treeNode = new TreeNode( file );
+    context.nodesByPath.put( path, treeNode );
+
+    String parentPath = parentPathOf( path );
+    TreeNode parent = parentPath == null ? null : context.nodesByPath.get( parentPath );
+
+    // the root is always there, so a missing parent means the node lives in a folder no query returned
+    if ( parent == null && materializeAncestors ) {
+      parent = materializeParent( context, node );
+    }
+
+    if ( parent != null ) {
+      parent.children.add( treeNode );
+    }
+
+    return treeNode;
+  }
+
+  /**
+   * Adds the parent folder of the given node to the tree, when it may belong to it, climbing on from there.
+   *
+   * @return the parent folder of the given node, <code>null</code> when the branch must be dropped
+   */
+  private static TreeNode materializeParent( final TreeQueryContext context, final Node node )
+    throws RepositoryException {
+    Node parentNode = node.getParent();
+
+    if ( !isBelowRoot( context.encodedRootPath, normalizePath( parentNode.getPath() ) ) ) {
+      return null;
+    }
+
+    RepositoryFile parentFile = acceptAncestor( context, parentNode );
+
+    if ( parentFile == null ) {
+      return null;
+    }
+
+    return add( context, parentNode, parentFile, true );
+  }
+
+  /**
+   * Mirrors <code>JcrRepositoryFileUtils.checkNodeForTree</code> together with the root checks its recursive call
+   * performs: an unsupported, unreadable, hidden or ACL node is skipped, and so is a node whose ACL cannot be read
+   * because access was denied.
+   *
+   * @return the file of the given node when it belongs to the tree being built, <code>null</code> when it must be
+   * skipped
+   */
+  private static RepositoryFile accept( final TreeQueryContext context, final Node node ) throws RepositoryException {
+    RepositoryFile file = acceptNode( context, node );
+
+    if ( file == null || !matchesStructuredFilter( file, context.filterSpec ) ) {
+      return null;
+    }
+
+    String path = normalizePath( file.getPath() );
+
+    if ( context.nodesByPath.containsKey( path )
+      || !isWithinDepth( context.rootPath, path, context.maxDepth )
+      || isAccessDenied( context.session, context.pentahoJcrConstants, file, context.accessVoterManager ) ) {
+      return null;
+    }
+
+    return file;
+  }
+
+  /**
+   * Same as {@link #accept(TreeQueryContext, Node)} without the filter, the depth and the duplicate checks, none of
+   * which apply to a folder that only carries the tree: it did not have to match the filter, it is shallower than the
+   * node it was materialized for, and the caller checks whether it is already there.
+   *
+   * @return the file of the given ancestor folder, <code>null</code> when the branch must be dropped
+   */
+  private static RepositoryFile acceptAncestor( final TreeQueryContext context, final Node node )
+    throws RepositoryException {
+    RepositoryFile file = acceptNode( context, node );
+
+    if ( file == null
+      || isAccessDenied( context.session, context.pentahoJcrConstants, file, context.accessVoterManager ) ) {
+      return null;
+    }
+
+    return file;
+  }
+
+  /**
+   * The checks every node of the tree goes through, whether it matched a query or it was materialized to carry its
+   * descendants.
+   */
+  private static RepositoryFile acceptNode( final TreeQueryContext context, final Node node )
+    throws RepositoryException {
+    // checked before the file is built, so that a repository full of deleted files costs no more than its paths
+    if ( isInTrash( context, node ) ) {
+      return null;
+    }
+
+    RepositoryFile file =
+      JcrRepositoryFileUtils.nodeToFile( context.session, context.pentahoJcrConstants, context.pathConversionHelper,
+        context.lockHelper, node );
+
+    if ( !JcrRepositoryFileUtils.isSupportedNodeType( context.pentahoJcrConstants, node ) ) {
+      return null;
+    }
+
+    // node paths are the encoded ones, hence the comparison against the encoded root path
+    if ( !context.repositoryRequest.isIncludeSystemFolders()
+      && context.encodedRootPath.equals( normalizePath( node.getParent().getPath() ) )
+      && isSystemFolder( context.session, node ) ) {
+      return null;
+    }
+
+    if ( file == null || file.isAclNode() || ( !context.repositoryRequest.isShowHidden() && file.isHidden() ) ) {
+      return null;
+    }
+
+    return file;
+  }
+
+  /**
+   * Applies the structured filter to the given file, which the query constraint only narrowed down. A folder is
+   * matched against the folder filter and a file against the file filter, exactly as the two queries intend.
+   */
+  private static boolean matchesStructuredFilter( final RepositoryFile file, final TreeNodeFilterSpec filterSpec ) {
+    return matchesNodeFilter( file.getName(),
+      file.isFolder() ? filterSpec.getFolderFilter() : filterSpec.getFileFilter() );
+  }
+
+  private static boolean matchesNodeFilter( final String nodeName, final String nodeFilter ) {
+    if ( nodeFilter == null || TreeNodeFilterSpec.DEFAULT_CHILD_NODE_FILTER.equals( nodeFilter ) ) {
+      return true;
+    }
+
+    String lowerName = nodeName.toLowerCase( Locale.ROOT );
+
+    for ( String pattern : nodeFilter.split( TreeNodeFilterSpec.INSIDE_FILTER_TOKEN_SEPARATOR ) ) {
+      if ( globToRegex( pattern ).matcher( lowerName ).matches() ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Only {@value RepositoryRequest#FILTER_WILDCARD} is a wildcard, every other character is a literal, exactly as in
+   * the node name glob of the traversal based tree.
+   */
+  private static Pattern globToRegex( final String pattern ) {
+    StringBuilder regex = new StringBuilder();
+
+    for ( String literal : pattern.toLowerCase( Locale.ROOT ).split( WILDCARD_SPLITTER, -1 ) ) {
+      if ( !regex.isEmpty() ) {
+        regex.append( ".*" );
+      }
+
+      regex.append( Pattern.quote( literal ) );
+    }
+
+    return Pattern.compile( regex.toString() );
+  }
+
+  /**
+   * Reads the ACL of the given file and votes on it. An {@link AccessDeniedException} raised while reading the ACL
+   * means the node must be skipped, exactly as in <code>JcrRepositoryFileUtils.checkNodeForTree</code>; every other
+   * {@link RepositoryException} propagates.
+   */
+  private static boolean isAccessDenied( final Session session, final PentahoJcrConstants pentahoJcrConstants,
+                                         final RepositoryFile file,
+                                         final IRepositoryAccessVoterManager accessVoterManager )
+    throws RepositoryException {
+    RepositoryFileAcl acl;
+
+    try {
+      acl = JcrRepositoryFileAclUtils.getAcl( session, pentahoJcrConstants, file.getId() );
+    } catch ( AccessDeniedException e ) {
+      logger.debug( "Access denied while reading the ACL of " + file.getPath(), e );
+      return true;
+    }
+
+    return !accessVoterManager.hasAccess( file, RepositoryFilePermission.READ, acl,
+      PentahoSessionHolder.getSession() );
+  }
+
+  private static boolean isSystemFolder( final Session session, final Node node ) throws RepositoryException {
+    Map<String, Serializable> fileMeta = JcrRepositoryFileUtils.getFileMetadata( session, node.getIdentifier() );
+    return fileMeta.containsKey( IUnifiedRepository.SYSTEM_FOLDER )
+      && (Boolean) fileMeta.get( IUnifiedRepository.SYSTEM_FOLDER );
+  }
+
+  /**
+   * Whether the given node is the trash folder of a user home folder, or one of its descendants, that is, whether it
+   * was deleted.
+   * <p>
+   * Only the part of the path below the root of the tree is looked at, so that the tree of a deleted folder, which a
+   * caller may legitimately ask for, still carries its content.
+   *
+   * @return <code>true</code> when the node was deleted and must be left out of the tree
+   */
+  private static boolean isInTrash( final TreeQueryContext context, final Node node ) throws RepositoryException {
+    String path = node.getPath();
+
+    if ( path.length() <= context.encodedRootPath.length() ) {
+      return false;
+    }
+
+    String belowRoot = path.substring( context.encodedRootPath.length() );
+
+    return belowRoot.contains( TRASH_FOLDER_PATH_SEGMENT )
+      || belowRoot.endsWith( PATH_SEPARATOR + TRASH_FOLDER_NAME );
+  }
+  // endregion Query execution
+
+  // region Tree assembly
+  private static RepositoryFileTree toRepositoryFileTree( final TreeNode node ) {
+    List<RepositoryFileTree> children = new ArrayList<>( node.children.size() );
+
+    for ( TreeNode child : node.children ) {
+      children.add( toRepositoryFileTree( child ) );
+    }
+
+    Collections.sort( children );
+
+    return new RepositoryFileTree( node.file, children );
+  }
+  // endregion Tree assembly
+
+  // region Path helpers
+  private static String normalizePath( final String path ) {
+    if ( path == null || path.isEmpty() ) {
+      return PATH_SEPARATOR;
+    }
+
+    if ( path.length() > 1 && path.endsWith( PATH_SEPARATOR ) ) {
+      return path.substring( 0, path.length() - 1 );
+    }
+
+    return path;
+  }
+
+  private static String parentPathOf( final String path ) {
+    int index = path.lastIndexOf( '/' );
+
+    if ( index < 0 ) {
+      return null;
+    }
+
+    return index == 0 ? PATH_SEPARATOR : path.substring( 0, index );
+  }
+
+  private static int depthOf( final String path ) {
+    int depth = 0;
+
+    for ( int i = 0; i < path.length(); i++ ) {
+      if ( path.charAt( i ) == '/' ) {
+        depth++;
+      }
+    }
+
+    return depth;
+  }
+
+  private static boolean isWithinDepth( final String rootPath, final String path, final int maxDepth ) {
+    if ( maxDepth < 0 ) {
+      return true;
+    }
+
+    int rootDepth = PATH_SEPARATOR.equals( rootPath ) ? 0 : depthOf( rootPath );
+
+    return depthOf( path ) - rootDepth <= maxDepth;
+  }
+
+  /**
+   * @return <code>true</code> when the given path is a strict descendant of the given root path
+   */
+  private static boolean isBelowRoot( final String rootPath, final String path ) {
+    String prefix = PATH_SEPARATOR.equals( rootPath ) ? rootPath : rootPath + PATH_SEPARATOR;
+
+    return path.length() > rootPath.length() && path.startsWith( prefix );
+  }
+  // endregion Path helpers
+
+  // region Inner classes
+
+  /**
+   * Everything the collection of a single query result needs, so that the helpers below do not carry a dozen
+   * parameters around.
+   */
+  private static final class TreeQueryContext {
+    private final Session session;
+    private final PentahoJcrConstants pentahoJcrConstants;
+    private final IPathConversionHelper pathConversionHelper;
+    private final ILockHelper lockHelper;
+    private final IRepositoryAccessVoterManager accessVoterManager;
+    private final RepositoryRequest repositoryRequest;
+    private final TreeNodeFilterSpec filterSpec;
+    private final int maxDepth;
+    private final Map<String, TreeNode> nodesByPath = new HashMap<>();
+    private String encodedRootPath;
+    private String rootPath;
+
+    private TreeQueryContext( final Session session, final PentahoJcrConstants pentahoJcrConstants,
+                              final IPathConversionHelper pathConversionHelper, final ILockHelper lockHelper,
+                              final IRepositoryAccessVoterManager accessVoterManager,
+                              final RepositoryRequest repositoryRequest ) {
+      this.session = session;
+      this.pentahoJcrConstants = pentahoJcrConstants;
+      this.pathConversionHelper = pathConversionHelper;
+      this.lockHelper = lockHelper;
+      this.accessVoterManager = accessVoterManager;
+      this.repositoryRequest = repositoryRequest;
+      this.filterSpec = TreeNodeFilterSpec.parse( repositoryRequest.getChildNodeFilter() );
+      this.maxDepth = repositoryRequest.getDepth();
+    }
+
+    /**
+     * @param encodedRootPath the encoded absolute path of the root, which is the form the JCR node paths carry, used
+     *                        to spot the direct children of the root exactly as the node traversal does and to stop
+     *                        the materialization of the ancestor folders
+     * @param rootFile        the file of the root node, which anchors the tree being assembled
+     */
+    private void setRoot( final String encodedRootPath, final RepositoryFile rootFile ) {
+      this.encodedRootPath = normalizePath( encodedRootPath );
+      this.rootPath = normalizePath( rootFile.getPath() );
+      this.nodesByPath.put( this.rootPath, new TreeNode( rootFile ) );
+    }
+  }
+
+  private static class TreeNode {
+    private final RepositoryFile file;
+    private final List<TreeNode> children = new ArrayList<>();
+
+    TreeNode( final RepositoryFile file ) {
+      this.file = file;
+    }
+  }
+  // endregion Inner classes
+}

--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/DefaultUnifiedRepositoryWebService.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/webservices/DefaultUnifiedRepositoryWebService.java
@@ -42,13 +42,14 @@ import org.pentaho.platform.api.repository2.unified.webservices.VersionSummaryDt
 import org.pentaho.platform.api.repository2.unified.webservices.StringKeyStringValueDto;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.repository2.locale.PentahoLocale;
+import org.pentaho.platform.repository2.unified.TreeNodeFilterSpec;
 import org.pentaho.platform.security.policy.rolebased.actions.AdministerSecurityAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link IUnifiedRepositoryWebService} that delegates to an {@link IUnifiedRepository} instance.
- * 
+ *
  * @author mlowery
  */
 @WebService( endpointInterface = "org.pentaho.platform.repository2.unified.webservices.IUnifiedRepositoryWebService",
@@ -107,6 +108,12 @@ public class DefaultUnifiedRepositoryWebService implements IUnifiedRepositoryWeb
 
   @Override
   public List<RepositoryFileDto> getChildrenFromRequest( RepositoryRequest repositoryRequest ) {
+    // the structured child node filter is only meaningful for tree requests;
+    // no provider applies it to a children request, so it is degraded here instead of returning nothing
+    if ( TreeNodeFilterSpec.applyFallback( repositoryRequest ) ) {
+      getLogger().warn( "The fileFilter/folderFilter syntax does not apply to a children request; "
+          + "the child node filter was reset to \"" + TreeNodeFilterSpec.DEFAULT_CHILD_NODE_FILTER + "\"." );
+    }
     return marshalFiles( repo.getChildren( repositoryRequest ), repositoryRequest );
   }
 

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/TreeNodeFilterSpecTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/TreeNodeFilterSpecTest.java
@@ -1,0 +1,165 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+package org.pentaho.platform.repository2.unified;
+
+import org.junit.Test;
+import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.pentaho.platform.api.repository2.unified.RepositoryRequest.FILTER_SEPARATOR;
+import static org.pentaho.platform.api.repository2.unified.RepositoryRequest.FILTER_WILDCARD;
+import static org.pentaho.platform.repository2.unified.TreeNodeFilterSpec.DEFAULT_CHILD_NODE_FILTER;
+import static org.pentaho.platform.repository2.unified.TreeNodeFilterSpec.FILE_FILTER_TOKEN;
+import static org.pentaho.platform.repository2.unified.TreeNodeFilterSpec.FILTER_TOKEN_SEPARATOR;
+import static org.pentaho.platform.repository2.unified.TreeNodeFilterSpec.FOLDER_FILTER_TOKEN;
+import static org.pentaho.platform.repository2.unified.TreeNodeFilterSpec.INSIDE_FILTER_TOKEN_SEPARATOR;
+
+public class TreeNodeFilterSpecTest {
+  private static final String KTR = FILTER_WILDCARD + ".ktr";
+  private static final String KJB = FILTER_WILDCARD + ".kjb";
+  private static final String PRPT = FILTER_WILDCARD + ".prpt";
+  private static final String SALES_FOLDER = "sales" + FILTER_WILDCARD;
+  private static final String YEAR_FOLDER = "2026" + FILTER_WILDCARD;
+
+  /**
+   * the two ktr/kjb patterns as they are written inside a single clause
+   */
+  private static final String KTR_AND_KJB = KTR + INSIDE_FILTER_TOKEN_SEPARATOR + KJB;
+
+  @Test
+  public void testLegacyFilterIsNotStructured() {
+    assertFalse( TreeNodeFilterSpec.parse( null ).isStructured() );
+    assertFalse( TreeNodeFilterSpec.parse( DEFAULT_CHILD_NODE_FILTER ).isStructured() );
+    assertFalse( TreeNodeFilterSpec.parse( KTR ).isStructured() );
+  }
+
+  @Test
+  public void testFileFilterOnly() {
+    // the patterns are deliberately spaced out, they must come back normalized
+    TreeNodeFilterSpec spec =
+      TreeNodeFilterSpec.parse( FILE_FILTER_TOKEN + KTR + INSIDE_FILTER_TOKEN_SEPARATOR + " " + KJB );
+
+    assertTrue( spec.isStructured() );
+    assertEquals( KTR_AND_KJB, spec.getFileFilter() );
+    assertNull( spec.getFolderFilter() );
+  }
+
+  @Test
+  public void testFolderFilterOnly() {
+    TreeNodeFilterSpec spec = TreeNodeFilterSpec.parse( FOLDER_FILTER_TOKEN + SALES_FOLDER );
+
+    assertTrue( spec.isStructured() );
+    assertEquals( SALES_FOLDER, spec.getFolderFilter() );
+    assertNull( spec.getFileFilter() );
+  }
+
+  @Test
+  public void testBothFilters() {
+    TreeNodeFilterSpec spec = TreeNodeFilterSpec.parse(
+      FILE_FILTER_TOKEN + PRPT + FILTER_TOKEN_SEPARATOR + FOLDER_FILTER_TOKEN + YEAR_FOLDER );
+
+    assertEquals( PRPT, spec.getFileFilter() );
+    assertEquals( YEAR_FOLDER, spec.getFolderFilter() );
+  }
+
+  @Test
+  public void testStructuredFilterSurvivesTheLegacyFilterParser() {
+    String structuredFilter = FILE_FILTER_TOKEN + KTR_AND_KJB;
+    RepositoryRequest request = new RepositoryRequest( "/public", true, -1,
+      structuredFilter + FILTER_SEPARATOR + RepositoryRequest.FILES_TYPE_FILTER.FILES_FOLDERS );
+
+    assertEquals( RepositoryRequest.FILES_TYPE_FILTER.FILES_FOLDERS, request.getTypes() );
+    assertEquals( structuredFilter, request.getChildNodeFilter() );
+
+    TreeNodeFilterSpec spec = TreeNodeFilterSpec.parse( request.getChildNodeFilter() );
+    assertTrue( spec.isStructured() );
+    assertEquals( KTR_AND_KJB, spec.getFileFilter() );
+    assertNull( spec.getFolderFilter() );
+  }
+
+  @Test
+  public void testUnknownClauseIsRejected() {
+    assertInvalid( FILE_FILTER_TOKEN + KTR + FILTER_TOKEN_SEPARATOR + "bogus=1" );
+  }
+
+  @Test
+  public void testHasStructuredTokens() {
+    assertTrue( TreeNodeFilterSpec.hasStructuredTokens( FILE_FILTER_TOKEN + KTR ) );
+    assertTrue( TreeNodeFilterSpec.hasStructuredTokens( FOLDER_FILTER_TOKEN + SALES_FOLDER ) );
+    assertFalse( TreeNodeFilterSpec.hasStructuredTokens( KTR ) );
+    assertFalse( TreeNodeFilterSpec.hasStructuredTokens( null ) );
+  }
+
+  @Test
+  public void testFallbackDegradesStructuredFilter() {
+    RepositoryRequest request = new RepositoryRequest( "/public", true, -1, FILE_FILTER_TOKEN + KTR
+      + FILTER_SEPARATOR + RepositoryRequest.FILES_TYPE_FILTER.FILES_FOLDERS );
+
+    assertTrue( TreeNodeFilterSpec.applyFallback( request ) );
+    assertEquals( DEFAULT_CHILD_NODE_FILTER, request.getChildNodeFilter() );
+  }
+
+  @Test
+  public void testFallbackLeavesLegacyFilterUntouched() {
+    RepositoryRequest request = new RepositoryRequest( "/public", true, -1,
+      KTR + FILTER_SEPARATOR + RepositoryRequest.FILES_TYPE_FILTER.FILES_FOLDERS );
+
+    assertFalse( TreeNodeFilterSpec.applyFallback( request ) );
+    assertEquals( KTR, request.getChildNodeFilter() );
+  }
+
+  @Test
+  public void testFallbackHandlesNullRequest() {
+    assertFalse( TreeNodeFilterSpec.applyFallback( null ) );
+  }
+
+  @Test
+  public void testEmptyPatternIsRejected() {
+    assertInvalid( FILE_FILTER_TOKEN + KTR + INSIDE_FILTER_TOKEN_SEPARATOR + INSIDE_FILTER_TOKEN_SEPARATOR );
+    assertInvalid( FOLDER_FILTER_TOKEN );
+  }
+
+  @Test
+  public void testIllegalCharactersAreRejected() {
+    assertInvalid( FILE_FILTER_TOKEN + "/etc/" + FILTER_WILDCARD );
+    assertInvalid( FOLDER_FILTER_TOKEN + SALES_FOLDER + "'" );
+  }
+
+  /**
+   * the legacy filter separator cannot appear inside a pattern, because it delimits the legacy filter itself
+   */
+  @Test
+  public void testLegacyFilterSeparatorIsRejected() {
+    assertInvalid( FILE_FILTER_TOKEN + KTR + FILTER_SEPARATOR + PRPT );
+  }
+
+  @Test
+  public void testControlCharactersAreRejected() {
+    assertInvalid( FILE_FILTER_TOKEN + "sales\treport" );
+    assertInvalid( FILE_FILTER_TOKEN + "sales\rreport" );
+    assertInvalid( FILE_FILTER_TOKEN + "sales\nreport" );
+  }
+
+  private static void assertInvalid( String childNodeFilter ) {
+    try {
+      TreeNodeFilterSpec.parse( childNodeFilter );
+      fail( "IllegalArgumentException should have been thrown for '" + childNodeFilter + "'" );
+    } catch ( IllegalArgumentException e ) {
+      // expected
+    }
+  }
+}

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtilsSql2ParsingTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtilsSql2ParsingTest.java
@@ -113,10 +113,13 @@ public class JcrTreeQueryUtilsSql2ParsingTest {
 
   @BeforeClass
   public static void startRepository() throws Exception {
-    InputStream configStream = JcrTreeQueryUtilsSql2ParsingTest.class.getResourceAsStream( REPO_CONFIG_FILE );
     String home = Files.createTempDirectory( TEST_REPOSITORY_LOCATION ).toAbsolutePath().toString();
 
-    repository = new TransientRepository( RepositoryConfig.create( configStream, home ) );
+    try ( InputStream configStream = JcrTreeQueryUtilsSql2ParsingTest.class.getResourceAsStream( REPO_CONFIG_FILE ) ) {
+      assertNotNull( "Missing test repository config " + REPO_CONFIG_FILE, configStream );
+      repository = new TransientRepository( RepositoryConfig.create( configStream, home ) );
+    }
+
     session = repository.login( new SimpleCredentials( "admin", "admin".toCharArray() ) );
 
     // the queried subtree must exist, so that the engine is exercised exactly as it is at runtime
@@ -396,7 +399,8 @@ public class JcrTreeQueryUtilsSql2ParsingTest {
   }
 
 
-  private static void addFile( final Node parent, final String name ) throws RepositoryException {    Node content = parent.addNode( name, FILE_NODE_TYPE ).addNode( "jcr:content", "nt:resource" );
+  private static void addFile( final Node parent, final String name ) throws RepositoryException {
+    Node content = parent.addNode( name, FILE_NODE_TYPE ).addNode( "jcr:content", "nt:resource" );
     content.setProperty( "jcr:data",
       session.getValueFactory().createBinary( new ByteArrayInputStream( "x".getBytes( StandardCharsets.UTF_8 ) ) ) );
   }

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtilsSql2ParsingTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtilsSql2ParsingTest.java
@@ -1,0 +1,411 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.jackrabbit.core.TransientRepository;
+import org.apache.jackrabbit.core.config.RepositoryConfig;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.pentaho.platform.api.repository2.unified.IRepositoryAccessVoterManager;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileTree;
+import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+import org.pentaho.platform.repository2.unified.TreeNodeFilterSpec;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.SimpleCredentials;
+import javax.jcr.UnsupportedRepositoryOperationException;
+import javax.jcr.query.InvalidQueryException;
+import javax.jcr.query.Query;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that the statements built by {@link JcrTreeQueryUtils} are accepted by a real JCR-SQL2 engine.
+ * <p>
+ * The reported failure was
+ *
+ * <pre>
+ * javax.jcr.query.InvalidQueryException: Query:
+ * SELECT * FROM [pho_nt:pentahoFile] WHERE ISDESCENDANTNODE([/pentaho/tenant0/home/admin])
+ *   AND (LOWER(NAME()) LIKE '%.xanalyzer' ESCAPE(*)'\' OR LOWER(NAME()) LIKE '%.prpt' ESCAPE '\'); expected: )
+ * </pre>
+ * <p>
+ * Unlike {@link JcrTreeQueryUtilsTest}, which asserts the statement text against a mocked query manager, this test
+ * hands the statements to a real Jackrabbit query manager, so it also covers what only the execution reveals.
+ */
+public class JcrTreeQueryUtilsSql2ParsingTest {
+  private static final String REPO_CONFIG_FILE = "/jackrabbit/repository-in-memory.xml";
+  private static final String TEST_REPOSITORY_LOCATION = "test-jcr-sql2_";
+
+  /**
+   * the path of the reported failure
+   */
+  private static final String ROOT_PATH = "/pentaho/tenant0/home/admin";
+
+  private static final String FILE_NODE_TYPE = "nt:file";
+  private static final String FOLDER_NODE_TYPE = "nt:folder";
+
+  /**
+   * the filter of the reported failure
+   */
+  private static final String REPORTED_FILTER =
+    TreeNodeFilterSpec.FILE_FILTER_TOKEN + "*.xanalyzer" + TreeNodeFilterSpec.INSIDE_FILTER_TOKEN_SEPARATOR + "*.prpt";
+
+  private static final String DESCENDANT_FILES =
+    "SELECT * FROM [" + FILE_NODE_TYPE + "] WHERE ISDESCENDANTNODE('" + ROOT_PATH + "')";
+
+  /**
+   * the statement the reported failure carried, which must remain invalid, so that this test keeps proving the engine
+   * rejects the <code>ESCAPE</code> clause instead of silently accepting anything
+   */
+  private static final String STATEMENT_WITH_ESCAPE_CLAUSE = DESCENDANT_FILES
+    + " AND (LOWER(LOCALNAME()) LIKE '%.xanalyzer' ESCAPE '\\' OR LOWER(LOCALNAME()) LIKE '%.prpt' ESCAPE '\\')";
+
+  /**
+   * a <code>LIKE</code> on <code>NAME()</code>, which parses but is rejected when the engine builds the query, so
+   * that this test also keeps proving the second limitation the constraint works around
+   */
+  private static final String STATEMENT_WITH_NODE_NAME = DESCENDANT_FILES
+    + " AND (LOWER(NAME()) LIKE '%.xanalyzer' OR LOWER(NAME()) LIKE '%.prpt')";
+
+  private static TransientRepository repository;
+  private static Session session;
+
+  private PentahoJcrConstants pentahoJcrConstants;
+  private IRepositoryAccessVoterManager accessVoterManager;
+
+  private MockedStatic<JcrRepositoryFileUtils> jcrRepositoryFileUtils;
+  private MockedStatic<JcrRepositoryFileAclUtils> jcrRepositoryFileAclUtils;
+
+  @BeforeClass
+  public static void startRepository() throws Exception {
+    InputStream configStream = JcrTreeQueryUtilsSql2ParsingTest.class.getResourceAsStream( REPO_CONFIG_FILE );
+    String home = Files.createTempDirectory( TEST_REPOSITORY_LOCATION ).toAbsolutePath().toString();
+
+    repository = new TransientRepository( RepositoryConfig.create( configStream, home ) );
+    session = repository.login( new SimpleCredentials( "admin", "admin".toCharArray() ) );
+
+    // the queried subtree must exist, so that the engine is exercised exactly as it is at runtime
+    Node root = session.getRootNode();
+
+    for ( String name : ROOT_PATH.substring( 1 ).split( "/" ) ) {
+      root = root.hasNode( name ) ? root.getNode( name ) : root.addNode( name, FOLDER_NODE_TYPE );
+    }
+
+    Node sales = root.addNode( "sales", FOLDER_NODE_TYPE );
+    root.addNode( "marketing", FOLDER_NODE_TYPE );
+
+    // only a_b.prpt really matches the "a_b.prpt" filter; axb.prpt matches the query constraint alone, because '_'
+    // is a LIKE wildcard that cannot be escaped
+    addFile( sales, "a_b.prpt" );
+    addFile( sales, "axb.prpt" );
+
+    // 100%25.prpt is the percent encoded form of a file named 100%.prpt
+    for ( String name : new String[] { "dashboard.xanalyzer", "report.prpt", "notes.txt", "100%25.prpt" } ) {
+      addFile( root, name );
+    }
+
+    session.save();
+  }
+
+  @AfterClass
+  public static void shutDownRepository() throws Exception {
+    String homeDir = repository.getHomeDir();
+
+    session.logout();
+    repository.shutdown();
+
+    FileUtils.deleteDirectory( new File( homeDir ) );
+
+    session = null;
+    repository = null;
+  }
+
+  @Before
+  public void setUp() {
+    pentahoJcrConstants = mock( PentahoJcrConstants.class );
+    // the real node types are used, so that the engine resolves them and only the name constraint is under test
+    when( pentahoJcrConstants.getPHO_NT_PENTAHOFILE() ).thenReturn( FILE_NODE_TYPE );
+    when( pentahoJcrConstants.getPHO_NT_PENTAHOFOLDER() ).thenReturn( FOLDER_NODE_TYPE );
+
+    accessVoterManager = mock( IRepositoryAccessVoterManager.class );
+    when( accessVoterManager.hasAccess( any(), any(), any(), any() ) ).thenReturn( true );
+
+    jcrRepositoryFileUtils = mockStatic( JcrRepositoryFileUtils.class );
+    jcrRepositoryFileUtils.when( () -> JcrRepositoryFileUtils.isSupportedNodeType( any(), any() ) ).thenReturn( true );
+    jcrRepositoryFileUtils.when( () -> JcrRepositoryFileUtils.getFileMetadata( any(), any() ) )
+      .thenReturn( Collections.<String, Serializable>emptyMap() );
+    jcrRepositoryFileUtils.when( () -> JcrRepositoryFileUtils.nodeToFile( any(), any(), any(), any(), any() ) )
+      .thenAnswer( invocation -> toFile( invocation.getArgument( 4 ) ) );
+
+    RepositoryFileAcl acl = mock( RepositoryFileAcl.class );
+    jcrRepositoryFileAclUtils = mockStatic( JcrRepositoryFileAclUtils.class );
+    jcrRepositoryFileAclUtils.when( () -> JcrRepositoryFileAclUtils.getAcl( any(), any(), any() ) ).thenReturn( acl );
+  }
+
+  @After
+  public void tearDown() {
+    jcrRepositoryFileUtils.close();
+    jcrRepositoryFileAclUtils.close();
+  }
+
+  /**
+   * the reported request, end to end: its statements must reach the engine and the tree must carry the matching
+   * nodes only
+   */
+  @Test
+  public void testReportedRequestIsAcceptedByTheEngine() throws Exception {
+    // no folder filter, so every folder below the root belongs to the tree, empty ones included, and notes.txt is
+    // the only file dropped
+    assertEquals( List.of( "100%25.prpt", "dashboard.xanalyzer", "marketing", "report.prpt", "sales" ),
+      childNamesOfTree( REPORTED_FILTER ) );
+  }
+
+  /**
+   * both queries carry a multi pattern constraint, which is where the <code>NAME()</code> limitation used to surface
+   */
+  @Test
+  public void testFileAndFolderFiltersAreBothExecutedByTheEngine() throws Exception {
+    String filter = REPORTED_FILTER + TreeNodeFilterSpec.FILTER_TOKEN_SEPARATOR
+      + TreeNodeFilterSpec.FOLDER_FILTER_TOKEN + "sales" + TreeNodeFilterSpec.INSIDE_FILTER_TOKEN_SEPARATOR
+      + "finance*";
+
+    // marketing is dropped by the folder filter, notes.txt by the file filter
+    assertEquals( List.of( "100%25.prpt", "dashboard.xanalyzer", "report.prpt", "sales" ),
+      childNamesOfTree( filter ) );
+  }
+
+  /**
+   * the constraint can only widen, so the in-memory matching is what makes the result exact: without it the tree
+   * would carry axb.prpt too
+   */
+  @Test
+  public void testInMemoryMatchingNarrowsTheWideningConstraint() throws Exception {
+    Query query = session.getWorkspace().getQueryManager()
+      .createQuery( DESCENDANT_FILES + " AND (LOWER(LOCALNAME()) LIKE 'a_b.prpt')", Query.JCR_SQL2 );
+
+    assertEquals( 2, query.execute().getNodes().getSize() );
+
+    assertEquals( List.of( "a_b.prpt" ),
+      childNamesOfTree( TreeNodeFilterSpec.FILE_FILTER_TOKEN + "a_b.prpt", ROOT_PATH + "/sales" ) );
+  }
+
+  /**
+   * a node name may be percent encoded while the filter carries the decoded form, so the constraint must keep
+   * matching at least every node the in-memory matching would accept
+   */
+  @Test
+  public void testEncodedNodeNameIsStillMatchedByTheWideningConstraint() throws Exception {
+    Query query = session.getWorkspace().getQueryManager()
+      .createQuery( DESCENDANT_FILES + " AND (LOWER(LOCALNAME()) LIKE '100%.prpt')", Query.JCR_SQL2 );
+
+    assertEquals( 1, query.execute().getNodes().getSize() );
+  }
+
+  /**
+   * the very statement of the reported failure, which the engine must keep rejecting
+   */
+  @Test
+  public void testStatementWithEscapeClauseIsRejectedByTheEngine() throws Exception {
+    try {
+      session.getWorkspace().getQueryManager().createQuery( STATEMENT_WITH_ESCAPE_CLAUSE, Query.JCR_SQL2 );
+      fail( "the engine was expected to reject the ESCAPE clause" );
+    } catch ( InvalidQueryException e ) {
+      assertNotNull( e.getMessage() );
+    }
+  }
+
+  /**
+   * a <code>LIKE</code> on <code>NAME()</code> parses, so only the execution reveals it is not supported
+   */
+  @Test( expected = UnsupportedRepositoryOperationException.class )
+  public void testStatementWithNodeNameLikeIsRejectedByTheEngine() throws Exception {
+    session.getWorkspace().getQueryManager().createQuery( STATEMENT_WITH_NODE_NAME, Query.JCR_SQL2 ).execute()
+      .getNodes();
+  }
+
+  /**
+   * a folder matching the folder filter deeper than a direct child of the root is only reachable when the folders
+   * between it and the root are materialized, which no query returns
+   */
+  @Test
+  public void testNestedMatchingFolderIsReachedThroughItsMaterializedParents() throws Exception {
+    Node deepRoot = session.getRootNode().addNode( "deep", FOLDER_NODE_TYPE );
+    Node sales = deepRoot.addNode( "2026", FOLDER_NODE_TYPE ).addNode( "sales", FOLDER_NODE_TYPE );
+    addFile( sales, "report.prpt" );
+    session.save();
+
+    try {
+      RepositoryFileTree tree = treeOf( TreeNodeFilterSpec.FOLDER_FILTER_TOKEN + "sales", "/deep" );
+
+      assertEquals( 1, tree.getChildren().size() );
+
+      RepositoryFileTree year = tree.getChildren().get( 0 );
+      assertEquals( "2026", year.getFile().getName() );
+      assertEquals( 1, year.getChildren().size() );
+
+      RepositoryFileTree salesTree = year.getChildren().get( 0 );
+      assertEquals( "sales", salesTree.getFile().getName() );
+      assertEquals( List.of( "report.prpt" ), childNamesOf( salesTree ) );
+    } finally {
+      deepRoot.remove();
+      session.save();
+    }
+  }
+
+  /**
+   * the deleted files keep their node type below the trash folder, so the file query returns them; they are no part
+   * of any tree, exactly as the traversal never descends into that internal folder
+   */
+  @Test
+  public void testDeletedFilesOfTheTrashFolderAreLeftOut() throws Exception {
+    Node deepRoot = session.getRootNode().addNode( "deep", FOLDER_NODE_TYPE );
+    // the pho namespace of the real trash folder id is not registered here, and the check does not look at it
+    Node trashedFolder = deepRoot.addNode( ".trash", FOLDER_NODE_TYPE ).addNode( "d78ca35b", FOLDER_NODE_TYPE )
+      .addNode( "New Folder", FOLDER_NODE_TYPE );
+    addFile( trashedFolder, "deleted.prpt" );
+    addFile( deepRoot, "kept.prpt" );
+    session.save();
+
+    try {
+      assertEquals( List.of( "kept.prpt" ),
+        childNamesOfTree( TreeNodeFilterSpec.FILE_FILTER_TOKEN + "*.prpt", "/deep" ) );
+
+      // the tree of the deleted folder itself still carries its content
+      assertEquals( List.of( "deleted.prpt" ), childNamesOfTree( TreeNodeFilterSpec.FILE_FILTER_TOKEN + "*.prpt",
+        "/deep/.trash/d78ca35b/New Folder" ) );
+    } finally {
+      deepRoot.remove();
+      session.save();
+    }
+  }
+
+  /**
+   * a wildcard folder filter makes every folder a match, which brings the whole folder structure back next to the
+   * narrowed set of files: the empty marketing folder belongs to the tree again
+   */
+  @Test
+  public void testWildcardFolderFilterKeepsTheWholeFolderStructure() throws Exception {
+    String filter = REPORTED_FILTER + TreeNodeFilterSpec.FILTER_TOKEN_SEPARATOR
+      + TreeNodeFilterSpec.FOLDER_FILTER_TOKEN + RepositoryRequest.FILTER_WILDCARD;
+
+    assertEquals( List.of( "100%25.prpt", "dashboard.xanalyzer", "marketing", "report.prpt", "sales" ),
+      childNamesOfTree( filter ) );
+  }
+
+  /**
+   * the bracketed path of the JCR-SQL2 statement is a node name, and the engine silently matches nothing when a
+   * segment carries a space, which repository names commonly do; the quoted path the statements carry behaves
+   */
+  @Test
+  public void testRootPathCarryingASpaceIsMatchedByTheEngine() throws Exception {
+    Node spaced = session.getRootNode().addNode( "My Reports", FOLDER_NODE_TYPE );
+    addFile( spaced, "report.prpt" );
+    session.save();
+
+    try {
+      Query bracketed = session.getWorkspace().getQueryManager().createQuery(
+        "SELECT * FROM [" + FILE_NODE_TYPE + "] WHERE ISDESCENDANTNODE([/My Reports])", Query.JCR_SQL2 );
+      assertEquals( 0, bracketed.execute().getNodes().getSize() );
+
+      assertEquals( List.of( "report.prpt" ),
+        childNamesOfTree( TreeNodeFilterSpec.FILE_FILTER_TOKEN + "*.prpt", "/My Reports" ) );
+    } finally {
+      spaced.remove();
+      session.save();
+    }
+  }
+
+  // region Fixture helpers
+
+  /**
+   * @return the sorted names of the children of the tree the given filter builds, rooted at {@link #ROOT_PATH}
+   */
+  private List<String> childNamesOfTree( final String childNodeFilter ) throws RepositoryException {
+    return childNamesOfTree( childNodeFilter, ROOT_PATH );
+  }
+
+  /**
+   * @return the sorted names of the children of the tree the given filter builds
+   */
+  private List<String> childNamesOfTree( final String childNodeFilter, final String rootPath )
+    throws RepositoryException {
+    return childNamesOf( treeOf( childNodeFilter, rootPath ) );
+  }
+
+  private static List<String> childNamesOf( final RepositoryFileTree tree ) {
+    List<String> names = new ArrayList<>();
+
+    for ( RepositoryFileTree child : tree.getChildren() ) {
+      names.add( child.getFile().getName() );
+    }
+
+    Collections.sort( names );
+
+    return names;
+  }
+
+  /**
+   * @return the tree the given filter builds, never <code>null</code>
+   */
+  private RepositoryFileTree treeOf( final String childNodeFilter, final String rootPath ) throws RepositoryException {
+    RepositoryRequest repositoryRequest = new RepositoryRequest( rootPath, true, -1, childNodeFilter );
+    repositoryRequest.setDepth( -1 );
+
+    RepositoryFileTree tree = JcrTreeQueryUtils.getTreeByQuery( session, pentahoJcrConstants,
+      mock( IPathConversionHelper.class ), mock( ILockHelper.class ), rootPath, repositoryRequest,
+      accessVoterManager );
+
+    assertNotNull( tree );
+
+    return tree;
+  }
+
+
+  private static void addFile( final Node parent, final String name ) throws RepositoryException {    Node content = parent.addNode( name, FILE_NODE_TYPE ).addNode( "jcr:content", "nt:resource" );
+    content.setProperty( "jcr:data",
+      session.getValueFactory().createBinary( new ByteArrayInputStream( "x".getBytes( StandardCharsets.UTF_8 ) ) ) );
+  }
+
+  private static RepositoryFile toFile( final Node node ) throws RepositoryException {
+    String path = node.getPath();
+    String name = path.substring( path.lastIndexOf( '/' ) + 1 );
+
+    return new RepositoryFile.Builder( path, name ).path( path ).folder( node.isNodeType( FOLDER_NODE_TYPE ) ).build();
+  }
+  // endregion Fixture helpers
+}

--- a/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtilsTest.java
+++ b/repository/src/test/java/org/pentaho/platform/repository2/unified/jcr/JcrTreeQueryUtilsTest.java
@@ -1,0 +1,840 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************/
+
+package org.pentaho.platform.repository2.unified.jcr;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.pentaho.platform.api.repository2.unified.IRepositoryAccessVoterManager;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileTree;
+import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+import org.pentaho.platform.repository2.unified.TreeNodeFilterSpec;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.Item;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests of {@link JcrTreeQueryUtils}, the JCR-SQL2 based tree retrieval.
+ */
+public class JcrTreeQueryUtilsTest {
+  private static final String FOLDER_NODE_TYPE = "pho_nt:pentahoFolder";
+  private static final String FILE_NODE_TYPE = "pho_nt:pentahoFile";
+  private static final String ROOT_PATH = "/home/admin";
+
+  /**
+   * the folder the deleted files of the root are moved to, named exactly as <code>DefaultDeleteHelper</code> does
+   */
+  private static final String TRASH_PATH = ROOT_PATH + "/.trash/pho:d78ca35b-852b-4f89-8d4f-61486d3ca1c3";
+  private static final String KTR_PATTERN = RepositoryRequest.FILTER_WILDCARD + ".KTR";
+  private static final String KJB_PATTERN = RepositoryRequest.FILTER_WILDCARD + ".kjb";
+  private static final String FOLDER_PATTERN = "sales*";
+  private static final String MARKETING_FOLDER_PATTERN = "marketing";
+  private static final String ESCAPED_PATTERN = "a_b%c*.ktr";
+
+  private Session session;
+  private QueryManager queryManager;
+  private PentahoJcrConstants pentahoJcrConstants;
+  private IPathConversionHelper pathConversionHelper;
+  private ILockHelper lockHelper;
+
+  /**
+   * the voter manager used by the tests that do not care about access control; it grants everything
+   */
+  private IRepositoryAccessVoterManager accessVoterManager;
+
+  private MockedStatic<JcrStringHelper> jcrStringHelper;
+  private MockedStatic<JcrRepositoryFileUtils> jcrRepositoryFileUtils;
+  private MockedStatic<JcrRepositoryFileAclUtils> jcrRepositoryFileAclUtils;
+
+  /**
+   * the file each mocked node is turned into by {@code JcrRepositoryFileUtils.nodeToFile}
+   */
+  private final Map<Node, RepositoryFile> filesByNode = new HashMap<>();
+
+  /**
+   * the nodes each query returns, keyed by the node type appearing in the statement
+   */
+  private final Map<String, List<Node>> nodesByNodeType = new HashMap<>();
+
+  /**
+   * every mocked node, keyed by its path, so that a node and its parents are mocked only once
+   */
+  private final Map<String, Node> nodesByPath = new HashMap<>();
+
+  private final List<String> statements = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    session = mock( Session.class );
+    Workspace workspace = mock( Workspace.class );
+    queryManager = mock( QueryManager.class );
+    when( session.getWorkspace() ).thenReturn( workspace );
+    when( workspace.getQueryManager() ).thenReturn( queryManager );
+
+    pentahoJcrConstants = mock( PentahoJcrConstants.class );
+    when( pentahoJcrConstants.getPHO_NT_PENTAHOFOLDER() ).thenReturn( FOLDER_NODE_TYPE );
+    when( pentahoJcrConstants.getPHO_NT_PENTAHOFILE() ).thenReturn( FILE_NODE_TYPE );
+
+    pathConversionHelper = mock( IPathConversionHelper.class );
+    lockHelper = mock( ILockHelper.class );
+
+    accessVoterManager = mock( IRepositoryAccessVoterManager.class );
+    when( accessVoterManager.hasAccess( any(), any(), any(), any() ) ).thenReturn( true );
+
+    nodesByNodeType.put( FOLDER_NODE_TYPE, new ArrayList<>() );
+    nodesByNodeType.put( FILE_NODE_TYPE, new ArrayList<>() );
+
+    when( queryManager.createQuery( anyString(), eq( Query.JCR_SQL2 ) ) ).thenAnswer( invocation -> {
+      String statement = invocation.getArgument( 0 );
+      statements.add( statement );
+
+      String nodeType = statement.contains( FOLDER_NODE_TYPE ) ? FOLDER_NODE_TYPE : FILE_NODE_TYPE;
+
+      return queryReturning( nodesByNodeType.get( nodeType ) );
+    } );
+
+    jcrStringHelper = mockStatic( JcrStringHelper.class );
+    jcrStringHelper.when( () -> JcrStringHelper.pathEncode( anyString() ) )
+      .thenAnswer( invocation -> invocation.getArgument( 0 ) );
+
+    jcrRepositoryFileUtils = mockStatic( JcrRepositoryFileUtils.class );
+    jcrRepositoryFileUtils.when( () -> JcrRepositoryFileUtils.isSupportedNodeType( any(), any() ) ).thenReturn( true );
+    jcrRepositoryFileUtils.when( () -> JcrRepositoryFileUtils.nodeToFile( any(), any(), any(), any(), any() ) )
+      .thenAnswer( invocation -> filesByNode.get( invocation.<Node>getArgument( 4 ) ) );
+    jcrRepositoryFileUtils.when( () -> JcrRepositoryFileUtils.getFileMetadata( any(), any() ) )
+      .thenReturn( Collections.<String, Serializable>emptyMap() );
+
+    RepositoryFileAcl acl = mock( RepositoryFileAcl.class );
+    jcrRepositoryFileAclUtils = mockStatic( JcrRepositoryFileAclUtils.class );
+    jcrRepositoryFileAclUtils.when( () -> JcrRepositoryFileAclUtils.getAcl( any(), any(), any() ) ).thenReturn( acl );
+  }
+
+  @After
+  public void tearDown() {
+    jcrStringHelper.close();
+    jcrRepositoryFileUtils.close();
+    jcrRepositoryFileAclUtils.close();
+  }
+
+  // region Tree assembly
+  @Test
+  public void testBuildsTreeOfFoldersAndFiles() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/sales" ) );
+    givenFiles( file( ROOT_PATH + "/sales/report.prpt" ), file( ROOT_PATH + "/summary.ktr" ) );
+
+    RepositoryFileTree tree = getTree( request( null ) );
+
+    assertNotNull( tree );
+    assertEquals( ROOT_PATH, tree.getFile().getPath() );
+    assertEquals( 2, tree.getChildren().size() );
+    // children are sorted by file name: sales ( folder ) then summary.ktr
+    assertEquals( "sales", tree.getChildren().get( 0 ).getFile().getName() );
+    assertEquals( "summary.ktr", tree.getChildren().get( 1 ).getFile().getName() );
+    assertEquals( 1, tree.getChildren().get( 0 ).getChildren().size() );
+    assertEquals( "report.prpt", tree.getChildren().get( 0 ).getChildren().get( 0 ).getFile().getName() );
+  }
+
+  /**
+   * the folder filter is the only thing that decides which folders the tree carries, so a file living in a folder it
+   * rejected has no folder to hang from and goes with it
+   */
+  @Test
+  public void testDropsFileWhoseFolderTheFolderFilterRejected() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFiles( file( ROOT_PATH + "/sales/report.prpt" ), file( ROOT_PATH + "/summary.ktr" ) );
+
+    RepositoryFileTree tree = getTree( request( TreeNodeFilterSpec.FOLDER_FILTER_TOKEN + MARKETING_FOLDER_PATTERN ) );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "summary.ktr", tree.getChildren().get( 0 ).getFile().getName() );
+  }
+
+  /**
+   * a file filter narrows the files alone: every folder still belongs to the tree, empty ones included
+   */
+  @Test
+  public void testFileFilterKeepsEveryFolder() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/test" ) );
+    givenFiles( file( ROOT_PATH + "/sales.prpt" ), file( ROOT_PATH + "/data.json" ) );
+
+    RepositoryFileTree tree = getTree( request( TreeNodeFilterSpec.FILE_FILTER_TOKEN + "*.prpt" ) );
+
+    assertNotNull( tree );
+    assertEquals( 2, tree.getChildren().size() );
+    assertEquals( "sales.prpt", tree.getChildren().get( 0 ).getFile().getName() );
+    assertEquals( "test", tree.getChildren().get( 1 ).getFile().getName() );
+    assertTrue( tree.getChildren().get( 1 ).getChildren().isEmpty() );
+
+    // both queries are issued: the folders are never left to the file filter
+    verify( queryManager, times( 2 ) ).createQuery( anyString(), eq( Query.JCR_SQL2 ) );
+  }
+
+  /**
+   * with FILES the files are what the caller is after, and the folders keep answering to the folder filter alone
+   */
+  @Test
+  public void testFilesTypeFilterLeavesTheFoldersToTheFolderFilter() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/marketing" ), folder( ROOT_PATH + "/sales" ) );
+    givenFiles( file( ROOT_PATH + "/sales/report.prpt" ) );
+
+    RepositoryRequest repositoryRequest = request( TreeNodeFilterSpec.FILE_FILTER_TOKEN + "*.prpt" );
+    repositoryRequest.setTypes( RepositoryRequest.FILES_TYPE_FILTER.FILES );
+
+    RepositoryFileTree tree = getTree( repositoryRequest );
+
+    assertNotNull( tree );
+    assertEquals( 2, tree.getChildren().size() );
+    assertEquals( "marketing", tree.getChildren().get( 0 ).getFile().getName() );
+    assertEquals( "sales", tree.getChildren().get( 1 ).getFile().getName() );
+    assertEquals( "report.prpt", tree.getChildren().get( 1 ).getChildren().get( 0 ).getFile().getName() );
+  }
+
+  @Test
+  public void testHonorsDepth() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/sales" ), folder( ROOT_PATH + "/sales/2026" ) );
+    givenFiles( file( ROOT_PATH + "/sales/2026/report.prpt" ) );
+
+    RepositoryRequest repositoryRequest = request( null );
+    repositoryRequest.setDepth( 1 );
+
+    RepositoryFileTree tree = getTree( repositoryRequest );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "sales", tree.getChildren().get( 0 ).getFile().getName() );
+    assertTrue( tree.getChildren().get( 0 ).getChildren().isEmpty() );
+  }
+
+  @Test
+  public void testDepthZeroReturnsRootOnlyWithoutQuerying() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+
+    RepositoryRequest repositoryRequest = request( null );
+    repositoryRequest.setDepth( 0 );
+
+    RepositoryFileTree tree = getTree( repositoryRequest );
+
+    assertNotNull( tree );
+    assertNull( tree.getChildren() );
+    verify( queryManager, never() ).createQuery( anyString(), anyString() );
+  }
+
+  @Test
+  public void testFoldersTypeFilterSkipsTheFileQuery() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/sales" ) );
+    givenFiles( file( ROOT_PATH + "/summary.ktr" ) );
+
+    RepositoryRequest repositoryRequest = request( null );
+    repositoryRequest.setTypes( RepositoryRequest.FILES_TYPE_FILTER.FOLDERS );
+
+    RepositoryFileTree tree = getTree( repositoryRequest );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "sales", tree.getChildren().get( 0 ).getFile().getName() );
+    verify( queryManager, times( 1 ) ).createQuery( anyString(), eq( Query.JCR_SQL2 ) );
+  }
+
+  /**
+   * with FOLDERS the files are out of the request, so a file filter cannot empty the tree: every folder is kept.
+   * This is a deliberate deviation from the traversal, which returns nothing at all because a folder name hardly
+   * ever matches a file name filter
+   */
+  @Test
+  public void testFoldersTypeFilterKeepsEveryFolderEvenWhenOnlyFilesAreFiltered() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/empty" ) );
+    givenFiles( file( ROOT_PATH + "/summary.prpt" ) );
+
+    RepositoryRequest repositoryRequest = request( TreeNodeFilterSpec.FILE_FILTER_TOKEN + KTR_PATTERN );
+    repositoryRequest.setTypes( RepositoryRequest.FILES_TYPE_FILTER.FOLDERS );
+
+    RepositoryFileTree tree = getTree( repositoryRequest );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "empty", tree.getChildren().get( 0 ).getFile().getName() );
+    verify( queryManager, times( 1 ) ).createQuery( anyString(), eq( Query.JCR_SQL2 ) );
+  }
+
+  /**
+   * a folder matching the folder filter deeper than a direct child of the root is only reachable when the folders
+   * between it and the root are materialized, which is what the node traversal walks through
+   */
+  @Test
+  public void testMaterializesTheFoldersBetweenAMatchingFolderAndTheRoot() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    // only the matching folder is returned by the folder query; "2026" never matches "sales*"
+    givenFolders( folder( ROOT_PATH + "/2026/sales" ) );
+    givenFiles( file( ROOT_PATH + "/2026/sales/report.prpt" ) );
+
+    RepositoryFileTree tree = getTree( request( TreeNodeFilterSpec.FOLDER_FILTER_TOKEN + FOLDER_PATTERN ) );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+
+    RepositoryFileTree year = tree.getChildren().get( 0 );
+    assertEquals( "2026", year.getFile().getName() );
+    assertEquals( 1, year.getChildren().size() );
+
+    RepositoryFileTree sales = year.getChildren().get( 0 );
+    assertEquals( "sales", sales.getFile().getName() );
+    assertEquals( 1, sales.getChildren().size() );
+    assertEquals( "report.prpt", sales.getChildren().get( 0 ).getFile().getName() );
+  }
+
+  /**
+   * a materialized folder is a folder of the tree like any other, so the files matching the file filter below it
+   * belong to the tree as well
+   */
+  @Test
+  public void testFilesAreAttachedToMaterializedFolders() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/2026/sales" ) );
+    givenFiles( file( ROOT_PATH + "/2026/summary.ktr" ), file( ROOT_PATH + "/2026/summary.prpt" ) );
+
+    RepositoryFileTree tree = getTree( request(
+      TreeNodeFilterSpec.FOLDER_FILTER_TOKEN + FOLDER_PATTERN + TreeNodeFilterSpec.FILTER_TOKEN_SEPARATOR
+        + TreeNodeFilterSpec.FILE_FILTER_TOKEN + KTR_PATTERN ) );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+
+    RepositoryFileTree year = tree.getChildren().get( 0 );
+    assertEquals( "2026", year.getFile().getName() );
+    assertEquals( 2, year.getChildren().size() );
+    assertEquals( "sales", year.getChildren().get( 0 ).getFile().getName() );
+    assertEquals( "summary.ktr", year.getChildren().get( 1 ).getFile().getName() );
+  }
+
+  /**
+   * a folder the traversal would refuse to descend into drops the branch, whether it matched the folder filter or it
+   * was materialized to carry a matching descendant
+   */
+  @Test
+  public void testDropsBranchWhoseMaterializedFolderIsHidden() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/2026/sales" ) );
+    filesByNode.put( nodeAt( ROOT_PATH + "/2026" ), hidden( folder( ROOT_PATH + "/2026" ) ) );
+
+    RepositoryFileTree tree = getTree( request( TreeNodeFilterSpec.FOLDER_FILTER_TOKEN + FOLDER_PATTERN ) );
+
+    assertNotNull( tree );
+    assertTrue( tree.getChildren().isEmpty() );
+  }
+
+  /**
+   * a query returns its nodes in no particular order, so a folder may be materialized before the query returns it,
+   * which must not duplicate it nor detach what was already attached to it
+   */
+  @Test
+  public void testFolderReturnedAfterItWasMaterializedIsNotDuplicated() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    // the child comes first, so "2026" is materialized before the query returns it
+    givenFolders( folder( ROOT_PATH + "/2026/sales" ), folder( ROOT_PATH + "/2026" ) );
+    givenFiles( file( ROOT_PATH + "/2026/summary.ktr" ) );
+
+    RepositoryFileTree tree = getTree( request( null ) );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+
+    RepositoryFileTree year = tree.getChildren().get( 0 );
+    assertEquals( "2026", year.getFile().getName() );
+    assertEquals( 2, year.getChildren().size() );
+    assertEquals( "sales", year.getChildren().get( 0 ).getFile().getName() );
+    assertEquals( "summary.ktr", year.getChildren().get( 1 ).getFile().getName() );
+  }
+
+  /**
+   * the depth is counted from the root, so a folder deeper than the requested depth is left out together with the
+   * folders that would only be materialized to carry it
+   */
+  @Test
+  public void testDoesNotMaterializeFoldersBeyondTheRequestedDepth() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/2026/sales" ) );
+
+    RepositoryRequest repositoryRequest = request( TreeNodeFilterSpec.FOLDER_FILTER_TOKEN + FOLDER_PATTERN );
+    repositoryRequest.setDepth( 1 );
+
+    RepositoryFileTree tree = getTree( repositoryRequest );
+
+    assertNotNull( tree );
+    assertTrue( tree.getChildren().isEmpty() );
+  }
+  // endregion Tree assembly
+
+  // region Node filtering
+  @Test
+  public void testSkipsHiddenAndAclNodesUnlessHiddenAreRequested() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFiles( hidden( file( ROOT_PATH + "/hidden.ktr" ) ), aclNode( file( ROOT_PATH + "/.acl" ) ),
+      file( ROOT_PATH + "/visible.ktr" ) );
+
+    RepositoryFileTree tree = getTree( request( null ) );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "visible.ktr", tree.getChildren().get( 0 ).getFile().getName() );
+  }
+
+  @Test
+  public void testShowHiddenIncludesHiddenNodes() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFiles( hidden( file( ROOT_PATH + "/hidden.ktr" ) ) );
+
+    RepositoryRequest repositoryRequest = request( null );
+    repositoryRequest.setShowHidden( true );
+
+    RepositoryFileTree tree = getTree( repositoryRequest );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+  }
+
+  @Test
+  public void testHiddenRootReturnsNull() throws Exception {
+    givenRoot( hidden( folder( ROOT_PATH ) ) );
+
+    assertNull( getTree( request( null ) ) );
+  }
+
+  /**
+   * the node traversal asserts the item is a node, so this one must fail the very same way
+   */
+  @Test( expected = IllegalArgumentException.class )
+  public void testNonNodeRootIsRejected() throws Exception {
+    Item item = mock( Item.class );
+    when( item.isNode() ).thenReturn( false );
+    when( session.getItem( ROOT_PATH ) ).thenReturn( item );
+
+    getTree( request( null ) );
+  }
+
+  /**
+   * a missing path surfaces as the {@link PathNotFoundException} raised by the session, never as a <code>null</code>
+   * tree
+   */
+  @Test( expected = PathNotFoundException.class )
+  public void testMissingRootPropagatesPathNotFound() throws Exception {
+    when( session.getItem( ROOT_PATH ) ).thenThrow( new PathNotFoundException( ROOT_PATH ) );
+
+    getTree( request( null ) );
+  }
+
+  @Test
+  public void testSkipsUnsupportedNodeTypes() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    Node unsupported = givenFiles( file( ROOT_PATH + "/summary.ktr" ) ).get( 0 );
+    jcrRepositoryFileUtils.when( () -> JcrRepositoryFileUtils.isSupportedNodeType( any(), eq( unsupported ) ) )
+      .thenReturn( false );
+
+    RepositoryFileTree tree = getTree( request( null ) );
+
+    assertNotNull( tree );
+    assertTrue( tree.getChildren().isEmpty() );
+  }
+
+  @Test
+  public void testSkipsSystemFoldersDirectlyBelowTheRoot() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    List<Node> folders = givenFolders( folder( ROOT_PATH + "/system" ) );
+    Node systemNode = folders.get( 0 );
+    when( systemNode.getIdentifier() ).thenReturn( "system-id" );
+
+    Map<String, Serializable> metadata = new HashMap<>();
+    metadata.put( IUnifiedRepository.SYSTEM_FOLDER, Boolean.TRUE );
+    jcrRepositoryFileUtils.when( () -> JcrRepositoryFileUtils.getFileMetadata( any(), eq( "system-id" ) ) )
+      .thenReturn( metadata );
+
+    assertTrue( getTree( requestWithoutSystemFolders() ).getChildren().isEmpty() );
+
+    // the default request includes them
+    assertEquals( 1, getTree( request( null ) ).getChildren().size() );
+  }
+
+  private static RepositoryRequest requestWithoutSystemFolders() {
+    RepositoryRequest repositoryRequest = request( null );
+    repositoryRequest.setIncludeSystemFolders( false );
+    return repositoryRequest;
+  }
+
+  /**
+   * the deleted files keep their node type below the trash folder, so the file query returns them; they are no part
+   * of any tree, exactly as the traversal never descends into that internal folder
+   */
+  @Test
+  public void testSkipsTheDeletedFilesOfTheTrashFolder() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( TRASH_PATH + "/New Folder" ) );
+    givenFiles( file( TRASH_PATH + "/New Folder/report.prpt" ), file( TRASH_PATH + "/deleted.ktr" ),
+      file( ROOT_PATH + "/summary.ktr" ) );
+
+    RepositoryFileTree tree = getTree( request( null ) );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "summary.ktr", tree.getChildren().get( 0 ).getFile().getName() );
+  }
+
+  /**
+   * only the part of the path below the root is looked at, so the tree of a deleted folder still carries its content
+   */
+  @Test
+  public void testTreeRootedInsideTheTrashCarriesItsContent() throws Exception {
+    String trashedFolderPath = TRASH_PATH + "/New Folder";
+    Node rootNode = nodeAt( trashedFolderPath );
+    filesByNode.put( rootNode, folder( trashedFolderPath ) );
+    when( session.getItem( trashedFolderPath ) ).thenReturn( rootNode );
+
+    givenFiles( file( trashedFolderPath + "/report.prpt" ) );
+
+    // the path of the request is not the one the tree is rooted at, which the caller passes on its own
+    RepositoryFileTree tree = JcrTreeQueryUtils.getTreeByQuery( session, pentahoJcrConstants, pathConversionHelper,
+      lockHelper, trashedFolderPath, request( null ), accessVoterManager );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "report.prpt", tree.getChildren().get( 0 ).getFile().getName() );
+  }
+
+  @Test
+  public void testSkipsNodesTheAccessVoterDenies() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFiles( file( ROOT_PATH + "/denied.ktr" ), file( ROOT_PATH + "/allowed.ktr" ) );
+
+    when( accessVoterManager.hasAccess( any(), eq( RepositoryFilePermission.READ ), any(), any() ) ).thenAnswer(
+      invocation -> !"denied.ktr".equals( invocation.<RepositoryFile>getArgument( 0 ).getName() ) );
+
+    RepositoryFileTree tree = getTree( request( null ) );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "allowed.ktr", tree.getChildren().get( 0 ).getFile().getName() );
+  }
+
+  @Test
+  public void testDeniedRootReturnsNull() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+
+    when( accessVoterManager.hasAccess( any(), any(), any(), any() ) ).thenReturn( false );
+
+    assertNull( getTree( request( null ) ) );
+  }
+
+  /**
+   * an ACL that cannot be read because access was denied only skips that node, exactly as the node traversal does
+   */
+  @Test
+  public void testSkipsNodesWhoseAclAccessIsDenied() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    RepositoryFile denied = file( ROOT_PATH + "/denied.ktr" );
+    givenFiles( denied, file( ROOT_PATH + "/allowed.ktr" ) );
+
+    jcrRepositoryFileAclUtils.when( () -> JcrRepositoryFileAclUtils.getAcl( any(), any(), eq( denied.getId() ) ) )
+      .thenThrow( new AccessDeniedException( "denied" ) );
+
+    RepositoryFileTree tree = getTree( request( null ) );
+
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "allowed.ktr", tree.getChildren().get( 0 ).getFile().getName() );
+  }
+
+  /**
+   * every other repository failure while reading an ACL propagates instead of silently pruning the node
+   */
+  @Test( expected = RepositoryException.class )
+  public void testPropagatesAclRepositoryFailures() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFiles( file( ROOT_PATH + "/summary.ktr" ) );
+
+    jcrRepositoryFileAclUtils.when( () -> JcrRepositoryFileAclUtils.getAcl( any(), any(), any() ) )
+      .thenThrow( new RepositoryException( "boom" ) );
+
+    getTree( request( null ) );
+  }
+  // endregion Node filtering
+
+  // region Statement building
+  @Test
+  public void testQueriesAreScopedToTheRootPathAndUnfilteredByDefault() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+
+    getTree( request( null ) );
+
+    assertEquals( 2, statements.size() );
+    // the path is quoted, not bracketed: a bracketed path carrying a space matches nothing
+    assertEquals( "SELECT * FROM [" + FOLDER_NODE_TYPE + "] WHERE ISDESCENDANTNODE('" + ROOT_PATH + "')",
+      statements.get( 0 ) );
+    assertEquals( "SELECT * FROM [" + FILE_NODE_TYPE + "] WHERE ISDESCENDANTNODE('" + ROOT_PATH + "')",
+      statements.get( 1 ) );
+  }
+
+  @Test
+  public void testStructuredFilterIsTranslatedIntoNameConstraints() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+
+    getTree(
+      request( TreeNodeFilterSpec.FILE_FILTER_TOKEN + KTR_PATTERN + TreeNodeFilterSpec.INSIDE_FILTER_TOKEN_SEPARATOR
+        + KJB_PATTERN + TreeNodeFilterSpec.FILTER_TOKEN_SEPARATOR + TreeNodeFilterSpec.FOLDER_FILTER_TOKEN
+        + FOLDER_PATTERN ) );
+
+    assertTrue( statements.get( 0 ).endsWith( " AND (LOWER(LOCALNAME()) LIKE 'sales%')" ) );
+    assertTrue( statements.get( 1 )
+      .endsWith( " AND (LOWER(LOCALNAME()) LIKE '%.ktr' OR LOWER(LOCALNAME()) LIKE '%.kjb')" ) );
+  }
+
+  /**
+   * the JCR-SQL2 implementation supports neither the <code>ESCAPE</code> clause nor a <code>LIKE</code> on
+   * <code>NAME()</code>, so the constraint may only widen the result set, which the in-memory matching then narrows
+   */
+  @Test
+  public void testLikeConstraintWidensAndExactNamesAreMatchedInMemory() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFiles( file( ROOT_PATH + "/aXbYc1.ktr" ), file( ROOT_PATH + "/a_b%c1.ktr" ) );
+
+    RepositoryFileTree tree = getTree( request( TreeNodeFilterSpec.FILE_FILTER_TOKEN + ESCAPED_PATTERN ) );
+
+    assertTrue( statements.get( 1 ).endsWith( " AND (LOWER(LOCALNAME()) LIKE 'a_b%c%.ktr')" ) );
+    assertFalse( statements.get( 1 ).contains( "ESCAPE" ) );
+    assertNotNull( tree );
+    assertEquals( 1, tree.getChildren().size() );
+    assertEquals( "a_b%c1.ktr", tree.getChildren().get( 0 ).getFile().getName() );
+  }
+
+  /**
+   * <code>LOCALNAME()</code> drops the namespace prefix, so a pattern carrying the separator is not pushed down and
+   * is answered by the in-memory matching alone
+   */
+  @Test
+  public void testPatternWithNamespaceSeparatorIsNotPushedDown() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFiles( file( ROOT_PATH + "/summary.ktr" ) );
+
+    RepositoryFileTree tree = getTree( request( TreeNodeFilterSpec.FILE_FILTER_TOKEN + "pho:*" ) );
+
+    assertTrue( statements.get( 1 ).endsWith( "')" ) );
+    assertNotNull( tree );
+    assertTrue( tree.getChildren().isEmpty() );
+  }
+
+  /**
+   * the file filter must not prune folders, and the folder filter must not prune files
+   */
+  @Test
+  public void testEachFilterOnlyAppliesToItsOwnNodeType() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/sales" ), folder( ROOT_PATH + "/marketing" ) );
+    givenFiles( file( ROOT_PATH + "/summary.ktr" ), file( ROOT_PATH + "/summary.prpt" ) );
+
+    RepositoryFileTree tree = getTree( request(
+      TreeNodeFilterSpec.FILE_FILTER_TOKEN + KTR_PATTERN + TreeNodeFilterSpec.FILTER_TOKEN_SEPARATOR
+        + TreeNodeFilterSpec.FOLDER_FILTER_TOKEN + FOLDER_PATTERN ) );
+
+    assertNotNull( tree );
+    assertEquals( 2, tree.getChildren().size() );
+    assertEquals( "sales", tree.getChildren().get( 0 ).getFile().getName() );
+    assertEquals( "summary.ktr", tree.getChildren().get( 1 ).getFile().getName() );
+  }
+
+  /**
+   * a wildcard folder filter selects every folder, which is what a missing folder filter does as well
+   */
+  @Test
+  public void testWildcardFolderFilterKeepsTheWholeFolderStructure() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+    givenFolders( folder( ROOT_PATH + "/test" ) );
+    givenFiles( file( ROOT_PATH + "/sales.prpt" ), file( ROOT_PATH + "/data.json" ) );
+
+    RepositoryFileTree tree = getTree( request(
+      TreeNodeFilterSpec.FILE_FILTER_TOKEN + "*.prpt" + TreeNodeFilterSpec.INSIDE_FILTER_TOKEN_SEPARATOR
+        + "*.xanalyzer" + TreeNodeFilterSpec.FILTER_TOKEN_SEPARATOR + TreeNodeFilterSpec.FOLDER_FILTER_TOKEN
+        + RepositoryRequest.FILTER_WILDCARD ) );
+
+    assertNotNull( tree );
+    assertEquals( 2, tree.getChildren().size() );
+    assertEquals( "sales.prpt", tree.getChildren().get( 0 ).getFile().getName() );
+    assertEquals( "test", tree.getChildren().get( 1 ).getFile().getName() );
+    // the wildcard is not pushed down, the folder query returns every folder below the root
+    assertTrue( statements.get( 0 ).endsWith( "')" ) );
+  }
+
+
+  @Test
+  public void testLegacyFilterAddsNoNameConstraint() throws Exception {
+    givenRoot( folder( ROOT_PATH ) );
+
+    getTree( request( RepositoryRequest.FILTER_WILDCARD + ".ktr" ) );
+
+    assertTrue( statements.get( 0 ).endsWith( "')" ) );
+    assertTrue( statements.get( 1 ).endsWith( "')" ) );
+  }
+  // endregion Statement building
+
+  // region Fixture helpers
+  private RepositoryFileTree getTree( final RepositoryRequest repositoryRequest ) throws RepositoryException {
+    return JcrTreeQueryUtils.getTreeByQuery( session, pentahoJcrConstants, pathConversionHelper, lockHelper, ROOT_PATH,
+      repositoryRequest, accessVoterManager );
+  }
+
+  private static RepositoryRequest request( final String childNodeFilter ) {
+    RepositoryRequest repositoryRequest = new RepositoryRequest( ROOT_PATH, false, -1, childNodeFilter );
+    repositoryRequest.setDepth( -1 );
+    return repositoryRequest;
+  }
+
+  private void givenRoot( final RepositoryFile rootFile ) throws RepositoryException {
+    Node rootNode = mock( Node.class );
+    when( rootNode.isNode() ).thenReturn( true );
+    when( rootNode.getPath() ).thenReturn( ROOT_PATH );
+    when( session.getItem( ROOT_PATH ) ).thenReturn( rootNode );
+    nodesByPath.put( ROOT_PATH, rootNode );
+    filesByNode.put( rootNode, rootFile );
+  }
+
+  private List<Node> givenFolders( final RepositoryFile... folders ) throws RepositoryException {
+    return givenNodes( FOLDER_NODE_TYPE, folders );
+  }
+
+  private List<Node> givenFiles( final RepositoryFile... files ) throws RepositoryException {
+    return givenNodes( FILE_NODE_TYPE, files );
+  }
+
+  private List<Node> givenNodes( final String nodeType, final RepositoryFile... files ) throws RepositoryException {
+    List<Node> nodes = new ArrayList<>();
+
+    for ( RepositoryFile file : files ) {
+      Node node = nodeAt( file.getPath() );
+      filesByNode.put( node, file );
+      nodes.add( node );
+    }
+
+    nodesByNodeType.get( nodeType ).addAll( nodes );
+
+    return nodes;
+  }
+
+  /**
+   * @return the mocked node of the given path, creating the whole chain of parent nodes up to the root when needed,
+   * so that the ancestor folders can be walked exactly as they are in a real repository
+   */
+  private Node nodeAt( final String path ) throws RepositoryException {
+    Node existing = nodesByPath.get( path );
+
+    if ( existing != null ) {
+      return existing;
+    }
+
+    Node node = mock( Node.class );
+    when( node.isNode() ).thenReturn( true );
+    when( node.getPath() ).thenReturn( path );
+    nodesByPath.put( path, node );
+
+    String parentPath = parentPathOf( path );
+
+    if ( !parentPath.isEmpty() ) {
+      Node parent = nodeAt( parentPath );
+      when( node.getParent() ).thenReturn( parent );
+      // an ancestor that no query returns is still turned into a file, exactly as the materialization does
+      filesByNode.putIfAbsent( parent, folder( parentPath ) );
+    }
+
+    return node;
+  }
+
+  private static String parentPathOf( final String path ) {
+    return path.substring( 0, path.lastIndexOf( '/' ) );
+  }
+
+  private static Query queryReturning( final List<Node> nodes ) throws RepositoryException {
+    Iterator<Node> iterator = new ArrayList<>( nodes ).iterator();
+
+    NodeIterator nodeIterator = mock( NodeIterator.class );
+    when( nodeIterator.hasNext() ).thenAnswer( invocation -> iterator.hasNext() );
+    when( nodeIterator.nextNode() ).thenAnswer( invocation -> iterator.next() );
+
+    QueryResult queryResult = mock( QueryResult.class );
+    when( queryResult.getNodes() ).thenReturn( nodeIterator );
+
+    Query query = mock( Query.class );
+    when( query.execute() ).thenReturn( queryResult );
+
+    return query;
+  }
+
+  private static RepositoryFile folder( final String path ) {
+    return newFile( path, true );
+  }
+
+  private static RepositoryFile file( final String path ) {
+    return newFile( path, false );
+  }
+
+  private static RepositoryFile newFile( final String path, final boolean folder ) {
+    String name = path.substring( path.lastIndexOf( '/' ) + 1 );
+    return new RepositoryFile.Builder( path, name ).path( path ).folder( folder ).build();
+  }
+
+  private static RepositoryFile hidden( final RepositoryFile file ) {
+    return new RepositoryFile.Builder( file ).hidden( true ).build();
+  }
+
+  private static RepositoryFile aclNode( final RepositoryFile file ) {
+    return new RepositoryFile.Builder( file ).aclNode( true ).build();
+  }
+  // endregion Fixture helpers
+}

--- a/repository/src/test/java/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDaoTest.java
+++ b/repository/src/test/java/org/pentaho/platform/security/userroledao/jackrabbit/AbstractJcrBackedUserRoleDaoTest.java
@@ -68,7 +68,7 @@ import static org.mockito.Mockito.when;
 @RunWith( MockitoJUnitRunner.class )
 public class AbstractJcrBackedUserRoleDaoTest {
 
-  private static final String REPO_CONFIG_FILE = "/jackrabbit/repository.xml";
+  private static final String REPO_CONFIG_FILE = "/jackrabbit/repository-in-memory.xml";
   private static TransientRepository repository;
   private static Session adminSession;
   private static final String TEST_REPOSITORY_LOCATION = "test-jcr_";

--- a/repository/src/test/java/org/pentaho/test/platform/repository2/unified/MockUnifiedRepository.java
+++ b/repository/src/test/java/org/pentaho/test/platform/repository2/unified/MockUnifiedRepository.java
@@ -70,7 +70,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Mock implementation of the {@link IUnifiedRepository} for unit testing.
- * 
+ *
  * @author dkincade
  * @author mlowery
  */
@@ -104,7 +104,7 @@ public class MockUnifiedRepository implements IUnifiedRepository {
 
   /**
    * Creates a mock.
-   * 
+   *
    * @param currentUserProvider
    *          create your own or use {@link SpringSecurityCurrentUserProvider}.
    */
@@ -457,14 +457,17 @@ public class MockUnifiedRepository implements IUnifiedRepository {
   private static boolean matches( final String in, final String pattern ) {
     StringBuilder buf = new StringBuilder();
     // build a regex
-    String[] patterns = pattern.split( "\\|" );
+    String[] patterns = pattern.split( Pattern.quote( RepositoryRequest.FILTER_SEPARATOR ) );
     for ( int i = 0; i < patterns.length; i++ ) {
       if ( i > 0 ) {
+        // regex alternation, not the filter separator
         buf.append( "|" );
       }
       String tmp = patterns[i].trim();
       tmp = tmp.replace( ".", "\\." );
-      tmp = tmp.replace( "*", ".*" );
+      // the filter wildcard becomes the regex "any sequence", which must stay a regex literal: building it from
+      // the constant would only work while the constant happens to be the regex quantifier '*'
+      tmp = tmp.replace( RepositoryRequest.FILTER_WILDCARD, ".*" );
       buf.append( tmp );
     }
     Pattern p = Pattern.compile( buf.toString() );

--- a/repository/src/test/resources/jackrabbit/repository-in-memory.xml
+++ b/repository/src/test/resources/jackrabbit/repository-in-memory.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<!--
+   Minimal Jackrabbit repository used by JcrTreeQueryUtilsSql2ParsingTest to parse and execute the JCR-SQL2
+   statements built by JcrTreeQueryUtils.
+
+   It differs from repository.xml in two points:
+   - the persistence managers are the in memory ones, because no JDBC driver is on the test classpath;
+   - no access control provider is configured, because the test does not exercise authorization.
+   The Lucene SearchIndex is kept, since it is what serves the queries.
+-->
+
+<!DOCTYPE Repository
+    PUBLIC "-//The Apache Software Foundation//DTD Jackrabbit 2.0//EN"
+    "http://jackrabbit.apache.org/dtd/repository-2.0.dtd">
+
+<Repository>
+
+  <FileSystem class="org.apache.jackrabbit.core.fs.local.LocalFileSystem">
+    <param name="path" value="${rep.home}/repository"/>
+  </FileSystem>
+
+  <Security appName="Jackrabbit">
+    <SecurityManager class="org.apache.jackrabbit.core.DefaultSecurityManager" workspaceName="security"/>
+    <AccessManager class="org.apache.jackrabbit.core.security.DefaultAccessManager"/>
+    <LoginModule class="org.apache.jackrabbit.core.security.authentication.DefaultLoginModule">
+      <param name="adminId" value="admin"/>
+    </LoginModule>
+  </Security>
+
+  <Workspaces rootPath="${rep.home}/workspaces" defaultWorkspace="default"/>
+
+  <Workspace name="${wsp.name}">
+
+    <FileSystem class="org.apache.jackrabbit.core.fs.local.LocalFileSystem">
+      <param name="path" value="${wsp.home}"/>
+    </FileSystem>
+
+    <PersistenceManager class="org.apache.jackrabbit.core.persistence.mem.InMemPersistenceManager">
+      <param name="persistent" value="false"/>
+    </PersistenceManager>
+
+    <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
+      <param name="path" value="${wsp.home}/index"/>
+    </SearchIndex>
+
+  </Workspace>
+
+  <Versioning rootPath="${rep.home}/version">
+
+    <FileSystem class="org.apache.jackrabbit.core.fs.local.LocalFileSystem">
+      <param name="path" value="${rep.home}/version"/>
+    </FileSystem>
+
+    <PersistenceManager class="org.apache.jackrabbit.core.persistence.mem.InMemPersistenceManager">
+      <param name="persistent" value="false"/>
+    </PersistenceManager>
+
+  </Versioning>
+
+</Repository>


### PR DESCRIPTION
This pull request introduces improvements to how file and folder filters are handled in repository requests, particularly by formalizing filter separator constants, improving documentation, and adding support for a new structured filter syntax that allows independent filtering of files and folders. It also ensures that providers that do not support the new structured form degrade gracefully to legacy behavior. Test cases and documentation are updated accordingly.

**Repository filter handling improvements:**

* Introduced new constants (`FILTER_SEPARATOR`, `FILTER_WILDCARD`, and related patterns) in `RepositoryRequest` to formalize filter separator and wildcard usage, replacing hardcoded strings throughout the codebase. [[1]](diffhunk://#diff-40afe9fffe59a46baeb45439a165144de742425c91f882988ca9a57621f4aadfR32-R44) [[2]](diffhunk://#diff-40afe9fffe59a46baeb45439a165144de742425c91f882988ca9a57621f4aadfL66-R79) [[3]](diffhunk://#diff-40afe9fffe59a46baeb45439a165144de742425c91f882988ca9a57621f4aadfL88-R101) [[4]](diffhunk://#diff-40afe9fffe59a46baeb45439a165144de742425c91f882988ca9a57621f4aadfL107-R120) [[5]](diffhunk://#diff-40afe9fffe59a46baeb45439a165144de742425c91f882988ca9a57621f4aadfL137-R151) [[6]](diffhunk://#diff-40afe9fffe59a46baeb45439a165144de742425c91f882988ca9a57621f4aadfL220-R237)
* Updated test cases and integration tests to use the new filter constants for constructing legacy and structured filters, ensuring consistency and maintainability. [[1]](diffhunk://#diff-642b28d83d0f7f7dbf4d7fb7109922e4385dabc98355dff50deb188901038826L35-R37) [[2]](diffhunk://#diff-642b28d83d0f7f7dbf4d7fb7109922e4385dabc98355dff50deb188901038826L102-R105) [[3]](diffhunk://#diff-c2a1bb30a7393e2f3b4f458d498ef83139fd064ba481d089e901d89eb423e19dL1947-R1948) [[4]](diffhunk://#diff-733110771204d1672a5d151ea4832e806b477ba79dc74bc22aaaf22e9f24a4e4L1832-R1852)

**Structured filter support:**

* Added the new `TreeNodeFilterSpec` class, which parses and validates a structured filter syntax for independent file and folder filtering, and provides fallback to legacy behavior when not supported by a provider.
* Updated `FileSystemRepositoryFileDao` to detect and degrade unsupported structured filters to a default wildcard filter, ensuring correct results for providers that do not implement the new syntax. [[1]](diffhunk://#diff-a404b1c580ed586518c8d3aebad1a8e0ecd2dc7aed377453f6c50833046dd733R56) [[2]](diffhunk://#diff-a404b1c580ed586518c8d3aebad1a8e0ecd2dc7aed377453f6c50833046dd733R292-R294)

**Documentation improvements:**

* Enhanced Javadoc in `FileResource` to document the new structured filter syntax, including usage examples and details about provider support and fallback behavior. [[1]](diffhunk://#diff-ee8aa60ad9720e4b43aed9ea793a7bc931e54e0e81c231bcb6d8d6c9c22ae7c6R1758-R1769) [[2]](diffhunk://#diff-ee8aa60ad9720e4b43aed9ea793a7bc931e54e0e81c231bcb6d8d6c9c22ae7c6R1898-R1909)

@pentaho/millenniumfalcon please review