### PR TITLE
[BISERVER-15769] - remove unused finalizer

### DIFF
--- a/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/sejcr/CredentialsStrategySessionFactory.java
+++ b/repository/src/main/java/org/pentaho/platform/repository2/unified/jcr/sejcr/CredentialsStrategySessionFactory.java
@@ -660,10 +660,5 @@ public class CredentialsStrategySessionFactory implements InitializingBean, Disp
       return (SessionImpl) target;
     }
 
-    @Override protected void finalize() throws Throwable {
-      if ( target.isLive() ) {
-        //        target.logout();
-      }
-    }
   }
 }


### PR DESCRIPTION
Was a no-op and caused the objects to stay in memory waiting for finalization