### PR TITLE
fix[BACKLOG-50636]: Backport metadata locale fixes to 11.0

### DIFF
--- a/extensions/src/it/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerNamingIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/plugin/services/importer/SolutionImportHandlerNamingIT.java
@@ -51,6 +51,7 @@ import org.pentaho.platform.api.repository2.unified.IRepositoryContentConverterH
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.data.simple.SimpleRepositoryFileData;
+import org.pentaho.platform.api.scheduler2.IScheduler;
 import org.pentaho.platform.core.mimetype.MimeType;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.boot.PlatformInitializationException;
@@ -152,6 +153,7 @@ public class SolutionImportHandlerNamingIT extends Assert {
     microPlatform.defineInstance( IPlatformMimeResolver.class, mimeResolver );
     microPlatform.defineInstance( ISolutionEngine.class, Mockito.mock( SolutionEngine.class ) );
     microPlatform.defineInstance( IDatasourceMgmtService.class, Mockito.mock( IDatasourceMgmtService.class ) );
+    microPlatform.defineInstance( "IScheduler2", Mockito.mock( IScheduler.class ) );
 
     IRepositoryContentConverterHandler converterHandler =
         new DefaultRepositoryContentConverterHandler( new HashMap<String, Converter>() );

--- a/extensions/src/it/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryIT.java
@@ -722,13 +722,13 @@ public class PentahoMetadataDomainRepositoryIT {
     domainRepositorySpy.createOrUpdateAnnotationsXml( domainFile, null, annotationsXml );
     verify( repository, times( 1 ) )
         .createFile( any( String.class ), any( RepositoryFile.class ), any( IRepositoryFileData.class ),
-            any( String.class ) );
+        nullable( String.class ) );
 
     // Update
     RepositoryFile annotationsFile = mock( RepositoryFile.class );
     domainRepositorySpy.createOrUpdateAnnotationsXml( domainFile, annotationsFile, annotationsXml );
     verify( repository, times( 1 ) )
-        .updateFile( any( RepositoryFile.class ), any( IRepositoryFileData.class ), any( String.class ) );
+      .updateFile( any( RepositoryFile.class ), any( IRepositoryFileData.class ), nullable( String.class ) );
 
     // Error
     doThrow( new RuntimeException() ).when( domainRepositorySpy ).getRepository();

--- a/extensions/src/it/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryIT.java
@@ -691,6 +691,11 @@ public class PentahoMetadataDomainRepositoryIT {
     domainRepositorySpy.storeAnnotationsXml( null, annotationsXml );
     verify( domainRepositorySpy, times( 0 ) ).getMetadataRepositoryFile( nullable( String.class ) );
 
+    final RepositoryFile domainFile = mock( RepositoryFile.class );
+    final RepositoryFile annotationsFile = mock( RepositoryFile.class );
+    doReturn( domainFile ).when( domainRepositorySpy ).getMetadataRepositoryFile( domainId );
+    doReturn( annotationsFile ).when( domainRepositorySpy ).getAnnotationsXmlFile( domainFile );
+
     domainRepositorySpy.storeAnnotationsXml( domainId, annotationsXml );
     verify( domainRepositorySpy, times( 1 ) ).getMetadataRepositoryFile( nullable( String.class ) );
     verify( domainRepositorySpy, times( 1 ) ).getAnnotationsXmlFile( any( RepositoryFile.class ) );

--- a/extensions/src/it/java/org/pentaho/platform/web/http/api/resources/services/FileServiceIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/web/http/api/resources/services/FileServiceIT.java
@@ -1046,6 +1046,9 @@ public class FileServiceIT {
     doReturn( mockExportFile ).when( mockExportProcessor ).performExport( mockRepoFile );
 
     doReturn( mockRepoFile ).when( fileService.repository ).getFile( nullable( String.class ) );
+    doReturn( true ).when( fileService.repository ).hasAccess( nullable( String.class ),
+      eq( EnumSet.of( RepositoryFilePermission.READ ) ) );
+    PentahoSystem.registerObject( fileService.repository );
     doReturn( mockAuthPolicy ).when( fileService ).getPolicy();
     doReturn( mockExportProcessor ).when( fileService ).getDownloadExportProcessor( nullable( String.class ), anyBoolean(),
       anyBoolean() );

--- a/extensions/src/it/java/org/pentaho/platform/web/http/api/resources/services/FileServiceIT.java
+++ b/extensions/src/it/java/org/pentaho/platform/web/http/api/resources/services/FileServiceIT.java
@@ -1080,6 +1080,7 @@ public class FileServiceIT {
 
     /* register  mockAuthPolicy with PentahoSystem so SystemUtils can use it */
     PentahoSystem.registerObject( mockAuthPolicy );
+    PentahoSystem.registerObject( fileService.repository );
 
     // Test 1: in the home-folder
     try {
@@ -1100,6 +1101,11 @@ public class FileServiceIT {
     } catch ( Throwable t ) {
       fail();
     }
+
+    RepositoryFile mockRepoFile = mock( RepositoryFile.class );
+    doReturn( mockRepoFile ).when( fileService.repository ).getFile( "/home/testUser/test_file" );
+    doReturn( true ).when( fileService.repository ).hasAccess( "/home/testUser/test_file",
+      EnumSet.of( RepositoryFilePermission.READ ) );
 
     // Test 3: while still being on the user's home folder, user loses 'Read Content' permission
     try {
@@ -2143,6 +2149,8 @@ public class FileServiceIT {
     doCallRealMethod().when( fs ).doCreateDirSafe( nullable( String.class ) );
     doCallRealMethod().when( fs ).decode( nullable( String.class ) );
     doCallRealMethod().when( fs ).isValidFolderName( nullable( String.class ) );
+    doCallRealMethod().when( fs ).isValidFolderName( nullable( String.class ), anyBoolean() );
+    doCallRealMethod().when( fs ).isValidFileName( nullable( String.class ), anyBoolean() );
     doReturn( "New Folder" ).when( fs ).idToPath( nullable( String.class ) );
     doReturn( true ).when( fs ).doCreateDirFor( "New Folder" );
 

--- a/extensions/src/it/resources/org/pentaho/platform/plugin/services/metadata/steel-wheels.xmi
+++ b/extensions/src/it/resources/org/pentaho/platform/plugin/services/metadata/steel-wheels.xmi
@@ -1,0 +1,7990 @@
+<?xml version = '1.0' encoding = 'UTF-8' ?>
+<XMI xmi.version='1.2' xmlns:CWM='org.omg.xmi.namespace.CWM'
+     xmlns:CWMMDB='org.omg.xmi.namespace.CWMMDB' xmlns:CWMRDB='org.omg.xmi.namespace.CWMRDB'
+     xmlns:CWMOLAP='org.omg.xmi.namespace.CWMOLAP' timestamp='Mon Aug 03 15:20:15 EDT 2009'>
+  <XMI.header>
+    <XMI.documentation>
+      <XMI.exporter>Netbeans XMI Writer</XMI.exporter>
+      <XMI.exporterVersion>1.0</XMI.exporterVersion>
+    </XMI.documentation>
+  </XMI.header>
+  <XMI.content>
+    <CWM:Class xmi.id='a1' name='Date' isAbstract='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a2' tag='CONCEPT_PARENT_NAME' value='Base'/>
+      </CWM:ModelElement.taggedValue>
+    </CWM:Class>
+    <CWM:Class xmi.id='a3' name='US_Currency' isAbstract='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a4' tag='CONCEPT_PARENT_NAME' value='Number'/>
+      </CWM:ModelElement.taggedValue>
+    </CWM:Class>
+    <CWM:Class xmi.id='a5' name='SurrogateKey' isAbstract='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a6' tag='CONCEPT_PARENT_NAME' value='ID'/>
+      </CWM:ModelElement.taggedValue>
+    </CWM:Class>
+    <CWM:Class xmi.id='a7' name='ID' isAbstract='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a8' tag='CONCEPT_PARENT_NAME' value='Number'/>
+      </CWM:ModelElement.taggedValue>
+    </CWM:Class>
+    <CWM:Class xmi.id='a9' name='Number' isAbstract='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a10' tag='CONCEPT_PARENT_NAME' value='Base'/>
+      </CWM:ModelElement.taggedValue>
+    </CWM:Class>
+    <CWM:Class xmi.id='a11' name='Base' isAbstract='false'/>
+    <CWMOLAP:Schema xmi.id='a12' name='BV_HUMAN_RESOURCES'/>
+    <CWMOLAP:Schema xmi.id='a13' name='BV_INVENTORY'/>
+    <CWMOLAP:Schema xmi.id='a14' name='BV_ORDERS'/>
+    <CWMMDB:Schema xmi.id='a15' name='BV_HUMAN_RESOURCES'>
+      <CWM:Namespace.ownedElement>
+        <CWM:KeyRelationship xmi.id='a16'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a17' tag='RELATIONSHIP_TABLENAME_PARENT' value='BT_OFFICES_OFFICES'/>
+            <CWM:TaggedValue xmi.id='a18' tag='RELATIONSHIP_TABLENAME_CHILD' value='BT_EMPLOYEES_EMPLOYEES'/>
+            <CWM:TaggedValue xmi.id='a19' tag='RELATIONSHIP_FIELDNAME_PARENT' value='BC_OFFICES_OFFICECODE'/>
+            <CWM:TaggedValue xmi.id='a20' tag='RELATIONSHIP_FIELDNAME_CHILD' value='BC_EMPLOYEES_OFFICECODE'/>
+            <CWM:TaggedValue xmi.id='a21' tag='RELATIONSHIP_TYPE' value='1:N'/>
+            <CWM:TaggedValue xmi.id='a22' tag='RELATIONSHIP_JOIN_ORDER_KEY'/>
+            <CWM:TaggedValue xmi.id='a23' tag='RELATIONSHIP_DESCRIPTION'/>
+          </CWM:ModelElement.taggedValue>
+        </CWM:KeyRelationship>
+        <CWM:Extent xmi.id='a24' name='BC_OFFICES_'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a25' tag='BUSINESS_CATEGORY_ROOT' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWM:Namespace.ownedElement>
+            <CWM:Attribute xmi.id='a26' name='BC_OFFICES_TERRITORY'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a27' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a28' name='BC_OFFICES_POSTALCODE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a29' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a30' name='BC_OFFICES_COUNTRY'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a31' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a32' name='BC_OFFICES_STATE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a33' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a34' name='BC_OFFICES_ADDRESSLINE2'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a35' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a36' name='BC_OFFICES_ADDRESSLINE1'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a37' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a38' name='BC_OFFICES_PHONE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a39' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a40' name='BC_OFFICES_CITY'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a41' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a42' name='BC_OFFICES_OFFICECODE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a43' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+          </CWM:Namespace.ownedElement>
+        </CWM:Extent>
+        <CWM:Extent xmi.id='a44' name='BC_EMPLOYEES_'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a45' tag='BUSINESS_CATEGORY_ROOT' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWM:Namespace.ownedElement>
+            <CWM:Attribute xmi.id='a46' name='BC_EMPLOYEES_JOBTITLE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a47' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a48' name='BC_EMPLOYEES_REPORTSTO'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a49' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a50' name='BC_EMPLOYEES_EMAIL'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a51' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a52' name='BC_EMPLOYEES_EXTENSION'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a53' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a54' name='BC_EMPLOYEES_FIRSTNAME'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a55' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a56' name='BC_EMPLOYEES_LASTNAME'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a57' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a58' name='BC_EMPLOYEES_EMPLOYEENUMBER'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a59' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+          </CWM:Namespace.ownedElement>
+        </CWM:Extent>
+      </CWM:Namespace.ownedElement>
+      <CWMMDB:Schema.dimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a60' name='BC_EMPLOYEES_EMPLOYEENUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a61' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='EMPLOYEENUMBER'/>
+            <CWM:TaggedValue xmi.id='a62' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_EMPLOYEES_EMPLOYEES'/>
+            <CWM:TaggedValue xmi.id='a63' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a64'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a65' name='BC_EMPLOYEES_LASTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a66' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='LASTNAME'/>
+            <CWM:TaggedValue xmi.id='a67' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_EMPLOYEES_EMPLOYEES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a64'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a68' name='BC_EMPLOYEES_FIRSTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a69' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='FIRSTNAME'/>
+            <CWM:TaggedValue xmi.id='a70' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_EMPLOYEES_EMPLOYEES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a64'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a71' name='BC_EMPLOYEES_EXTENSION'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a72' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='EXTENSION'/>
+            <CWM:TaggedValue xmi.id='a73' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_EMPLOYEES_EMPLOYEES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a64'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a74' name='BC_EMPLOYEES_EMAIL'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a75' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='EMAIL'/>
+            <CWM:TaggedValue xmi.id='a76' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_EMPLOYEES_EMPLOYEES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a64'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a77' name='BC_EMPLOYEES_OFFICECODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a78' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='OFFICECODE'/>
+            <CWM:TaggedValue xmi.id='a79' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_EMPLOYEES_EMPLOYEES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a64'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a80' name='BC_EMPLOYEES_REPORTSTO'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a81' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='REPORTSTO'/>
+            <CWM:TaggedValue xmi.id='a82' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_EMPLOYEES_EMPLOYEES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a64'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a83' name='BC_EMPLOYEES_JOBTITLE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a84' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='JOBTITLE'/>
+            <CWM:TaggedValue xmi.id='a85' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_EMPLOYEES_EMPLOYEES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a64'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a86' name='BC_OFFICES_OFFICECODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a87' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='OFFICECODE'/>
+            <CWM:TaggedValue xmi.id='a88' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_OFFICES_OFFICES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a89'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a90' name='BC_OFFICES_CITY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a91' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CITY'/>
+            <CWM:TaggedValue xmi.id='a92' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_OFFICES_OFFICES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a89'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a93' name='BC_OFFICES_PHONE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a94' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PHONE'/>
+            <CWM:TaggedValue xmi.id='a95' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_OFFICES_OFFICES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a89'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a96' name='BC_OFFICES_ADDRESSLINE1'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a97' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='ADDRESSLINE1'/>
+            <CWM:TaggedValue xmi.id='a98' tag='BUSINESS_COLUMN_BUSINESS_TABLE' value='BT_OFFICES_OFFICES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a89'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a99' name='BC_OFFICES_ADDRESSLINE2'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a100' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='ADDRESSLINE2'/>
+            <CWM:TaggedValue xmi.id='a101' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_OFFICES_OFFICES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a89'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a102' name='BC_OFFICES_STATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a103' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='STATE'/>
+            <CWM:TaggedValue xmi.id='a104' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_OFFICES_OFFICES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a89'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a105' name='BC_OFFICES_COUNTRY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a106' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='COUNTRY'/>
+            <CWM:TaggedValue xmi.id='a107' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_OFFICES_OFFICES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a89'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a108' name='BC_OFFICES_POSTALCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a109' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='POSTALCODE'/>
+            <CWM:TaggedValue xmi.id='a110' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_OFFICES_OFFICES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a89'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a111' name='BC_OFFICES_TERRITORY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a112' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='TERRITORY'/>
+            <CWM:TaggedValue xmi.id='a113' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_OFFICES_OFFICES'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a89'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+      </CWMMDB:Schema.dimensionedObject>
+      <CWMMDB:Schema.dimension>
+        <CWMMDB:Dimension xmi.id='a64' name='BT_EMPLOYEES_EMPLOYEES' isAbstract='false'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a114' tag='BUSINESS_TABLE_PHYSICAL_TABLE_NAME'
+                             value='PT_EMPLOYEES'/>
+            <CWM:TaggedValue xmi.id='a115' tag='TAG_POSITION_X' value='213'/>
+            <CWM:TaggedValue xmi.id='a116' tag='TAG_POSITION_Y' value='151'/>
+            <CWM:TaggedValue xmi.id='a117' tag='TABLE_IS_DRAWN' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:Dimension.dimensionedObject>
+            <CWMMDB:DimensionedObject xmi.idref='a60'/>
+            <CWMMDB:DimensionedObject xmi.idref='a65'/>
+            <CWMMDB:DimensionedObject xmi.idref='a68'/>
+            <CWMMDB:DimensionedObject xmi.idref='a71'/>
+            <CWMMDB:DimensionedObject xmi.idref='a74'/>
+            <CWMMDB:DimensionedObject xmi.idref='a77'/>
+            <CWMMDB:DimensionedObject xmi.idref='a80'/>
+            <CWMMDB:DimensionedObject xmi.idref='a83'/>
+          </CWMMDB:Dimension.dimensionedObject>
+        </CWMMDB:Dimension>
+        <CWMMDB:Dimension xmi.id='a89' name='BT_OFFICES_OFFICES' isAbstract='false'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a118' tag='BUSINESS_TABLE_PHYSICAL_TABLE_NAME'
+                             value='PT_OFFICES'/>
+            <CWM:TaggedValue xmi.id='a119' tag='TAG_POSITION_X' value='114'/>
+            <CWM:TaggedValue xmi.id='a120' tag='TAG_POSITION_Y' value='151'/>
+            <CWM:TaggedValue xmi.id='a121' tag='TABLE_IS_DRAWN' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:Dimension.dimensionedObject>
+            <CWMMDB:DimensionedObject xmi.idref='a86'/>
+            <CWMMDB:DimensionedObject xmi.idref='a90'/>
+            <CWMMDB:DimensionedObject xmi.idref='a93'/>
+            <CWMMDB:DimensionedObject xmi.idref='a96'/>
+            <CWMMDB:DimensionedObject xmi.idref='a99'/>
+            <CWMMDB:DimensionedObject xmi.idref='a102'/>
+            <CWMMDB:DimensionedObject xmi.idref='a105'/>
+            <CWMMDB:DimensionedObject xmi.idref='a108'/>
+            <CWMMDB:DimensionedObject xmi.idref='a111'/>
+          </CWMMDB:Dimension.dimensionedObject>
+        </CWMMDB:Dimension>
+      </CWMMDB:Schema.dimension>
+    </CWMMDB:Schema>
+    <CWMMDB:Schema xmi.id='a122' name='BV_INVENTORY'>
+      <CWM:Namespace.ownedElement>
+        <CWM:Extent xmi.id='a123' name='CAT_PRODUCTS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a124' tag='BUSINESS_CATEGORY_ROOT' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWM:Namespace.ownedElement>
+            <CWM:Attribute xmi.id='a125' name='BC_PRODUCTS_PRODUCTCODE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a126' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a127' name='BC_PRODUCTS_PRODUCTNAME'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a128' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a129' name='BC_PRODUCTS_PRODUCTLINE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a130' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a131' name='BC_PRODUCTS_PRODUCTSCALE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a132' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a133' name='BC_PRODUCTS_PRODUCTVENDOR'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a134' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a135' name='BC_PRODUCTS_PRODUCTDESCRIPTION'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a136' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+          </CWM:Namespace.ownedElement>
+        </CWM:Extent>
+        <CWM:Extent xmi.id='a137' name='CAT_INVENTORY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a138' tag='BUSINESS_CATEGORY_ROOT' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWM:Namespace.ownedElement>
+            <CWM:Attribute xmi.id='a139' name='BC_PRODUCTS_QUANTITYINSTOCK'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a140' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a141' name='BC_PRODUCTS_BUYPRICE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a142' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a143' name='BC_PRODUCTS_MSRP'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a144' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+          </CWM:Namespace.ownedElement>
+        </CWM:Extent>
+      </CWM:Namespace.ownedElement>
+      <CWMMDB:Schema.dimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a145' name='BC_PRODUCTS_PRODUCTCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a146' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTCODE'/>
+            <CWM:TaggedValue xmi.id='a147' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a148'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a149' name='BC_PRODUCTS_PRODUCTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a150' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTNAME'/>
+            <CWM:TaggedValue xmi.id='a151' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a148'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a152' name='BC_PRODUCTS_PRODUCTLINE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a153' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTLINE'/>
+            <CWM:TaggedValue xmi.id='a154' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a148'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a155' name='BC_PRODUCTS_PRODUCTSCALE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a156' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTSCALE'/>
+            <CWM:TaggedValue xmi.id='a157' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a148'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a158' name='BC_PRODUCTS_PRODUCTVENDOR'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a159' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTVENDOR'/>
+            <CWM:TaggedValue xmi.id='a160' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a148'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a161' name='BC_PRODUCTS_PRODUCTDESCRIPTION'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a162' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTDESCRIPTION'/>
+            <CWM:TaggedValue xmi.id='a163' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a148'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a164' name='BC_PRODUCTS_QUANTITYINSTOCK'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a165' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='QUANTITYINSTOCK'/>
+            <CWM:TaggedValue xmi.id='a166' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+            <CWM:TaggedValue xmi.id='a167' tag='CONCEPT_PARENT_NAME' value='Number'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a148'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a168' name='BC_PRODUCTS_BUYPRICE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a169' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='BUYPRICE'/>
+            <CWM:TaggedValue xmi.id='a170' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+            <CWM:TaggedValue xmi.id='a171' tag='CONCEPT_PARENT_NAME' value='US_Currency'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a148'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a172' name='BC_PRODUCTS_MSRP'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a173' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='MSRP'/>
+            <CWM:TaggedValue xmi.id='a174' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+            <CWM:TaggedValue xmi.id='a175' tag='CONCEPT_PARENT_NAME' value='US_Currency'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a148'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+      </CWMMDB:Schema.dimensionedObject>
+      <CWMMDB:Schema.dimension>
+        <CWMMDB:Dimension xmi.id='a148' name='BT_PRODUCTS_PRODUCTS' isAbstract='false'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a176' tag='BUSINESS_TABLE_PHYSICAL_TABLE_NAME'
+                             value='PT_PRODUCTS'/>
+            <CWM:TaggedValue xmi.id='a177' tag='TAG_POSITION_X' value='91'/>
+            <CWM:TaggedValue xmi.id='a178' tag='TAG_POSITION_Y' value='125'/>
+            <CWM:TaggedValue xmi.id='a179' tag='TABLE_IS_DRAWN' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:Dimension.dimensionedObject>
+            <CWMMDB:DimensionedObject xmi.idref='a145'/>
+            <CWMMDB:DimensionedObject xmi.idref='a149'/>
+            <CWMMDB:DimensionedObject xmi.idref='a152'/>
+            <CWMMDB:DimensionedObject xmi.idref='a155'/>
+            <CWMMDB:DimensionedObject xmi.idref='a158'/>
+            <CWMMDB:DimensionedObject xmi.idref='a161'/>
+            <CWMMDB:DimensionedObject xmi.idref='a164'/>
+            <CWMMDB:DimensionedObject xmi.idref='a168'/>
+            <CWMMDB:DimensionedObject xmi.idref='a172'/>
+          </CWMMDB:Dimension.dimensionedObject>
+        </CWMMDB:Dimension>
+      </CWMMDB:Schema.dimension>
+    </CWMMDB:Schema>
+    <CWMMDB:Schema xmi.id='a180' name='BV_ORDERS'>
+      <CWM:Namespace.ownedElement>
+        <CWM:KeyRelationship xmi.id='a181'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a182' tag='RELATIONSHIP_TABLENAME_PARENT' value='BT_ORDERS_ORDERS'/>
+            <CWM:TaggedValue xmi.id='a183' tag='RELATIONSHIP_TABLENAME_CHILD' value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+            <CWM:TaggedValue xmi.id='a184' tag='RELATIONSHIP_FIELDNAME_PARENT' value='BC_ORDERS_CUSTOMERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a185' tag='RELATIONSHIP_FIELDNAME_CHILD' value='BC_CUSTOMER_W_TER_CUSTOMERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a186' tag='RELATIONSHIP_TYPE' value='1:N'/>
+            <CWM:TaggedValue xmi.id='a187' tag='RELATIONSHIP_JOIN_ORDER_KEY'/>
+            <CWM:TaggedValue xmi.id='a188' tag='RELATIONSHIP_DESCRIPTION'/>
+          </CWM:ModelElement.taggedValue>
+        </CWM:KeyRelationship>
+        <CWM:KeyRelationship xmi.id='a189'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a190' tag='RELATIONSHIP_TABLENAME_PARENT' value='BT_ORDERS_ORDERS'/>
+            <CWM:TaggedValue xmi.id='a191' tag='RELATIONSHIP_TABLENAME_CHILD' value='BT_ORDERDETAILS_ORDERDETAILS'/>
+            <CWM:TaggedValue xmi.id='a192' tag='RELATIONSHIP_FIELDNAME_PARENT' value='BC_ORDERS_ORDERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a193' tag='RELATIONSHIP_FIELDNAME_CHILD' value='BC_ORDERDETAILS_ORDERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a194' tag='RELATIONSHIP_TYPE' value='1:N'/>
+            <CWM:TaggedValue xmi.id='a195' tag='RELATIONSHIP_JOIN_ORDER_KEY'/>
+            <CWM:TaggedValue xmi.id='a196' tag='RELATIONSHIP_DESCRIPTION'/>
+          </CWM:ModelElement.taggedValue>
+        </CWM:KeyRelationship>
+        <CWM:KeyRelationship xmi.id='a197'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a198' tag='RELATIONSHIP_TABLENAME_PARENT' value='BT_ORDERDETAILS_ORDERDETAILS'/>
+            <CWM:TaggedValue xmi.id='a199' tag='RELATIONSHIP_TABLENAME_CHILD' value='BT_PRODUCTS_PRODUCTS'/>
+            <CWM:TaggedValue xmi.id='a200' tag='RELATIONSHIP_FIELDNAME_PARENT' value='BC_ORDERDETAILS_PRODUCTCODE'/>
+            <CWM:TaggedValue xmi.id='a201' tag='RELATIONSHIP_FIELDNAME_CHILD' value='BC_PRODUCTS_PRODUCTCODE'/>
+            <CWM:TaggedValue xmi.id='a202' tag='RELATIONSHIP_TYPE' value='N:N'/>
+            <CWM:TaggedValue xmi.id='a203' tag='RELATIONSHIP_JOIN_ORDER_KEY'/>
+            <CWM:TaggedValue xmi.id='a204' tag='RELATIONSHIP_DESCRIPTION'/>
+          </CWM:ModelElement.taggedValue>
+        </CWM:KeyRelationship>
+        <CWM:KeyRelationship xmi.id='a205'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a206' tag='RELATIONSHIP_TABLENAME_PARENT' value='BT_ORDERS_ORDERS'/>
+            <CWM:TaggedValue xmi.id='a207' tag='RELATIONSHIP_TABLENAME_CHILD' value='BT_PAYMENTS_PAYMENTS'/>
+            <CWM:TaggedValue xmi.id='a208' tag='RELATIONSHIP_FIELDNAME_PARENT' value='BC_ORDERS_CUSTOMERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a209' tag='RELATIONSHIP_FIELDNAME_CHILD' value='BC_PAYMENTS_CUSTOMERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a210' tag='RELATIONSHIP_TYPE' value='1:1'/>
+            <CWM:TaggedValue xmi.id='a211' tag='RELATIONSHIP_JOIN_ORDER_KEY'/>
+            <CWM:TaggedValue xmi.id='a212' tag='RELATIONSHIP_DESCRIPTION'/>
+          </CWM:ModelElement.taggedValue>
+        </CWM:KeyRelationship>
+        <CWM:Extent xmi.id='a213' name='BC_CUSTOMER_W_TER_'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a214' tag='BUSINESS_CATEGORY_ROOT' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWM:Namespace.ownedElement>
+            <CWM:Attribute xmi.id='a215' name='BC_CUSTOMER_W_TER_TERRITORY'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a216' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a217' name='BC_CUSTOMER_W_TER_CREDITLIMIT'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a218' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a219' name='BC_CUSTOMER_W_TER_EMPLOYEENUMBER'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a220' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a221' name='BC_CUSTOMER_W_TER_COUNTRY'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a222' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a223' name='BC_CUSTOMER_W_TER_POSTALCODE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a224' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a225' name='BC_CUSTOMER_W_TER_STATE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a226' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a227' name='BC_CUSTOMER_W_TER_CITY'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a228' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a229' name='BC_CUSTOMER_W_TER_ADDRESSLINE2'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a230' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a231' name='BC_CUSTOMER_W_TER_ADDRESSLINE1'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a232' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a233' name='BC_CUSTOMER_W_TER_PHONE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a234' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a235' name='BC_CUSTOMER_W_TER_CUSTOMERNAME'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a236' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a237' name='BC_CUSTOMER_W_TER_CUSTOMERNUMBER'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a238' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a239' name='BC_CUSTOMER_W_TER_CONTACT'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a240' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+          </CWM:Namespace.ownedElement>
+        </CWM:Extent>
+        <CWM:Extent xmi.id='a241' name='CAT_ORDERS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a242' tag='BUSINESS_CATEGORY_ROOT' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWM:Namespace.ownedElement>
+            <CWM:Attribute xmi.id='a243' name='BC_ORDERS_ORDERNUMBER'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a244' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a245' name='BC_ORDERS_ORDERDATE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a246' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a247' name='BC_ORDERS_REQUIREDDATE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a248' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a249' name='BC_ORDERS_SHIPPEDDATE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a250' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a251' name='BC_ORDERS_STATUS'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a252' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a253' name='BC_ORDERS_COMMENTS'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a254' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a255' name='BC_ORDERDETAILS_QUANTITYORDERED'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a256' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a257' name='BC_ORDERDETAILS_PRICEEACH'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a258' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a259' name='BC_ORDERDETAILS_TOTAL'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a260' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+          </CWM:Namespace.ownedElement>
+        </CWM:Extent>
+        <CWM:Extent xmi.id='a261' name='CAT_PRODUCTS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a262' tag='BUSINESS_CATEGORY_ROOT' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWM:Namespace.ownedElement>
+            <CWM:Attribute xmi.id='a263' name='BC_ORDERS_COMMENTS'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a264' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a265' name='BC_PRODUCTS_PRODUCTCODE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a266' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a267' name='BC_PRODUCTS_PRODUCTNAME'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a268' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a269' name='BC_PRODUCTS_PRODUCTLINE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a270' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a271' name='BC_PRODUCTS_PRODUCTSCALE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a272' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a273' name='BC_PRODUCTS_PRODUCTVENDOR'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a274' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a275' name='BC_PRODUCTS_PRODUCTDESCRIPTION'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a276' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a277' name='BC_PRODUCTS_BUYPRICE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a278' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a279' name='BC_PRODUCTS_MSRP'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a280' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+          </CWM:Namespace.ownedElement>
+        </CWM:Extent>
+        <CWM:Extent xmi.id='a281' name='CAT_PAYMENTS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a282' tag='BUSINESS_CATEGORY_ROOT' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWM:Namespace.ownedElement>
+            <CWM:Attribute xmi.id='a283' name='BC_PAYMENTS_CHECKNUMBER'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a284' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a285' name='BC_PAYMENTS_PAYMENTDATE'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a286' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+            <CWM:Attribute xmi.id='a287' name='BC_PAYMENTS_AMOUNT'>
+              <CWM:ModelElement.taggedValue>
+                <CWM:TaggedValue xmi.id='a288' tag='BUSINESS_CATEGORY_TYPE' value='Column'/>
+              </CWM:ModelElement.taggedValue>
+            </CWM:Attribute>
+          </CWM:Namespace.ownedElement>
+        </CWM:Extent>
+      </CWM:Namespace.ownedElement>
+      <CWMMDB:Schema.dimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a289' name='BC_PAYMENTS_CUSTOMERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a290' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CUSTOMERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a291' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PAYMENTS_PAYMENTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a292'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a293' name='BC_PAYMENTS_CHECKNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a294' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CHECKNUMBER'/>
+            <CWM:TaggedValue xmi.id='a295' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PAYMENTS_PAYMENTS'/>
+            <CWM:TaggedValue xmi.id='a296' tag='CONCEPT_PARENT_NAME' value='Number'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a292'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a297' name='BC_PAYMENTS_PAYMENTDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a298' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PAYMENTDATE'/>
+            <CWM:TaggedValue xmi.id='a299' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PAYMENTS_PAYMENTS'/>
+            <CWM:TaggedValue xmi.id='a300' tag='CONCEPT_PARENT_NAME' value='Date'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a292'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a301' name='BC_PAYMENTS_AMOUNT'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a302' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='AMOUNT'/>
+            <CWM:TaggedValue xmi.id='a303' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PAYMENTS_PAYMENTS'/>
+            <CWM:TaggedValue xmi.id='a304' tag='CONCEPT_PARENT_NAME' value='US_Currency'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a292'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a305' name='BC_PRODUCTS_PRODUCTCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a306' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTCODE'/>
+            <CWM:TaggedValue xmi.id='a307' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a308'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a309' name='BC_PRODUCTS_PRODUCTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a310' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTNAME'/>
+            <CWM:TaggedValue xmi.id='a311' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a308'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a312' name='BC_PRODUCTS_PRODUCTLINE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a313' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTLINE'/>
+            <CWM:TaggedValue xmi.id='a314' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a308'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a315' name='BC_PRODUCTS_PRODUCTSCALE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a316' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTSCALE'/>
+            <CWM:TaggedValue xmi.id='a317' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a308'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a318' name='BC_PRODUCTS_PRODUCTVENDOR'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a319' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTVENDOR'/>
+            <CWM:TaggedValue xmi.id='a320' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a308'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a321' name='BC_PRODUCTS_PRODUCTDESCRIPTION'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a322' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTDESCRIPTION'/>
+            <CWM:TaggedValue xmi.id='a323' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a308'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a324' name='BC_PRODUCTS_QUANTITYINSTOCK'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a325' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='QUANTITYINSTOCK'/>
+            <CWM:TaggedValue xmi.id='a326' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a308'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a327' name='BC_PRODUCTS_BUYPRICE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a328' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='BUYPRICE'/>
+            <CWM:TaggedValue xmi.id='a329' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+            <CWM:TaggedValue xmi.id='a330' tag='CONCEPT_PARENT_NAME' value='US_Currency'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a308'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a331' name='BC_PRODUCTS_MSRP'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a332' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='MSRP'/>
+            <CWM:TaggedValue xmi.id='a333' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_PRODUCTS_PRODUCTS'/>
+            <CWM:TaggedValue xmi.id='a334' tag='CONCEPT_PARENT_NAME' value='US_Currency'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a308'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a335' name='BC_ORDERDETAILS_ORDERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a336' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='ORDERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a337' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERDETAILS_ORDERDETAILS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a338'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a339' name='BC_ORDERDETAILS_PRODUCTCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a340' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRODUCTCODE'/>
+            <CWM:TaggedValue xmi.id='a341' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERDETAILS_ORDERDETAILS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a338'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a342' name='BC_ORDERDETAILS_QUANTITYORDERED'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a343' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='QUANTITYORDERED'/>
+            <CWM:TaggedValue xmi.id='a344' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERDETAILS_ORDERDETAILS'/>
+            <CWM:TaggedValue xmi.id='a345' tag='CONCEPT_PARENT_NAME' value='Number'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a338'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a346' name='BC_ORDERDETAILS_PRICEEACH'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a347' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PRICEEACH'/>
+            <CWM:TaggedValue xmi.id='a348' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERDETAILS_ORDERDETAILS'/>
+            <CWM:TaggedValue xmi.id='a349' tag='CONCEPT_PARENT_NAME' value='US_Currency'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a338'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a350' name='BC_ORDERDETAILS_ORDERLINENUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a351' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='ORDERLINENUMBER'/>
+            <CWM:TaggedValue xmi.id='a352' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERDETAILS_ORDERDETAILS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a338'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a353' name='BC_ORDERDETAILS_TOTAL'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a354' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PC_TOTAL'/>
+            <CWM:TaggedValue xmi.id='a355' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERDETAILS_ORDERDETAILS'/>
+            <CWM:TaggedValue xmi.id='a356' tag='CONCEPT_PARENT_NAME' value='US_Currency'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a338'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a357' name='BC_ORDERS_ORDERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a358' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='ORDERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a359' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERS_ORDERS'/>
+            <CWM:TaggedValue xmi.id='a360' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a361'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a362' name='BC_ORDERS_ORDERDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a363' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='ORDERDATE'/>
+            <CWM:TaggedValue xmi.id='a364' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERS_ORDERS'/>
+            <CWM:TaggedValue xmi.id='a365' tag='CONCEPT_PARENT_NAME' value='Date'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a361'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a366' name='BC_ORDERS_REQUIREDDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a367' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='REQUIREDDATE'/>
+            <CWM:TaggedValue xmi.id='a368' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERS_ORDERS'/>
+            <CWM:TaggedValue xmi.id='a369' tag='CONCEPT_PARENT_NAME' value='Date'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a361'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a370' name='BC_ORDERS_SHIPPEDDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a371' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='SHIPPEDDATE'/>
+            <CWM:TaggedValue xmi.id='a372' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERS_ORDERS'/>
+            <CWM:TaggedValue xmi.id='a373' tag='CONCEPT_PARENT_NAME' value='Date'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a361'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a374' name='BC_ORDERS_STATUS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a375' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='STATUS'/>
+            <CWM:TaggedValue xmi.id='a376' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERS_ORDERS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a361'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a377' name='BC_ORDERS_COMMENTS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a378' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='COMMENTS'/>
+            <CWM:TaggedValue xmi.id='a379' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERS_ORDERS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a361'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a380' name='BC_ORDERS_CUSTOMERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a381' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CUSTOMERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a382' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_ORDERS_ORDERS'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a361'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a383' name='BC_CUSTOMER_W_TER_TERRITORY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a384' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='TERRITORY'/>
+            <CWM:TaggedValue xmi.id='a385' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+            <CWM:TaggedValue xmi.id='a386' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a388' name='BC_CUSTOMER_W_TER_CREDITLIMIT'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a389' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CREDITLIMIT'/>
+            <CWM:TaggedValue xmi.id='a390' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a391' name='BC_CUSTOMER_W_TER_EMPLOYEENUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a392' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='EMPLOYEENUMBER'/>
+            <CWM:TaggedValue xmi.id='a393' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+            <CWM:TaggedValue xmi.id='a394' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a395' name='BC_CUSTOMER_W_TER_COUNTRY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a396' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='COUNTRY'/>
+            <CWM:TaggedValue xmi.id='a397' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a398' name='BC_CUSTOMER_W_TER_POSTALCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a399' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='POSTALCODE'/>
+            <CWM:TaggedValue xmi.id='a400' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a401' name='BC_CUSTOMER_W_TER_STATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a402' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='STATE'/>
+            <CWM:TaggedValue xmi.id='a403' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a404' name='BC_CUSTOMER_W_TER_CITY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a405' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CITY'/>
+            <CWM:TaggedValue xmi.id='a406' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a407' name='BC_CUSTOMER_W_TER_ADDRESSLINE2'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a408' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='ADDRESSLINE2'/>
+            <CWM:TaggedValue xmi.id='a409' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a410' name='BC_CUSTOMER_W_TER_ADDRESSLINE1'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a411' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='ADDRESSLINE1'/>
+            <CWM:TaggedValue xmi.id='a412' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a413' name='BC_CUSTOMER_W_TER_PHONE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a414' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PHONE'/>
+            <CWM:TaggedValue xmi.id='a415' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a416' name='BC_CUSTOMER_W_TER_CONTACTFIRSTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a417' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CONTACTFIRSTNAME'/>
+            <CWM:TaggedValue xmi.id='a418' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a419' name='BC_CUSTOMER_W_TER_CONTACTLASTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a420' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CONTACTLASTNAME'/>
+            <CWM:TaggedValue xmi.id='a421' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a422' name='BC_CUSTOMER_W_TER_CUSTOMERNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a423' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CUSTOMERNAME'/>
+            <CWM:TaggedValue xmi.id='a424' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a425' name='BC_CUSTOMER_W_TER_CUSTOMERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a426' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='CUSTOMERNUMBER'/>
+            <CWM:TaggedValue xmi.id='a427' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+        <CWMMDB:DimensionedObject xmi.id='a428' name='BC_CUSTOMER_W_TER_CONTACT'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a429' tag='BUSINESS_COLUMN_PHYSICAL_COLUMN_NAME'
+                             value='PC_CONTACT'/>
+            <CWM:TaggedValue xmi.id='a430' tag='BUSINESS_COLUMN_BUSINESS_TABLE'
+                             value='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:DimensionedObject.dimension>
+            <CWMMDB:Dimension xmi.idref='a387'/>
+          </CWMMDB:DimensionedObject.dimension>
+        </CWMMDB:DimensionedObject>
+      </CWMMDB:Schema.dimensionedObject>
+      <CWMMDB:Schema.dimension>
+        <CWMMDB:Dimension xmi.id='a292' name='BT_PAYMENTS_PAYMENTS' isAbstract='false'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a431' tag='BUSINESS_TABLE_PHYSICAL_TABLE_NAME'
+                             value='PT_PAYMENTS'/>
+            <CWM:TaggedValue xmi.id='a432' tag='TAG_POSITION_X' value='188'/>
+            <CWM:TaggedValue xmi.id='a433' tag='TAG_POSITION_Y' value='248'/>
+            <CWM:TaggedValue xmi.id='a434' tag='TABLE_IS_DRAWN' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:Dimension.dimensionedObject>
+            <CWMMDB:DimensionedObject xmi.idref='a289'/>
+            <CWMMDB:DimensionedObject xmi.idref='a293'/>
+            <CWMMDB:DimensionedObject xmi.idref='a297'/>
+            <CWMMDB:DimensionedObject xmi.idref='a301'/>
+          </CWMMDB:Dimension.dimensionedObject>
+        </CWMMDB:Dimension>
+        <CWMMDB:Dimension xmi.id='a308' name='BT_PRODUCTS_PRODUCTS' isAbstract='false'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a435' tag='BUSINESS_TABLE_PHYSICAL_TABLE_NAME'
+                             value='PT_PRODUCTS'/>
+            <CWM:TaggedValue xmi.id='a436' tag='TAG_POSITION_X' value='414'/>
+            <CWM:TaggedValue xmi.id='a437' tag='TAG_POSITION_Y' value='131'/>
+            <CWM:TaggedValue xmi.id='a438' tag='TABLE_IS_DRAWN' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:Dimension.dimensionedObject>
+            <CWMMDB:DimensionedObject xmi.idref='a305'/>
+            <CWMMDB:DimensionedObject xmi.idref='a309'/>
+            <CWMMDB:DimensionedObject xmi.idref='a312'/>
+            <CWMMDB:DimensionedObject xmi.idref='a315'/>
+            <CWMMDB:DimensionedObject xmi.idref='a318'/>
+            <CWMMDB:DimensionedObject xmi.idref='a321'/>
+            <CWMMDB:DimensionedObject xmi.idref='a324'/>
+            <CWMMDB:DimensionedObject xmi.idref='a327'/>
+            <CWMMDB:DimensionedObject xmi.idref='a331'/>
+          </CWMMDB:Dimension.dimensionedObject>
+        </CWMMDB:Dimension>
+        <CWMMDB:Dimension xmi.id='a338' name='BT_ORDERDETAILS_ORDERDETAILS'
+                          isAbstract='false'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a439' tag='BUSINESS_TABLE_PHYSICAL_TABLE_NAME'
+                             value='PT_ORDERDETAILS'/>
+            <CWM:TaggedValue xmi.id='a440' tag='TAG_POSITION_X' value='301'/>
+            <CWM:TaggedValue xmi.id='a441' tag='TAG_POSITION_Y' value='131'/>
+            <CWM:TaggedValue xmi.id='a442' tag='TABLE_IS_DRAWN' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:Dimension.dimensionedObject>
+            <CWMMDB:DimensionedObject xmi.idref='a335'/>
+            <CWMMDB:DimensionedObject xmi.idref='a339'/>
+            <CWMMDB:DimensionedObject xmi.idref='a342'/>
+            <CWMMDB:DimensionedObject xmi.idref='a346'/>
+            <CWMMDB:DimensionedObject xmi.idref='a350'/>
+            <CWMMDB:DimensionedObject xmi.idref='a353'/>
+          </CWMMDB:Dimension.dimensionedObject>
+        </CWMMDB:Dimension>
+        <CWMMDB:Dimension xmi.id='a361' name='BT_ORDERS_ORDERS' isAbstract='false'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a443' tag='BUSINESS_TABLE_PHYSICAL_TABLE_NAME'
+                             value='PT_ORDERS'/>
+            <CWM:TaggedValue xmi.id='a444' tag='TAG_POSITION_X' value='188'/>
+            <CWM:TaggedValue xmi.id='a445' tag='TAG_POSITION_Y' value='131'/>
+            <CWM:TaggedValue xmi.id='a446' tag='TABLE_IS_DRAWN' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:Dimension.dimensionedObject>
+            <CWMMDB:DimensionedObject xmi.idref='a357'/>
+            <CWMMDB:DimensionedObject xmi.idref='a362'/>
+            <CWMMDB:DimensionedObject xmi.idref='a366'/>
+            <CWMMDB:DimensionedObject xmi.idref='a370'/>
+            <CWMMDB:DimensionedObject xmi.idref='a374'/>
+            <CWMMDB:DimensionedObject xmi.idref='a377'/>
+            <CWMMDB:DimensionedObject xmi.idref='a380'/>
+          </CWMMDB:Dimension.dimensionedObject>
+        </CWMMDB:Dimension>
+        <CWMMDB:Dimension xmi.id='a387' name='BT_CUSTOMER_W_TER_CUSTOMER_W_TER'
+                          isAbstract='false'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a447' tag='BUSINESS_TABLE_PHYSICAL_TABLE_NAME'
+                             value='PT_CUSTOMER_W_TER'/>
+            <CWM:TaggedValue xmi.id='a448' tag='TAG_POSITION_X' value='75'/>
+            <CWM:TaggedValue xmi.id='a449' tag='TAG_POSITION_Y' value='131'/>
+            <CWM:TaggedValue xmi.id='a450' tag='TABLE_IS_DRAWN' value='Y'/>
+          </CWM:ModelElement.taggedValue>
+          <CWMMDB:Dimension.dimensionedObject>
+            <CWMMDB:DimensionedObject xmi.idref='a383'/>
+            <CWMMDB:DimensionedObject xmi.idref='a388'/>
+            <CWMMDB:DimensionedObject xmi.idref='a391'/>
+            <CWMMDB:DimensionedObject xmi.idref='a395'/>
+            <CWMMDB:DimensionedObject xmi.idref='a398'/>
+            <CWMMDB:DimensionedObject xmi.idref='a401'/>
+            <CWMMDB:DimensionedObject xmi.idref='a404'/>
+            <CWMMDB:DimensionedObject xmi.idref='a407'/>
+            <CWMMDB:DimensionedObject xmi.idref='a410'/>
+            <CWMMDB:DimensionedObject xmi.idref='a413'/>
+            <CWMMDB:DimensionedObject xmi.idref='a416'/>
+            <CWMMDB:DimensionedObject xmi.idref='a419'/>
+            <CWMMDB:DimensionedObject xmi.idref='a422'/>
+            <CWMMDB:DimensionedObject xmi.idref='a425'/>
+            <CWMMDB:DimensionedObject xmi.idref='a428'/>
+          </CWMMDB:Dimension.dimensionedObject>
+        </CWMMDB:Dimension>
+      </CWMMDB:Schema.dimension>
+    </CWMMDB:Schema>
+    <CWMRDB:Table xmi.id='a451' name='PT_TRIAL_BALANCE' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a452' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a453' name='Amount'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a454' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a455' name='Detail'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a456' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a457' name='Category2'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a458' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a459' name='Category'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a460' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a461' name='Account_Num'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a462' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a463' name='Type'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a464' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a465' name='PT_TIME' isAbstract='false' isTemporary='false'
+                  isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a466' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a467' name='QTR_DESC'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a468' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a469' name='QTR_NAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a470' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a471' name='MONTH_DESC'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a472' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a473' name='MONTH_NAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a474' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a475' name='YEAR_ID'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a476' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a477' name='QTR_ID'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a478' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a479' name='MONTH_ID'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a480' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a481' name='TIME_ID'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a482' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a483' name='PT_QUADRANT_ACTUALS' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a484' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a485' name='VARIANCE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a486' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a487' name='BUDGET'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a488' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a489' name='ACTUAL'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a490' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a491' name='POSITIONTITLE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a492' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a493' name='DEPARTMENT'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a494' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a495' name='REGION'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a496' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a497' name='PT_PRODUCTS' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a498' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a499' name='MSRP'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a500' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a501' name='BUYPRICE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a502' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a503' name='QUANTITYINSTOCK'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a504' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a505' name='PRODUCTDESCRIPTION'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a506' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a507' name='PRODUCTVENDOR'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a508' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a509' name='PRODUCTSCALE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a510' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a511' name='PRODUCTLINE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a512' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a513' name='PRODUCTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a514' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a515' name='PRODUCTCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a516' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a517' name='PT_PAYMENTS' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a518' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a519' name='AMOUNT'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a520' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a521' name='PAYMENTDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a522' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a523' name='CHECKNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a524' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a525' name='CUSTOMERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a526' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a527' name='PT_ORDERS' isAbstract='false' isTemporary='false'
+                  isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a528' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a529' name='CUSTOMERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a530' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a531' name='COMMENTS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a532' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a533' name='STATUS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a534' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a535' name='SHIPPEDDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a536' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a537' name='REQUIREDDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a538' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a539' name='ORDERDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a540' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a541' name='ORDERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a542' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a543' name='PC_ORDER_MONTH'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a544' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a545' name='PT_ORDERFACT' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a546' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a547' name='YEAR_ID'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a548' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a549' name='MONTH_ID'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a550' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a551' name='QTR_ID'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a552' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a553' name='TIME_ID'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a554' tag='CONCEPT_PARENT_NAME' value='ID'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a555' name='CUSTOMERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a556' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a557' name='COMMENTS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a558' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a559' name='STATUS'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a560' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a561' name='SHIPPEDDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a562' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a563' name='REQUIREDDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a564' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a565' name='ORDERDATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a566' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a567' name='TOTALPRICE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a568' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a569' name='ORDERLINENUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a570' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a571' name='PRICEEACH'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a572' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a573' name='QUANTITYORDERED'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a574' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a575' name='PRODUCTCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a576' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a577' name='ORDERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a578' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a579' name='PT_ORDERDETAILS' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a580' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a581' name='PC_TOTAL'/>
+        <CWMRDB:Column xmi.id='a582' name='ORDERLINENUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a583' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a584' name='PRICEEACH'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a585' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a586' name='QUANTITYORDERED'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a587' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a588' name='PRODUCTCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a589' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a590' name='ORDERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a591' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a592' name='PT_OFFICES' isAbstract='false' isTemporary='false'
+                  isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a593' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a594' name='TERRITORY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a595' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a596' name='POSTALCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a597' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a598' name='COUNTRY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a599' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a600' name='STATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a601' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a602' name='ADDRESSLINE2'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a603' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a604' name='ADDRESSLINE1'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a605' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a606' name='PHONE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a607' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a608' name='CITY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a609' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a610' name='OFFICECODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a611' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a612' name='PT_EMPLOYEES' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a613' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a614' name='JOBTITLE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a615' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a616' name='REPORTSTO'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a617' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a618' name='OFFICECODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a619' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a620' name='EMAIL'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a621' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a622' name='EXTENSION'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a623' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a624' name='FIRSTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a625' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a626' name='LASTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a627' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a628' name='EMPLOYEENUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a629' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a630' name='PT_DEPARTMENT_MANAGERS' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a631' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a632' name='EMAIL'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a633' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a634' name='MANAGER_NAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a635' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a636' name='REGION'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a637' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a638' name='PT_CUSTOMER_W_TER' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a639' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a640' name='TERRITORY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a641' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a642' name='CREDITLIMIT'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a643' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a644' name='EMPLOYEENUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a645' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a646' name='COUNTRY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a647' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a648' name='POSTALCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a649' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a650' name='STATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a651' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a652' name='CITY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a653' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a654' name='ADDRESSLINE2'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a655' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a656' name='ADDRESSLINE1'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a657' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a658' name='PHONE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a659' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a660' name='CONTACTFIRSTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a661' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a662' name='CONTACTLASTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a663' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a664' name='CUSTOMERNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a665' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a666' name='CUSTOMERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a667' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a668' name='PC_CONTACT'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a669' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Table xmi.id='a670' name='PT_CUSTOMERS' isAbstract='false'
+                  isTemporary='false' isSystem='false'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a671' tag='TABLE_TARGET_DATABASE_NAME' value='SampleData'/>
+      </CWM:ModelElement.taggedValue>
+      <CWM:Namespace.ownedElement>
+        <CWMRDB:Column xmi.id='a672' name='CREDITLIMIT'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a673' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a674' name='SALESREPEMPLOYEENUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a675' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a676' name='COUNTRY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a677' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a678' name='POSTALCODE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a679' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a680' name='STATE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a681' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a682' name='CITY'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a683' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a684' name='ADDRESSLINE2'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a685' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a686' name='ADDRESSLINE1'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a687' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a688' name='PHONE'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a689' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a690' name='CONTACTFIRSTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a691' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a692' name='CONTACTLASTNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a693' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a694' name='CUSTOMERNAME'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a695' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+        <CWMRDB:Column xmi.id='a696' name='CUSTOMERNUMBER'>
+          <CWM:ModelElement.taggedValue>
+            <CWM:TaggedValue xmi.id='a697' tag='CONCEPT_PARENT_NAME' value='Base'/>
+          </CWM:ModelElement.taggedValue>
+        </CWMRDB:Column>
+      </CWM:Namespace.ownedElement>
+    </CWMRDB:Table>
+    <CWMRDB:Catalog xmi.id='a698' name='SampleData'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a699' tag='DATABASE_SERVER' value='localhost'/>
+        <CWM:TaggedValue xmi.id='a700' tag='DATABASE_TYPE' value='HYPERSONIC'/>
+        <CWM:TaggedValue xmi.id='a701' tag='DATABASE_ACCESS' value='JNDI'/>
+        <CWM:TaggedValue xmi.id='a702' tag='DATABASE_DATABASE' value='SampleData'/>
+        <CWM:TaggedValue xmi.id='a703' tag='DATABASE_PORT' value=''/>
+        <CWM:TaggedValue xmi.id='a704' tag='DATABASE_USERNAME' value=''/>
+        <CWM:TaggedValue xmi.id='a705' tag='DATABASE_PASSWORD' value=''/>
+        <CWM:TaggedValue xmi.id='a706' tag='DATABASE_SERVERNAME' value=''/>
+        <CWM:TaggedValue xmi.id='a707' tag='DATABASE_DATA_TABLESPACE' value=''/>
+        <CWM:TaggedValue xmi.id='a708' tag='DATABASE_INDEX_TABLESPACE' value=''/>
+        <CWM:TaggedValue xmi.id='a709' tag='DATABASE_ATTRIBUTE_PREFIX_EXTRA_OPTION_MYSQL.defaultFetchSize'
+                         value='500'/>
+        <CWM:TaggedValue xmi.id='a710' tag='DATABASE_ATTRIBUTE_PREFIX_EXTRA_OPTION_MYSQL.useCursorFetch'
+                         value='true'/>
+        <CWM:TaggedValue xmi.id='a711' tag='DATABASE_ATTRIBUTE_PREFIX_STREAM_RESULTS'
+                         value='Y'/>
+        <CWM:TaggedValue xmi.id='a712' tag='DATABASE_ATTRIBUTE_PREFIX_USE_POOLING'
+                         value='N'/>
+        <CWM:TaggedValue xmi.id='a713' tag='DATABASE_ATTRIBUTE_PREFIX_IS_CLUSTERED'
+                         value='N'/>
+        <CWM:TaggedValue xmi.id='a714' tag='DATABASE_ATTRIBUTE_PREFIX_MAXIMUM_POOL_SIZE'
+                         value='10'/>
+        <CWM:TaggedValue xmi.id='a715' tag='DATABASE_JDBC_URL' value='jdbc:hsqldb:SampleData'/>
+      </CWM:ModelElement.taggedValue>
+    </CWMRDB:Catalog>
+    <CWM:Description xmi.id='a716' name='mask' body='MM-dd-yyyy' type='String'>
+      <CWM:Description.modelElement>
+        <CWM:Class xmi.idref='a1'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a717' name='mask' body='$#,##0.00;($#,##0.00)'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWM:Class xmi.idref='a3'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a718' name='hidden' body='Y' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWM:Class xmi.idref='a5'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a719' name='mask' body='#' type='String'>
+      <CWM:Description.modelElement>
+        <CWM:Class xmi.idref='a7'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a720' name='mask' body='#,###.##' type='String'>
+      <CWM:Description.modelElement>
+        <CWM:Class xmi.idref='a9'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a721' name='font' body='Arial-10' type='Font'>
+      <CWM:Description.modelElement>
+        <CWM:Class xmi.idref='a11'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a722' name='name' body='Trial Balance' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a451'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a723' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a451'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a724' name='target_table' body='TRIAL_BALANCE'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a451'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a725' name='name' body='Amount' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a453'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a726' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a453'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a727' name='formula' body='Amount' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a453'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a728' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a453'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a729' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a453'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a730' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a453'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a731' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a453'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a732' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a453'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a733' name='name' body='Detail' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a455'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a734' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a455'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a735' name='formula' body='Detail' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a455'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a736' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a455'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a737' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a455'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a738' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a455'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a739' name='fieldtype' body='Attribute' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a455'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a740' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a455'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a741' name='name' body='Category2' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a457'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a742' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a457'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a743' name='formula' body='Category2' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a457'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a744' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a457'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a745' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a457'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a746' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a457'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a747' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a457'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a748' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a457'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a749' name='name' body='Category' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a459'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a750' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a459'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a751' name='formula' body='Category' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a459'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a752' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a459'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a753' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a459'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a754' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a459'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a755' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a459'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a756' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a459'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a757' name='name' body='Account Num' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a461'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a758' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a461'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a759' name='formula' body='Account_Num' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a461'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a760' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a461'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a761' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a461'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a762' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a461'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a763' name='fieldtype' body='Attribute' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a461'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a764' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a461'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a765' name='name' body='Type' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a463'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a766' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a463'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a767' name='formula' body='Type' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a463'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a768' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a463'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a769' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a463'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a770' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a463'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a771' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a463'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a772' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a463'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a773' name='name' body='Time' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a465'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a774' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a465'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a775' name='target_table' body='DIM_TIME'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a465'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a776' name='name' body='Qtr Desc' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a467'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a777' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a467'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a778' name='formula' body='QTR_DESC' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a467'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a779' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a467'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a780' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a467'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a781' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a467'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a782' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a467'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a783' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a467'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a784' name='name' body='Qtr Name' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a469'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a785' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a469'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a786' name='formula' body='QTR_NAME' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a469'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a787' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a469'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a788' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a469'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a789' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a469'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a790' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a469'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a791' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a469'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a792' name='name' body='Month Desc' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a471'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a793' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a471'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a794' name='formula' body='MONTH_DESC' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a471'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a795' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a471'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a796' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a471'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a797' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a471'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a798' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a471'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a799' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a471'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a800' name='name' body='Month Name' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a473'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a801' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a473'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a802' name='formula' body='MONTH_NAME' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a473'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a803' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a473'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a804' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a473'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a805' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a473'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a806' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a473'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a807' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a473'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a808' name='name' body='Year Id' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a475'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a809' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a475'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a810' name='formula' body='YEAR_ID' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a475'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a811' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a475'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a812' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a475'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a813' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a475'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a814' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a475'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a815' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a475'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a816' name='name' body='Qtr Id' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a477'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a817' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a477'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a818' name='formula' body='QTR_ID' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a477'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a819' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a477'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a820' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a477'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a821' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a477'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a822' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a477'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a823' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a477'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a824' name='name' body='Month Id' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a479'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a825' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a479'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a826' name='formula' body='MONTH_ID' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a479'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a827' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a479'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a828' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a479'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a829' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a479'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a830' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a479'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a831' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a479'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a832' name='name' body='Time Id' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a481'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a833' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a481'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a834' name='formula' body='TIME_ID' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a481'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a835' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a481'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a836' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a481'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a837' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a481'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a838' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a481'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a839' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a481'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a840' name='name' body='Quadrant Actuals'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a483'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a841' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a483'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a842' name='target_table' body='QUADRANT_ACTUALS'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a483'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a843' name='name' body='Variance' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a485'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a844' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a485'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a845' name='formula' body='VARIANCE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a485'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a846' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a485'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a847' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a485'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a848' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a485'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a849' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a485'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a850' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a485'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a851' name='name' body='Budget' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a487'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a852' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a487'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a853' name='formula' body='BUDGET' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a487'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a854' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a487'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a855' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a487'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a856' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a487'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a857' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a487'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a858' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a487'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a859' name='name' body='Actual' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a489'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a860' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a489'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a861' name='formula' body='ACTUAL' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a489'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a862' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a489'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a863' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a489'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a864' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a489'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a865' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a489'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a866' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a489'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a867' name='name' body='Positiontitle' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a491'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a868' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a491'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a869' name='formula' body='POSITIONTITLE'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a491'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a870' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a491'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a871' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a491'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a872' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a491'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a873' name='fieldtype' body='Attribute' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a491'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a874' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a491'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a875' name='name' body='Department' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a493'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a876' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a493'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a877' name='formula' body='DEPARTMENT' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a493'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a878' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a493'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a879' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a493'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a880' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a493'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a881' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a493'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a882' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a493'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a883' name='name' body='Region' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a495'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a884' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a495'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a885' name='formula' body='REGION' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a495'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a886' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a495'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a887' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a495'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a888' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a495'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a889' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a495'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a890' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a495'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a891' name='name' body='Products' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a497'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a892' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a497'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a893' name='target_table' body='PRODUCTS'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a497'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a894' name='name' body='MSRP' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a499'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a895' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a499'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a896' name='formula' body='MSRP' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a499'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a897' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a499'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a898' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a499'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a899' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a499'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a900' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a499'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a901' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a499'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a902' name='name' body='Buy Price' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a501'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a903' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a501'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a904' name='formula' body='BUYPRICE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a501'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a905' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a501'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a906' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a501'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a907' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a501'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a908' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a501'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a909' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a501'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a910' name='name' body='Quantity In Stock'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a503'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a911' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a503'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a912' name='formula' body='QUANTITYINSTOCK'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a503'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a913' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a503'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a914' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a503'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a915' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a503'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a916' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a503'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a917' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a503'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a918' name='name' body='Product Description'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a505'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a919' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a505'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a920' name='formula' body='PRODUCTDESCRIPTION'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a505'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a921' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a505'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a922' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a505'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a923' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a505'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a924' name='fieldtype' body='Attribute' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a505'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a925' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a505'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a926' name='name' body='Product Vendor' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a507'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a927' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a507'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a928' name='formula' body='PRODUCTVENDOR'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a507'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a929' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a507'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a930' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a507'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a931' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a507'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a932' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a507'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a933' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a507'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a934' name='name' body='Product Scale' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a509'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a935' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a509'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a936' name='formula' body='PRODUCTSCALE'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a509'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a937' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a509'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a938' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a509'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a939' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a509'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a940' name='fieldtype' body='Attribute' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a509'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a941' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a509'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a942' name='name' body='Product Line' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a511'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a943' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a511'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a944' name='formula' body='PRODUCTLINE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a511'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a945' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a511'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a946' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a511'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a947' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a511'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a948' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a511'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a949' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a511'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a950' name='name' body='Product Name' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a513'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a951' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a513'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a952' name='formula' body='PRODUCTNAME' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a513'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a953' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a513'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a954' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a513'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a955' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a513'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a956' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a513'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a957' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a513'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a958' name='name' body='Product Code' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a515'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a959' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a515'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a960' name='formula' body='PRODUCTCODE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a515'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a961' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a515'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a962' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a515'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a963' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a515'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a964' name='fieldtype' body='Attribute' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a515'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a965' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a515'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a966' name='name' body='Payments' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a517'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a967' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a517'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a968' name='target_table' body='PAYMENTS'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a517'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a969' name='name' body='Amount' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a519'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a970' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a519'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a971' name='formula' body='AMOUNT' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a519'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a972' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a519'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a973' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a519'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a974' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a519'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a975' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a519'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a976' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a519'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a977' name='name' body='Payment Date' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a521'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a978' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a521'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a979' name='formula' body='PAYMENTDATE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a521'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a980' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a521'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a981' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a521'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a982' name='datatype' body='Date,-1,-1' type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a521'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a983' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a521'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a984' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a521'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a985' name='name' body='Check Number' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a523'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a986' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a523'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a987' name='formula' body='CHECKNUMBER' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a523'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a988' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a523'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a989' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a523'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a990' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a523'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a991' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a523'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a992' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a523'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a993' name='name' body='Customernumber' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a525'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a994' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a525'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a995' name='formula' body='CUSTOMERNUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a525'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a996' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a525'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a997' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a525'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a998' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a525'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a999' name='fieldtype' body='Dimension' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a525'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1000' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a525'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1001' name='name' body='Orders' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a527'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1002' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a527'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1003' name='target_table' body='ORDERS'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a527'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1004' name='name' body='Customernumber'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a529'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1005' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a529'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1006' name='formula' body='CUSTOMERNUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a529'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1007' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a529'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1008' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a529'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1009' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a529'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1010' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a529'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1011' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a529'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1012' name='name' body='Comments' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a531'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1013' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a531'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1014' name='formula' body='COMMENTS' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a531'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1015' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a531'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1016' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a531'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1017' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a531'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1018' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a531'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1019' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a531'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1020' name='name' body='Status' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a533'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1021' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a533'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1022' name='formula' body='STATUS' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a533'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1023' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a533'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1024' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a533'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1025' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a533'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1026' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a533'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1027' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a533'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1028' name='name' body='Shipped Date' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a535'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1029' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a535'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1030' name='formula' body='SHIPPEDDATE'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a535'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1031' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a535'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1032' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a535'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1033' name='datatype' body='Date,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a535'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1034' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a535'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1035' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a535'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1036' name='name' body='Required Date' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a537'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1037' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a537'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1038' name='formula' body='REQUIREDDATE'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a537'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1039' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a537'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1040' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a537'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1041' name='datatype' body='Date,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a537'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1042' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a537'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1043' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a537'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1044' name='name' body='Order Date' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a539'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1045' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a539'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1046' name='formula' body='ORDERDATE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a539'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1047' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a539'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1048' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a539'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1049' name='datatype' body='Date,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a539'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1050' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a539'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1051' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a539'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1052' name='name' body='Order Number' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a541'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1053' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a541'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1054' name='formula' body='ORDERNUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a541'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1055' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a541'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1056' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a541'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1057' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a541'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1058' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a541'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1059' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;  &lt;aggregation&gt;count&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;count_distinct&lt;/aggregation&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a541'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1060' name='name' body='Order Month' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a543'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1061' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a543'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1062' name='formula' body='MONTH([ORDERDATE])&amp;&quot;-&quot;&amp;YEAR([ORDERDATE])'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a543'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1063' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a543'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1064' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a543'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1065' name='datatype' body='Date,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a543'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1066' name='fieldtype' body='Other' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a543'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1067' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a543'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1068' name='name' body='Orderfact' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a545'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1069' name='tabletype' body='Fact' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a545'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1070' name='target_table' body='ORDERFACT'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a545'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1071' name='name' body='Year Id' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a547'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1072' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a547'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1073' name='formula' body='YEAR_ID' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a547'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1074' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a547'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1075' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a547'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1076' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a547'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1077' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a547'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1078' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a547'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1079' name='name' body='Month Id' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a549'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1080' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a549'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1081' name='formula' body='MONTH_ID' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a549'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1082' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a549'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1083' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a549'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1084' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a549'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1085' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a549'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1086' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a549'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1087' name='name' body='Qtr Id' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a551'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1088' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a551'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1089' name='formula' body='QTR_ID' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a551'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1090' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a551'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1091' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a551'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1092' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a551'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1093' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a551'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1094' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a551'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1095' name='name' body='Time Id' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a553'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1096' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a553'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1097' name='formula' body='TIME_ID' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a553'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1098' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a553'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1099' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a553'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1100' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a553'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1101' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a553'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1102' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a553'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1103' name='name' body='Customernumber'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a555'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1104' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a555'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1105' name='formula' body='CUSTOMERNUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a555'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1106' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a555'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1107' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a555'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1108' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a555'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1109' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a555'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1110' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a555'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1111' name='name' body='Comments' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a557'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1112' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a557'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1113' name='formula' body='COMMENTS' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a557'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1114' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a557'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1115' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a557'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1116' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a557'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1117' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a557'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1118' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a557'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1119' name='name' body='Status' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a559'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1120' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a559'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1121' name='formula' body='STATUS' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a559'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1122' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a559'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1123' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a559'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1124' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a559'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1125' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a559'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1126' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a559'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1127' name='name' body='Shippeddate' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a561'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1128' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a561'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1129' name='formula' body='SHIPPEDDATE'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a561'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1130' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a561'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1131' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a561'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1132' name='datatype' body='Date,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a561'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1133' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a561'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1134' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a561'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1135' name='name' body='Requireddate' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a563'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1136' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a563'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1137' name='formula' body='REQUIREDDATE'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a563'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1138' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a563'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1139' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a563'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1140' name='datatype' body='Date,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a563'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1141' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a563'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1142' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a563'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1143' name='name' body='Orderdate' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a565'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1144' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a565'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1145' name='formula' body='ORDERDATE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a565'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1146' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a565'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1147' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a565'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1148' name='datatype' body='Date,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a565'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1149' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a565'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1150' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a565'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1151' name='name' body='Totalprice' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a567'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1152' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a567'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1153' name='formula' body='TOTALPRICE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a567'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1154' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a567'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1155' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a567'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1156' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a567'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1157' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a567'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1158' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a567'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1159' name='name' body='Orderlinenumber'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a569'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1160' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a569'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1161' name='formula' body='ORDERLINENUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a569'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1162' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a569'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1163' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a569'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1164' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a569'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1165' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a569'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1166' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a569'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1167' name='name' body='Priceeach' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a571'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1168' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a571'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1169' name='formula' body='PRICEEACH' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a571'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1170' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a571'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1171' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a571'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1172' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a571'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1173' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a571'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1174' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a571'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1175' name='name' body='Quantityordered'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a573'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1176' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a573'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1177' name='formula' body='QUANTITYORDERED'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a573'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1178' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a573'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1179' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a573'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1180' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a573'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1181' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a573'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1182' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a573'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1183' name='name' body='Productcode' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a575'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1184' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a575'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1185' name='formula' body='PRODUCTCODE'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a575'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1186' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a575'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1187' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a575'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1188' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a575'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1189' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a575'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1190' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a575'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1191' name='name' body='Ordernumber' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a577'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1192' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a577'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1193' name='formula' body='ORDERNUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a577'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1194' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a577'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1195' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a577'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1196' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a577'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1197' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a577'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1198' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a577'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1199' name='name' body='Orderdetails' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a579'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1200' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a579'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1201' name='target_table' body='ORDERDETAILS'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a579'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1202' name='name' body='Total' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a581'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1203' name='aggregation' body='sum' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a581'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1204' name='formula' body='[QUANTITYORDERED]*[PRICEEACH]'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a581'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1205' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a581'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1206' name='exact' body='Y' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a581'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1207' name='datatype' body='Unknown,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a581'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1208' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a581'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1209' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;  &lt;aggregation&gt;sum&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;average&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;minimum&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;maximum&lt;/aggregation&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a581'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1210' name='name' body='Orderlinenumber'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a582'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1211' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a582'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1212' name='formula' body='ORDERLINENUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a582'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1213' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a582'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1214' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a582'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1215' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a582'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1216' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a582'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1217' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a582'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1218' name='name' body='Price Each' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a584'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1219' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a584'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1220' name='formula' body='PRICEEACH' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a584'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1221' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a584'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1222' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a584'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1223' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a584'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1224' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a584'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1225' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a584'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1226' name='name' body='Quantity Ordered'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a586'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1227' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a586'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1228' name='formula' body='QUANTITYORDERED'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a586'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1229' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a586'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1230' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a586'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1231' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a586'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1232' name='fieldtype' body='Fact' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a586'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1233' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a586'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1234' name='name' body='Productcode' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a588'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1235' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a588'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1236' name='formula' body='PRODUCTCODE'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a588'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1237' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a588'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1238' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a588'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1239' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a588'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1240' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a588'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1241' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a588'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1242' name='name' body='Ordernumber' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a590'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1243' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a590'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1244' name='formula' body='ORDERNUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a590'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1245' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a590'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1246' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a590'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1247' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a590'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1248' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a590'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1249' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;  &lt;aggregation&gt;count&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;count_distinct&lt;/aggregation&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a590'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1250' name='name' body='Offices' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a592'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1251' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a592'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1252' name='target_table' body='OFFICES'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a592'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1253' name='name' body='Territory' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a594'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1254' name='name' body='Territorio' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a594'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1255' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a594'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1256' name='formula' body='TERRITORY' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a594'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1257' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a594'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1258' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a594'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1259' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a594'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1260' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a594'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1261' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a594'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1262' name='name' body='Postal code' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a596'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1263' name='name' body='Código postal' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a596'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1264' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a596'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1265' name='formula' body='POSTALCODE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a596'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1266' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a596'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1267' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a596'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1268' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a596'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1269' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a596'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1270' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a596'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1271' name='name' body='Country' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a598'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1272' name='name' body='País' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a598'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1273' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a598'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1274' name='formula' body='COUNTRY' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a598'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1275' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a598'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1276' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a598'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1277' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a598'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1278' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a598'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1279' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a598'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1280' name='name' body='State' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a600'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1281' name='name' body='Estado' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a600'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1282' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a600'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1283' name='formula' body='STATE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a600'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1284' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a600'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1285' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a600'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1286' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a600'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1287' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a600'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1288' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a600'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1289' name='name' body='Address Line 2'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a602'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1290' name='name' body='Dirección 2' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a602'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1291' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a602'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1292' name='formula' body='ADDRESSLINE2'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a602'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1293' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a602'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1294' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a602'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1295' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a602'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1296' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a602'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1297' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a602'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1298' name='name' body='Address Line 1'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a604'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1299' name='name' body='Dirección 1' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a604'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1300' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a604'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1301' name='formula' body='ADDRESSLINE1'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a604'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1302' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a604'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1303' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a604'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1304' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a604'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1305' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a604'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1306' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a604'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1307' name='name' body='Phone Number' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a606'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1308' name='name' body='Número De Teléfono'
+                     language='es' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a606'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1309' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a606'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1310' name='formula' body='PHONE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a606'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1311' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a606'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1312' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a606'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1313' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a606'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1314' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a606'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1315' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a606'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1316' name='name' body='City' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a608'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1317' name='name' body='Ciudad' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a608'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1318' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a608'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1319' name='formula' body='CITY' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a608'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1320' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a608'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1321' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a608'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1322' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a608'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1323' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a608'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1324' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a608'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1325' name='name' body='Office Code' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a610'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1326' name='name' body='Código De la Oficina'
+                     language='es' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a610'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1327' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a610'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1328' name='formula' body='OFFICECODE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a610'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1329' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a610'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1330' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a610'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1331' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a610'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1332' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a610'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1333' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a610'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1334' name='name' body='Employees' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a612'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1335' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a612'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1336' name='target_table' body='EMPLOYEES'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a612'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1337' name='name' body='Job Title' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a614'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1338' name='name' body='Título Del Trabajo'
+                     language='es' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a614'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1339' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a614'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1340' name='formula' body='JOBTITLE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a614'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1341' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a614'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1342' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a614'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1343' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a614'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1344' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a614'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1345' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a614'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1346' name='name' body='Manager' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a616'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1347' name='name' body='Encargado' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a616'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1348' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a616'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1349' name='formula' body='REPORTSTO' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a616'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1350' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a616'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1351' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a616'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1352' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a616'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1353' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a616'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1354' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a616'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1355' name='name' body='Officecode' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a618'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1356' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a618'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1357' name='formula' body='OFFICECODE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a618'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1358' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a618'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1359' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a618'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1360' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a618'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1361' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a618'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1362' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a618'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1363' name='name' body='Email' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a620'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1364' name='name' body='Email' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a620'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1365' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a620'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1366' name='formula' body='EMAIL' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a620'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1367' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a620'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1368' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a620'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1369' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a620'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1370' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a620'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1371' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a620'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1372' name='name' body='Extension' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a622'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1373' name='name' body='Extensión' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a622'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1374' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a622'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1375' name='formula' body='EXTENSION' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a622'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1376' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a622'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1377' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a622'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1378' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a622'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1379' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a622'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1380' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a622'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1381' name='name' body='First Name' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a624'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1382' name='name' body='Nombre' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a624'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1383' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a624'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1384' name='formula' body='FIRSTNAME' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a624'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1385' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a624'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1386' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a624'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1387' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a624'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1388' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a624'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1389' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a624'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1390' name='name' body='Last Name' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a626'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1391' name='name' body='Nombre Pasado' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a626'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1392' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a626'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1393' name='formula' body='LASTNAME' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a626'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1394' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a626'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1395' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a626'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1396' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a626'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1397' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a626'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1398' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a626'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1399' name='name' body='Employee ID' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a628'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1400' name='name' body='Identificación Del Empleado'
+                     language='es' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a628'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1401' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a628'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1402' name='formula' body='EMPLOYEENUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a628'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1403' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a628'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1404' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a628'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1405' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a628'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1406' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a628'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1407' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a628'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1408' name='name' body='Department Managers'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a630'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1409' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a630'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1410' name='target_table' body='DEPARTMENT_MANAGERS'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a630'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1411' name='name' body='Email' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a632'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1412' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a632'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1413' name='formula' body='EMAIL' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a632'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1414' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a632'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1415' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a632'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1416' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a632'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1417' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a632'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1418' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a632'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1419' name='name' body='Manager Name' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a634'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1420' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a634'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1421' name='formula' body='MANAGER_NAME'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a634'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1422' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a634'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1423' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a634'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1424' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a634'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1425' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a634'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1426' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a634'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1427' name='name' body='Region' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a636'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1428' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a636'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1429' name='formula' body='REGION' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a636'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1430' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a636'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1431' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a636'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1432' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a636'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1433' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a636'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1434' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a636'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1435' name='name' body='Customer W Ter'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a638'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1436' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a638'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1437' name='target_table' body='CUSTOMER_W_TER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a638'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1438' name='name' body='Territory' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a640'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1439' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a640'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1440' name='formula' body='TERRITORY' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a640'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1441' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a640'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1442' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a640'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1443' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a640'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1444' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a640'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1445' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a640'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1446' name='name' body='Credit Limit' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a642'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1447' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a642'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1448' name='formula' body='CREDITLIMIT'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a642'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1449' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a642'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1450' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a642'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1451' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a642'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1452' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a642'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1453' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a642'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1454' name='name' body='Employee Number'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a644'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1455' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a644'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1456' name='formula' body='EMPLOYEENUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a644'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1457' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a644'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1458' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a644'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1459' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a644'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1460' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a644'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1461' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a644'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1462' name='name' body='Country' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a646'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1463' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a646'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1464' name='formula' body='COUNTRY' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a646'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1465' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a646'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1466' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a646'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1467' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a646'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1468' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a646'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1469' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a646'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1470' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a646'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1471' name='name' body='Postalcode' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a648'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1472' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a648'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1473' name='formula' body='POSTALCODE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a648'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1474' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a648'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1475' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a648'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1476' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a648'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1477' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a648'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1478' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a648'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1479' name='name' body='State' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a650'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1480' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a650'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1481' name='formula' body='STATE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a650'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1482' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a650'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1483' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a650'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1484' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a650'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1485' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a650'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1486' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a650'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1487' name='name' body='City' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a652'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1488' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a652'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1489' name='formula' body='CITY' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a652'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1490' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a652'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1491' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a652'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1492' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a652'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1493' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a652'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1494' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a652'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1495' name='name' body='Addressline2' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a654'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1496' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a654'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1497' name='formula' body='ADDRESSLINE2'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a654'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1498' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a654'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1499' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a654'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1500' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a654'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1501' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a654'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1502' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a654'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1503' name='name' body='Addressline1' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a656'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1504' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a656'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1505' name='formula' body='ADDRESSLINE1'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a656'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1506' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a656'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1507' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a656'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1508' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a656'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1509' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a656'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1510' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a656'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1511' name='name' body='Phone' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a658'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1512' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a658'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1513' name='formula' body='PHONE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a658'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1514' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a658'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1515' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a658'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1516' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a658'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1517' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a658'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1518' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a658'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1519' name='name' body='Contact First Name'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a660'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1520' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a660'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1521' name='formula' body='CONTACTFIRSTNAME'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a660'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1522' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a660'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1523' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a660'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1524' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a660'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1525' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a660'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1526' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a660'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1527' name='name' body='Contact Last Name'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a662'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1528' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a662'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1529' name='formula' body='CONTACTLASTNAME'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a662'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1530' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a662'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1531' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a662'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1532' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a662'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1533' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a662'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1534' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a662'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1535' name='name' body='Customer Name' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a664'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1536' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a664'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1537' name='formula' body='CUSTOMERNAME'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a664'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1538' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a664'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1539' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a664'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1540' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a664'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1541' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a664'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1542' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a664'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1543' name='name' body='Customer Number'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a666'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1544' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a666'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1545' name='formula' body='CUSTOMERNUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a666'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1546' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a666'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1547' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a666'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1548' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a666'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1549' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a666'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1550' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a666'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1551' name='name' body='Contact Name' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a668'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1552' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a668'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1553' name='formula' body='[CONTACTLASTNAME]+&quot;, &quot;+[CONTACTFIRSTNAME]'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a668'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1554' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a668'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1555' name='exact' body='Y' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a668'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1556' name='datatype' body='Unknown,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a668'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1557' name='fieldtype' body='Other' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a668'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1558' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a668'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1559' name='name' body='Customers' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a670'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1560' name='tabletype' body='Other' type='TableType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a670'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1561' name='target_table' body='CUSTOMERS'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Table xmi.idref='a670'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1562' name='name' body='Creditlimit' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a672'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1563' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a672'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1564' name='formula' body='CREDITLIMIT'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a672'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1565' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a672'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1566' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a672'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1567' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a672'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1568' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a672'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1569' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a672'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1570' name='name' body='Salesrepemployeenumber'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a674'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1571' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a674'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1572' name='formula' body='SALESREPEMPLOYEENUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a674'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1573' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a674'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1574' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a674'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1575' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a674'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1576' name='fieldtype' body='Key' type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a674'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1577' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a674'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1578' name='name' body='Country' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a676'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1579' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a676'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1580' name='formula' body='COUNTRY' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a676'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1581' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a676'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1582' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a676'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1583' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a676'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1584' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a676'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1585' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a676'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1586' name='name' body='Zip' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a678'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1587' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a678'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1588' name='formula' body='POSTALCODE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a678'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1589' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a678'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1590' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a678'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1591' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a678'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1592' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a678'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1593' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a678'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1594' name='name' body='State' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a680'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1595' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a680'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1596' name='formula' body='STATE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a680'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1597' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a680'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1598' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a680'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1599' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a680'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1600' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a680'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1601' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a680'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1602' name='name' body='City' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a682'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1603' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a682'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1604' name='formula' body='CITY' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a682'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1605' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a682'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1606' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a682'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1607' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a682'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1608' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a682'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1609' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a682'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1610' name='name' body='Address Line 2'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a684'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1611' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a684'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1612' name='formula' body='ADDRESSLINE2'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a684'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1613' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a684'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1614' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a684'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1615' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a684'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1616' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a684'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1617' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a684'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1618' name='name' body='Address Line 1'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a686'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1619' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a686'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1620' name='formula' body='ADDRESSLINE1'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a686'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1621' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a686'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1622' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a686'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1623' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a686'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1624' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a686'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1625' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a686'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1626' name='name' body='Phone' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a688'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1627' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a688'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1628' name='formula' body='PHONE' type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a688'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1629' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a688'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1630' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a688'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1631' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a688'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1632' name='fieldtype' body='Attribute'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a688'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1633' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a688'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1634' name='name' body='Contactfirstname'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a690'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1635' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a690'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1636' name='formula' body='CONTACTFIRSTNAME'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a690'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1637' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a690'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1638' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a690'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1639' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a690'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1640' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a690'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1641' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a690'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1642' name='name' body='Contactlastname'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a692'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1643' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a692'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1644' name='formula' body='CONTACTLASTNAME'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a692'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1645' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a692'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1646' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a692'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1647' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a692'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1648' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a692'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1649' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a692'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1650' name='name' body='Customer Name' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a694'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1651' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a694'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1652' name='formula' body='CUSTOMERNAME'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a694'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1653' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a694'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1654' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a694'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1655' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a694'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1656' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a694'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1657' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a694'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1658' name='name' body='Customer Number'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a696'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1659' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a696'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1660' name='formula' body='CUSTOMERNUMBER'
+                     type='String'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a696'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1661' name='hidden' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a696'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1662' name='exact' body='N' type='Boolean'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a696'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1663' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a696'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1664' name='fieldtype' body='Dimension'
+                     type='FieldType'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a696'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1665' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMRDB:Column xmi.idref='a696'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1666' name='name' body='Human Resources'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a15'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1667' name='name' body='Recursos Humanos'
+                     language='es' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a15'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1668' name='description' body='This model contains information about Employees.'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a15'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1669' name='description' body='Este modelo contiene la información sobre empleados.'
+                     language='es' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a15'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1670' name='security'
+                     body='&lt;security&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Admin&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;&lt;/security&gt;&#13;&#10;'
+                     type='Security'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a15'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1671' name='row_level_security'
+                     body='&lt;row-level-security type=&quot;none&quot;&gt;&lt;formula&gt;&lt;![CDATA[]]&gt;&lt;/formula&gt;&lt;entries&gt;&lt;/entries&gt;&lt;/row-level-security&gt;'
+                     type='RowLevelSecurity'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a15'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1672' name='name' body='Employees' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Dimension xmi.idref='a64'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1673' name='name' body='Offices' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Dimension xmi.idref='a89'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1674' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a105'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1675' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a108'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1676' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a111'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1677' name='name' body='Offices' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a24'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1678' name='name' body='Oficinas' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a24'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1679' name='security'
+                     body='&lt;security&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;user&lt;/type&gt;&lt;name&gt;suzy&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Admin&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;&lt;/security&gt;&#13;&#10;'
+                     type='Security'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a24'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1680' name='name' body='Employees' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a44'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1681' name='name' body='Empleados' language='es'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a44'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1682' name='security'
+                     body='&lt;security&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;user&lt;/type&gt;&lt;name&gt;suzy&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Admin&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;&lt;/security&gt;&#13;&#10;'
+                     type='Security'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a44'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1683' name='name' body='Inventory' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a122'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1684' name='description'
+                     body='This model contains information about products and product inventory.'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a122'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1685' name='security'
+                     body='&lt;security&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;user&lt;/type&gt;&lt;name&gt;suzy&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Admin&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;&lt;/security&gt;&#13;&#10;'
+                     type='Security'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a122'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1686' name='row_level_security'
+                     body='&lt;row-level-security type=&quot;none&quot;&gt;&lt;formula&gt;&lt;![CDATA[]]&gt;&lt;/formula&gt;&lt;entries&gt;&lt;/entries&gt;&lt;/row-level-security&gt;'
+                     type='RowLevelSecurity'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a122'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1687' name='name' body='Products' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Dimension xmi.idref='a148'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1688' name='name' body='Products' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a123'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1689' name='description' body='This category contains information about current products.'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a123'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1690' name='security'
+                     body='&lt;security&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;user&lt;/type&gt;&lt;name&gt;suzy&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Admin&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;&lt;/security&gt;&#13;&#10;'
+                     type='Security'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a123'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1691' name='name' body='Inventory and Cost'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a137'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1692' name='description'
+                     body='This category contains details on product costs, MSRP and quantity in stock.'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a137'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1693' name='security'
+                     body='&lt;security&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;user&lt;/type&gt;&lt;name&gt;suzy&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Admin&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;&lt;/security&gt;&#13;&#10;'
+                     type='Security'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a137'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1694' name='name' body='Orders' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a180'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1695' name='description'
+                     body='This model contains information about customers and their orders.'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a180'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1696' name='security'
+                     body='&lt;security&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;user&lt;/type&gt;&lt;name&gt;suzy&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;dev&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;-1&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;  &lt;owner-rights&gt;&#13;&#10;  &lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Admin&lt;/name&gt;&lt;/owner&gt; &lt;rights&gt;31&lt;/rights&gt;&#13;&#10;  &lt;/owner-rights&gt;&#13;&#10;&lt;/security&gt;&#13;&#10;'
+                     type='Security'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a180'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1697' name='row_level_security'
+                     body='&lt;row-level-security type=&quot;role-based&quot;&gt;&lt;formula&gt;&lt;![CDATA[]]&gt;&lt;/formula&gt;&lt;entries&gt;&lt;entry&gt;&lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;ceo&lt;/name&gt;&lt;/owner&gt;&lt;formula&gt;&lt;![CDATA[TRUE()]]&gt;&lt;/formula&gt;&lt;/entry&gt;&lt;entry&gt;&lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Anonymous&lt;/name&gt;&lt;/owner&gt;&lt;formula&gt;&lt;![CDATA[TRUE()]]&gt;&lt;/formula&gt;&lt;/entry&gt;&lt;entry&gt;&lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;cto&lt;/name&gt;&lt;/owner&gt;&lt;formula&gt;&lt;![CDATA[TRUE()]]&gt;&lt;/formula&gt;&lt;/entry&gt;&lt;entry&gt;&lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;devmgr&lt;/name&gt;&lt;/owner&gt;&lt;formula&gt;&lt;![CDATA[TRUE()]]&gt;&lt;/formula&gt;&lt;/entry&gt;&lt;entry&gt;&lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;is&lt;/name&gt;&lt;/owner&gt;&lt;formula&gt;&lt;![CDATA[TRUE()]]&gt;&lt;/formula&gt;&lt;/entry&gt;&lt;entry&gt;&lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;dev&lt;/name&gt;&lt;/owner&gt;&lt;formula&gt;&lt;![CDATA[[BT_CUSTOMER_W_TER_CUSTOMER_W_TER.BC_CUSTOMER_W_TER_TERRITORY]=&quot;NA&quot;]]&gt;&lt;/formula&gt;&lt;/entry&gt;&lt;entry&gt;&lt;owner&gt;&lt;type&gt;role&lt;/type&gt;&lt;name&gt;Admin&lt;/name&gt;&lt;/owner&gt;&lt;formula&gt;&lt;![CDATA[TRUE()]]&gt;&lt;/formula&gt;&lt;/entry&gt;&lt;/entries&gt;&lt;/row-level-security&gt;'
+                     type='RowLevelSecurity'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Schema xmi.idref='a180'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1698' name='name' body='Payments' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Dimension xmi.idref='a292'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1699' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a293'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1700' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a297'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1701' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a301'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1702' name='name' body='Products' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Dimension xmi.idref='a308'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1703' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a305'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1704' name='column_width' body='1,12' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a312'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1705' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a315'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1706' name='column_width' body='1,18' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a318'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1707' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a324'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1708' name='aggregation' body='sum' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a327'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1709' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a327'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1710' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;  &lt;aggregation&gt;sum&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;average&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;minimum&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;maximum&lt;/aggregation&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a327'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1711' name='aggregation' body='average'
+                     type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a331'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1712' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a331'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1713' name='name' body='Orderdetails' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Dimension xmi.idref='a338'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1714' name='datatype' body='String,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a335'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1715' name='alignment' body='left' type='Alignment'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a335'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1716' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a335'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1717' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a339'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1718' name='aggregation' body='sum' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a342'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1719' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a342'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1720' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;  &lt;aggregation&gt;sum&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;average&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;minimum&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;maximum&lt;/aggregation&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a342'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1721' name='name' body='Price Sold' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a346'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1722' name='aggregation' body='sum' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a346'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1723' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a346'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1724' name='aggregation_list'
+                     body='&lt;aggregationlist&gt;&#13;&#10;  &lt;aggregation&gt;sum&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;average&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;minimum&lt;/aggregation&gt;&#13;&#10;  &lt;aggregation&gt;maximum&lt;/aggregation&gt;&#13;&#10;&lt;/aggregationlist&gt;&#13;&#10;'
+                     type='AggregationList'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a346'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1725' name='comments' body='This field is computed as Quantity Ordered times Price Sold'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a353'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1726' name='aggregation' body='sum' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a353'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1727' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a353'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1728' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a353'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1729' name='name' body='Orders' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Dimension xmi.idref='a361'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1730' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a357'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1731' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a362'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1732' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a362'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1733' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a366'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1734' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a370'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1735' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a377'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1736' name='foreground_color' body='0,0,160'
+                     type='Color'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a377'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1737' name='font' body='Arial-10-italic'
+                     type='Font'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a377'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1738' name='column_width' body='1,35' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a377'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1739' name='datatype' body='Numeric,-1,-1'
+                     type='DataType'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a380'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1740' name='column_width' body='1,12' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a380'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1741' name='name' body='Customer W Ter'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWMMDB:Dimension xmi.idref='a387'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1742' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a383'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1743' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a383'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1744' name='foreground_color' body='255,0,0'
+                     type='Color'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a388'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1745' name='column_width' body='1,8' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a388'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1746' name='column_width' body='1,12' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a391'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1747' name='column_width' body='1,12' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a395'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1748' name='column_width' body='1,12' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a401'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1749' name='column_width' body='1,12' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a404'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1750' name='column_width' body='1,10' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a413'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1751' name='column_width' body='1,12' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a416'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1752' name='column_width' body='1,12' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a419'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1753' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a422'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1754' name='column_width' body='1,22' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a422'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1755' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a425'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1756' name='column_width' body='1,12' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a425'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1757' name='aggregation' body='none' type='Aggregation'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a428'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1758' name='column_width' body='1,20' type='ColumnWidth'>
+      <CWM:Description.modelElement>
+        <CWMMDB:DimensionedObject xmi.idref='a428'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1759' name='name' body='Customer' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a213'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1760' name='name' body='Orders' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a241'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1761' name='description'
+                     body='This category contains information about orders including ordernumber, order date, required date, shipping status, etc.'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a241'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1762' name='name' body='Products' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a261'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1763' name='description' body='This category contains inforamtion about products.'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a261'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1764' name='name' body='Payments' language='en_US'
+                     type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a281'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Description xmi.id='a1765' name='description' body='This category contains details about customer payments.'
+                     language='en_US' type='LocString'>
+      <CWM:Description.modelElement>
+        <CWM:Extent xmi.idref='a281'/>
+      </CWM:Description.modelElement>
+    </CWM:Description>
+    <CWM:Event xmi.id='a1766' name='SECURITY_SERVICE'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a1767' tag='SECURITY_SERVICE_URL' value='http://localhost:8080/pentaho/ServiceAction'/>
+        <CWM:TaggedValue xmi.id='a1768' tag='SECURITY_DETAILS_NAME' value='SecurityDetails'/>
+        <CWM:TaggedValue xmi.id='a1769' tag='SECURITY_DETAIL_NAME' value='details'/>
+        <CWM:TaggedValue xmi.id='a1770' tag='SECURITY_DETAIL_TYPE' value='All'/>
+        <CWM:TaggedValue xmi.id='a1771' tag='SECURITY_USERNAME' value='admin'/>
+        <CWM:TaggedValue xmi.id='a1772' tag='SECURITY_PASSWORD' value='password'/>
+        <CWM:TaggedValue xmi.id='a1773' tag='SECURITY_PROXY_HOST' value=''/>
+        <CWM:TaggedValue xmi.id='a1774' tag='SECURITY_PROXY_PORT' value=''/>
+        <CWM:TaggedValue xmi.id='a1775' tag='SECURITY_NON_PROXY_HOSTS'/>
+        <CWM:TaggedValue xmi.id='a1776' tag='SECURITY_FILENAME' value=''/>
+        <CWM:TaggedValue xmi.id='a1777' tag='SECURITY_URL'
+                         value='http://localhost:8080/pentaho/ServiceAction?action=SecurityDetails&amp;details=all'/>
+      </CWM:ModelElement.taggedValue>
+    </CWM:Event>
+    <CWM:Parameter xmi.id='a1778' name='en_US'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a1779' tag='LOCALE_DESCRIPTION' value='English (American)'/>
+        <CWM:TaggedValue xmi.id='a1780' tag='LOCALE_ORDER' value='1'/>
+        <CWM:TaggedValue xmi.id='a1781' tag='LOCALE_IS_DEFAULT' value='Y'/>
+      </CWM:ModelElement.taggedValue>
+    </CWM:Parameter>
+    <CWM:Parameter xmi.id='a1782' name='es'>
+      <CWM:ModelElement.taggedValue>
+        <CWM:TaggedValue xmi.id='a1783' tag='LOCALE_DESCRIPTION' value='Spanish'/>
+        <CWM:TaggedValue xmi.id='a1784' tag='LOCALE_ORDER' value='2'/>
+        <CWM:TaggedValue xmi.id='a1785' tag='LOCALE_IS_DEFAULT' value='N'/>
+      </CWM:ModelElement.taggedValue>
+    </CWM:Parameter>
+  </XMI.content>
+</XMI>

--- a/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
+++ b/extensions/src/main/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepository.java
@@ -1035,13 +1035,12 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
     if ( StringUtils.isEmpty( locale ) ) {
       // This is a domain file
       metadataMap.put( PROPERTY_NAME_TYPE, TYPE_DOMAIN );
+      addDataSourceType( metadataMap, data );
     } else {
       // This is a locale property file
       metadataMap.put( PROPERTY_NAME_TYPE, TYPE_LOCALE );
       metadataMap.put( PROPERTY_NAME_LOCALE, locale );
     }
-
-    addDataSourceType( metadataMap, data );
 
     // Create the new file
     final RepositoryFile file = repository.createFile( getMetadataDir().getId(),
@@ -1055,7 +1054,9 @@ public class PentahoMetadataDomainRepository implements IMetadataDomainRepositor
   public RepositoryFile updateFile( RepositoryFile domainFile, SimpleRepositoryFileData data ) {
 
     final Map<String, Serializable> fileMetadata = repository.getFileMetadata( domainFile.getId() );
-    addDataSourceType( fileMetadata, data );
+    if ( isDomain( fileMetadata ) ) {
+      addDataSourceType( fileMetadata, data );
+    }
     repository.setFileMetadata( domainFile.getId(), fileMetadata );
     return repository.updateFile( domainFile, data, null );
   }

--- a/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/plugin/services/metadata/PentahoMetadataDomainRepositoryTest.java
@@ -66,6 +66,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.pentaho.platform.api.repository2.unified.RepositoryFilePermission.READ;
@@ -336,7 +337,6 @@ public class PentahoMetadataDomainRepositoryTest {
     String createdFileId = "TEST_CREATED_FILE_ID";
 
     XmiParser xmiParser = Mockito.mock( XmiParser.class );
-    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
 
     RepositoryFile rfCreated = Mockito.mock( RepositoryFile.class );
     when( rfCreated.getId() ).thenReturn( createdFileId );
@@ -354,13 +354,11 @@ public class PentahoMetadataDomainRepositoryTest {
     PentahoMetadataDomainRepository pmdr = new PentahoMetadataDomainRepository( repository, null, xmiParser, null );
 
     SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
-    when( srfd.getInputStream() ).thenReturn( new ByteArrayInputStream( new byte[0] ) );
 
     Map<String, Serializable> expectedMetadataMap = new HashMap<String, Serializable>() {{
       put( PROPERTY_NAME_DOMAIN_ID, domainId );
       put( PROPERTY_NAME_TYPE, TYPE_LOCALE );
       put( PROPERTY_NAME_LOCALE, locale );
-      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
     } };
 
     // EXECUTE
@@ -376,6 +374,7 @@ public class PentahoMetadataDomainRepositoryTest {
             isNull() );
 
     verify( repository, times( 0 ) ).updateFile( any(), any(), any() );
+    verify( xmiParser, never() ).parseXmi( any( InputStream.class ) );
 
     verify( repository, times( 1 ) ).setFileMetadata(
             argThat( id -> createdFileId.equals( id ) ),
@@ -498,10 +497,8 @@ public class PentahoMetadataDomainRepositoryTest {
     } };
 
     XmiParser xmiParser = Mockito.mock( XmiParser.class );
-    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
 
     SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
-    when( srfd.getInputStream() ).thenReturn( new ByteArrayInputStream( new byte[0] ) );
 
     IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
 
@@ -521,6 +518,7 @@ public class PentahoMetadataDomainRepositoryTest {
             argThat( map -> equalMaps( expectedMetadataMap, map ) ) );
 
     verify( repository, times( 0 ) ).createFile( any(), any(), any(), any() );
+    verify( xmiParser, never() ).parseXmi( any( InputStream.class ) );
 
     verify( repository, times( 1 ) ).updateFile(
             eq( domainFile ),
@@ -544,14 +542,12 @@ public class PentahoMetadataDomainRepositoryTest {
       put( PROPERTY_NAME_DOMAIN_ID, domainId );
       put( PROPERTY_NAME_TYPE, TYPE_LOCALE );
       put( PROPERTY_NAME_LOCALE, "jp" );
-      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.METADATA.toString() );
+      put( PROPERTY_NAME_DATASOURCE_TYPE, PentahoDataSourceType.DATA_SOURCE_WIZARD.toString() );
     } };
 
     XmiParser xmiParser = Mockito.mock( XmiParser.class );
-    when( xmiParser.parseXmi( any( InputStream.class ) ) ).thenReturn( createMetadataTestObject() );
 
     SimpleRepositoryFileData srfd = Mockito.mock( SimpleRepositoryFileData.class );
-    when( srfd.getInputStream() ).thenReturn( new ByteArrayInputStream( new byte[0] ) );
 
     IUnifiedRepository repository = Mockito.mock( IUnifiedRepository.class );
 
@@ -571,6 +567,7 @@ public class PentahoMetadataDomainRepositoryTest {
             argThat( map -> equalMaps( expectedMetadataMap, map ) ) );
 
     verify( repository, times( 0 ) ).createFile( any(), any(), any(), any() );
+    verify( xmiParser, never() ).parseXmi( any( InputStream.class ) );
 
     verify( repository, times( 1 ) ).updateFile(
             eq( domainFile ),


### PR DESCRIPTION
## Summary
- Backport the metadata and service integration-test fixes from #6334 to `11.0`.
- Parse and set datasource-type metadata only for domain XMI files, not locale property files.
- Complete repository and scheduler mocks required by the affected service integration tests.
- Add the Steel Wheels metadata fixture and coverage asserting locale files do not invoke `XmiParser`.

## Validation
- Cherry-picked cleanly onto `upstream/11.0` (`22ae570482`).
- `git diff --check` passes.
- Local Maven test execution is blocked before compilation because the required Pentaho Maven repository returns invalid HTML/failed metadata for `11.0.0.0-SNAPSHOT` dependencies.