### PR TITLE
fix: Opening job or transformation results on downloading it to tomcat/temp directory [BACKLOG-46769][SP-xx]

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
@@ -95,6 +95,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.channels.IllegalSelectorException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.GeneralSecurityException;
 import java.security.InvalidParameterException;
 import java.text.Collator;
@@ -254,13 +256,21 @@ public class FileService {
   }
 
   private StreamingOutput getBackupStream() throws IOException, ExportException {
-    File zipFile = getBackupExporter().performExport();
-    final FileInputStream inputStream = new FileInputStream( zipFile );
-
+    final File zipFile = getBackupExporter().performExport();
     return new StreamingOutput() {
       @Override
       public void write( OutputStream output ) throws IOException {
-        IOUtils.copy( inputStream, output );
+        try ( FileInputStream inputStream = new FileInputStream( zipFile ) ) {
+          IOUtils.copy( inputStream, output );
+        } finally {
+          try {
+            if ( zipFile != null && !Files.deleteIfExists( zipFile.toPath() ) ) {
+              logger.warn( Messages.getInstance().getString( "FileService.WARN_UNABLE_TO_DELETE_TEMP_FILE", zipFile.getAbsolutePath() ) );
+            }
+          } catch ( Exception e ) {
+            logger.warn( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_DELETE_TEMP_FILE", zipFile.getAbsolutePath() ), e );
+          }
+        }
       }
     };
   }
@@ -1869,12 +1879,21 @@ public class FileService {
   protected StreamingOutput getDownloadStream( RepositoryFile repositoryFile, BaseExportProcessor exportProcessor )
       throws ExportException, IOException {
     File zipFile = exportProcessor.performExport( repositoryFile );
-    final FileInputStream is = new FileInputStream( zipFile );
     // copy streaming output
     return new StreamingOutput() {
       @Override
       public void write( OutputStream output ) throws IOException {
-        IOUtils.copy( is, output );
+        try ( final FileInputStream is = new FileInputStream( zipFile ) ) {
+          IOUtils.copy(is, output);
+        } finally {
+          try {
+            if ( zipFile != null && !Files.deleteIfExists( zipFile.toPath() ) ) {
+              logger.warn( Messages.getInstance().getString( "FileService.WARN_UNABLE_TO_DELETE_TEMP_FILE", zipFile.getAbsolutePath() ) );
+            }
+          } catch ( Exception e ) {
+            logger.warn( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_DELETE_TEMP_FILE", zipFile.getAbsolutePath() ), e );
+          }
+        }
       }
     };
   }

--- a/extensions/src/main/resources/org/pentaho/platform/web/http/messages/messages.properties
+++ b/extensions/src/main/resources/org/pentaho/platform/web/http/messages/messages.properties
@@ -156,3 +156,4 @@ RepositoryResource.USER_NOT_AUTHORIZED_TO_EDIT=User is not authorized to edit th
 FileService.ERROR_INVALID_LOG_FILENAME=Invalid log file name {0}
 FileService.ERROR_UNABLE_TO_GET_PLATFORM_EXPORTER=Unable to get platform exporter from the system. Platform exporter has not been configured
 FileService.ERROR_UNABLE_TO_GET_EXPORT_LOGGER=Unable to get export logger from the platform exporter. Export logger is null"
+FileService.WARN_UNABLE_TO_DELETE_TEMP_FILE=Failed to delete temporary file {0}


### PR DESCRIPTION
Backport of [BACKLOG-46769](https://github.com/pentaho/pentaho-platform/pull/6053) to address [BISERVER-15706](https://pentaho-eng.atlassian.net/browse/BISERVER-15706).

Draft until SPs are open and target is 10.2.0.11

[BISERVER-15706]: https://pentaho-eng.atlassian.net/browse/BISERVER-15706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BACKLOG-46769]: https://hv-eng.atlassian.net/browse/BACKLOG-46769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ