### PR TITLE
fix: finalize import-export logging resources [BISERVER-15747]

### DIFF
--- a/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
+++ b/extensions/src/main/java/org/pentaho/platform/web/http/api/resources/services/FileService.java
@@ -160,40 +160,28 @@ public class FileService {
       encodedFileName = makeEncodedFileName( outputFile );
       IRepositoryExportLogger exportLogger;
       Level level = Level.valueOf( logLevel );
-      FileOutputStream fileOutputStream = null;
-      try {
-        validateFilePath( logFile );
-        fileOutputStream = new FileOutputStream( logFile );
-      } catch ( FileNotFoundException e ) {
-        try {
-          fileOutputStream = retrieveFallbackLogFileLocation( "backup" );
-        } catch ( FileNotFoundException fileNotFoundException ) {
-          throw new ExportException( fileNotFoundException );
-        }
-      }
-      ByteArrayOutputStream exportLoggerSream = new ByteArrayOutputStream();
-      IPentahoPlatformExporter exporter = PentahoSystem.get( IPentahoPlatformExporter.class );
-      if ( exporter == null ) {
-        logger.error( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_GET_PLATFORM_EXPORTER" ) );
-        throw new ExportException( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_GET_PLATFORM_EXPORTER" ) );
-      }
 
-      exportLogger = exporter.getRepositoryExportLogger();
-      if ( exportLogger == null ) {
-        logger.error( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_GET_EXPORT_LOGGER" ) );
-        throw new ExportException( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_GET_EXPORT_LOGGER" ) );
+      try ( FileOutputStream logOutputStream = createLogFileOutputStream( logFile, "backup" );
+        ByteArrayOutputStream exportLoggerStream = new ByteArrayOutputStream() ) {
+        IPentahoPlatformExporter exporter = PentahoSystem.get( IPentahoPlatformExporter.class );
+        if ( exporter == null ) {
+          logger.error( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_GET_PLATFORM_EXPORTER" ) );
+          throw new ExportException( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_GET_PLATFORM_EXPORTER" ) );
+        }
+
+        exportLogger = exporter.getRepositoryExportLogger();
+        if ( exportLogger == null ) {
+          logger.error( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_GET_EXPORT_LOGGER" ) );
+          throw new ExportException( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_GET_EXPORT_LOGGER" ) );
+        }
+        RepositoryTextLayout stringLayout = new RepositoryTextLayout( level );
+        exportLogger.startJob( exportLoggerStream, level, stringLayout );
+        StreamingOutput streamingOutput = performBackupAndWriteLog( exportLogger, exportLoggerStream, logOutputStream );
+        final String attachment = HttpMimeTypeListener.buildContentDispositionValue( outputFile, true );
+        return new DownloadFileWrapper( streamingOutput, attachment, encodedFileName );
+      } catch ( FileNotFoundException e ) {
+        throw new ExportException( e );
       }
-      RepositoryTextLayout stringLayout = new RepositoryTextLayout( level );
-      exportLogger.startJob( exportLoggerSream, level, stringLayout );
-      StreamingOutput streamingOutput = getBackupStream();
-      exportLogger.endJob();
-      try {
-        exportLoggerSream.writeTo( fileOutputStream );
-      } catch ( IOException e ) {
-        logger.error( e.getLocalizedMessage() );
-      }
-      final String attachment = HttpMimeTypeListener.buildContentDispositionValue( outputFile, true );
-      return new DownloadFileWrapper( streamingOutput, attachment, encodedFileName );
     } else {
       throw new SecurityException();
     }
@@ -208,6 +196,15 @@ public class FileService {
     return new FileOutputStream( fallbacklogFilePath );
   }
 
+  private FileOutputStream createLogFileOutputStream( String logFile, String fallbackPrefix ) throws FileNotFoundException {
+    try {
+      validateFilePath( logFile );
+      return new FileOutputStream( logFile );
+    } catch ( FileNotFoundException e ) {
+      return retrieveFallbackLogFileLocation( fallbackPrefix );
+    }
+  }
+
   public void systemRestore( final InputStream fileUpload, String overwriteFile,
                              String applyAclSettings, String overwriteAclSettings, String logFile, String logLevel, String backupBundlePath ) throws IllegalArgumentException, PlatformImportException, SecurityException {
     if ( doCanAdminister() ) {
@@ -218,18 +215,6 @@ public class FileService {
       IRepositoryImportLogger importLogger;
       Level level = Level.valueOf( logLevel );
 
-      FileOutputStream fileOutputStream = null;
-      try {
-        validateFilePath( logFile );
-        fileOutputStream = new FileOutputStream( logFile );
-      } catch ( FileNotFoundException e ) {
-        try {
-          fileOutputStream = retrieveFallbackLogFileLocation( "restore" );
-        } catch ( FileNotFoundException fileNotFoundException ) {
-          throw new PlatformImportException( fileNotFoundException.getLocalizedMessage() );
-        }
-      }
-      ByteArrayOutputStream importLoggerStream = new ByteArrayOutputStream();
       String importDirectory = "/";
       RepositoryFileImportBundle.Builder bundleBuilder = new RepositoryFileImportBundle.Builder();
       bundleBuilder.input( fileUpload );
@@ -244,25 +229,63 @@ public class FileService {
       bundleBuilder.retainOwnership( true );
       bundleBuilder.preserveDsw( true );
 
-      ImportSession.getSession().setAclProperties( applyAclSettingsFlag, true, overwriteAclSettingsFlag );
+      try ( FileOutputStream logOutputStream = createLogFileOutputStream( logFile, "restore" );
+        ByteArrayOutputStream importLoggerStream = new ByteArrayOutputStream() ) {
+        ImportSession.getSession().setAclProperties( applyAclSettingsFlag, true, overwriteAclSettingsFlag );
 
-      IPlatformImporter importer = PentahoSystem.get( IPlatformImporter.class );
-      importLogger = importer.getRepositoryImportLogger();
-      RepositoryTextLayout stringLayout = new RepositoryTextLayout( level );
-      importLogger.setPerformingRestore( true );
-      importLogger.startJob( importLoggerStream, importDirectory, level, stringLayout );
-      try {
-        importer.importFile( bundleBuilder.build() );
-      } finally {
-        importLogger.endJob();
-        try {
-          importLoggerStream.writeTo( fileOutputStream );
-        } catch ( IOException e ) {
-          e.printStackTrace();
-        }
+        IPlatformImporter importer = PentahoSystem.get( IPlatformImporter.class );
+        importLogger = importer.getRepositoryImportLogger();
+        RepositoryTextLayout stringLayout = new RepositoryTextLayout( level );
+        importLogger.setPerformingRestore( true );
+        importLogger.startJob( importLoggerStream, importDirectory, level, stringLayout );
+        performRestoreAndWriteLog( importer, bundleBuilder, importLogger, importLoggerStream, logOutputStream );
+      } catch ( IOException e ) {
+        throw new PlatformImportException( e.getLocalizedMessage(), e );
       }
     } else {
       throw new SecurityException();
+    }
+  }
+
+  private void writeLog( ByteArrayOutputStream loggerStream, FileOutputStream logOutputStream ) {
+    try {
+      loggerStream.writeTo( logOutputStream );
+    } catch ( IOException e ) {
+      logger.error( e.getLocalizedMessage(), e );
+    }
+  }
+
+  private StreamingOutput performBackupAndWriteLog( IRepositoryExportLogger exportLogger, ByteArrayOutputStream exportLoggerStream,
+                                                     FileOutputStream logOutputStream ) throws IOException, ExportException {
+    try {
+      return getBackupStream();
+    } finally {
+      exportLogger.endJob();
+      writeLog( exportLoggerStream, logOutputStream );
+    }
+  }
+
+  private void performRestoreAndWriteLog( IPlatformImporter importer, RepositoryFileImportBundle.Builder bundleBuilder,
+                                          IRepositoryImportLogger importLogger, ByteArrayOutputStream importLoggerStream,
+                                          FileOutputStream logOutputStream ) throws PlatformImportException {
+    try {
+      importer.importFile( bundleBuilder.build() );
+    } finally {
+      importLogger.endJob();
+      writeLog( importLoggerStream, logOutputStream );
+    }
+  }
+
+  private void deleteFileQuietly( File file ) {
+    if ( file == null ) {
+      return;
+    }
+    try {
+      if ( !Files.deleteIfExists( file.toPath() ) ) {
+        logger.warn( Messages.getInstance().getString( "FileService.WARN_UNABLE_TO_DELETE_TEMP_FILE", file.getAbsolutePath() ) );
+      }
+    } catch ( Exception e ) {
+      logger.warn( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_DELETE_TEMP_FILE", file.getAbsolutePath() ), e );
     }
   }
 
@@ -274,13 +297,7 @@ public class FileService {
         try ( FileInputStream inputStream = new FileInputStream( zipFile ) ) {
           IOUtils.copy( inputStream, output );
         } finally {
-          try {
-            if ( zipFile != null && !Files.deleteIfExists( zipFile.toPath() ) ) {
-              logger.warn( Messages.getInstance().getString( "FileService.WARN_UNABLE_TO_DELETE_TEMP_FILE", zipFile.getAbsolutePath() ) );
-            }
-          } catch ( Exception e ) {
-            logger.warn( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_DELETE_TEMP_FILE", zipFile.getAbsolutePath() ), e );
-          }
+          deleteFileQuietly( zipFile );
         }
       }
     };
@@ -2033,13 +2050,7 @@ public class FileService {
         try ( final FileInputStream is = new FileInputStream( zipFile ) ) {
           IOUtils.copy(is, output);
         } finally {
-          try {
-            if ( zipFile != null && !Files.deleteIfExists( zipFile.toPath() ) ) {
-              logger.warn( Messages.getInstance().getString( "FileService.WARN_UNABLE_TO_DELETE_TEMP_FILE", zipFile.getAbsolutePath() ) );
-            }
-          } catch ( Exception e ) {
-            logger.warn( Messages.getInstance().getString( "FileService.ERROR_UNABLE_TO_DELETE_TEMP_FILE", zipFile.getAbsolutePath() ), e );
-          }
+          deleteFileQuietly( zipFile );
         }
       }
     };

--- a/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
+++ b/extensions/src/test/java/org/pentaho/platform/web/http/api/resources/services/FileServiceTest.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.pentaho.platform.api.engine.IPentahoObjectFactory;
 import org.pentaho.platform.api.engine.IPentahoObjectReference;
 import org.pentaho.platform.api.engine.IPentahoSession;
@@ -26,15 +27,21 @@ import org.pentaho.platform.api.engine.ISystemSettings;
 import org.pentaho.platform.api.engine.ObjectFactoryException;
 import org.pentaho.platform.api.engine.IAuthorizationPolicy;
 import org.pentaho.platform.api.engine.PentahoAccessControlException;
+import org.pentaho.platform.api.importexport.ExportException;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
+import org.pentaho.platform.api.util.IPentahoPlatformExporter;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.plugin.services.importexport.BaseExportProcessor;
 import org.pentaho.platform.plugin.services.importexport.ExportHandler;
+import org.pentaho.platform.plugin.services.importexport.ImportSession;
+import org.pentaho.platform.plugin.services.importer.IPlatformImporter;
 import org.pentaho.platform.repository2.ClientRepositoryPaths;
 import org.pentaho.platform.repository2.unified.fileio.RepositoryFileOutputStream;
 import org.pentaho.platform.repository2.unified.webservices.DefaultUnifiedRepositoryWebService;
 import org.pentaho.platform.security.policy.rolebased.actions.RepositoryCreateAction;
+
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -46,6 +53,7 @@ import java.security.InvalidParameterException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
 import jakarta.ws.rs.core.StreamingOutput;
 
 import static org.junit.Assert.assertEquals;
@@ -63,6 +71,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 
 public class FileServiceTest {
 
@@ -96,7 +105,7 @@ public class FileServiceTest {
               add( pentahoObjectReference );
             } } );
     } catch ( ObjectFactoryException e ) {
-      e.printStackTrace();
+      throw e;
     }
     when( settingsService.getSystemSetting( nullable( String.class ), nullable( String.class ) ) ).thenReturn( "" );
     PentahoSystem.registerObjectFactory( objectFactory );
@@ -1076,6 +1085,54 @@ public class FileServiceTest {
     }
 
     verify( fileService ).clearBowlCache();
+  }
+
+  @Test
+  public void testSystemBackupClosesLogFileWhenExportCannotStart() throws Exception {
+    File logFile = File.createTempFile( "backup", ".log" );
+    String logFilePath = logFile.getAbsolutePath();
+    doReturn( true ).when( fileService ).doCanAdminister();
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = mockStatic( PentahoSystem.class ) ) {
+      pentahoSystem.when( () -> PentahoSystem.get( IPentahoPlatformExporter.class ) ).thenReturn( null );
+
+      boolean failedWithoutExporter = false;
+      try {
+        fileService.systemBackup( logFilePath, "DEBUG", "backup.zip" );
+      } catch ( ExportException expected ) {
+        // The failure is intentional; the log file must still be released.
+        failedWithoutExporter = true;
+      }
+      assertTrue( "Expected the backup to fail without an exporter", failedWithoutExporter );
+    }
+
+    assertTrue( logFile.delete() );
+  }
+
+  @Test
+  public void testSystemRestoreClosesLogFileWhenImportCannotStart() throws Exception {
+    File logFile = File.createTempFile( "restore", ".log" );
+    String logFilePath = logFile.getAbsolutePath();
+    InputStream fileUpload = mock( InputStream.class );
+    doReturn( true ).when( fileService ).doCanAdminister();
+    ImportSession importSession = mock( ImportSession.class );
+
+    try ( MockedStatic<PentahoSystem> pentahoSystem = mockStatic( PentahoSystem.class );
+          MockedStatic<ImportSession> importSessionStatic = mockStatic( ImportSession.class ) ) {
+      importSessionStatic.when( ImportSession::getSession ).thenReturn( importSession );
+      pentahoSystem.when( () -> PentahoSystem.get( IPlatformImporter.class ) ).thenReturn( null );
+
+      boolean failedWithoutImporter = false;
+      try {
+        fileService.systemRestore( fileUpload, "true", "true", "true", logFilePath, "DEBUG", "backup.zip" );
+      } catch ( NullPointerException expected ) {
+        // The failure is intentional; the log file must still be released.
+        failedWithoutImporter = true;
+      }
+      assertTrue( "Expected the restore to fail without an importer", failedWithoutImporter );
+    }
+
+    assertTrue( logFile.delete() );
   }
 
   private static String encode( String pathControlCharacter ) throws UnsupportedEncodingException {


### PR DESCRIPTION
### Summary
This PR addresses a reported Windows concern that import/export log files could remain locked after backup or restore operations, preventing them from being deleted or moved.

Manual testing on the current 11.1 master build did not reproduce the reported file-lock behavior. However, code inspection showed that the backup and restore log `FileOutputStream`s were not explicitly closed. This PR makes ownership of those streams explicit and ensures they are released deterministically.

### Core Fix
- Manage the backup and restore log `FileOutputStream`s with try-with-resources.
- Manage the associated in-memory `ByteArrayOutputStream`s in the same resource scopes.
- Add regression tests that create real temporary log files and verify they can be deleted after backup/restore fail early.

### Additional fixes
- Ensure export logger cleanup and log persistence run when backup stream creation fails.
- Preserve the original `IOException` as the cause when restore resource handling fails.
- Replace message-only and `printStackTrace()` error handling with platform logging that retains the exception cause.
- Extract duplicated fallback logfile creation, logger finalization, log writing, and temporary ZIP cleanup into helpers.
- Remove nested resource-handling blocks identified during review without changing the backup or restore business flow.

### Validation
Focused `FileServiceTest` execution completed successfully with Maven. The regression tests verify both backup and restore release their log files after early failure.
